### PR TITLE
Add DSK cards: Haunted Screen, Living Phone, Cursed Recording, Keys to the House

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CursedRecording.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CursedRecording.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cursed Recording
+ * {2}{R}{R}
+ * Artifact
+ *
+ * Whenever you cast an instant or sorcery spell, put a time counter on this artifact. Then if there
+ * are seven or more time counters on it, remove those counters and it deals 20 damage to you.
+ * {T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new
+ *      targets for the copy.
+ *
+ * The "Then if ..." clause is a resolution-time check ([ConditionalEffect] +
+ * [Conditions.SourceCounterCountAtLeast]), not an intervening-if on the trigger. Because the count
+ * is checked after every single counter is added, it can only ever reach exactly seven, so removing
+ * seven time counters is faithful to "remove those counters". The activated ability arms a
+ * one-shot delayed copy of the next instant/sorcery spell via [Effects.CopyNextSpellCast]
+ * (which lets the controller choose new targets for the copy).
+ */
+val CursedRecording = card("Cursed Recording") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "Whenever you cast an instant or sorcery spell, put a time counter on this " +
+        "artifact. Then if there are seven or more time counters on it, remove those counters and " +
+        "it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, " +
+        "copy that spell. You may choose new targets for the copy."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastInstantOrSorcery
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.TIME, 1, EffectTarget.Self),
+            ConditionalEffect(
+                condition = Conditions.SourceCounterCountAtLeast(Counters.TIME, 7),
+                effect = Effects.Composite(
+                    Effects.RemoveCounters(Counters.TIME, 7, EffectTarget.Self),
+                    Effects.DealDamage(20, EffectTarget.Controller, damageSource = EffectTarget.Self),
+                ),
+            ),
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.CopyNextSpellCast(1)
+        description = "{T}: When you next cast an instant or sorcery spell this turn, copy that " +
+            "spell. You may choose new targets for the copy."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "131"
+        artist = "Kim Sokol"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d13a247c-c941-488a-b13b-bffb1f1f368a.jpg?1726286337"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/HauntedScreen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/HauntedScreen.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Haunted Screen
+ * {3}
+ * Artifact
+ *
+ * {T}: Add {W} or {B}.
+ * {T}, Pay 1 life: Add {G}, {U}, or {R}.
+ * {7}: Put seven +1/+1 counters on this artifact. It becomes a 0/0 Spirit creature in
+ *      addition to its other types. Activate only once.
+ *
+ * Following the established dual-mana-rock convention (Troll-Horn Cameo), each "or" mana
+ * ability is modeled as one single-color mana ability per producible color. The animate
+ * ability puts seven +1/+1 counters (so the 0/0 base becomes a 7/7) and makes the artifact
+ * a Spirit creature in addition to its other types via [Effects.BecomeCreature]
+ * (CREATURE is always added, the artifact type is kept), permanently. "Activate only once"
+ * maps to [ActivationRestriction.Once].
+ */
+val HauntedScreen = card("Haunted Screen") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add {W} or {B}.\n{T}, Pay 1 life: Add {G}, {U}, or {R}.\n{7}: Put seven " +
+        "+1/+1 counters on this artifact. It becomes a 0/0 Spirit creature in addition to its " +
+        "other types. Activate only once."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.PayLife(1))
+        effect = Effects.AddMana(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{7}")
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 7, EffectTarget.Self),
+            Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 0,
+                toughness = 0,
+                creatureTypes = setOf("Spirit"),
+                duration = Duration.Permanent,
+            ),
+        )
+        restrictions = listOf(ActivationRestriction.Once)
+        description = "{7}: Put seven +1/+1 counters on this artifact. It becomes a 0/0 Spirit " +
+            "creature in addition to its other types. Activate only once."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "250"
+        artist = "Sean Murray"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e7d552f-a7ac-4a49-a582-9d378137005f.jpg?1726286805"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LivingPhone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LivingPhone.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Living Phone
+ * {2}{W}
+ * Artifact Creature — Toy
+ * 2/1
+ *
+ * When this creature dies, look at the top five cards of your library. You may reveal a creature
+ * card with power 2 or less from among them and put it into your hand. Put the rest on the bottom
+ * of your library in a random order.
+ *
+ * Dies-trigger flavor of the shared [Patterns.Library.lookAtTopRevealMatchingToHand] recipe: the
+ * reveal is optional (choose up to one), filtered to creatures with power <= 2, and the rest go to
+ * the bottom of the library in a random order (the pattern's defaults).
+ */
+val LivingPhone = card("Living Phone") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Toy"
+    power = 2
+    toughness = 1
+    oracleText = "When this creature dies, look at the top five cards of your library. You may " +
+        "reveal a creature card with power 2 or less from among them and put it into your hand. " +
+        "Put the rest on the bottom of your library in a random order."
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(5),
+            filter = GameObjectFilter.Creature.powerAtMost(2),
+            prompt = "You may reveal a creature card with power 2 or less to put into your hand",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "20"
+        artist = "Domenico Cava"
+        imageUri = "https://cards.scryfall.io/normal/front/8/2/8266f93b-f91c-4427-a222-075ceb0be3af.jpg?1726285933"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -2221,6 +2221,109 @@
     ]
 }
 
