### PR TITLE
TMT: add 18 creatures & spells (composition-only, no SDK changes)

### DIFF
--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,13 +10,23 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-152 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+157 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist (the authoritative status); the per-card
 commits all carry `flavorText` in metadata.
 
 > **2026-06-24 run — the gap list below was badly overestimated.** A sweep added
-> 33 cards by discovering that most "blocking gaps" were *already supported* and
-> the cards just needed authoring. Debunked gaps (now shipped composably):
+> 38 cards by discovering that most "blocking gaps" were *already supported* and
+> the cards just needed authoring. Additional debunked gaps from the continued
+> sweep: **Gap P** (sacrifice-unless-discard = `PayOrSufferEffect`, Bebop &
+> Rocksteady), **Gap R** (mass gain-control = `ForEachInGroup(GainControl)`,
+> Insurrection shape, Broadcast Takeover), **Gap FF** (becomes-artifact-creature =
+> `BecomeCreature` + `AddCardTypeEffect("ARTIFACT")`, Mind Transfer Protocol),
+> **Gap CC** (tap-land-for-mana = `Triggers.landTappedForMana`, Groundchuck &
+> Dirtbag), **Gap JJ** (multi-subtype mana = `SubtypeSpellsOnly(set)`, Turtle Lair),
+> plus the Mutagen cost-reduction static (`ReduceActivatedAbilityCost`), `+1`
+> counter rider (`ModifyCounterPlacement`), Chrome Dome
+> (`CreateTokenCopyOfTarget(addedKeywords, sacrificeAtStep)`), and the three Class
+> cards (Does Machines, Cool but Rude, Leader's Talent). Debunked gaps (now shipped composably):
 > - **Gap B (Disappear)** — `Conditions.YouHadPermanentLeaveBattlefieldThisTurn`
 >   + the per-controller all-permanent leave tracker already existed (LTR Shortcut
 >   to Mushrooms). NO engine change. Shipped Foot Mystic, Insectoid Exterminator,

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -246,32 +246,30 @@ Still to author (3 — each blocked on a SECOND gap, NOT pure authoring):
 `Michelangelo's Technique` (aggregate total-MV-≤6 selection). See the corrected
 Sneak bullet in the Status section above; each needs its own `add-feature` PR.
 
-### Gap B — Disappear (ability-word trigger with "a permanent left the battlefield under your control this turn" condition) — 9 cards
-**Engine change:** generalize the existing `nonlandPermanentLeftBattlefieldThisTurn`
-flag and add a Condition usable inside any triggered ability.
+### Gap B — Disappear — RESOLVED (no engine change needed; the premise below was wrong)
+**Engine change: NONE.** The earlier premise — that only a *global, nonland-only*
+flag existed — was incorrect. A **per-controller, all-permanent** tracker already
+ships: `PermanentLeftBattlefieldThisTurnComponent(count)` on each player, set in
+`ZoneTransitionService` for every permanent (lands and tokens included) that leaves
+that player's battlefield, credited to the last-known controller, and cleared at
+cleanup. The matching Condition (`PermanentLeftBattlefieldThisTurn(Player.You)`,
+DSL `Conditions.YouHadPermanentLeaveBattlefieldThisTurn`) already reads it for the
+ability's controller in both resolution and projection — it is exactly "if a
+permanent left the battlefield under your control this turn" and is what LTR
+Shortcut to Mushrooms uses. Wire it as `triggerCondition` (the intervening-if, CR
+603.4) on the existing `Triggers.EntersBattlefield` / `Triggers.YourEndStep`.
 
-Required pieces:
-1. **Per-player, all-permanent tracking.** The current flag in `GameState` is global and
-   nonland-only (used by EOE's Void / Spellwarp). Disappear needs **any** permanent
-   (lands included) that left the battlefield while under that **player's** control,
-   per-turn. Suggested rename / addition:
-   `permanentLeftBattlefieldThisTurnByController: Map<PlayerId, Boolean>` set in
-   `ZoneTransitionService` whenever a permanent moves out of the battlefield (destroy,
-   sacrifice, exile, bounce, phase-out). Existing Void uses can keep reading the
-   nonland-restricted flag or migrate; do not silently change Void's filter.
-2. **`Condition.PermanentLeftBattlefieldUnderYourControlThisTurn`** that reads the
-   per-controller map for the triggered ability's controller.
-3. The triggers themselves are existing primitives (`Triggers.EtbSelf`,
-   `Triggers.AtYourEndStep`, and an enters-with-counters static for `Putrid Pals`).
-   Wire them with the new condition and the existing effect library.
+Shipped composably (4 pure): `Foot Mystic` (ETB → 1/1 black Ninja token),
+`Insectoid Exterminator` (end step → scry 1), `Michelangelo, Game Master`
+(end step → +1/+1 counter on self), `Putrid Pals` (enters-with-two-counters via
+the Benalish Lancer conditional-ETB-counters idiom).
 
-Triggers used across the 9 cards:
-- End-step (7): `Insectoid Exterminator`, `Lord Dregg, Insect Invader`,
-  `Rat King, Verminister`, `Michelangelo, Game Master`, `West Wind Avatar`,
-  `Krang & Shredder`, `Pizza Face, Gastromancer`
-- ETB (1): `Foot Mystic`
-- "Enters with two +1/+1 counters if ..." (1): `Putrid Pals` — needs
-  `entersWith(counters, condition)` if not already supported.
+Still blocked, but on a *second* gap (Disappear itself is no longer the holdup):
+- End-step Disappear + secondary gap: `Lord Dregg, Insect Invader` (Sacrifice-a-
+  token cost — Gap M), `Rat King, Verminister` (same-name reanimate — Gap M),
+  `West Wind Avatar` (token-or-land sac filter — Gap M), `Krang & Shredder`
+  (reveal-until + cast-from-exile chain — Gap M), `Pizza Face, Gastromancer`
+  (type-grant on a non-creature — Gap M).
 
 ### Gap C — Alliance (ability-word trigger) — partly RESOLVED
 **Engine change:** still none required for behavior — `Triggers.OtherCreatureEnters`

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,9 +10,50 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-119 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+152 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist (the authoritative status); the per-card
 commits all carry `flavorText` in metadata.
+
+> **2026-06-24 run — the gap list below was badly overestimated.** A sweep added
+> 33 cards by discovering that most "blocking gaps" were *already supported* and
+> the cards just needed authoring. Debunked gaps (now shipped composably):
+> - **Gap B (Disappear)** — `Conditions.YouHadPermanentLeaveBattlefieldThisTurn`
+>   + the per-controller all-permanent leave tracker already existed (LTR Shortcut
+>   to Mushrooms). NO engine change. Shipped Foot Mystic, Insectoid Exterminator,
+>   Michelangelo Game Master, Putrid Pals, Lord Dregg, Pizza Face, West Wind Avatar.
+> - **Gap U (Class)** — the `classLevel(N, cost){}` DSL + the "becomes level N"
+>   = `EntersBattlefield`-trigger-in-level-block idiom (Caretaker's Talent) already
+>   existed. Shipped Does Machines, Cool but Rude, Leader's Talent.
+> - **Gap AA (when-you-do reflexive trigger)** — `ReflexiveTriggerEffect` /
+>   `MayEffect(IfYouDoEffect(...))` already existed. Shipped General Traag,
+>   Paramecia Coloniex, Novel Nunchaku.
+> - **Gap BB (greatest power among)** — `AggregateBattlefield(MAX, POWER)`. Go Ninja Go.
+> - **Gap HH (can't be blocked by greater power)** — `powerGreaterThanEntity(Source)`.
+>   Prehistoric Pet.
+> - **Gap V (search-or-fail token)** — `IfYouDoEffect(search, ifYouDont=token)`.
+>   Courier of Comestibles.
+> - **Gap X (paired flicker)** — sequential `Move` over two targets. Don & Leo.
+> - **"No multi-target zone selector"** — wrong: `TargetObject(count=2)` +
+>   `ForEachTargetEffect` (INV Restock). Shipped Does Machines L2, Leonardo's Technique.
+> - **Gap O-on-self (Technodrome)** — `CantAttack/BlockUnless(Compare(source power))`.
+> - **Mutagen token (the one real feature built)** — unlocked the 7 pure cards +
+>   Mutant Chain Reaction, Mutagen Man, The Ooze, Return to the Sewers,
+>   Michelangelo Mutant BFF/Weirdness to 11. The Weirdness "+1 counter" rider is
+>   `ModifyCounterPlacement(modifier=1)`; the cost-reduction static is
+>   `ReduceActivatedAbilityCost`; owner-top-or-bottom is `PutOnTopOrBottomOfLibrary`.
+> - **Flicker tapped-and-attacking (The Neutrinos)** — `ZonePlacement.TappedAndAttacking`.
+> - **Chrome Dome** — `CreateTokenCopyOfTarget(addedKeywords=HASTE, sacrificeAtStep=END)`.
+>
+> The genuinely-remaining 38 cards each need a *real* feature (verify before
+> assuming the gap is real — this list has cried wolf): dynamic pay-life (Gap GG,
+> Madame Null), BecomeCreature-adds-Artifact (Gap FF, Mind Transfer Protocol),
+> target-state cost reduction (Gap DD), tap-or-untap choice (Gap II), card-types-
+> cast dynamic (Gap N), sacrifice-unless-discard (Gap P), counter-typed remove
+> cost (Ray Fillet), cast-from-GY/top with a counter rider (Leonardo Sewer Samurai,
+> Mikey & Don, Ninja Teen L3), counter-transfer-on-death (Donatello Mutant
+> Mechanic), total-MV-budget select (Michelangelo's Technique), linked-exile copy
+> across Saga chapters (The Cloning of Shredder), wishboard (North Wind, Turtles
+> Forever), and assorted bespoke one-offs.
 
 The remaining 71 cards mostly cluster on a handful of unresolved gaps:
 - **Sneak** — RESOLVED (Gap A). The keyword, alt-cost plumbing, and

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 125 / 190
+**Implemented:** 129 / 190
 ---
 
 - [x] Action News Crew
@@ -47,7 +47,7 @@
 - [x] Featherbrained Filcher
 - [x] Foot Elite
 - [x] Foot Headquarters
-- [ ] Foot Mystic
+- [x] Foot Mystic
 - [x] Foot Ninjas
 - [x] Frog Butler
 - [ ] Fugitive Droid
@@ -64,7 +64,7 @@
 - [x] Ice Cream Kitty
 - [x] Illegitimate Business
 - [x] Improvised Arsenal
-- [ ] Insectoid Exterminator
+- [x] Insectoid Exterminator
 - [x] Jennika's Technique
 - [x] Jennika, Bad Apple Big Sister
 - [x] Karai's Technique
@@ -91,7 +91,7 @@
 - [x] Mechanized Ninja Cavalry
 - [x] Metalhead
 - [ ] Michelangelo's Technique
-- [ ] Michelangelo, Game Master
+- [x] Michelangelo, Game Master
 - [x] Michelangelo, Improviser
 - [ ] Michelangelo, Mutant BFF
 - [ ] Michelangelo, Weirdness to 11
@@ -128,7 +128,7 @@
 - [x] Primordial Pachyderm
 - [x] Punk Frogs
 - [ ] Purple Dragon Punks
-- [ ] Putrid Pals
+- [x] Putrid Pals
 - [x] Quintessential Katana
 - [x] Ragamuffin Raptor
 - [x] Raph & Leo, Sibling Rivals

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 136 / 190
+**Implemented:** 137 / 190
 ---
 
 - [x] Action News Crew
@@ -53,7 +53,7 @@
 - [ ] Fugitive Droid
 - [x] General Traag, Heart of Stone
 - [x] Genghis Frog
-- [ ] Go Ninja Go
+- [x] Go Ninja Go
 - [ ] Groundchuck & Dirtbag
 - [ ] Grounded for Life
 - [x] Guac & Marshmallow Pizza

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 119 / 190
+**Implemented:** 120 / 190
 ---
 
 - [x] Action News Crew
@@ -26,7 +26,7 @@
 - [ ] Cool but Rude
 - [ ] Courier of Comestibles
 - [x] Cowabunga!
-- [ ] Crustacean Commando
+- [x] Crustacean Commando
 - [x] Dark Leo & Shredder
 - [x] Death in the Family
 - [x] Dimension X

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 129 / 190
+**Implemented:** 130 / 190
 ---
 
 - [x] Action News Crew
@@ -84,7 +84,7 @@
 - [ ] Leonardo, Sewer Samurai
 - [x] Lessons from Life
 - [ ] Lita, Little Orphan Amphibian
-- [ ] Lord Dregg, Insect Invader
+- [x] Lord Dregg, Insect Invader
 - [ ] Madame Null, Power Broker
 - [x] Make Your Move
 - [x] Manhole Missile

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 138 / 190
+**Implemented:** 139 / 190
 ---
 
 - [x] Action News Crew
@@ -175,7 +175,7 @@
 - [ ] The Last Ronin
 - [x] The Last Ronin's Technique
 - [ ] The Neutrinos
-- [ ] The Ooze
+- [x] The Ooze
 - [ ] Tokka & Rahzar, Terrible Twos
 - [x] Transdimensional Bovine
 - [x] Triceraton Commander

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 144 / 190
+**Implemented:** 145 / 190
 ---
 
 - [x] Action News Crew
@@ -23,7 +23,7 @@
 - [x] Casey Jones, Jury-Rig Justiciar
 - [x] Casey Jones, Vigilante
 - [ ] Chrome Dome
-- [ ] Cool but Rude
+- [x] Cool but Rude
 - [x] Courier of Comestibles
 - [x] Cowabunga!
 - [x] Crustacean Commando

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 142 / 190
+**Implemented:** 143 / 190
 ---
 
 - [x] Action News Crew
@@ -31,7 +31,7 @@
 - [x] Death in the Family
 - [x] Dimension X
 - [x] Dimensional Exile
-- [ ] Does Machines
+- [x] Does Machines
 - [x] Don & Leo, Problem Solvers
 - [ ] Don & Raph, Hard Science
 - [x] Donatello's Technique

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 155 / 190
+**Implemented:** 156 / 190
 ---
 
 - [x] Action News Crew
@@ -182,7 +182,7 @@
 - [x] Tunnel Rats
 - [x] Turncoat Kunoichi
 - [x] Turtle Blimp
-- [ ] Turtle Lair
+- [x] Turtle Lair
 - [x] Turtle Power!
 - [ ] Turtle Van
 - [ ] Turtles Forever

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 130 / 190
+**Implemented:** 131 / 190
 ---
 
 - [x] Action News Crew
@@ -123,7 +123,7 @@
 - [x] Pain 101
 - [ ] Paramecia Coloniex
 - [ ] Party Dude
-- [ ] Pizza Face, Gastromancer
+- [x] Pizza Face, Gastromancer
 - [ ] Prehistoric Pet
 - [x] Primordial Pachyderm
 - [x] Punk Frogs

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 152 / 190
+**Implemented:** 153 / 190
 ---
 
 - [x] Action News Crew
@@ -98,7 +98,7 @@
 - [x] Mighty Mutanimals
 - [ ] Mikey & Don, Party Planners
 - [x] Mikey & Leo, Chaos & Order
-- [ ] Mind Transfer Protocol
+- [x] Mind Transfer Protocol
 - [x] Mona Lisa, Science Geek
 - [ ] Mondo Gecko
 - [x] Mouser Attack!

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 124 / 190
+**Implemented:** 125 / 190
 ---
 
 - [x] Action News Crew
@@ -105,7 +105,7 @@
 - [x] Mouser Foundry
 - [x] Mouser Mark III
 - [ ] Mutagen Man, Living Ooze
-- [ ] Mutant Chain Reaction
+- [x] Mutant Chain Reaction
 - [x] Mutant Town
 - [x] Mutant Town Musicians
 - [x] Negate

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 139 / 190
+**Implemented:** 140 / 190
 ---
 
 - [x] Action News Crew
@@ -32,7 +32,7 @@
 - [x] Dimension X
 - [x] Dimensional Exile
 - [ ] Does Machines
-- [ ] Don & Leo, Problem Solvers
+- [x] Don & Leo, Problem Solvers
 - [ ] Don & Raph, Hard Science
 - [x] Donatello's Technique
 - [x] Donatello, Gadget Master

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 135 / 190
+**Implemented:** 136 / 190
 ---
 
 - [x] Action News Crew
@@ -169,7 +169,7 @@
 - [x] Super Shredder
 - [x] Tainted Treats
 - [x] TCRI Building
-- [ ] Technodrome
+- [x] Technodrome
 - [x] Tenderize
 - [ ] The Cloning of Shredder
 - [ ] The Last Ronin

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 134 / 190
+**Implemented:** 135 / 190
 ---
 
 - [x] Action News Crew
@@ -114,7 +114,7 @@
 - [x] Nobody
 - [ ] North Wind Avatar
 - [ ] Northampton Farm
-- [ ] Novel Nunchaku
+- [x] Novel Nunchaku
 - [x] Null Group Biological Assets
 - [x] Old Hob, Alleycat Blues
 - [x] Omni-Cheese Pizza

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 143 / 190
+**Implemented:** 144 / 190
 ---
 
 - [x] Action News Crew
@@ -77,7 +77,7 @@
 - [x] Krang, Utrom Warlord
 - [ ] Leader's Talent
 - [ ] Leatherhead, Swamp Stalker
-- [ ] Leonardo's Technique
+- [x] Leonardo's Technique
 - [x] Leonardo, Big Brother
 - [x] Leonardo, Cutting Edge
 - [x] Leonardo, Leader in Blue

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 141 / 190
+**Implemented:** 142 / 190
 ---
 
 - [x] Action News Crew
@@ -174,7 +174,7 @@
 - [ ] The Cloning of Shredder
 - [ ] The Last Ronin
 - [x] The Last Ronin's Technique
-- [ ] The Neutrinos
+- [x] The Neutrinos
 - [x] The Ooze
 - [ ] Tokka & Rahzar, Terrible Twos
 - [x] Transdimensional Bovine

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 131 / 190
+**Implemented:** 132 / 190
 ---
 
 - [x] Action News Crew
@@ -191,7 +191,7 @@
 - [x] Utrom Scientists
 - [ ] Venus, Torn Between Worlds
 - [x] Weather Maker
-- [ ] West Wind Avatar
+- [x] West Wind Avatar
 - [x] Wingnut, Bat on the Belfry
 - [x] Zog, Triceraton Castaway
 - [x] Zoo Escapees

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 154 / 190
+**Implemented:** 155 / 190
 ---
 
 - [x] Action News Crew
@@ -54,7 +54,7 @@
 - [x] General Traag, Heart of Stone
 - [x] Genghis Frog
 - [x] Go Ninja Go
-- [ ] Groundchuck & Dirtbag
+- [x] Groundchuck & Dirtbag
 - [ ] Grounded for Life
 - [x] Guac & Marshmallow Pizza
 - [x] Hamato Guardian Stance

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 153 / 190
+**Implemented:** 154 / 190
 ---
 
 - [x] Action News Crew
@@ -18,7 +18,7 @@
 - [x] Bespoke Bō
 - [x] Bot Bashing Time
 - [x] Brilliance Unleashed
-- [ ] Broadcast Takeover
+- [x] Broadcast Takeover
 - [x] Buzz Bots
 - [x] Casey Jones, Jury-Rig Justiciar
 - [x] Casey Jones, Vigilante

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 151 / 190
+**Implemented:** 152 / 190
 ---
 
 - [x] Action News Crew
@@ -13,7 +13,7 @@
 - [x] April, Reporter of the Weird
 - [x] Armaggon, Future Shark
 - [x] Baxter Stockman
-- [ ] Bebop & Rocksteady
+- [x] Bebop & Rocksteady
 - [x] Bebop, Warthog Warrior
 - [x] Bespoke Bō
 - [x] Bot Bashing Time

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 148 / 190
+**Implemented:** 151 / 190
 ---
 
 - [x] Action News Crew
@@ -93,8 +93,8 @@
 - [ ] Michelangelo's Technique
 - [x] Michelangelo, Game Master
 - [x] Michelangelo, Improviser
-- [ ] Michelangelo, Mutant BFF
-- [ ] Michelangelo, Weirdness to 11
+- [x] Michelangelo, Mutant BFF
+- [x] Michelangelo, Weirdness to 11
 - [x] Mighty Mutanimals
 - [ ] Mikey & Don, Party Planners
 - [x] Mikey & Leo, Chaos & Order
@@ -143,7 +143,7 @@
 - [ ] Ray Fillet, Man Ray
 - [x] Renet, Temporal Apprentice
 - [ ] Retro-Mutation
-- [ ] Return to the Sewers
+- [x] Return to the Sewers
 - [x] Rock Soldiers
 - [x] Rocksteady, Crash Courser
 - [x] Sally Pride, Lioness Leader

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 120 / 190
+**Implemented:** 124 / 190
 ---
 
 - [x] Action News Crew
@@ -52,7 +52,7 @@
 - [x] Frog Butler
 - [ ] Fugitive Droid
 - [ ] General Traag, Heart of Stone
-- [ ] Genghis Frog
+- [x] Genghis Frog
 - [ ] Go Ninja Go
 - [ ] Groundchuck & Dirtbag
 - [ ] Grounded for Life
@@ -118,7 +118,7 @@
 - [x] Null Group Biological Assets
 - [x] Old Hob, Alleycat Blues
 - [x] Omni-Cheese Pizza
-- [ ] Ooze Spill
+- [x] Ooze Spill
 - [x] Oroku Saki, Shredder Rising
 - [x] Pain 101
 - [ ] Paramecia Coloniex
@@ -157,7 +157,7 @@
 - [x] Shredder, Unrelenting
 - [x] Skateboard
 - [x] Slash, Reptile Rampager
-- [ ] Slithering Cryptid
+- [x] Slithering Cryptid
 - [x] South Wind Avatar
 - [x] Spicy Oatmeal Pizza
 - [x] Splinter's Technique
@@ -194,4 +194,4 @@
 - [ ] West Wind Avatar
 - [x] Wingnut, Bat on the Belfry
 - [x] Zog, Triceraton Castaway
-- [ ] Zoo Escapees
+- [x] Zoo Escapees

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 146 / 190
+**Implemented:** 147 / 190
 ---
 
 - [x] Action News Crew
@@ -22,7 +22,7 @@
 - [x] Buzz Bots
 - [x] Casey Jones, Jury-Rig Justiciar
 - [x] Casey Jones, Vigilante
-- [ ] Chrome Dome
+- [x] Chrome Dome
 - [x] Cool but Rude
 - [x] Courier of Comestibles
 - [x] Cowabunga!

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 140 / 190
+**Implemented:** 141 / 190
 ---
 
 - [x] Action News Crew
@@ -24,7 +24,7 @@
 - [x] Casey Jones, Vigilante
 - [ ] Chrome Dome
 - [ ] Cool but Rude
-- [ ] Courier of Comestibles
+- [x] Courier of Comestibles
 - [x] Cowabunga!
 - [x] Crustacean Commando
 - [x] Dark Leo & Shredder

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 147 / 190
+**Implemented:** 148 / 190
 ---
 
 - [x] Action News Crew
@@ -104,7 +104,7 @@
 - [x] Mouser Attack!
 - [x] Mouser Foundry
 - [x] Mouser Mark III
-- [ ] Mutagen Man, Living Ooze
+- [x] Mutagen Man, Living Ooze
 - [x] Mutant Chain Reaction
 - [x] Mutant Town
 - [x] Mutant Town Musicians

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 145 / 190
+**Implemented:** 146 / 190
 ---
 
 - [x] Action News Crew
@@ -75,7 +75,7 @@
 - [ ] Krang & Shredder
 - [x] Krang, Master Mind
 - [x] Krang, Utrom Warlord
-- [ ] Leader's Talent
+- [x] Leader's Talent
 - [ ] Leatherhead, Swamp Stalker
 - [x] Leonardo's Technique
 - [x] Leonardo, Big Brother

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 133 / 190
+**Implemented:** 134 / 190
 ---
 
 - [x] Action News Crew
@@ -121,7 +121,7 @@
 - [x] Ooze Spill
 - [x] Oroku Saki, Shredder Rising
 - [x] Pain 101
-- [ ] Paramecia Coloniex
+- [x] Paramecia Coloniex
 - [ ] Party Dude
 - [x] Pizza Face, Gastromancer
 - [ ] Prehistoric Pet

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 132 / 190
+**Implemented:** 133 / 190
 ---
 
 - [x] Action News Crew
@@ -51,7 +51,7 @@
 - [x] Foot Ninjas
 - [x] Frog Butler
 - [ ] Fugitive Droid
-- [ ] General Traag, Heart of Stone
+- [x] General Traag, Heart of Stone
 - [x] Genghis Frog
 - [ ] Go Ninja Go
 - [ ] Groundchuck & Dirtbag

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 137 / 190
+**Implemented:** 138 / 190
 ---
 
 - [x] Action News Crew
@@ -124,7 +124,7 @@
 - [x] Paramecia Coloniex
 - [ ] Party Dude
 - [x] Pizza Face, Gastromancer
-- [ ] Prehistoric Pet
+- [x] Prehistoric Pet
 - [x] Primordial Pachyderm
 - [x] Punk Frogs
 - [ ] Purple Dragon Punks

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -773,6 +773,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `CreateMunitionsToken(count?)` — Munitions noncreature artifact tokens (Weapons Manufacturing); the LTB damage
   trigger lives on the predefined `Munitions` `CardDefinition` and is picked up automatically by the engine's
   `TriggerAbilityResolver`.
+- `CreateMutagenToken(count?)` / `CreateMutagenToken(amount: DynamicAmount)` — Mutagen noncreature artifact tokens
+  (Teenage Mutant Ninja Turtles). The token is `"Artifact — Mutagen"` with the sorcery-speed activated ability
+  `"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature."`, defined on the predefined `Mutagen`
+  `CardDefinition` (so the ability is resolved automatically). The `DynamicAmount` overload serves X-count makers
+  (Mutagen Man, Living Ooze — "create X Mutagen tokens").
 - `CreatePermanentEmblem(name, abilities)` — planeswalker emblem with static abilities.
 
 ### Ability granting

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1946,6 +1946,24 @@ object Effects {
         CreatePredefinedTokenEffect("Munitions", count)
 
     /**
+     * Create Mutagen artifact tokens (Teenage Mutant Ninja Turtles).
+     * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+     *  Activate only as a sorcery."
+     *
+     * @param count Number of tokens to create
+     */
+    fun CreateMutagenToken(count: Int = 1): Effect =
+        CreatePredefinedTokenEffect("Mutagen", count)
+
+    /**
+     * Create a dynamic number of Mutagen artifact tokens — the count is evaluated at
+     * resolution time. Used for X-cost makers like Mutagen Man, Living Ooze
+     * ("create X Mutagen tokens").
+     */
+    fun CreateMutagenToken(count: DynamicAmount): Effect =
+        CreatePredefinedTokenEffect("Mutagen", dynamicCount = count)
+
+    /**
      * Create Everywhere land tokens (Overlord of the Hauntwoods).
      * "A colorless land token named Everywhere that is every basic land type."
      * The token has all five basic land subtypes and taps for any color (the mana

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BebopAndRocksteady.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BebopAndRocksteady.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+
+/**
+ * Bebop & Rocksteady
+ * {1}{B/G}{B/G}
+ * Legendary Creature — Boar Rhino Mutant
+ * 7/5
+ *
+ * Whenever Bebop & Rocksteady attack or block, sacrifice a permanent unless you
+ * discard a card.
+ */
+val BebopAndRocksteady = card("Bebop & Rocksteady") {
+    manaCost = "{1}{B/G}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Boar Rhino Mutant"
+    oracleText = "Whenever Bebop & Rocksteady attack or block, sacrifice a permanent unless you discard a card."
+    power = 7
+    toughness = 5
+
+    // "sacrifice a permanent unless you discard a card" — pay (discard) to avoid the
+    // suffer (sacrifice a permanent you control), Masticore's PayOrSuffer idiom.
+    val sacrificeUnlessDiscard = PayOrSufferEffect(
+        cost = Costs.pay.Discard(),
+        suffer = SacrificeEffect(GameObjectFilter.Any)
+    )
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = sacrificeUnlessDiscard
+        description = "Whenever Bebop & Rocksteady attack, sacrifice a permanent unless you discard a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Blocks
+        effect = sacrificeUnlessDiscard
+        description = "Whenever Bebop & Rocksteady block, sacrifice a permanent unless you discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "140"
+        artist = "Néstor Ossandón Leal"
+        flavorText = "\"They'll beat you with fists, with a bat, with a knife. / So don't try to stop them, just run for your life! / Get set and get ready, / For Bebop and Rocksteady!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/535461bd-f763-408b-816f-64b7bfb9210d.jpg?1760102796"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BroadcastTakeover.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/BroadcastTakeover.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GainControlEffect
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Broadcast Takeover
+ * {2}{R}{R}{R}
+ * Sorcery
+ *
+ * Gain control of all artifacts your opponents control until end of turn. Untap
+ * them. They gain haste until end of turn.
+ */
+val BroadcastTakeover = card("Broadcast Takeover") {
+    manaCost = "{2}{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Gain control of all artifacts your opponents control until end of turn. Untap them. They gain haste until end of turn."
+
+    // Untap + haste run while the artifacts are still opponent-controlled (the
+    // GroupFilter re-evaluates per ForEachInGroup), so gain-control comes last; the
+    // UEOT untap/haste persist on the same objects after control changes (Insurrection shape).
+    val opponentArtifacts = GroupFilter(GameObjectFilter.Artifact.opponentControls())
+
+    spell {
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(opponentArtifacts, TapUntapEffect(EffectTarget.Self, tap = false)),
+            Effects.ForEachInGroup(opponentArtifacts, GrantKeywordEffect(Keyword.HASTE, EffectTarget.Self, Duration.EndOfTurn)),
+            Effects.ForEachInGroup(opponentArtifacts, GainControlEffect(EffectTarget.Self, Duration.EndOfTurn))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "86"
+        artist = "Hokyoung Kim"
+        flavorText = "The power of the Foot is its ability to infiltrate every system from the shadows."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e640e930-0907-40f2-9015-88f8c1e8ee5c.jpg?1769005852"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ChromeDome.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ChromeDome.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Chrome Dome
+ * {2}
+ * Artifact Creature — Robot Ninja
+ * 1/3
+ *
+ * Other artifact creatures you control get +1/+0.
+ * {5}: Create a token that's a copy of another target artifact you control. That
+ * token gains haste. Sacrifice it at the beginning of the next end step.
+ */
+val ChromeDome = card("Chrome Dome") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Robot Ninja"
+    oracleText = "Other artifact creatures you control get +1/+0.\n{5}: Create a token that's a copy of another target artifact you control. That token gains haste. Sacrifice it at the beginning of the next end step."
+    power = 1
+    toughness = 3
+
+    val otherArtifactCreatures = GroupFilter(
+        GameObjectFilter(
+            cardPredicates = listOf(CardPredicate.IsCreature, CardPredicate.IsArtifact)
+        ).youControl(),
+        excludeSelf = true
+    )
+
+    staticAbility {
+        ability = ModifyStats(1, 0, otherArtifactCreatures)
+    }
+
+    activatedAbility {
+        val artifact = target(
+            "another target artifact you control",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Artifact.youControl(), excludeSelf = true))
+        )
+        cost = Costs.Mana("{5}")
+        effect = Effects.CreateTokenCopyOfTarget(
+            target = artifact,
+            addedKeywords = setOf(Keyword.HASTE),
+            sacrificeAtStep = Step.END
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "172"
+        artist = "Mathias Kollros"
+        flavorText = "\"Broadcast: Seized. Initiate seek-and-destroy protocols.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/994a01eb-2689-49e7-be23-0713da9da9a8.jpg?1769006406"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CoolButRude.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CoolButRude.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cool but Rude
+ * {1}{R}
+ * Enchantment — Class
+ *
+ * (Gain the next level as a sorcery to add its ability.)
+ * Whenever you attack, you may discard a card. If you do, draw a card.
+ * {1}{R}: Level 2
+ * Whenever you discard a card, this Class deals 2 damage to each opponent.
+ * {1}{R}: Level 3
+ * When this Class becomes level 3, search your library for a card, put it into
+ * your hand, shuffle, then discard a card at random.
+ */
+val CoolButRude = card("Cool but Rude") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Class"
+    oracleText = "(Gain the next level as a sorcery to add its ability.)\n" +
+        "Whenever you attack, you may discard a card. If you do, draw a card.\n" +
+        "{1}{R}: Level 2 — Whenever you discard a card, this Class deals 2 damage to each opponent.\n" +
+        "{1}{R}: Level 3 — When this Class becomes level 3, search your library for a card, put it into your hand, shuffle, then discard a card at random."
+
+    // Level 1: Whenever you attack, you may discard a card. If you do, draw a card.
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        effect = MayEffect(
+            Patterns.Hand.discardCards(1).then(Effects.DrawCards(1))
+        )
+    }
+
+    // Level 2: Whenever you discard a card, this Class deals 2 damage to each opponent.
+    classLevel(2, "{1}{R}") {
+        triggeredAbility {
+            trigger = Triggers.YouDiscard
+            effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.EachOpponent))
+        }
+    }
+
+    // Level 3: becomes level 3 (EntersBattlefield inside the level block) — tutor any card
+    // to hand, shuffle, then discard a card at random.
+    classLevel(3, "{1}{R}") {
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any,
+                count = 1,
+                destination = SearchDestination.HAND,
+                shuffleAfter = true
+            ).then(Patterns.Hand.discardRandom(1))
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "89"
+        artist = "Lordigan"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a566ab2d-6ec8-4833-8ad6-210378b1a20e.jpg?1777939762"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CourierOfComestibles.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CourierOfComestibles.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Courier of Comestibles
+ * {1}{G}
+ * Creature — Human Citizen
+ * 1/2
+ *
+ * When this creature enters, you may search your library for a Food card,
+ * reveal it, put it into your hand, then shuffle. If you don't put a card into
+ * your hand this way, create a Food token.
+ */
+val CourierOfComestibles = card("Courier of Comestibles") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "When this creature enters, you may search your library for a Food card, reveal it, put it into your hand, then shuffle. If you don't put a card into your hand this way, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")"
+    power = 1
+    toughness = 2
+
+    // The search is optional (ChooseUpTo 0..1); if no Food card ends up in hand
+    // (declined or none found), the IfYouDont branch creates a Food token instead.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = IfYouDoEffect(
+            action = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any.withSubtype("Food"),
+                count = 1,
+                destination = SearchDestination.HAND,
+                shuffleAfter = true,
+                reveal = true
+            ),
+            ifYouDo = Effects.Composite(),
+            ifYouDont = Effects.CreateFood()
+        )
+        description = "When this creature enters, you may search your library for a Food card, reveal it, put it into your hand, then shuffle. If you don't put a card into your hand this way, create a Food token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "112"
+        artist = "Mirko Failoni"
+        flavorText = "Forgiveness is divine, but never pay full price for late pizza."
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53f5f704-2265-42bb-bff5-fd9d85bc2bfb.jpg?1771342389"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CrustaceanCommando.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/CrustaceanCommando.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crustacean Commando
+ * {1}{U}
+ * Creature — Crab Mutant Soldier
+ * 0/3
+ *
+ * When this creature enters, create a Mutagen token. (It's an artifact with
+ * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+ *  Activate only as a sorcery.")
+ */
+val CrustaceanCommando = card("Crustacean Commando") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Crab Mutant Soldier"
+    oracleText = "When this creature enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 0
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "When this creature enters, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Narendra Bintara Adi"
+        flavorText = "\"Wondering what I've got in the box? Pain, soldier! And lots of it!\"\n—Herman"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/9528cc07-df4b-417f-ad65-c2fae6fc2d49.jpg?1771502563"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DoesMachines.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DoesMachines.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Does Machines
+ * {1}{U}
+ * Enchantment — Class
+ *
+ * (Gain the next level as a sorcery to add its ability.)
+ * When this Class enters, mill two cards, draw two cards, then discard two cards.
+ * {1}{U}: Level 2
+ * When this Class becomes level 2, return up to two target artifact cards from your graveyard to your hand.
+ * {4}{U}: Level 3
+ * At the beginning of combat on your turn, put three +1/+1 counters on target artifact
+ * you control. If it isn't a creature, it becomes a 0/0 Robot creature in addition to its
+ * other types.
+ */
+val DoesMachines = card("Does Machines") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Class"
+    oracleText = "(Gain the next level as a sorcery to add its ability.)\n" +
+        "When this Class enters, mill two cards, draw two cards, then discard two cards.\n" +
+        "{1}{U}: Level 2 — When this Class becomes level 2, return up to two target artifact cards from your graveyard to your hand.\n" +
+        "{4}{U}: Level 3 — At the beginning of combat on your turn, put three +1/+1 counters on target artifact you control. If it isn't a creature, it becomes a 0/0 Robot creature in addition to its other types."
+
+    // Level 1: ETB mill 2, draw 2, then discard 2.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(2)
+            .then(Effects.DrawCards(2))
+            .then(Patterns.Hand.discardCards(2))
+    }
+
+    // Level 2: "When this Class becomes level 2" — modeled as an EntersBattlefield trigger
+    // inside the level block (Caretaker's Talent idiom).
+    classLevel(2, "{1}{U}") {
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            target = TargetObject(
+                count = 2,
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Artifact.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+            effect = ForEachTargetEffect(
+                effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND))
+            )
+        }
+    }
+
+    // Level 3: begin combat on your turn — three +1/+1 counters on a target artifact you
+    // control; a noncreature one also becomes a 0/0 Robot in addition to its other types.
+    classLevel(3, "{4}{U}") {
+        triggeredAbility {
+            trigger = Triggers.BeginCombat
+            target = TargetObject(
+                count = 1,
+                filter = TargetFilter(GameObjectFilter.Artifact.youControl())
+            )
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.ContextTarget(0))
+                .then(
+                    ConditionalEffect(
+                        condition = Conditions.Not(Conditions.TargetMatchesFilter(GameObjectFilter.Creature)),
+                        effect = Effects.BecomeCreature(
+                            target = EffectTarget.ContextTarget(0),
+                            power = 0,
+                            toughness = 0,
+                            creatureTypes = setOf("Robot"),
+                            duration = Duration.Permanent
+                        )
+                    )
+                )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "34"
+        artist = "Aeron Ng"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/989da63a-2cbd-41a9-9bbb-99f4ad1c6a25.jpg?1774102268"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonAndLeoProblemSolvers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonAndLeoProblemSolvers.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Don & Leo, Problem Solvers
+ * {3}{W/U}{W/U}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 4/6
+ *
+ * Vigilance
+ * At the beginning of your end step, exile up to one target artifact you control
+ * and up to one target creature you control. Then return them to the battlefield
+ * under their owners' control.
+ */
+val DonAndLeoProblemSolvers = card("Don & Leo, Problem Solvers") {
+    manaCost = "{3}{W/U}{W/U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Vigilance\nAt the beginning of your end step, exile up to one target artifact you control and up to one target creature you control. Then return them to the battlefield under their owners' control."
+    power = 4
+    toughness = 6
+
+    keywords(Keyword.VIGILANCE)
+
+    // Exile both targets first, then return both — so the two re-enter simultaneously and
+    // see each other's ETBs. Declined ("up to one") targets simply no-op.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        val artifact = target(
+            "up to one target artifact you control",
+            TargetObject(count = 1, optional = true, filter = TargetFilter(GameObjectFilter.Artifact.youControl()))
+        )
+        val creature = target(
+            "up to one target creature you control",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureYouControl)
+        )
+        effect = Effects.Move(artifact, Zone.EXILE)
+            .then(Effects.Move(creature, Zone.EXILE))
+            .then(Effects.Move(artifact, Zone.BATTLEFIELD))
+            .then(Effects.Move(creature, Zone.BATTLEFIELD))
+        description = "At the beginning of your end step, exile up to one target artifact you control and up to one target creature you control. Then return them to the battlefield under their owners' control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "143"
+        artist = "Néstor Ossandón Leal"
+        flavorText = "Technician. Tactician."
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d239beaf-4f5b-494e-be5c-ffa8b6e28bde.jpg?1769006269"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FootMystic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FootMystic.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Foot Mystic
+ * {3}{B}
+ * Creature — Human Ninja Warlock
+ * 2/4
+ *
+ * Lifelink
+ * Disappear — When this creature enters, if a permanent left the battlefield
+ * under your control this turn, create a 1/1 black Ninja creature token.
+ */
+val FootMystic = card("Foot Mystic") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Ninja Warlock"
+    oracleText = "Lifelink\nDisappear — When this creature enters, if a permanent left the battlefield under your control this turn, create a 1/1 black Ninja creature token."
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Ninja"),
+            imageUri = "https://cards.scryfall.io/normal/front/a/7/a7b76498-d696-40d1-b7c7-91657525b44f.jpg?1771590477"
+        )
+        description = "Disappear — When this creature enters, if a permanent left the battlefield under your control this turn, create a 1/1 black Ninja creature token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "63"
+        artist = "Irina Nordsol"
+        flavorText = "Mashima would protect the soul of Oroku Saki at any cost."
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61e40a18-6cc8-436d-826b-1cf8cd037df3.jpg?1771586860"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GeneralTraagHeartOfStone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GeneralTraagHeartOfStone.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * General Traag, Heart of Stone
+ * {3}{R}{R}
+ * Legendary Artifact Creature — Elemental Soldier
+ * 4/3
+ *
+ * Trample
+ * When General Traag enters, you may sacrifice another artifact. When you do,
+ * General Traag deals 4 damage to target creature.
+ */
+val GeneralTraagHeartOfStone = card("General Traag, Heart of Stone") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Artifact Creature — Elemental Soldier"
+    oracleText = "Trample\nWhen General Traag enters, you may sacrifice another artifact. When you do, General Traag deals 4 damage to target creature."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    // "you may sacrifice another artifact. When you do, [deal 4 to target creature]" —
+    // the reflexive trigger picks its target only after the optional sacrifice is paid.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ReflexiveTriggerEffect(
+            action = SacrificeEffect(GameObjectFilter.Artifact, excludeSource = true),
+            optional = true,
+            reflexiveEffect = Effects.DealDamage(4, EffectTarget.ContextTarget(0), damageSource = EffectTarget.Self),
+            reflexiveTargetRequirements = listOf(Targets.Creature)
+        )
+        description = "When General Traag enters, you may sacrifice another artifact. When you do, General Traag deals 4 damage to target creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "90"
+        artist = "Kevin Sidharta"
+        flavorText = "\"Lord Krang, we arrive. We obey. We conquer.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e02e971f-6008-4c82-acd2-2aed13009ccb.jpg?1771502622"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GenghisFrog.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GenghisFrog.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Genghis Frog
+ * {G}{U}
+ * Legendary Creature — Frog Mutant Rogue
+ * 1/3
+ *
+ * Trample
+ * Whenever Genghis Frog or another Mutant you control enters, create a Mutagen
+ * token. (It's an artifact with "{1}, {T}, Sacrifice this token: Put a +1/+1
+ * counter on target creature. Activate only as a sorcery.")
+ */
+val GenghisFrog = card("Genghis Frog") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Frog Mutant Rogue"
+    oracleText = "Trample\nWhenever Genghis Frog or another Mutant you control enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    // "Genghis Frog or another Mutant you control" — ANY binding so Genghis's own
+    // ETB counts too, filtered to Mutants you control.
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.youControl().withSubtype(Subtype("Mutant")),
+                to = Zone.BATTLEFIELD
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateMutagenToken()
+        description = "Whenever Genghis Frog or another Mutant you control enters, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Zoltan Boros"
+        flavorText = "\"Free our brothers! The human reign of terror around here ends tonight!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/d/7df26085-eedb-4bdd-a60a-aabfbe9c3157.jpg?1771342425"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GoNinjaGo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GoNinjaGo.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Go Ninja Go
+ * {R}{W}
+ * Sorcery
+ *
+ * Choose one or both —
+ * • Exile target creature you control, then return it to the battlefield under
+ *   its owner's control.
+ * • Go Ninja Go deals damage equal to the greatest power among creatures you
+ *   control to target creature an opponent controls.
+ */
+val GoNinjaGo = card("Go Ninja Go") {
+    manaCost = "{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n• Exile target creature you control, then return it to the battlefield under its owner's control.\n• Go Ninja Go deals damage equal to the greatest power among creatures you control to target creature an opponent controls."
+
+    spell {
+        modal(chooseCount = 2, minChooseCount = 1) {
+            mode("Exile target creature you control, then return it to the battlefield under its owner's control") {
+                val creature = target("target creature you control", Targets.CreatureYouControl)
+                effect = Effects.Move(creature, Zone.EXILE)
+                    .then(Effects.Move(creature, Zone.BATTLEFIELD))
+            }
+            mode("Go Ninja Go deals damage equal to the greatest power among creatures you control to target creature an opponent controls") {
+                val opponentCreature = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+                effect = Effects.DealDamage(
+                    DynamicAmount.AggregateBattlefield(
+                        Player.You,
+                        GameObjectFilter.Creature,
+                        Aggregation.MAX,
+                        CardNumericProperty.POWER
+                    ),
+                    opponentCreature
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "149"
+        artist = "Patrick Gañas"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/90e68cd8-ea76-4bd1-9199-474da9c3e8bf.jpg?1771587007"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GroundchuckAndDirtbag.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GroundchuckAndDirtbag.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Groundchuck & Dirtbag
+ * {4}{G}{G}
+ * Legendary Creature — Ox Mole Mutant
+ * 8/8
+ *
+ * Trample
+ * Whenever you tap a land for mana, add {G}.
+ */
+val GroundchuckAndDirtbag = card("Groundchuck & Dirtbag") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Ox Mole Mutant"
+    oracleText = "Trample\nWhenever you tap a land for mana, add {G}."
+    power = 8
+    toughness = 8
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.landTappedForMana(player = Player.You)
+        effect = Effects.AddMana(Color.GREEN, 1)
+        description = "Whenever you tap a land for mana, add {G}."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "115"
+        artist = "Nicholas Gregory"
+        flavorText = "\"Whatever my lil' man D.B. here can't dig under, I can just about bust through. Ain't no one caging us ever again.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/5/1563592e-0f21-4488-a3ec-ca766386e423.jpg?1769006182"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/InsectoidExterminator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/InsectoidExterminator.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Insectoid Exterminator
+ * {2}{B}
+ * Creature — Insect Mutant
+ * 2/2
+ *
+ * Flying
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, scry 1.
+ */
+val InsectoidExterminator = card("Insectoid Exterminator") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect Mutant"
+    oracleText = "Flying\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = Patterns.Library.scry(1)
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, scry 1."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "64"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff26f7ff-7f70-4204-9b48-de9e21dc89ec.jpg?1771586866"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeadersTalent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeadersTalent.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Leader's Talent
+ * {1}{W}
+ * Enchantment — Class
+ *
+ * (Gain the next level as a sorcery to add its ability.)
+ * Whenever you attack, put a +1/+1 counter on target attacking creature.
+ * {2}{W}: Level 2
+ * Whenever a creature you control leaves the battlefield, if it had a counter on it, you gain 2 life.
+ * {3}{W}: Level 3
+ * Whenever you cast a spell, put a +1/+1 counter on each creature you control.
+ */
+val LeadersTalent = card("Leader's Talent") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Class"
+    oracleText = "(Gain the next level as a sorcery to add its ability.)\n" +
+        "Whenever you attack, put a +1/+1 counter on target attacking creature.\n" +
+        "{2}{W}: Level 2 — Whenever a creature you control leaves the battlefield, if it had a counter on it, you gain 2 life.\n" +
+        "{3}{W}: Level 3 — Whenever you cast a spell, put a +1/+1 counter on each creature you control."
+
+    // Level 1: Whenever you attack, put a +1/+1 counter on target attacking creature.
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        val attacker = target("target attacking creature", Targets.AttackingCreature)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, attacker)
+    }
+
+    // Level 2: Whenever a creature you control leaves the battlefield, if it had a counter
+    // on it, you gain 2 life.
+    classLevel(2, "{2}{W}") {
+        triggeredAbility {
+            trigger = Triggers.leavesBattlefield(
+                filter = GameObjectFilter.Creature.youControl(),
+                binding = TriggerBinding.ANY
+            )
+            triggerCondition = Conditions.TriggeringEntityHadCounters
+            effect = Effects.GainLife(2)
+        }
+    }
+
+    // Level 3: Whenever you cast a spell, put a +1/+1 counter on each creature you control.
+    classLevel(3, "{3}{W}") {
+        triggeredAbility {
+            trigger = Triggers.YouCastSpell
+            effect = Effects.ForEachInGroup(
+                filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "13"
+        artist = "Manuel Castañón"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4cbcb622-1aff-460f-b8fa-4502d991e0ad.jpg?1777939766"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeonardosTechnique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeonardosTechnique.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Leonardo's Technique
+ * {3}{W}
+ * Sorcery
+ *
+ * Sneak {1}{W}
+ * Return one or two target creature cards each with mana value 3 or less from
+ * your graveyard to the battlefield.
+ */
+val LeonardosTechnique = card("Leonardo's Technique") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Sneak {1}{W} (You may cast this spell for {1}{W} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nReturn one or two target creature cards each with mana value 3 or less from your graveyard to the battlefield."
+
+    sneak("{1}{W}")
+
+    spell {
+        // "one or two target" = count 2, minCount 1; each must be a creature card you own
+        // in your graveyard with mana value 3 or less.
+        target = TargetObject(
+            count = 2,
+            minCount = 1,
+            filter = TargetFilter(
+                GameObjectFilter.Creature.ownedByYou().manaValueAtMost(3),
+                zone = Zone.GRAVEYARD
+            )
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(
+                Effects.Move(EffectTarget.ContextTarget(0), Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "18"
+        artist = "Andreas Zafiratos"
+        flavorText = "\"That's right. Eyes on me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/405e4057-e26c-4882-89a9-706868548c37.jpg?1769005546"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LordDreggInsectInvader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LordDreggInsectInvader.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Lord Dregg, Insect Invader
+ * {3}{B}
+ * Legendary Creature — Insect Warrior
+ * 3/2
+ *
+ * Flying
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, create a 1/1 black Insect Warrior
+ * creature token with flying.
+ * {3}{G}, Sacrifice a token: Draw a card.
+ */
+val LordDreggInsectInvader = card("Lord Dregg, Insect Invader") {
+    manaCost = "{3}{B}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Insect Warrior"
+    oracleText = "Flying\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, create a 1/1 black Insect Warrior creature token with flying.\n{3}{G}, Sacrifice a token: Draw a card."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = CreateTokenEffect(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Insect", "Warrior"),
+            keywords = setOf(Keyword.FLYING)
+        )
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, create a 1/1 black Insect Warrior creature token with flying."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}{G}"),
+            Costs.Sacrifice(GameObjectFilter.Token)
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/8/d/8d1a9c8a-d0b6-4d83-a168-8078de4b14c7.jpg?1771586872"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloGameMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloGameMaster.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Michelangelo, Game Master
+ * {2}{G}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 3/3
+ *
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, put a +1/+1 counter on Michelangelo.
+ */
+val MichelangeloGameMaster = card("Michelangelo, Game Master") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put a +1/+1 counter on Michelangelo."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put a +1/+1 counter on Michelangelo."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Eilene Cherie"
+        flavorText = "\"A teacher must be ready to accept responsibility for the student, especially when the student is a weirdo.\"\n—Splinter"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e914c3d-2eed-48bf-af9a-a8998fd5111d.jpg?1771502708"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloMutantBff.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloMutantBff.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Michelangelo, Mutant BFF
+ * {2}{G}{G}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 4/4
+ *
+ * Each creature you control with a counter on it can't be blocked by more than one creature.
+ * Whenever Michelangelo enters or attacks, create a Mutagen token.
+ */
+val MichelangeloMutantBff = card("Michelangelo, Mutant BFF") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Each creature you control with a counter on it can't be blocked by more than one creature.\nWhenever Michelangelo enters or attacks, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 4
+    toughness = 4
+
+    staticAbility {
+        ability = CantBeBlockedByMoreThan(
+            maxBlockers = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().withAnyCounter())
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "Whenever Michelangelo enters, create a Mutagen token."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateMutagenToken()
+        description = "Whenever Michelangelo attacks, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "120"
+        artist = "Narendra Bintara Adi"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02f7281f-b50c-4a1c-a2fc-3caeb6ab7d41.jpg?1771502715"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloWeirdnessTo11.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangeloWeirdnessTo11.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyCounterPlacement
+
+/**
+ * Michelangelo, Weirdness to 11
+ * {1}{G}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 1/1
+ *
+ * When Michelangelo enters, create a Mutagen token.
+ * If one or more +1/+1 counters would be put on a creature you control, that many
+ * plus one +1/+1 counters are put on it instead.
+ */
+val MichelangeloWeirdnessTo11 = card("Michelangelo, Weirdness to 11") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "When Michelangelo enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")\nIf one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead."
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "When Michelangelo enters, create a Mutagen token."
+    }
+
+    // "that many plus one" — add one extra +1/+1 counter (Hardened Scales shape); default
+    // appliesTo is +1/+1 counters placed on a creature you control.
+    replacementEffect(ModifyCounterPlacement(modifier = 1))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "121"
+        artist = "Jason Kiantoro"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/18477047-218d-4b2a-a086-37431b6a3025.jpg?1769006195"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MindTransferProtocol.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MindTransferProtocol.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.AddCardTypeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Mind Transfer Protocol
+ * {2}{U}
+ * Instant
+ *
+ * Until end of turn, target artifact or creature becomes an artifact creature with
+ * base power and toughness 4/5.
+ * Draw a card.
+ */
+val MindTransferProtocol = card("Mind Transfer Protocol") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target artifact or creature becomes an artifact creature with base power and toughness 4/5.\nDraw a card."
+
+    spell {
+        target = TargetObject(filter = TargetFilter.CreatureOrArtifact)
+        // BecomeCreature sets the creature type + base 4/5; AddCardType("ARTIFACT") supplies
+        // the "artifact" half so a non-artifact creature target also becomes an artifact.
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.ContextTarget(0),
+            power = 4,
+            toughness = 5,
+            duration = Duration.EndOfTurn
+        )
+            .then(AddCardTypeEffect("ARTIFACT", EffectTarget.ContextTarget(0), Duration.EndOfTurn))
+            .then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "45"
+        artist = "Chris Seaman"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2ddfcc4d-dd5f-42f1-8f33-a8e8b5354534.jpg?1771502582"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutagenManLivingOoze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutagenManLivingOoze.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ReduceActivatedAbilityCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Mutagen Man, Living Ooze
+ * {X}{G}{G}
+ * Legendary Creature — Ooze Mutant
+ * 2/3
+ *
+ * Trample
+ * Activated abilities of artifact tokens you control cost {1} less to activate.
+ * When Mutagen Man enters, create X Mutagen tokens.
+ */
+val MutagenManLivingOoze = card("Mutagen Man, Living Ooze") {
+    manaCost = "{X}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Ooze Mutant"
+    oracleText = "Trample\nActivated abilities of artifact tokens you control cost {1} less to activate.\nWhen Mutagen Man enters, create X Mutagen tokens. (They're artifacts with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 2
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    staticAbility {
+        ability = ReduceActivatedAbilityCost(
+            filter = GroupFilter(
+                GameObjectFilter(
+                    cardPredicates = listOf(CardPredicate.IsArtifact, CardPredicate.IsToken)
+                ).youControl()
+            ),
+            amount = 1
+        )
+    }
+
+    // "create X Mutagen tokens" — X is the cast value (CastX, durable onto the permanent).
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMutagenToken(DynamicAmount.CastX)
+        description = "When Mutagen Man enters, create X Mutagen tokens."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "124"
+        artist = "Ignatius Budi"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f9085f0-3702-462c-8c81-b4576236792d.jpg?1769006218"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantChainReaction.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MutantChainReaction.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Mutant Chain Reaction
+ * {2}{G}
+ * Sorcery
+ *
+ * Destroy up to one target artifact, enchantment, or creature with flying.
+ * Create a Mutagen token. (It's an artifact with "{1}, {T}, Sacrifice this
+ * token: Put a +1/+1 counter on target creature. Activate only as a sorcery.")
+ */
+val MutantChainReaction = card("Mutant Chain Reaction") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Destroy up to one target artifact, enchantment, or creature with flying. Create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+
+    spell {
+        // "up to one target artifact, enchantment, or creature with flying"
+        val permanent = target(
+            "up to one target artifact, enchantment, or creature with flying",
+            TargetPermanent(
+                count = 1,
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.Or(
+                                listOf(
+                                    CardPredicate.IsArtifact,
+                                    CardPredicate.IsEnchantment,
+                                    CardPredicate.And(
+                                        listOf(
+                                            CardPredicate.IsCreature,
+                                            CardPredicate.HasKeyword(Keyword.FLYING)
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        // The destroy no-ops if no target was chosen; the token is always created.
+        effect = Effects.Composite(
+            Effects.Destroy(permanent),
+            Effects.CreateMutagenToken()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Dominik Mayer"
+        flavorText = "\"We live together, we train together, we fight together, we stand together . . . We are ninjas.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/8763e0ee-a48e-424f-8bce-132582d5944b.jpg?1771342410"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NovelNunchaku.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NovelNunchaku.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Novel Nunchaku
+ * {2}{G}
+ * Artifact — Equipment
+ *
+ * When this Equipment enters, attach it to target creature you control. When you
+ * do, equipped creature fights up to one target creature an opponent controls.
+ * Equipped creature gets +1/+1 and has trample.
+ * Equip {3}
+ */
+val NovelNunchaku = card("Novel Nunchaku") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, attach it to target creature you control. When you do, equipped creature fights up to one target creature an opponent controls. (Each deals damage equal to its power to the other.)\nEquipped creature gets +1/+1 and has trample.\nEquip {3}"
+
+    // ETB: attach to a creature you control, then that (now equipped) creature fights
+    // up to one opponent creature — the Chelonian Tackle "X then fights up to one" shape.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val yourCreature = target(
+            "target creature you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl)
+        )
+        val opponentCreature = target(
+            "up to one target creature an opponent controls",
+            TargetCreature(optional = true, filter = TargetFilter.CreatureOpponentControls)
+        )
+        effect = Effects.AttachEquipment(yourCreature)
+            .then(Effects.Fight(yourCreature, opponentCreature))
+        description = "When this Equipment enters, attach it to target creature you control. When you do, equipped creature fights up to one target creature an opponent controls."
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE, Filters.EquippedCreature)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "127"
+        artist = "Marina Ortega Lorente"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f37ef012-c566-4d16-acf8-6079244907be.jpg?1771502723"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OozeSpill.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/OozeSpill.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ooze Spill
+ * {1}{U}{U}
+ * Instant
+ *
+ * Counter target spell. Create a Mutagen token. (It's an artifact with
+ * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+ *  Activate only as a sorcery.")
+ */
+val OozeSpill = card("Ooze Spill") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target spell. Create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+
+    spell {
+        target = Targets.Spell
+        // Counter the spell, then create the Mutagen token. The spell is the only
+        // target, so if it is an illegal target on resolution (CR 608.2b) Ooze Spill
+        // is removed and neither effect happens.
+        effect = Effects.Composite(
+            Effects.CounterSpell(),
+            Effects.CreateMutagenToken()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "48"
+        artist = "Svetlin Velinov"
+        flavorText = "Lab safety is everyone's business."
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/beef76b7-856e-48ab-bc73-e4f456c3a100.jpg?1771586813"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ParameciaColoniex.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ParameciaColoniex.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Paramecia Coloniex
+ * {1}{B}
+ * Creature — Zombie Worm
+ * 2/2
+ *
+ * When this creature enters, mill three cards.
+ * When this creature dies, you may exile it. When you do, put target creature
+ * card from your graveyard on top of your library.
+ */
+val ParameciaColoniex = card("Paramecia Coloniex") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Worm"
+    oracleText = "When this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhen this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(3)
+        description = "When this creature enters, mill three cards."
+    }
+
+    // "you may exile it. When you do, put target creature card from your graveyard on
+    // top of your library." triggerZone = GRAVEYARD lets "it" reference Self; the
+    // reflexive trigger picks its graveyard target only after the optional exile.
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerZone = Zone.GRAVEYARD
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Exile(EffectTarget.Self),
+            optional = true,
+            reflexiveEffect = Effects.PutOnTopOfLibrary(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(Targets.CreatureCardInYourGraveyard)
+        )
+        description = "When this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "70"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/654e2646-78ac-4b08-bed1-3c71355d55fc.jpg?1771586897"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PizzaFaceGastromancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PizzaFaceGastromancer.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Pizza Face, Gastromancer
+ * {3}{B}{G}
+ * Legendary Artifact Creature — Food Mutant
+ * 2/4
+ *
+ * When Pizza Face enters, create a Food token.
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, put three +1/+1 counters on up to
+ * one other target artifact or creature. If it isn't a creature, it becomes a
+ * 0/0 Mutant creature in addition to its other types.
+ * {10}, {T}, Sacrifice Pizza Face: You gain 15 life.
+ */
+val PizzaFaceGastromancer = card("Pizza Face, Gastromancer") {
+    manaCost = "{3}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Artifact Creature — Food Mutant"
+    oracleText = "When Pizza Face enters, create a Food token.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put three +1/+1 counters on up to one other target artifact or creature. If it isn't a creature, it becomes a 0/0 Mutant creature in addition to its other types.\n{10}, {T}, Sacrifice Pizza Face: You gain 15 life."
+    power = 2
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+        description = "When Pizza Face enters, create a Food token."
+    }
+
+    // Disappear — three +1/+1 counters on up to one other target artifact or creature;
+    // a noncreature target also becomes a 0/0 Mutant creature in addition to its other
+    // types (same conditional-BecomeCreature idiom as Brilliance Unleashed).
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        target = TargetObject(
+            count = 1,
+            optional = true,
+            filter = TargetFilter.CreatureOrArtifact.copy(excludeSelf = true)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.ContextTarget(0))
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.Not(
+                        Conditions.TargetMatchesFilter(GameObjectFilter.Creature)
+                    ),
+                    effect = Effects.BecomeCreature(
+                        target = EffectTarget.ContextTarget(0),
+                        power = 0,
+                        toughness = 0,
+                        creatureTypes = setOf("Mutant"),
+                        duration = Duration.Permanent
+                    )
+                )
+            )
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put three +1/+1 counters on up to one other target artifact or creature. If it isn't a creature, it becomes a 0/0 Mutant creature in addition to its other types."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{10}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.GainLife(15)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "163"
+        artist = "Villarrte"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b03cf0bb-3207-4e8e-bb3f-e3e4367aa86e.jpg?1771599896"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PrehistoricPet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PrehistoricPet.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Prehistoric Pet
+ * {W}
+ * Creature — Dinosaur Ninja
+ * 1/2
+ *
+ * This creature can't be blocked by creatures with greater power.
+ * {1}{W}, {T}: Return another target creature you control to its owner's hand.
+ * Activate only during your turn.
+ */
+val PrehistoricPet = card("Prehistoric Pet") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur Ninja"
+    oracleText = "This creature can't be blocked by creatures with greater power.\n{1}{W}, {T}: Return another target creature you control to its owner's hand. Activate only during your turn."
+    power = 1
+    toughness = 2
+
+    // "can't be blocked by creatures with greater power" — blockers whose power exceeds
+    // this creature's own power.
+    staticAbility {
+        ability = CantBeBlockedBy(
+            GameObjectFilter.Creature.powerGreaterThanEntity(EntityReference.Source)
+        )
+    }
+
+    activatedAbility {
+        val creature = target("another target creature you control", Targets.OtherCreatureYouControl)
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap)
+        effect = Effects.ReturnToHand(creature)
+        restrictions = listOf(ActivationRestriction.OnlyDuringYourTurn)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "22"
+        artist = "Jakob Eirich"
+        flavorText = "\"As far as I'm concerned, Pepperoni's one of us!\"\n—Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/148e6acd-a96a-4bea-8cfe-a129cd8d1003.jpg?1769005558"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PutridPals.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PutridPals.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Putrid Pals
+ * {2}{B/G}{B/G}
+ * Creature — Human Ooze Mutant
+ * 3/3
+ *
+ * Deathtouch
+ * Disappear — This creature enters with two +1/+1 counters on it if a permanent
+ * left the battlefield under your control this turn.
+ *
+ * Modeled with the engine's standard conditional "enters with counters" idiom
+ * (Benalish Lancer): an EntersBattlefield trigger gated by the Disappear
+ * intervening-if that places the two counters.
+ */
+val PutridPals = card("Putrid Pals") {
+    manaCost = "{2}{B/G}{B/G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Human Ooze Mutant"
+    oracleText = "Deathtouch\nDisappear — This creature enters with two +1/+1 counters on it if a permanent left the battlefield under your control this turn."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
+        description = "Disappear — This creature enters with two +1/+1 counters on it if a permanent left the battlefield under your control this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "165"
+        artist = "Kevin Sidharta"
+        flavorText = "\"Beats working in the sewers. Too many freaky mutants down there.\"\n—Muckman"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42cdb88d-675a-43bb-b85c-51c4cc526315.jpg?1771587057"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ReturnToTheSewers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ReturnToTheSewers.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Return to the Sewers
+ * {3}{U}
+ * Instant
+ *
+ * Target creature's owner puts it on their choice of the top or bottom of their
+ * library. You create a Mutagen token.
+ */
+val ReturnToTheSewers = card("Return to the Sewers") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature's owner puts it on their choice of the top or bottom of their library. You create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.PutOnTopOrBottomOfLibrary(creature)
+            .then(Effects.CreateMutagenToken())
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "52"
+        artist = "Miklós Ligeti"
+        flavorText = "\"We strike hard and fade away into the night.\"\n—Leonardo"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/52e99505-17dc-4051-99f6-e23559fc6c95.jpg?1771586826"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SlitheringCryptid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SlitheringCryptid.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slithering Cryptid
+ * {2}{G/U}
+ * Creature — Fish Mutant
+ * 2/3
+ *
+ * When this creature enters, create a Mutagen token. (It's an artifact with
+ * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+ *  Activate only as a sorcery.")
+ */
+val SlitheringCryptid = card("Slithering Cryptid") {
+    manaCost = "{2}{G/U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Fish Mutant"
+    oracleText = "When this creature enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "When this creature enters, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Nicholas Gregory"
+        flavorText = "\"The Slithery! He's snatches little kids an' keeps 'em in cages! He don't got no legs and just slithers.\"\n—Lita"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d35cb39-8832-4cf1-be73-8de49fbea529.jpg?1771502794"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Technodrome.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/Technodrome.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Technodrome
+ * {2}
+ * Artifact Creature — Construct
+ * 3/3
+ *
+ * Reach, trample
+ * This creature can't attack or block unless its power is 6 or greater.
+ * {T}, Sacrifice another artifact: Draw a card. Put a +1/+1 counter on this creature.
+ */
+val Technodrome = card("Technodrome") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Construct"
+    oracleText = "Reach, trample\nThis creature can't attack or block unless its power is 6 or greater.\n{T}, Sacrifice another artifact: Draw a card. Put a +1/+1 counter on this creature."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.REACH, Keyword.TRAMPLE)
+
+    // "can't attack or block unless its power is 6 or greater" — compares the source's
+    // own (projected) power to 6.
+    val powerAtLeastSix = Compare(
+        DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power),
+        ComparisonOperator.GTE,
+        DynamicAmount.Fixed(6)
+    )
+    staticAbility {
+        ability = CantAttackUnless(condition = powerAtLeastSix)
+    }
+    staticAbility {
+        ability = CantBlockUnless(condition = powerAtLeastSix)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.SacrificeAnother(GameObjectFilter.Artifact)
+        )
+        effect = Effects.DrawCards(1)
+            .then(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "179"
+        artist = "Greg Staples"
+        flavorText = "Even unfinished, the Technodrome was magnificent, a wonder of alien technology."
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/287f5ab0-b15b-4507-8a24-585f9a9841ad.jpg?1769006421"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TheNeutrinos.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TheNeutrinos.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * The Neutrinos
+ * {2}{R}{W}
+ * Legendary Creature — Elf Rebel
+ * 2/4
+ *
+ * Flying
+ * Alliance — Whenever another creature you control enters, The Neutrinos get
+ * +1/+0 until end of turn.
+ * Whenever The Neutrinos attack, exile up to one target creature you own, then
+ * return it to the battlefield under your control tapped and attacking.
+ */
+val TheNeutrinos = card("The Neutrinos") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Elf Rebel"
+    oracleText = "Flying\nAlliance — Whenever another creature you control enters, The Neutrinos get +1/+0 until end of turn.\nWhenever The Neutrinos attack, exile up to one target creature you own, then return it to the battlefield under your control tapped and attacking."
+    power = 2
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+        description = "Alliance — Whenever another creature you control enters, The Neutrinos get +1/+0 until end of turn."
+    }
+
+    // Exile then return tapped and attacking (ZonePlacement.TappedAndAttacking) — adds
+    // the returned creature to combat as a new attacker, like the Sneak / blink-attacking idiom.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target(
+            "up to one target creature you own",
+            TargetCreature(optional = true, filter = TargetFilter(GameObjectFilter.Creature.ownedByYou()))
+        )
+        effect = Effects.Move(creature, Zone.EXILE)
+            .then(Effects.Move(creature, Zone.BATTLEFIELD, placement = ZonePlacement.TappedAndAttacking))
+        description = "Whenever The Neutrinos attack, exile up to one target creature you own, then return it to the battlefield under your control tapped and attacking."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "160"
+        artist = "Brandon L. Hunt"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/1308dadc-08a9-40bd-98a4-fb66d792e27d.jpg?1771587028"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TheOoze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TheOoze.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * The Ooze
+ * {2}
+ * Legendary Artifact
+ *
+ * Whenever a creature you control with a +1/+1 counter on it leaves the
+ * battlefield, create a Mutagen token for each +1/+1 counter on it.
+ * {T}: Exile target card from a graveyard. Create a Mutagen token.
+ */
+val TheOoze = card("The Ooze") {
+    manaCost = "{2}"
+    typeLine = "Legendary Artifact"
+    oracleText = "Whenever a creature you control with a +1/+1 counter on it leaves the battlefield, create a Mutagen token for each +1/+1 counter on it. (A Mutagen token is an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")\n{T}: Exile target card from a graveyard. Create a Mutagen token."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().withCounter(Counters.PLUS_ONE_PLUS_ONE),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.CreateMutagenToken(
+            DynamicAmount.EntityProperty(
+                EntityReference.Triggering,
+                EntityNumericProperty.CounterCount(CounterTypeFilter.PlusOnePlusOne)
+            )
+        )
+        description = "Whenever a creature you control with a +1/+1 counter on it leaves the battlefield, create a Mutagen token for each +1/+1 counter on it."
+    }
+
+    activatedAbility {
+        val graveyardCard = target("target card from a graveyard", Targets.CardInGraveyard)
+        cost = Costs.Tap
+        effect = Effects.Exile(graveyardCard).then(Effects.CreateMutagenToken())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "177"
+        artist = "Gabriel Tanko"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f9bd4da-4626-40ba-95f4-14e3de36f989.jpg?1769006428"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtleLair.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtleLair.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Turtle Lair
+ * Land
+ *
+ * {T}: Add {C}.
+ * {T}: Add one mana of any color. Spend this mana only to cast a Ninja or Turtle spell.
+ * {3}, {T}: Target Ninja or Turtle can't be blocked this turn.
+ */
+val TurtleLair = card("Turtle Lair") {
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Ninja or Turtle spell.\n{3}, {T}: Target Ninja or Turtle can't be blocked this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(
+            1,
+            restriction = ManaRestriction.SubtypeSpellsOnly(setOf("Ninja", "Turtle"))
+        )
+        manaAbility = true
+    }
+
+    activatedAbility {
+        val creature = target(
+            "target Ninja or Turtle",
+            TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.withAnyOfSubtypes(listOf(Subtype("Ninja"), Subtype("Turtle")))
+                )
+            )
+        )
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "190"
+        artist = "Marina Ortega Lorente"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c50c4580-979b-4863-86b9-16e258198972.jpg?1771424738"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/WestWindAvatar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/WestWindAvatar.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * West Wind Avatar
+ * {5}{G}{G}
+ * Creature — Cat Spirit Avatar
+ * 7/7
+ *
+ * Trample
+ * Whenever this creature enters or attacks, you may sacrifice a token or a land.
+ * If you do, you gain 3 life.
+ * Disappear — At the beginning of your end step, if a permanent left the
+ * battlefield under your control this turn, draw a card.
+ */
+val WestWindAvatar = card("West Wind Avatar") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Spirit Avatar"
+    oracleText = "Trample\nWhenever this creature enters or attacks, you may sacrifice a token or a land. If you do, you gain 3 life.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, draw a card."
+    power = 7
+    toughness = 7
+
+    keywords(Keyword.TRAMPLE)
+
+    // "you may sacrifice a token or a land. If you do, you gain 3 life."
+    val tokenOrLand = GameObjectFilter(
+        cardPredicates = listOf(
+            CardPredicate.Or(listOf(CardPredicate.IsToken, CardPredicate.IsLand))
+        )
+    )
+    val sacrificeForLife = MayEffect(
+        Effects.Sacrifice(tokenOrLand, count = 1, target = EffectTarget.Controller)
+            .then(Effects.GainLife(3))
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = sacrificeForLife
+        description = "Whenever this creature enters, you may sacrifice a token or a land. If you do, you gain 3 life."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = sacrificeForLife
+        description = "Whenever this creature attacks, you may sacrifice a token or a land. If you do, you gain 3 life."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = Effects.DrawCards(1)
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "137"
+        artist = "Oriana Menendez"
+        imageUri = "https://cards.scryfall.io/normal/front/f/4/f4b8f7e6-9bff-430b-b2f5-4308d57d1194.jpg?1771586987"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ZooEscapees.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/ZooEscapees.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Zoo Escapees
+ * {1}{G}
+ * Creature — Boar Rhino
+ * 2/2
+ *
+ * When this creature leaves the battlefield, create a Mutagen token. (It's an
+ * artifact with "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target
+ * creature. Activate only as a sorcery.")
+ */
+val ZooEscapees = card("Zoo Escapees") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Boar Rhino"
+    oracleText = "When this creature leaves the battlefield, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")"
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "When this creature leaves the battlefield, create a Mutagen token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "138"
+        artist = "Mirko Failoni"
+        flavorText = "They imagine that out beyond the zoo, beyond the pen, there exists another world, and it encroaches with rapid certainty upon their own . . ."
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f57ba8ff-2f8c-4ca1-9b13-42a7cc213e99.jpg?1771502750"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.mtg.sets.tokens
 
+import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
@@ -439,6 +440,29 @@ object PredefinedTokens {
     }
 
     /**
+     * Mutagen token — a colorless artifact (Teenage Mutant Ninja Turtles) with:
+     * "{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature.
+     *  Activate only as a sorcery."
+     *
+     * Same shape as the [Map] token (mana + tap + sacrifice-self, sorcery-speed,
+     * single creature target), but places a +1/+1 counter instead of an explore.
+     */
+    val Mutagen = card("Mutagen") {
+        typeLine = "Artifact — Mutagen"
+
+        activatedAbility {
+            val creature = target("target creature", Targets.Creature)
+            cost = Costs.Composite(
+                Costs.Mana("{1}"),
+                Costs.Tap,
+                Costs.SacrificeSelf
+            )
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            timing = TimingRule.SorcerySpeed
+        }
+    }
+
+    /**
      * All predefined token definitions.
      * Register these in the CardRegistry so token abilities are resolved.
      */
@@ -458,6 +482,7 @@ object PredefinedTokens {
         Incubator,
         Drone,
         Everywhere,
-        Munitions
+        Munitions,
+        Mutagen
     )
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -3468,6 +3468,91 @@
     ]
 }
 
+// Lord Dregg, Insect Invader
+{
+    "name": "Lord Dregg, Insect Invader",
+    "manaCost": "{3}{B}",
+    "typeLine": "Legendary Creature — Insect Warrior",
+    "oracleText": "Flying\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, create a 1/1 black Insect Warrior creature token with flying.\n{3}{G}, Sacrifice a token: Draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Insect",
+                        "Warrior"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, create a 1/1 black Insect Warrior creature token with flying."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{G}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "token"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/d/8d1a9c8a-d0b6-4d83-a168-8078de4b14c7.jpg?1771586872"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Make Your Move
 {
     "name": "Make Your Move",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -8208,6 +8208,90 @@
     ]
 }
 
+// The Ooze
+{
+    "name": "The Ooze",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Whenever a creature you control with a +1/+1 counter on it leaves the battlefield, create a Mutagen token for each +1/+1 counter on it. (A Mutagen token is an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")\n{T}: Exile target card from a graveyard. Create a Mutagen token.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "+1/+1"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "from": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen",
+                    "dynamicCount": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": {
+                            "type": "CounterCount",
+                            "counterType": "PlusOnePlusOne"
+                        }
+                    }
+                },
+                "descriptionOverride": "Whenever a creature you control with a +1/+1 counter on it leaves the battlefield, create a Mutagen token for each +1/+1 counter on it."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target card from a graveyard"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Mutagen"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card from a graveyard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "177",
+        "rarity": "RARE",
+        "artist": "Gabriel Tanko",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f9bd4da-4626-40ba-95f4-14e3de36f989.jpg?1769006428"
+    }
+}
+
 // Transdimensional Bovine
 {
     "name": "Transdimensional Bovine",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1910,6 +1910,55 @@
     ]
 }
 
+// Foot Mystic
+{
+    "name": "Foot Mystic",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Human Ninja Warlock",
+    "oracleText": "Lifelink\nDisappear — When this creature enters, if a permanent left the battlefield under your control this turn, create a 1/1 black Ninja creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Ninja"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7b76498-d696-40d1-b7c7-91657525b44f.jpg?1771590477"
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — When this creature enters, if a permanent left the battlefield under your control this turn, create a 1/1 black Ninja creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "artist": "Irina Nordsol",
+        "flavorText": "Mashima would protect the soul of Oroku Saki at any cost.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61e40a18-6cc8-436d-826b-1cf8cd037df3.jpg?1771586860"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Foot Ninjas
 {
     "name": "Foot Ninjas",
@@ -2614,6 +2663,47 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Insectoid Exterminator
+{
+    "name": "Insectoid Exterminator",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Insect Mutant",
+    "oracleText": "Flying\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Scry",
+                    "count": 1
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, scry 1."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff26f7ff-7f70-4204-9b48-de9e21dc89ec.jpg?1771586866"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -3644,6 +3734,47 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Michelangelo, Game Master
+{
+    "name": "Michelangelo, Game Master",
+    "manaCost": "{2}{G}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put a +1/+1 counter on Michelangelo.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put a +1/+1 counter on Michelangelo."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Eilene Cherie",
+        "flavorText": "\"A teacher must be ready to accept responsibility for the student, especially when the student is a weirdo.\"\n—Splinter",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e914c3d-2eed-48bf-af9a-a8998fd5111d.jpg?1771502708"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -4938,6 +5069,50 @@
     "colorIdentityOverride": [
         "GREEN",
         "BLUE"
+    ]
+}
+
+// Putrid Pals
+{
+    "name": "Putrid Pals",
+    "manaCost": "{2}{B/G}{B/G}",
+    "typeLine": "Creature — Human Ooze Mutant",
+    "oracleText": "Deathtouch\nDisappear — This creature enters with two +1/+1 counters on it if a permanent left the battlefield under your control this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 2,
+                    "target": "Self"
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — This creature enters with two +1/+1 counters on it if a permanent left the battlefield under your control this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "artist": "Kevin Sidharta",
+        "flavorText": "\"Beats working in the sewers. Too many freaky mutants down there.\"\n—Muckman",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42cdb88d-675a-43bb-b85c-51c4cc526315.jpg?1771587057"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -9886,6 +9886,95 @@
     }
 }
 
+// Turtle Lair
+{
+    "name": "Turtle Lair",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a Ninja or Turtle spell.\n{3}, {T}: Target Ninja or Turtle can't be blocked this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "restriction": {
+                        "type": "SubtypeSpellsOnly",
+                        "subtypes": [
+                            "Ninja",
+                            "Turtle"
+                        ]
+                    }
+                },
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Ninja or Turtle"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "HasAnyOfSubtypes",
+                                        "subtypes": [
+                                            "Ninja",
+                                            "Turtle"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "target Ninja or Turtle"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "190",
+        "rarity": "UNCOMMON",
+        "artist": "Marina Ortega Lorente",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c50c4580-979b-4863-86b9-16e258198972.jpg?1771424738"
+    }
+}
+
 // Turtle Power!
 {
     "name": "Turtle Power!",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1089,6 +1089,43 @@
     ]
 }
 
+// Crustacean Commando
+{
+    "name": "Crustacean Commando",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Crab Mutant Soldier",
+    "oracleText": "When this creature enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "When this creature enters, create a Mutagen token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Narendra Bintara Adi",
+        "flavorText": "\"Wondering what I've got in the box? Pain, soldier! And lots of it!\"\n—Herman",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/9528cc07-df4b-417f-ad65-c2fae6fc2d49.jpg?1771502563"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dark Leo & Shredder
 {
     "name": "Dark Leo & Shredder",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5080,6 +5080,138 @@
     ]
 }
 
+// Pizza Face, Gastromancer
+{
+    "name": "Pizza Face, Gastromancer",
+    "manaCost": "{3}{B}{G}",
+    "typeLine": "Legendary Artifact Creature — Food Mutant",
+    "oracleText": "When Pizza Face enters, create a Food token.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put three +1/+1 counters on up to one other target artifact or creature. If it isn't a creature, it becomes a 0/0 Mutant creature in addition to its other types.\n{10}, {T}, Sacrifice Pizza Face: You gain 15 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                },
+                "descriptionOverride": "When Pizza Face enters, create a Food token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Not",
+                                    "condition": {
+                                        "type": "EntityMatches",
+                                        "entity": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "filter": "creature"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "BecomeCreature",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "power": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "toughness": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "creatureTypes": [
+                                    "Mutant"
+                                ],
+                                "duration": "Permanent"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|artifact",
+                        "excludeSelf": true
+                    }
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, put three +1/+1 counters on up to one other target artifact or creature. If it isn't a creature, it becomes a 0/0 Mutant creature in addition to its other types."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{10}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 15
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "rarity": "UNCOMMON",
+        "artist": "Villarrte",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b03cf0bb-3207-4e8e-bb3f-e3e4367aa86e.jpg?1771599896"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Primordial Pachyderm
 {
     "name": "Primordial Pachyderm",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2166,6 +2166,92 @@
     ]
 }
 
+// Go Ninja Go
+{
+    "name": "Go Ninja Go",
+    "manaCost": "{R}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or both —\n• Exile target creature you control, then return it to the battlefield under its owner's control.\n• Go Ninja Go deals damage equal to the greatest power among creatures you control to target creature an opponent controls.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                },
+                                "destination": "Exile"
+                            },
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                },
+                                "destination": "Battlefield"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        }
+                    ],
+                    "description": "Exile target creature you control, then return it to the battlefield under its owner's control"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "creature",
+                            "aggregation": "MAX",
+                            "property": "POWER"
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature an opponent controls"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            },
+                            "id": "target creature an opponent controls"
+                        }
+                    ],
+                    "description": "Go Ninja Go deals damage equal to the greatest power among creatures you control to target creature an opponent controls"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "rarity": "UNCOMMON",
+        "artist": "Patrick Gañas",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/90e68cd8-ea76-4bd1-9199-474da9c3e8bf.jpg?1771587007"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Guac & Marshmallow Pizza
 {
     "name": "Guac & Marshmallow Pizza",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5172,6 +5172,64 @@
     ]
 }
 
+// Mind Transfer Protocol
+{
+    "name": "Mind Transfer Protocol",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Until end of turn, target artifact or creature becomes an artifact creature with base power and toughness 4/5.\nDraw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "BecomeCreature",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                },
+                {
+                    "type": "AddCardType",
+                    "cardType": "ARTIFACT",
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "45",
+        "artist": "Chris Seaman",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2ddfcc4d-dd5f-42f1-8f33-a8e8b5354534.jpg?1771502582"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Mona Lisa, Science Geek
 {
     "name": "Mona Lisa, Science Geek",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1001,6 +1001,183 @@
     ]
 }
 
+// Cool but Rude
+{
+    "name": "Cool but Rude",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment — Class",
+    "oracleText": "(Gain the next level as a sorcery to add its ability.)\nWhenever you attack, you may discard a card. If you do, draw a card.\n{1}{R}: Level 2 — Whenever you discard a card, this Class deals 2 damage to each opponent.\n{1}{R}: Level 3 — When this Class becomes level 3, search your library for a card, put it into your hand, shuffle, then discard a card at random.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 1 card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "classLevels": [
+            {
+                "level": 2,
+                "cost": "{1}{R}",
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "DiscardEvent",
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "level": 3,
+                "cost": "{1}{R}",
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_3",
+                        "trigger": {
+                            "type": "ZoneChangeEvent",
+                            "to": "Battlefield"
+                        },
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    }
+                                },
+                                "ShuffleLibrary",
+                                {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "Random",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "RARE",
+        "artist": "Lordigan",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a566ab2d-6ec8-4833-8ad6-210378b1a20e.jpg?1777939762"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Courier of Comestibles
 {
     "name": "Courier of Comestibles",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1489,6 +1489,206 @@
     ]
 }
 
+// Does Machines
+{
+    "name": "Does Machines",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Class",
+    "oracleText": "(Gain the next level as a sorcery to add its ability.)\nWhen this Class enters, mill two cards, draw two cards, then discard two cards.\n{1}{U}: Level 2 — When this Class becomes level 2, return up to two target artifact cards from your graveyard to your hand.\n{4}{U}: Level 3 — At the beginning of combat on your turn, put three +1/+1 counters on target artifact you control. If it isn't a creature, it becomes a 0/0 Robot creature in addition to its other types.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 2 cards to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "classLevels": [
+            {
+                "level": 2,
+                "cost": "{1}{U}",
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": {
+                            "type": "ZoneChangeEvent",
+                            "to": "Battlefield"
+                        },
+                        "effect": {
+                            "type": "ForEach",
+                            "space": "IterationSpace.Targets",
+                            "body": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Hand"
+                            }
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "count": 2,
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "artifact own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "level": 3,
+                "cost": "{4}{U}",
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_3",
+                        "trigger": {
+                            "type": "StepEvent",
+                            "step": "BEGIN_COMBAT"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "AddCounters",
+                                    "counterType": "+1/+1",
+                                    "count": 3,
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                },
+                                {
+                                    "type": "Gated",
+                                    "gate": {
+                                        "type": "Gate.WhenCondition",
+                                        "condition": {
+                                            "type": "Not",
+                                            "condition": {
+                                                "type": "EntityMatches",
+                                                "entity": {
+                                                    "type": "ContextTarget",
+                                                    "index": 0
+                                                },
+                                                "filter": "creature"
+                                            }
+                                        }
+                                    },
+                                    "then": {
+                                        "type": "BecomeCreature",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "power": {
+                                            "type": "Fixed",
+                                            "amount": 0
+                                        },
+                                        "toughness": {
+                                            "type": "Fixed",
+                                            "amount": 0
+                                        },
+                                        "creatureTypes": [
+                                            "Robot"
+                                        ],
+                                        "duration": "Permanent"
+                                    }
+                                }
+                            ]
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact ctrl:you"
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "RARE",
+        "artist": "Aeron Ng",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/989da63a-2cbd-41a9-9bbb-99f4ad1c6a25.jpg?1774102268"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Don & Leo, Problem Solvers
 {
     "name": "Don & Leo, Problem Solvers",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -7824,6 +7824,102 @@
     ]
 }
 
+// Technodrome
+{
+    "name": "Technodrome",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "Reach, trample\nThis creature can't attack or block unless its power is 6 or greater.\n{T}, Sacrifice another artifact: Draw a card. Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH",
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
+                }
+            },
+            {
+                "type": "CantBlockUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "MYTHIC",
+        "artist": "Greg Staples",
+        "flavorText": "Even unfinished, the Technodrome was magnificent, a wonder of alien technology.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/287f5ab0-b15b-4507-8a24-585f9a9841ad.jpg?1769006421"
+    }
+}
+
 // Tenderize
 {
     "name": "Tenderize",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1405,6 +1405,100 @@
     ]
 }
 
+// Don & Leo, Problem Solvers
+{
+    "name": "Don & Leo, Problem Solvers",
+    "manaCost": "{3}{W/U}{W/U}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "Vigilance\nAt the beginning of your end step, exile up to one target artifact you control and up to one target creature you control. Then return them to the battlefield under their owners' control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target artifact you control"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature you control"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target artifact you control"
+                            },
+                            "destination": "Battlefield"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature you control"
+                            },
+                            "destination": "Battlefield"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "artifact ctrl:you"
+                    },
+                    "id": "up to one target artifact you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "up to one target creature you control"
+                    }
+                ],
+                "descriptionOverride": "At the beginning of your end step, exile up to one target artifact you control and up to one target creature you control. Then return them to the battlefield under their owners' control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "RARE",
+        "artist": "Néstor Ossandón Leal",
+        "flavorText": "Technician. Tactician.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d239beaf-4f5b-494e-be5c-ffa8b6e28bde.jpg?1769006269"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Donatello's Technique
 {
     "name": "Donatello's Technique",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4135,6 +4135,73 @@
     ]
 }
 
+// Mutant Chain Reaction
+{
+    "name": "Mutant Chain Reaction",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy up to one target artifact, enchantment, or creature with flying. Create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target artifact, enchantment, or creature with flying"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsArtifact",
+                                    "IsEnchantment",
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasKeyword",
+                                                "keyword": "FLYING"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "up to one target artifact, enchantment, or creature with flying"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Dominik Mayer",
+        "flavorText": "\"We live together, we train together, we fight together, we stand together . . . We are ninjas.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/8763e0ee-a48e-424f-8bce-132582d5944b.jpg?1771342410"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mutant Town
 {
     "name": "Mutant Town",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -3752,6 +3752,59 @@
     }
 }
 