+// Cursed Recording
+{
+    "name": "Cursed Recording",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Artifact",
+    "oracleText": "Whenever you cast an instant or sorcery spell, put a time counter on this artifact. Then if there are seven or more time counters on it, remove those counters and it deals 20 damage to you.\n{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "time",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "EntityProperty",
+                                        "entity": "Source",
+                                        "numericProperty": {
+                                            "type": "CounterCount",
+                                            "counterType": {
+                                                "type": "Named",
+                                                "name": "time"
+                                            }
+                                        }
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 7
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "RemoveCounters",
+                                        "counterType": "time",
+                                        "count": 7,
+                                        "target": "Self"
+                                    },
+                                    {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 20
+                                        },
+                                        "target": "Controller",
+                                        "damageSource": "Self"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "CopyNextSpellCast",
+                "descriptionOverride": "{T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new targets for the copy."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "131",
+        "rarity": "RARE",
+        "artist": "Kim Sokol",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d13a247c-c941-488a-b13b-bffb1f1f368a.jpg?1726286337"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cynical Loner
 {
     "name": "Cynical Loner",
@@ -5659,6 +5762,151 @@
     ]
 }
 
+// Haunted Screen
+{
+    "name": "Haunted Screen",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add {W} or {B}.\n{T}, Pay 1 life: Add {G}, {U}, or {R}.\n{7}: Put seven +1/+1 counters on this artifact. It becomes a 0/0 Spirit creature in addition to its other types. Activate only once.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_5",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomPayLife",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_6",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{7}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 7,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "BecomeCreature",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "creatureTypes": [
+                                "Spirit"
+                            ],
+                            "duration": "Permanent"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ],
+                "descriptionOverride": "{7}: Put seven +1/+1 counters on this artifact. It becomes a 0/0 Spirit creature in addition to its other types. Activate only once."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "UNCOMMON",
+        "artist": "Sean Murray",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e7d552f-a7ac-4a49-a582-9d378137005f.jpg?1726286805"
+    },
+    "colorIdentityOverride": []
+}
+
 // Hauntwoods Shrieker
 {
     "name": "Hauntwoods Shrieker",
@@ -6978,6 +7226,89 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Living Phone
+{
+    "name": "Living Phone",
+    "manaCost": "{2}{W}",
+    "typeLine": "Artifact Creature — Toy",
+    "oracleText": "When this creature dies, look at the top five cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature pow<=2",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature card with power 2 or less to put into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "artist": "Domenico Cava",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/2/8266f93b-f91c-4427-a222-075ceb0be3af.jpg?1726285933"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CursedRecordingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CursedRecordingScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.CursedRecording
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.StormCopyEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cursed Recording (DSK #131) — {2}{R}{R} Artifact.
+ *
+ * "Whenever you cast an instant or sorcery spell, put a time counter on this artifact. Then if there
+ * are seven or more time counters on it, remove those counters and it deals 20 damage to you.
+ * {T}: When you next cast an instant or sorcery spell this turn, copy that spell. You may choose new
+ * targets for the copy."
+ *
+ * Exercises (1) the cast-an-instant-or-sorcery trigger adding a time counter, (2) the resolution-time
+ * "Then if there are seven or more time counters" check removing the counters and dealing 20 damage
+ * to the controller, and (3) the {T} arming of a one-shot delayed spell copy.
+ */
+class CursedRecordingScenarioTest : FunSpec({
+
+    val copyAbilityId = CursedRecording.activatedAbilities.first().id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + CursedRecording)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun timeCounters(driver: GameTestDriver, recording: EntityId): Int =
+        driver.state.getEntity(recording)?.get<CountersComponent>()?.getCount(CounterType.TIME) ?: 0
+
+    test("casting an instant puts a time counter on Cursed Recording") {
+        val driver = newDriver()
+        val player = driver.player1
+        val opponent = driver.player2
+
+        val recording = driver.putPermanentOnBattlefield(player, "Cursed Recording")
+
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, targets = listOf(opponent)).isSuccess shouldBe true
+        while (driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+
+        timeCounters(driver, recording) shouldBe 1
+    }
+
+    test("seventh time counter removes the counters and deals 20 damage to you") {
+        val driver = newDriver()
+        val player = driver.player1
+        val opponent = driver.player2
+
+        val recording = driver.putPermanentOnBattlefield(player, "Cursed Recording")
+        // Pre-load six time counters so the next cast pushes it to seven.
+        driver.addComponent(recording, CountersComponent(mapOf(CounterType.TIME to 6)))
+        // Raise life so the 20 damage doesn't end the game.
+        driver.setLifeTotal(player, 40)
+
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, targets = listOf(opponent)).isSuccess shouldBe true
+        while (driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+
+        // The counters were removed and the controller took 20.
+        timeCounters(driver, recording) shouldBe 0
+        driver.getLifeTotal(player) shouldBe 20
+    }
+
+    test("{T} arms a copy of the next instant or sorcery cast this turn") {
+        val driver = newDriver()
+        val player = driver.player1
+        val opponent = driver.player2
+
+        val recording = driver.putPermanentOnBattlefield(player, "Cursed Recording")
+
+        // Arm the delayed copy.
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = recording, abilityId = copyAbilityId)
+        ).error shouldBe null
+        driver.bothPass() // resolve the {T} ability — registers the pending spell copy
+        driver.state.pendingSpellCopies.size shouldBe 1
+
+        // Cast an instant — it gets copied (a storm-copy trigger lands on the stack) and the pending
+        // copy is consumed.
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, targets = listOf(opponent)).isSuccess shouldBe true
+
+        val stormCopies = driver.state.stack.mapNotNull {
+            driver.state.getEntity(it)?.get<TriggeredAbilityOnStackComponent>()
+        }.count { it.effect is StormCopyEffect }
+        stormCopies shouldBe 1
+        driver.state.pendingSpellCopies.size shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HauntedScreenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HauntedScreenScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.HauntedScreen
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Haunted Screen (DSK #250) — {3} Artifact mana rock with a one-shot animate ability:
+ *
+ * "{7}: Put seven +1/+1 counters on this artifact. It becomes a 0/0 Spirit creature in addition to
+ * its other types. Activate only once."
+ *
+ * Exercises the [com.wingedsheep.sdk.scripting.effects.BecomeCreatureEffect] animate composed with
+ * seven +1/+1 counters (so the 0/0 base reads as a 7/7), the Spirit subtype and the kept artifact
+ * type ("in addition to its other types"), and the [com.wingedsheep.sdk.scripting.ActivationRestriction.Once]
+ * once-ever restriction.
+ */
+class HauntedScreenScenarioTest : FunSpec({
+
+    val animateAbilityId = HauntedScreen.activatedAbilities.first { !it.isManaAbility }.id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + HauntedScreen)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("{7} animates into a 7/7 Spirit artifact creature with seven +1/+1 counters") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val screen = driver.putPermanentOnBattlefield(player, "Haunted Screen")
+        driver.giveColorlessMana(player, 7)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = screen, abilityId = animateAbilityId)
+        ).error shouldBe null
+        driver.bothPass() // resolve the animate ability
+
+        // Seven +1/+1 counters.
+        driver.state.getEntity(screen)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 7
+
+        val projected = driver.state.projectedState
+        // Now a 0/0 base + seven counters = 7/7 creature.
+        projected.isCreature(screen) shouldBe true
+        projected.getPower(screen) shouldBe 7
+        projected.getToughness(screen) shouldBe 7
+        // Spirit added, artifact kept ("in addition to its other types").
+        projected.hasSubtype(screen, "Spirit") shouldBe true
+        projected.hasType(screen, "ARTIFACT") shouldBe true
+    }
+
+    test("animate ability can be activated only once") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val screen = driver.putPermanentOnBattlefield(player, "Haunted Screen")
+        driver.giveColorlessMana(player, 7)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = screen, abilityId = animateAbilityId)
+        ).error shouldBe null
+        driver.bothPass()
+
+        // A second activation is rejected even with the mana available (Activate only once).
+        driver.giveColorlessMana(player, 7)
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = screen, abilityId = animateAbilityId)
+        ).error shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LivingPhoneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LivingPhoneScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.LivingPhone
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Living Phone (DSK #20) — {2}{W} Artifact Creature — Toy 2/1.
+ *
+ * "When this creature dies, look at the top five cards of your library. You may reveal a creature
+ * card with power 2 or less from among them and put it into your hand. Put the rest on the bottom
+ * of your library in a random order."
+ *
+ * Exercises the look-at-top-five → optional filtered reveal-to-hand → rest-to-bottom-in-random-order
+ * pipeline ([com.wingedsheep.sdk.dsl.LibraryPatterns.lookAtTopRevealMatchingToHand]) on a dies
+ * trigger, including the "you may" decline path.
+ */
+class LivingPhoneScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + LivingPhone)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun librarySize(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.state.getZone(ZoneKey(playerId, Zone.LIBRARY)).size
+
+    test("dies: reveals a power-2-or-less creature to hand, rest to bottom of library") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val phone = driver.putCreatureOnBattlefield(player, "Living Phone")
+        // Top of library: a power-2 creature on top (matches), Forests beneath (don't match).
+        val bear = driver.putCardOnTopOfLibrary(player, "Grizzly Bears") // 2/2 — power 2
+
+        val libBefore = librarySize(driver, player) // includes the freshly-stacked Grizzly Bears
+
+        // Bolt the 2/1 Living Phone to kill it and fire the dies trigger.
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, targets = listOf(phone)).isSuccess shouldBe true
+        driver.bothPass() // resolve the bolt — Living Phone dies, queuing the dies trigger
+        driver.bothPass() // resolve the dies trigger — pauses at the optional reveal
+
+        driver.isPaused shouldBe true
+        val pick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pick.options shouldContain bear
+
+        // Reveal the Grizzly Bears and put it into hand.
+        driver.submitDecision(player, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(bear)))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // Grizzly Bears is in hand; the other four looked-at cards went to the bottom.
+        driver.getHand(player) shouldContain bear
+        // Library: started at libBefore, looked at 5 (removed), 1 to hand + 4 to bottom = libBefore - 1.
+        librarySize(driver, player) shouldBe libBefore - 1
+    }
+
+    test("dies: the reveal is optional — declining leaves the hand untouched") {
+        val driver = newDriver()
+        val player = driver.player1
+
+        val phone = driver.putCreatureOnBattlefield(player, "Living Phone")
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val libBefore = librarySize(driver, player)
+
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        val handAfterBolt = driver.getHandSize(player) - 1 // hand once the bolt is cast away
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, targets = listOf(phone)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.isPaused shouldBe true
+        val pick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+
+        // Decline: choose nothing — all five looked-at cards go to the bottom.
+        driver.submitDecision(player, CardsSelectedResponse(decisionId = pick.id, selectedCards = emptyList()))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        driver.getHandSize(player) shouldBe handAfterBolt
+        // All five looked-at cards returned to the bottom — library size unchanged.
+        librarySize(driver, player) shouldBe libBefore
+    }
+})