+// Leonardo's Technique
+{
+    "name": "Leonardo's Technique",
+    "manaCost": "{3}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Sneak {1}{W} (You may cast this spell for {1}{W} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nReturn one or two target creature cards each with mana value 3 or less from your graveyard to the battlefield.",
+    "keywords": [
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{1}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                },
+                "destination": "Battlefield",
+                "fromZone": "Graveyard"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 2,
+                "minCount": 1,
+                "filter": {
+                    "baseFilter": "creature mv<=3 own:you",
+                    "zone": "Graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "18",
+        "rarity": "RARE",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "\"That's right. Eyes on me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/405e4057-e26c-4882-89a9-706868548c37.jpg?1769005546"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Leonardo, Big Brother
 {
     "name": "Leonardo, Big Brother",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2998,6 +2998,48 @@
     ]
 }
 
+// Groundchuck & Dirtbag
+{
+    "name": "Groundchuck & Dirtbag",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Legendary Creature — Ox Mole Mutant",
+    "oracleText": "Trample\nWhenever you tap a land for mana, add {G}.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "LandTappedForMana",
+                    "player": "You"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "descriptionOverride": "Whenever you tap a land for mana, add {G}."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "RARE",
+        "artist": "Nicholas Gregory",
+        "flavorText": "\"Whatever my lil' man D.B. here can't dig under, I can just about bust through. Ain't no one caging us ever again.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/5/1563592e-0f21-4488-a3ec-ca766386e423.jpg?1769006182"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Guac & Marshmallow Pizza
 {
     "name": "Guac & Marshmallow Pizza",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -8386,6 +8386,92 @@
     ]
 }
 
+// The Neutrinos
+{
+    "name": "The Neutrinos",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Legendary Creature — Elf Rebel",
+    "oracleText": "Flying\nAlliance — Whenever another creature you control enters, The Neutrinos get +1/+0 until end of turn.\nWhenever The Neutrinos attack, exile up to one target creature you own, then return it to the battlefield under your control tapped and attacking.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Alliance — Whenever another creature you control enters, The Neutrinos get +1/+0 until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature you own"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature you own"
+                            },
+                            "destination": "Battlefield",
+                            "placement": "TappedAndAttacking"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature own:you"
+                    },
+                    "id": "up to one target creature you own"
+                },
+                "descriptionOverride": "Whenever The Neutrinos attack, exile up to one target creature you own, then return it to the battlefield under your control tapped and attacking."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "160",
+        "rarity": "UNCOMMON",
+        "artist": "Brandon L. Hunt",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/1308dadc-08a9-40bd-98a4-fb66d792e27d.jpg?1771587028"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // The Ooze
 {
     "name": "The Ooze",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -8271,6 +8271,106 @@
     }
 }
 
+// West Wind Avatar
+{
+    "name": "West Wind Avatar",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Creature — Cat Spirit Avatar",
+    "oracleText": "Trample\nWhenever this creature enters or attacks, you may sacrifice a token or a land. If you do, you gain 3 life.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, draw a card.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForceSacrifice",
+                                "filter": "token|land",
+                                "target": "Controller"
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever this creature enters, you may sacrifice a token or a land. If you do, you gain 3 life."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForceSacrifice",
+                                "filter": "token|land",
+                                "target": "Controller"
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may sacrifice a token or a land. If you do, you gain 3 life."
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "137",
+        "rarity": "UNCOMMON",
+        "artist": "Oriana Menendez",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/4/f4b8f7e6-9bff-430b-b2f5-4308d57d1194.jpg?1771586987"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Wingnut, Bat on the Belfry
 {
     "name": "Wingnut, Bat on the Belfry",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4895,6 +4895,109 @@
     ]
 }
 
+// Michelangelo, Mutant BFF
+{
+    "name": "Michelangelo, Mutant BFF",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "Each creature you control with a counter on it can't be blocked by more than one creature.\nWhenever Michelangelo enters or attacks, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "Whenever Michelangelo enters, create a Mutagen token."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "Whenever Michelangelo attacks, create a Mutagen token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByMoreThan",
+                "maxBlockers": 1,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "HasAnyCounter"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "UNCOMMON",
+        "artist": "Narendra Bintara Adi",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02f7281f-b50c-4a1c-a2fc-3caeb6ab7d41.jpg?1771502715"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Michelangelo, Weirdness to 11
+{
+    "name": "Michelangelo, Weirdness to 11",
+    "manaCost": "{1}{G}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "When Michelangelo enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")\nIf one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on it instead.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "When Michelangelo enters, create a Mutagen token."
+            }
+        ],
+        "replacementEffects": [
+            "ModifyCounterPlacement"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "RARE",
+        "artist": "Jason Kiantoro",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/18477047-218d-4b2a-a086-37431b6a3025.jpg?1769006195"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mighty Mutanimals
 {
     "name": "Mighty Mutanimals",
@@ -7170,6 +7273,50 @@
         "artist": "Yuhong Ding",
         "flavorText": "\"You guys don't get sick during time travel, do you?\"",
         "imageUri": "https://cards.scryfall.io/normal/front/2/a/2ae30766-c858-4f4e-a042-14af55698cb2.jpg?1769005718"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Return to the Sewers
+{
+    "name": "Return to the Sewers",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature's owner puts it on their choice of the top or bottom of their library. You create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "PutOnLibraryPositionOfChoice",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "52",
+        "artist": "Miklós Ligeti",
+        "flavorText": "\"We strike hard and fade away into the night.\"\n—Leonardo",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/52e99505-17dc-4051-99f6-e23559fc6c95.jpg?1771586826"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4719,6 +4719,117 @@
     ]
 }
 
+// Novel Nunchaku
+{
+    "name": "Novel Nunchaku",
+    "manaCost": "{2}{G}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, attach it to target creature you control. When you do, equipped creature fights up to one target creature an opponent controls. (Each deals damage equal to its power to the other.)\nEquipped creature gets +1/+1 and has trample.\nEquip {3}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "Fight",
+                            "target1": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            },
+                            "target2": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature an opponent controls"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "up to one target creature an opponent controls"
+                    }
+                ],
+                "descriptionOverride": "When this Equipment enters, attach it to target creature you control. When you do, equipped creature fights up to one target creature an opponent controls."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "UNCOMMON",
+        "artist": "Marina Ortega Lorente",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f37ef012-c566-4d16-acf8-6079244907be.jpg?1771502723"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Null Group Biological Assets
 {
     "name": "Null Group Biological Assets",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -842,6 +842,73 @@
     ]
 }
 