### PR DESCRIPTION
Implements four Duskmourn: House of Horror (DSK) cards (one skipped — see below). Each implemented card uses only existing SDK primitives and ships with a rules-engine scenario test; the DSK card-snapshot golden was re-blessed (purely additive).

## Cards

- **Haunted Screen** (#250) — **Implemented.** Dual mana-rock abilities (`{T}: Add {W} or {B}` / `{T}, Pay 1 life: Add {G}, {U}, or {R}`, modeled per the established one-ability-per-color convention from Troll-Horn Cameo) plus a once-only `{7}` animate: seven +1/+1 counters and `Effects.BecomeCreature` into a 0/0 Spirit (CREATURE added, artifact type kept), gated by `ActivationRestriction.Once`.
- **Living Phone** (#20) — **Implemented.** Dies trigger via `Patterns.Library.lookAtTopRevealMatchingToHand`: look at the top five, optionally reveal a creature with power 2 or less to hand, put the rest on the bottom in a random order (the pattern's defaults). Covers the "you may" decline path.
- **Cursed Recording** (#131) — **Implemented.** Cast-an-instant-or-sorcery trigger adds a time counter, with a resolution-time `ConditionalEffect` + `Conditions.SourceCounterCountAtLeast(time, 7)` that removes the counters and deals 20 damage to the controller; plus a `{T}` delayed copy of the next instant/sorcery (`Effects.CopyNextSpellCast`, which lets the controller choose new targets).
- **Keys to the House** (#251) — **Skipped.** Its first ability (search a basic land to hand) is supported, but the second ability, "Lock or unlock a door of target Room you control," has no engine support — there is no lock/unlock-door effect for the Room mechanic (the SDK only handles door unlocking as a built-in special action). Implementing it would require a new SDK effect type (add-feature scope), so it was left out per the task's skip-if-needs-new-feature guidance.

## Tests

- `HauntedScreenScenarioTest` — animate produces a 7/7 Spirit artifact creature with seven counters; second activation rejected (Activate only once).
- `LivingPhoneScenarioTest` — reveals a power-2 creature to hand with the rest binned to the bottom; decline path leaves the hand untouched.
- `CursedRecordingScenarioTest` — counter on cast; seventh counter removes the counters and deals 20; `{T}` arms a one-shot copy of the next instant/sorcery.

All three scenario test classes pass; `CardLintTest` and `CardDefinitionSnapshotTest` pass; `check-card-printing` confirms all three are canonical in DSK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)