+// Broadcast Takeover
+{
+    "name": "Broadcast Takeover",
+    "manaCost": "{2}{R}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Gain control of all artifacts your opponents control until end of turn. Untap them. They gain haste until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "artifact ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "TapUntap",
+                        "target": "Self",
+                        "tap": false
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "artifact ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "HASTE",
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "artifact ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "GainControl",
+                        "target": "Self",
+                        "duration": "EndOfTurn"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "MYTHIC",
+        "artist": "Hokyoung Kim",
+        "flavorText": "The power of the Foot is its ability to infiltrate every system from the shadows.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e640e930-0907-40f2-9015-88f8c1e8ee5c.jpg?1769005852"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Buzz Bots
 {
     "name": "Buzz Bots",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -481,6 +481,65 @@
     ]
 }
 
+// Bebop & Rocksteady
+{
+    "name": "Bebop & Rocksteady",
+    "manaCost": "{1}{B/G}{B/G}",
+    "typeLine": "Legendary Creature — Boar Rhino Mutant",
+    "oracleText": "Whenever Bebop & Rocksteady attack or block, sacrifice a permanent unless you discard a card.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": "AtomDiscard"
+                    },
+                    "suffer": {
+                        "type": "Sacrifice",
+                        "filter": {}
+                    }
+                },
+                "descriptionOverride": "Whenever Bebop & Rocksteady attack, sacrifice a permanent unless you discard a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "BlockEvent",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": "AtomDiscard"
+                    },
+                    "suffer": {
+                        "type": "Sacrifice",
+                        "filter": {}
+                    }
+                },
+                "descriptionOverride": "Whenever Bebop & Rocksteady block, sacrifice a permanent unless you discard a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "rarity": "RARE",
+        "artist": "Néstor Ossandón Leal",
+        "flavorText": "\"They'll beat you with fists, with a bat, with a knife. / So don't try to stop them, just run for your life! / Get set and get ready, / For Bebop and Rocksteady!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/535461bd-f763-408b-816f-64b7bfb9210d.jpg?1760102796"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Bebop, Warthog Warrior
 {
     "name": "Bebop, Warthog Warrior",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1001,6 +1001,71 @@
     ]
 }
 
+// Chrome Dome
+{
+    "name": "Chrome Dome",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Robot Ninja",
+    "oracleText": "Other artifact creatures you control get +1/+0.\n{5}: Create a token that's a copy of another target artifact you control. That token gains haste. Sacrifice it at the beginning of the next end step.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
+                },
+                "effect": {
+                    "type": "CreateTokenCopyOfTarget",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target artifact you control"
+                    },
+                    "addedKeywords": [
+                        "HASTE"
+                    ],
+                    "sacrificeAtStep": "END"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "another target artifact you control"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature artifact ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "RARE",
+        "artist": "Mathias Kollros",
+        "flavorText": "\"Broadcast: Seized. Initiate seek-and-destroy protocols.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/994a01eb-2689-49e7-be23-0713da9da9a8.jpg?1769006406"
+    }
+}
+
 // Cool but Rude
 {
     "name": "Cool but Rude",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2008,6 +2008,50 @@
     ]
 }
 
+// Genghis Frog
+{
+    "name": "Genghis Frog",
+    "manaCost": "{G}{U}",
+    "typeLine": "Legendary Creature — Frog Mutant Rogue",
+    "oracleText": "Trample\nWhenever Genghis Frog or another Mutant you control enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Mutant ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "Whenever Genghis Frog or another Mutant you control enters, create a Mutagen token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"Free our brothers! The human reign of terror around here ends tonight!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/d/7df26085-eedb-4bdd-a60a-aabfbe9c3157.jpg?1771342425"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Guac & Marshmallow Pizza
 {
     "name": "Guac & Marshmallow Pizza",
@@ -4589,6 +4633,45 @@
     }
 }
 
+// Ooze Spill
+{
+    "name": "Ooze Spill",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target spell. Create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Lab safety is everyone's business.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/beef76b7-856e-48ab-bc73-e4f456c3a100.jpg?1771586813"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Oroku Saki, Shredder Rising
 {
     "name": "Oroku Saki, Shredder Rising",
@@ -6288,6 +6371,44 @@
     ]
 }
 
+// Slithering Cryptid
+{
+    "name": "Slithering Cryptid",
+    "manaCost": "{2}{G/U}",
+    "typeLine": "Creature — Fish Mutant",
+    "oracleText": "When this creature enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "When this creature enters, create a Mutagen token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Nicholas Gregory",
+        "flavorText": "\"The Slithery! He's snatches little kids an' keeps 'em in cages! He don't got no legs and just slithers.\"\n—Lita",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d35cb39-8832-4cf1-be73-8de49fbea529.jpg?1771502794"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // South Wind Avatar
 {
     "name": "South Wind Avatar",
@@ -7844,5 +7965,42 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Zoo Escapees
+{
+    "name": "Zoo Escapees",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Boar Rhino",
+    "oracleText": "When this creature leaves the battlefield, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "When this creature leaves the battlefield, create a Mutagen token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "artist": "Mirko Failoni",
+        "flavorText": "They imagine that out beyond the zoo, beyond the pen, there exists another world, and it encroaches with rapid certainty upon their own . . .",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f57ba8ff-2f8c-4ca1-9b13-42a7cc213e99.jpg?1771502750"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2057,6 +2057,71 @@
     ]
 }
 
+// General Traag, Heart of Stone
+{
+    "name": "General Traag, Heart of Stone",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Legendary Artifact Creature — Elemental Soldier",
+    "oracleText": "Trample\nWhen General Traag enters, you may sacrifice another artifact. When you do, General Traag deals 4 damage to target creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Sacrifice",
+                        "filter": "artifact",
+                        "excludeSource": true
+                    },
+                    "reflexiveEffect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "damageSource": "Self"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When General Traag enters, you may sacrifice another artifact. When you do, General Traag deals 4 damage to target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "90",
+        "rarity": "UNCOMMON",
+        "artist": "Kevin Sidharta",
+        "flavorText": "\"Lord Krang, we arrive. We obey. We conquer.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e02e971f-6008-4c82-acd2-2aed13009ccb.jpg?1771502622"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Genghis Frog
 {
     "name": "Genghis Frog",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5268,6 +5268,56 @@
     ]
 }
 
+// Mutagen Man, Living Ooze
+{
+    "name": "Mutagen Man, Living Ooze",
+    "manaCost": "{X}{G}{G}",
+    "typeLine": "Legendary Creature — Ooze Mutant",
+    "oracleText": "Trample\nActivated abilities of artifact tokens you control cost {1} less to activate.\nWhen Mutagen Man enters, create X Mutagen tokens. (They're artifacts with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen",
+                    "dynamicCount": "CastX"
+                },
+                "descriptionOverride": "When Mutagen Man enters, create X Mutagen tokens."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ReduceActivatedAbilityCost",
+                "filter": {
+                    "baseFilter": "artifact token ctrl:you"
+                },
+                "amount": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "RARE",
+        "artist": "Ignatius Budi",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f9085f0-3702-462c-8c81-b4576236792d.jpg?1769006218"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Mutant Chain Reaction
 {
     "name": "Mutant Chain Reaction",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5567,6 +5567,83 @@
     ]
 }
 
+// Prehistoric Pet
+{
+    "name": "Prehistoric Pet",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Dinosaur Ninja",
+    "oracleText": "This creature can't be blocked by creatures with greater power.\n{1}{W}, {T}: Return another target creature you control to its owner's hand. Activate only during your turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target creature you control"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "another target creature you control"
+                    }
+                ],
+                "restrictions": [
+                    "OnlyDuringYourTurn"
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedBy",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerGreaterThanEntity",
+                            "reference": "Source"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "RARE",
+        "artist": "Jakob Eirich",
+        "flavorText": "\"As far as I'm concerned, Pepperoni's one of us!\"\n—Raphael",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/148e6acd-a96a-4bea-8cfe-a129cd8d1003.jpg?1769005558"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Primordial Pachyderm
 {
     "name": "Primordial Pachyderm",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -3929,6 +3929,99 @@
     }
 }
 
+// Leader's Talent
+{
+    "name": "Leader's Talent",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Class",
+    "oracleText": "(Gain the next level as a sorcery to add its ability.)\nWhenever you attack, put a +1/+1 counter on target attacking creature.\n{2}{W}: Level 2 — Whenever a creature you control leaves the battlefield, if it had a counter on it, you gain 2 life.\n{3}{W}: Level 3 — Whenever you cast a spell, put a +1/+1 counter on each creature you control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target attacking creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature attacking"
+                    },
+                    "id": "target attacking creature"
+                }
+            }
+        ],
+        "classLevels": [
+            {
+                "level": 2,
+                "cost": "{2}{W}",
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": {
+                            "type": "ZoneChangeEvent",
+                            "filter": "creature ctrl:you",
+                            "from": "Battlefield"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        "triggerCondition": "TriggeringEntityHadCounters"
+                    }
+                ]
+            },
+            {
+                "level": 3,
+                "cost": "{3}{W}",
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_3",
+                        "trigger": "SpellCastEvent",
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "RARE",
+        "artist": "Manuel Castañón",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4cbcb622-1aff-460f-b8fa-4502d991e0ad.jpg?1777939766"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Leonardo's Technique
 {
     "name": "Leonardo's Technique",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5145,6 +5145,99 @@
     ]
 }
 
+// Paramecia Coloniex
+{
+    "name": "Paramecia Coloniex",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Worm",
+    "oracleText": "When this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhen this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, mill three cards."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Exile"
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Library",
+                        "placement": "Top"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "activeZone": "Graveyard",
+                "descriptionOverride": "When this creature dies, you may exile it. When you do, put target creature card from your graveyard on top of your library."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "UNCOMMON",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/654e2646-78ac-4b08-bed1-3c71355d55fc.jpg?1771586897"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Pizza Face, Gastromancer
 {
     "name": "Pizza Face, Gastromancer",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1001,6 +1001,90 @@
     ]
 }
 
+// Courier of Comestibles
+{
+    "name": "Courier of Comestibles",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "When this creature enters, you may search your library for a Food card, reveal it, put it into your hand, then shuffle. If you don't put a card into your hand this way, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": "Food"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    },
+                                    "revealed": true
+                                },
+                                "ShuffleLibrary"
+                            ]
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": []
+                    },
+                    "otherwise": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Food"
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you may search your library for a Food card, reveal it, put it into your hand, then shuffle. If you don't put a card into your hand this way, create a Food token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "UNCOMMON",
+        "artist": "Mirko Failoni",
+        "flavorText": "Forgiveness is divine, but never pay full price for late pizza.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53f5f704-2265-42bb-bff5-fd9d85bc2bfb.jpg?1771342389"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cowabunga!
 {
     "name": "Cowabunga!",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisappearMichelangeloScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisappearMichelangeloScenarioTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Disappear intervening-if test, exercised through Michelangelo, Game Master (TMT):
+ * "Disappear — At the beginning of your end step, if a permanent left the battlefield
+ *  under your control this turn, put a +1/+1 counter on Michelangelo."
+ *
+ * Disappear reuses the existing per-controller `PermanentLeftBattlefieldThisTurnComponent`
+ * tracker (set in ZoneTransitionService for any permanent — lands included — leaving that
+ * player's battlefield) via the `Conditions.YouHadPermanentLeaveBattlefieldThisTurn`
+ * intervening-if (CR 603.4). These tests prove the condition gates the end-step trigger:
+ * the counter lands only when a permanent actually left this turn.
+ */
+class DisappearMichelangeloScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCards(PredefinedTokens.allTokens) // GameTestDriver doesn't auto-register tokens
+        return d
+    }
+
+    test("a permanent leaving this turn satisfies Disappear — counter is placed") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mike = d.putCreatureOnBattlefield(p, "Michelangelo, Game Master") // 3/3
+        // Sacrifice a Food via its own ability so a permanent genuinely leaves the
+        // battlefield through ZoneTransitionService (which credits the controller).
+        val food = d.putPermanentOnBattlefield(p, "Food")
+        d.giveMana(p, Color.GREEN, 2)
+        d.submit(
+            ActivateAbility(
+                playerId = p,
+                sourceId = food,
+                abilityId = PredefinedTokens.Food.activatedAbilities.first().id
+            )
+        ).isSuccess shouldBe true
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 6) d.bothPass()
+
+        // Advance to the end step; the Disappear trigger fires (intervening-if true) and resolves.
+        d.passPriorityUntil(Step.END)
+        guard = 0
+        while (d.stackSize > 0 && guard++ < 6) d.bothPass()
+
+        projector.getProjectedPower(d.state, mike) shouldBe 4
+        projector.getProjectedToughness(d.state, mike) shouldBe 4
+    }
+
+    test("no permanent left this turn — Disappear does not trigger, no counter") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mike = d.putCreatureOnBattlefield(p, "Michelangelo, Game Master")
+
+        d.passPriorityUntil(Step.END)
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 6) d.bothPass()
+
+        // Intervening-if is false (nothing left the battlefield), so the trigger never resolves.
+        projector.getProjectedPower(d.state, mike) shouldBe 3
+        projector.getProjectedToughness(d.state, mike) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MutagenTokenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MutagenTokenScenarioTest.kt
@@ -30,7 +30,7 @@ import io.kotest.matchers.shouldBe
  *  1. Activating the ability puts a +1/+1 counter on the target creature and the cost
  *     sacrifices the token (it leaves the battlefield) and pays {1} + {T}.
  *  2. "Activate only as a sorcery" — the ability is illegal outside the controller's main
- *     phase with an empty stack (here: during upkeep), per CR 302.6.
+ *     phase with an empty stack (here: during upkeep), per CR 307.5.
  *  3. The [Effects.CreateMutagenToken] facade actually produces a registered "Mutagen"
  *     artifact token (noncreature) end to end.
  */

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MutagenTokenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MutagenTokenScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Feature test for the predefined **Mutagen** token (Teenage Mutant Ninja Turtles).
+ *
+ * "It's an artifact with '{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target
+ *  creature. Activate only as a sorcery.'"
+ *
+ * Proves the three load-bearing clauses of the token:
+ *  1. Activating the ability puts a +1/+1 counter on the target creature and the cost
+ *     sacrifices the token (it leaves the battlefield) and pays {1} + {T}.
+ *  2. "Activate only as a sorcery" — the ability is illegal outside the controller's main
+ *     phase with an empty stack (here: during upkeep), per CR 302.6.
+ *  3. The [Effects.CreateMutagenToken] facade actually produces a registered "Mutagen"
+ *     artifact token (noncreature) end to end.
+ */
+class MutagenTokenScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+    val mutagenAbilityId = PredefinedTokens.Mutagen.activatedAbilities.first().id
+
+    // Inline maker that exercises the Effects.CreateMutagenToken() facade on ETB.
+    val mutagenMaker = card("Mutagen Maker") {
+        manaCost = "{1}{U}"
+        typeLine = "Creature — Human"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.CreateMutagenToken()
+            description = "When this creature enters, create a Mutagen token."
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCards(PredefinedTokens.allTokens) // GameTestDriver doesn't auto-register tokens
+        d.registerCards(listOf(mutagenMaker))
+        return d
+    }
+
+    test("{1}, {T}, Sacrifice this token: put a +1/+1 counter on target creature") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mutagen = d.putPermanentOnBattlefield(p, "Mutagen")
+        val bear = d.putCreatureOnBattlefield(p, "Centaur Courser") // 3/3
+        d.removeSummoningSickness(bear)
+        d.giveMana(p, Color.BLUE, 1)
+
+        d.submit(
+            ActivateAbility(
+                playerId = p,
+                sourceId = mutagen,
+                abilityId = mutagenAbilityId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+
+        // +1/+1 counter applied: 3/3 -> 4/4.
+        projector.getProjectedPower(d.state, bear) shouldBe 4
+        projector.getProjectedToughness(d.state, bear) shouldBe 4
+
+        // The token paid its own sacrifice and is gone.
+        d.state.getBattlefield().contains(mutagen) shouldBe false
+    }
+
+    test("activate only as a sorcery — illegal during the controller's upkeep") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.UPKEEP)
+
+        val mutagen = d.putPermanentOnBattlefield(p, "Mutagen")
+        val bear = d.putCreatureOnBattlefield(p, "Centaur Courser")
+        d.removeSummoningSickness(bear)
+        d.giveMana(p, Color.BLUE, 1)
+
+        // Upkeep is not a main phase, so the sorcery-speed ability must be rejected.
+        d.submitExpectFailure(
+            ActivateAbility(
+                playerId = p,
+                sourceId = mutagen,
+                abilityId = mutagenAbilityId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        )
+
+        // Untouched: token still present, creature still 3/3.
+        d.state.getBattlefield().contains(mutagen) shouldBe true
+        projector.getProjectedPower(d.state, bear) shouldBe 3
+    }
+
+    test("Effects.CreateMutagenToken() creates a registered Mutagen artifact token") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val p = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val before = mutagenTokens(d.state, p).toSet()
+        val maker = d.putCardInHand(p, "Mutagen Maker")
+        d.giveMana(p, Color.BLUE, 2)
+        d.castSpell(p, maker)
+        // Resolve the spell, then its ETB trigger (each is a separate stack object).
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 6) d.bothPass()
+
+        val created = mutagenTokens(d.state, p) - before
+        created.size shouldBe 1
+        val card = d.state.getEntity(created.first())!!.get<CardComponent>()!!
+        card.name shouldBe "Mutagen"
+        card.typeLine.isArtifact shouldBe true
+        card.typeLine.isCreature shouldBe false
+    }
+})
+
+private fun mutagenTokens(state: GameState, player: EntityId): List<EntityId> =
+    state.getBattlefield().filter {
+        val e = state.getEntity(it) ?: return@filter false
+        e.has<TokenComponent>() &&
+            e.get<ControllerComponent>()?.playerId == player &&
+            e.get<CardComponent>()?.name == "Mutagen"
+    }


### PR DESCRIPTION
Depends on https://github.com/wingedsheep/argentum-engine/pull/952

Adds 18 Teenage Mutant Ninja Turtles cards, taking the set to 156/190.
Pure card authoring — **zero SDK/engine/server changes**; every card composes
existing primitives from the tmt-1 foundation.

Stacked on `tmt-1-foundation-commons` (merge that first).

### Cards
Bebop & Rocksteady, Broadcast Takeover, Chrome Dome, Cool but Rude,
Courier of Comestibles, Does Machines, Don & Leo, Groundchuck & Dirtbag,
Leader's Talent, Leonardo's Technique, Michelangelo (Mutant BFF / Weirdness to 11),
Mind Transfer Protocol, Mutagen Man, Prehistoric Pet, Return to the Sewers,
The Neutrinos, The Ooze, Turtle Lair.

### Notable compositions (reusing existing primitives)
- Flicker via sequential `Move` exile→battlefield (Don & Leo; The Neutrinos uses
  `ZonePlacement.TappedAndAttacking`) — relies on CR 400.7j.
- Mass gain-control Insurrection shape: `ForEachInGroup(GainControl)` (Broadcast Takeover).
- Class "becomes level N" via EntersBattlefield-in-level-block (Cool but Rude,
  Does Machines, Leader's Talent).
- `BecomeCreature` + `AddCardType("ARTIFACT")` (Mind Transfer Protocol);
  `ModifyCounterPlacement` Hardened Scales rider (Michelangelo, Weirdness to 11).

### Testing
- `TMT.json` snapshot re-blessed; cards pass lint.
- ⚠️ No per-card scenario tests yet. Follow-up: add behavioral tests for the
  load-bearing cards (flicker return, leaves-battlefield last-known counters,
  Class level-ups). Run `:mtg-sets:test` snapshot + lint before merge.