### PR TITLE
Add DSK cards: Oblivious Bookworm, Reluctant Role Model, Orphans of the Wheat, Unwilling Vessel

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5111,7 +5111,11 @@ substitution.
   self-sacrifice/exile cost wipes them first, `DynamicAmounts.lastKnownSourceCounters(...)` (CR 112.7a; see §13).
   `rev` (`Counters.REV`): DSK — Chainsaw, whose "whenever one or more creatures die" batched trigger accumulates one
   per death batch and whose `+X/+0` static reads the count via `DynamicAmounts.countersOnSelf(...)` applied to the
-  equipped creature — another pure passive counter with no inherent rule.)
+  equipped creature — another pure passive counter with no inherent rule.
+  `possession` (`Counters.POSSESSION`): DSK — Unwilling Vessel, whose Eerie triggers (an enchantment you control
+  entering / fully unlocking a Room) each accumulate one and whose dies trigger reads the total counter count via
+  `DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_TOTAL_COUNTER_COUNT)` to size the X/X Spirit token it
+  leaves behind — another pure passive counter with no inherent rule.)
 - `stun` — CR 122.1d, a built-in replacement: "If a permanent with a stun counter on it would become untapped,
   instead remove a stun counter from it." Engine-wired through `untapOrConsumeStun` (`rules-engine/core/UntapHelpers.kt`),
   which is invoked from the untap step (`BeginningPhaseManager`), from `TapUntapExecutor`'s untap branch, and from the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/CounterType.kt
@@ -58,7 +58,8 @@ enum class CounterType {
     NEST,
     PAGE,
     REV,
-    DOOM
+    DOOM,
+    POSSESSION
 }
 
 /**
@@ -182,6 +183,14 @@ object Counters {
      * activated ability removes one. No inherent rule.
      */
     const val DOOM = "doom"
+
+    /**
+     * Possession counter (DSK — Unwilling Vessel). Passive storage counter with no inherent rule;
+     * Eerie triggers accumulate it (an enchantment you control entering / fully unlocking a Room
+     * each add one) and the card's dies trigger reads the count to size the X/X Spirit token it
+     * leaves behind. No inherent rule.
+     */
+    const val POSSESSION = "possession"
 
     /**
      * Wildcard sentinel for triggers/events that fire on counters of *any* type, e.g.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/OrphansOfTheWheat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/OrphansOfTheWheat.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.TapUntapCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Orphans of the Wheat — Duskmourn: House of Horror #22
+ * {1}{W} · Creature — Human · 2/1
+ *
+ * Whenever this creature attacks, tap any number of untapped creatures you control. This creature
+ * gets +1/+1 until end of turn for each creature tapped this way.
+ *
+ * "Tap any number" (zero allowed, so no "may" is needed) is the Gather → Select → Tap pipeline:
+ * gather your untapped creatures, choose any number of them on the battlefield, tap that
+ * selection, then pump this creature. The buff reads the auto-derived selection count
+ * (`DynamicAmount.VariableReference("tapped_count")`), which `ModifyStatsExecutor` snapshots into a
+ * fixed +N/+N floating effect lasting until end of turn — so later untapping doesn't change it.
+ * The attacker itself was tapped by attacking (no vigilance), so it isn't in the untapped pool.
+ */
+val OrphansOfTheWheat = card("Orphans of the Wheat") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever this creature attacks, tap any number of untapped creatures you " +
+        "control. This creature gets +1/+1 until end of turn for each creature tapped this way."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.ControlledPermanents(
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature.youControl().untapped()
+                    ),
+                    storeAs = "candidates"
+                ),
+                SelectFromCollectionEffect(
+                    from = "candidates",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    storeSelected = "tapped",
+                    prompt = "Tap any number of untapped creatures you control",
+                    useTargetingUI = true
+                ),
+                TapUntapCollectionEffect("tapped", tap = true),
+                Effects.ModifyStats(
+                    power = DynamicAmount.VariableReference("tapped_count"),
+                    toughness = DynamicAmount.VariableReference("tapped_count"),
+                    target = EffectTarget.Self
+                )
+            )
+        )
+        description = "Whenever this creature attacks, tap any number of untapped creatures you " +
+            "control. This creature gets +1/+1 until end of turn for each creature tapped this way."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "22"
+        artist = "Julie Dillon"
+        flavorText = "Their only family is each other, and their only toys are those who wander too far into the fields."
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ef4aab1-8bc0-4652-91d7-3e8b20b411ad.jpg?1726285941"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ReluctantRoleModel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ReluctantRoleModel.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Reluctant Role Model — Duskmourn: House of Horror #26
+ * {1}{W} · Creature — Human Survivor · 2/2
+ *
+ * Survival — At the beginning of your second main phase, if this creature is tapped, put a
+ * flying, lifelink, or +1/+1 counter on it.
+ * Whenever this creature or another creature you control dies, if it had counters on it, put
+ * those counters on up to one target creature.
+ *
+ * First ability: the "Survival" ability word is flavor only — mechanically this is an
+ * intervening-"if" postcombat-main trigger gated on the source being tapped
+ * (`Triggers.YourPostcombatMain` + `Conditions.SourceIsTapped`), exactly like the other DSK
+ * Survival creatures. "put a flying, lifelink, or +1/+1 counter" is the controller's choice at
+ * resolution, modeled as `Effects.ChooseAction` over the three keyword/+1+1 counter kinds, each
+ * adding one counter to this creature (`EffectTarget.Self`). Flying and lifelink are keyword
+ * counters (CR 122.1b) granting their keyword via the projected keyword-counter map.
+ *
+ * Second ability: "this creature or another creature you control dies" is
+ * `Triggers.YourCreatureDies` (ANY binding, creatures-you-control filter — includes this card
+ * itself). The intervening "if it had counters on it" (CR 603.4) is
+ * `Conditions.TriggeringEntityHadCounters`, reading the dying creature's last-known total
+ * counter count. `Effects.MoveAllLastKnownCounters` puts the same number of each kind of counter
+ * the dying creature had onto the chosen "up to one target creature" (any creature, optional).
+ */
+val ReluctantRoleModel = card("Reluctant Role Model") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Survivor"
+    power = 2
+    toughness = 2
+    oracleText = "Survival — At the beginning of your second main phase, if this creature is " +
+        "tapped, put a flying, lifelink, or +1/+1 counter on it.\n" +
+        "Whenever this creature or another creature you control dies, if it had counters on it, " +
+        "put those counters on up to one target creature."
+
+    // Survival — At the beginning of your second main phase, if this creature is tapped,
+    // put a flying, lifelink, or +1/+1 counter on it.
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.SourceIsTapped
+        effect = Effects.ChooseAction(
+            listOf(
+                EffectChoice(
+                    label = "Flying counter",
+                    effect = Effects.AddCounters(Counters.FLYING, 1, EffectTarget.Self),
+                ),
+                EffectChoice(
+                    label = "Lifelink counter",
+                    effect = Effects.AddCounters(Counters.LIFELINK, 1, EffectTarget.Self),
+                ),
+                EffectChoice(
+                    label = "+1/+1 counter",
+                    effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                ),
+            )
+        )
+        description = "Survival — At the beginning of your second main phase, if this creature " +
+            "is tapped, put a flying, lifelink, or +1/+1 counter on it."
+    }
+
+    // Whenever this creature or another creature you control dies, if it had counters on it,
+    // put those counters on up to one target creature.
+    triggeredAbility {
+        trigger = Triggers.YourCreatureDies
+        triggerCondition = Conditions.TriggeringEntityHadCounters
+        target = TargetCreature(optional = true)
+        effect = Effects.MoveAllLastKnownCounters(EffectTarget.ContextTarget(0))
+        description = "Whenever this creature or another creature you control dies, if it had " +
+            "counters on it, put those counters on up to one target creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "26"
+        artist = "Chris Rallis"
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4dde86d6-34a0-4b3b-a46a-d9941501d08c.jpg?1726285956"
+
+        ruling("2024-09-20", "If Reluctant Role Model dies at the same time as one or more other creatures with counters on them, its last ability will trigger for each of those creatures.")
+        ruling("2024-09-20", "Reluctant Role Model's last ability doesn't cause you to move counters from the creature that died onto the target creature. Rather, you put the same number of each kind of counter the creature that died had when it died onto the target creature.")
+        ruling("2024-09-20", "If the creature that died had -1/-1 counters on it when it died, Reluctant Role Model's last ability will include those as well. This may result in the target creature also dying.")
+        ruling("2024-09-20", "If a creature with a survival ability isn't tapped when your second main phase begins, the ability won't trigger at all.")
+        ruling("2024-09-20", "If a creature's survival ability triggers but that creature is untapped when the ability begins to resolve, that ability won't do anything.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnwillingVessel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnwillingVessel.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+
+/**
+ * Unwilling Vessel — Duskmourn: House of Horror #81
+ * {2}{U} · Creature — Human Wizard · 3/2
+ *
+ * Vigilance
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, put a
+ * possession counter on this creature.
+ * When this creature dies, create an X/X blue Spirit creature token with flying, where X is the
+ * number of counters on this creature.
+ *
+ * The "Eerie" ability word is flavor; mechanically it is two triggered abilities (like the other
+ * DSK Eerie creatures, e.g. Balemurk Leech): one on `Triggers.entersBattlefield` filtered to
+ * enchantments you control, one on `Triggers.RoomFullyUnlocked`. Each adds one possession counter
+ * (a passive storage counter, no inherent rule) to this creature. The dies trigger creates one
+ * X/X token where X is read at death from `ContextPropertyKey.LAST_KNOWN_TOTAL_COUNTER_COUNT` —
+ * the total number of counters of every kind on the creature when it died (per the ruling, +1/+1
+ * and -1/-1 counters are included, not just possession counters).
+ */
+val UnwillingVessel = card("Unwilling Vessel") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 3
+    toughness = 2
+    oracleText = "Vigilance\n" +
+        "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, " +
+        "put a possession counter on this creature.\n" +
+        "When this creature dies, create an X/X blue Spirit creature token with flying, where X is " +
+        "the number of counters on this creature."
+
+    keywords(Keyword.VIGILANCE, Keyword.EERIE)
+
+    // Eerie trigger — part 1: whenever an enchantment you control enters
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.AddCounters(Counters.POSSESSION, 1, EffectTarget.Self)
+        description = "Eerie — Whenever an enchantment you control enters, put a possession " +
+            "counter on this creature."
+    }
+
+    // Eerie trigger — part 2: whenever you fully unlock a Room
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        effect = Effects.AddCounters(Counters.POSSESSION, 1, EffectTarget.Self)
+        description = "Eerie — Whenever you fully unlock a Room, put a possession counter on this " +
+            "creature."
+    }
+
+    // When this creature dies, create an X/X blue Spirit creature token with flying.
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateDynamicToken(
+            dynamicPower = DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_TOTAL_COUNTER_COUNT),
+            dynamicToughness = DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_TOTAL_COUNTER_COUNT),
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/9/0/90f6d606-55ca-4431-ae61-5d4f05259403.jpg?1726236595",
+        )
+        description = "When this creature dies, create an X/X blue Spirit creature token with " +
+            "flying, where X is the number of counters on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "81"
+        artist = "Josu Hernaiz"
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5d1758ed-fe33-4ead-8c83-e54fabcb4cfe.jpg?1726286151"
+
+        ruling("2024-09-20", "If a permanent with an eerie ability enters at the same time as one or more enchantments, its ability will trigger for each of those enchantments.")
+        ruling("2024-09-20", "An ability that triggers \"whenever you fully unlock a Room\" triggers when a door becomes unlocked and the other door of that Room is already unlocked, or when both doors of that Room become unlocked simultaneously.")
+        ruling("2024-09-20", "Use the total number of counters that were on Unwilling Vessel when it died, including all of the +1/+1 and -1/-1 counters, to determine the value of X.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -7751,6 +7751,74 @@
     ]
 }
 
+// Orphans of the Wheat
+{
+    "name": "Orphans of the Wheat",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human",
+    "oracleText": "Whenever this creature attacks, tap any number of untapped creatures you control. This creature gets +1/+1 until end of turn for each creature tapped this way.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "ControlledPermanents",
+                                "filter": "creature untapped ctrl:you"
+                            },
+                            "storeAs": "candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "candidates",
+                            "selection": "ChooseAnyNumber",
+                            "storeSelected": "tapped",
+                            "prompt": "Tap any number of untapped creatures you control",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "TapUntapCollection",
+                            "collectionName": "tapped"
+                        },
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "VariableReference",
+                                "variableName": "tapped_count"
+                            },
+                            "toughnessModifier": {
+                                "type": "VariableReference",
+                                "variableName": "tapped_count"
+                            },
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature attacks, tap any number of untapped creatures you control. This creature gets +1/+1 until end of turn for each creature tapped this way."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "UNCOMMON",
+        "artist": "Julie Dillon",
+        "flavorText": "Their only family is each other, and their only toys are those who wander too far into the fields.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ef4aab1-8bc0-4652-91d7-3e8b20b411ad.jpg?1726285941"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Osseous Sticktwister
 {
     "name": "Osseous Sticktwister",
@@ -9322,6 +9390,119 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Reluctant Role Model
+{
+    "name": "Reluctant Role Model",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Survivor",
+    "oracleText": "Survival — At the beginning of your second main phase, if this creature is tapped, put a flying, lifelink, or +1/+1 counter on it.\nWhenever this creature or another creature you control dies, if it had counters on it, put those counters on up to one target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ChooseAction",
+                    "choices": [
+                        {
+                            "label": "Flying counter",
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "flying",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "label": "Lifelink counter",
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "lifelink",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "label": "+1/+1 counter",
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "tapped"
+                },
+                "descriptionOverride": "Survival — At the beginning of your second main phase, if this creature is tapped, put a flying, lifelink, or +1/+1 counter on it."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": "MoveAllLastKnownCounters",
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "triggerCondition": "TriggeringEntityHadCounters",
+                "descriptionOverride": "Whenever this creature or another creature you control dies, if it had counters on it, put those counters on up to one target creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "26",
+        "rarity": "RARE",
+        "artist": "Chris Rallis",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4dde86d6-34a0-4b3b-a46a-d9941501d08c.jpg?1726285956",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "If Reluctant Role Model dies at the same time as one or more other creatures with counters on them, its last ability will trigger for each of those creatures."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "Reluctant Role Model's last ability doesn't cause you to move counters from the creature that died onto the target creature. Rather, you put the same number of each kind of counter the creature that died had when it died onto the target creature."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If the creature that died had -1/-1 counters on it when it died, Reluctant Role Model's last ability will include those as well. This may result in the target creature also dying."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If a creature with a survival ability isn't tapped when your second main phase begins, the ability won't trigger at all."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If a creature's survival ability triggers but that creature is untapped when the ability begins to resolve, that ability won't do anything."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -12572,6 +12753,109 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Unwilling Vessel
+{
+    "name": "Unwilling Vessel",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Vigilance\nEerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, put a possession counter on this creature.\nWhen this creature dies, create an X/X blue Spirit creature token with flying, where X is the number of counters on this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE",
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "possession",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, put a possession counter on this creature."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "possession",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, put a possession counter on this creature."
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 0,
+                    "toughness": 0,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/9/0/90f6d606-55ca-4431-ae61-5d4f05259403.jpg?1726236595",
+                    "dynamicPower": {
+                        "type": "ContextProperty",
+                        "key": "LAST_KNOWN_TOTAL_COUNTER_COUNT"
+                    },
+                    "dynamicToughness": {
+                        "type": "ContextProperty",
+                        "key": "LAST_KNOWN_TOTAL_COUNTER_COUNT"
+                    }
+                },
+                "descriptionOverride": "When this creature dies, create an X/X blue Spirit creature token with flying, where X is the number of counters on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5d1758ed-fe33-4ead-8c83-e54fabcb4cfe.jpg?1726286151",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "If a permanent with an eerie ability enters at the same time as one or more enchantments, its ability will trigger for each of those enchantments."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "An ability that triggers \"whenever you fully unlock a Room\" triggers when a door becomes unlocked and the other door of that Room is already unlocked, or when both doors of that Room become unlocked simultaneously."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "Use the total number of counters that were on Unwilling Vessel when it died, including all of the +1/+1 and -1/-1 counters, to determine the value of X."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrphansOfTheWheatScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OrphansOfTheWheatScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Orphans of the Wheat (DSK #22) — {1}{W} 2/1 Creature — Human.
+ *
+ * "Whenever this creature attacks, tap any number of untapped creatures you control. This creature
+ *  gets +1/+1 until end of turn for each creature tapped this way."
+ *
+ * The attack trigger gathers your untapped creatures, lets you tap any number of them
+ * (`SelectCardsDecision`), and pumps this creature +1/+1 per creature tapped this way — a fixed
+ * snapshot of the selection count applied until end of turn.
+ */
+class OrphansOfTheWheatScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun tapped(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Boolean =
+            game.state.getEntity(id)?.get<TappedComponent>() != null
+
+        context("Orphans of the Wheat — tap any number on attack") {
+
+            test("tapping two creatures pumps it +2/+2 and taps those creatures") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Orphans of the Wheat", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val orphans = game.findPermanent("Orphans of the Wheat")!!
+                val bear = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Orphans of the Wheat" to 2)).error shouldBe null
+
+                var guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) {
+                    game.resolveStack()
+                }
+                val decision = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision to tap creatures; got ${game.getPendingDecision()}")
+                game.submitDecision(CardsSelectedResponse(decision.id, listOf(bear, giant)))
+                game.resolveStack()
+
+                withClue("Both chosen creatures are now tapped") {
+                    tapped(game, bear) shouldBe true
+                    tapped(game, giant) shouldBe true
+                }
+                withClue("Orphans got +2/+2 (2/1 base -> 4/3)") {
+                    game.state.projectedState.getPower(orphans) shouldBe 4
+                    game.state.projectedState.getToughness(orphans) shouldBe 3
+                }
+            }
+
+            test("tapping zero creatures leaves it at its printed stats") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Orphans of the Wheat", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val orphans = game.findPermanent("Orphans of the Wheat")!!
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Orphans of the Wheat" to 2)).error shouldBe null
+
+                var guard = 0
+                while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) {
+                    game.resolveStack()
+                }
+                val decision = game.getPendingDecision() as? SelectCardsDecision
+                    ?: error("expected a SelectCardsDecision to tap creatures; got ${game.getPendingDecision()}")
+                // Choose to tap nothing.
+                game.submitDecision(CardsSelectedResponse(decision.id, emptyList()))
+                game.resolveStack()
+
+                withClue("The Bear stays untapped — nothing was tapped this way") {
+                    tapped(game, bear) shouldBe false
+                }
+                withClue("Orphans stays 2/1 — +0/+0") {
+                    game.state.projectedState.getPower(orphans) shouldBe 2
+                    game.state.projectedState.getToughness(orphans) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReluctantRoleModelScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReluctantRoleModelScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Reluctant Role Model (DSK #26) — {1}{W} 2/2 Creature — Human Survivor.
+ *
+ * "Survival — At the beginning of your second main phase, if this creature is tapped, put a
+ *  flying, lifelink, or +1/+1 counter on it.
+ *  Whenever this creature or another creature you control dies, if it had counters on it, put
+ *  those counters on up to one target creature."
+ *
+ * (a) The Survival trigger is an intervening-if postcombat-main trigger gated on the source being
+ *     tapped; the payoff is a `ChooseAction` over a flying / lifelink / +1/+1 counter.
+ * (b) The dies trigger uses `Conditions.TriggeringEntityHadCounters` + `MoveAllLastKnownCounters`
+ *     to relocate the dying creature's counters onto up to one target creature.
+ */
+class ReluctantRoleModelScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun counter(game: TestGame, id: com.wingedsheep.sdk.model.EntityId, type: CounterType): Int =
+            game.state.getEntity(id)?.get<CountersComponent>()?.getCount(type) ?: 0
+
+        context("Reluctant Role Model — Survival counter choice") {
+
+            test("tapped at second main phase lets you put a chosen +1/+1 counter on it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Reluctant Role Model", tapped = true, summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rrm = game.findPermanent("Reluctant Role Model")!!
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                var guard = 0
+                while (game.getPendingDecision() !is ChooseOptionDecision && guard++ < 20) {
+                    game.resolveStack()
+                }
+
+                val decision = game.getPendingDecision() as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision for the counter choice; got ${game.getPendingDecision()}")
+                // Options: [0]=flying, [1]=lifelink, [2]=+1/+1. Pick +1/+1.
+                game.submitDecision(OptionChosenResponse(decision.id, 2))
+                game.resolveStack()
+
+                withClue("A +1/+1 counter was placed on Reluctant Role Model") {
+                    counter(game, rrm, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+            }
+
+            test("untapped at second main phase does not trigger Survival") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Reluctant Role Model", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rrm = game.findPermanent("Reluctant Role Model")!!
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                withClue("Intervening-if (this creature is tapped) is false — no counter and no decision") {
+                    game.hasPendingDecision() shouldBe false
+                    counter(game, rrm, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 0
+                    counter(game, rrm, CounterType.FLYING) shouldBe 0
+                    counter(game, rrm, CounterType.LIFELINK) shouldBe 0
+                }
+            }
+        }
+
+        context("Reluctant Role Model — dies, move counters") {
+
+            test("when it dies with counters, they move to up to one target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Reluctant Role Model", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rrm = game.findPermanent("Reluctant Role Model")!!
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                // Stamp two +1/+1 counters (RRM becomes 4/4) so a single 3-damage bolt won't kill
+                // it — use lethal another way: give it just one counter so a 3-damage bolt kills the
+                // resulting 3/3.
+                game.state = game.state.updateEntity(rrm) {
+                    it.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+                }
+
+                game.castSpell(1, "Lightning Bolt", rrm)
+                game.resolveStack()
+
+                withClue("Reluctant Role Model is dead") {
+                    game.findPermanent("Reluctant Role Model") shouldBe null
+                }
+
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(bear))
+                    game.resolveStack()
+                }
+
+                withClue("Its +1/+1 counter moved onto the Bear") {
+                    counter(game, bear, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+            }
+
+            test("a creature that died with no counters does not trigger the move") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Reluctant Role Model", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bear = game.findPermanent("Grizzly Bears")!!
+
+                // Kill the counterless Bear (a creature you control) — intervening-if is false.
+                game.castSpell(1, "Lightning Bolt", bear)
+                game.resolveStack()
+
+                withClue("Bear is dead") { game.findPermanent("Grizzly Bears") shouldBe null }
+                withClue("No pending target decision — 'if it had counters' is false") {
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnwillingVesselScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnwillingVesselScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Unwilling Vessel (DSK #81) — {2}{U} 3/2 Creature — Human Wizard.
+ *
+ * "Vigilance
+ *  Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, put a
+ *  possession counter on this creature.
+ *  When this creature dies, create an X/X blue Spirit creature token with flying, where X is the
+ *  number of counters on this creature."
+ *
+ * (a) The Eerie enchantment-enters trigger adds a possession counter.
+ * (b) The dies trigger creates a single X/X flying Spirit token, X = the creature's total
+ *     last-known counter count.
+ */
+class UnwillingVesselScenarioTest : ScenarioTestBase() {
+
+    init {
+        fun possession(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+            game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.POSSESSION) ?: 0
+
+        context("Unwilling Vessel — Eerie possession counter") {
+
+            test("an enchantment you control entering puts a possession counter on it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Unwilling Vessel", summoningSickness = false)
+                    .withCardInHand(1, "Test Enchantment") // {1}{W}
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vessel = game.findPermanent("Unwilling Vessel")!!
+                withClue("Starts with no possession counters") { possession(game, vessel) shouldBe 0 }
+
+                game.castSpell(1, "Test Enchantment").error shouldBe null
+                game.resolveStack()
+
+                withClue("Eerie added one possession counter") { possession(game, vessel) shouldBe 1 }
+            }
+
+            test("an opponent's enchantment entering does not add a counter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Unwilling Vessel", summoningSickness = false)
+                    .withCardInHand(2, "Test Enchantment")
+                    .withLandsOnBattlefield(2, "Plains", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vessel = game.findPermanent("Unwilling Vessel")!!
+
+                game.castSpell(2, "Test Enchantment").error shouldBe null
+                game.resolveStack()
+
+                withClue("No counter — the enchantment isn't yours") { possession(game, vessel) shouldBe 0 }
+            }
+        }
+
+        context("Unwilling Vessel — dies token") {
+
+            test("dying with two counters leaves a 2/2 flying blue Spirit token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Unwilling Vessel", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vessel = game.findPermanent("Unwilling Vessel")!!
+                // Stamp two possession counters (Vessel is a 3/2; a 3-damage bolt still kills it).
+                game.state = game.state.updateEntity(vessel) {
+                    it.with(CountersComponent(mapOf(CounterType.POSSESSION to 2)))
+                }
+
+                game.castSpell(1, "Lightning Bolt", vessel)
+                game.resolveStack()
+
+                withClue("Unwilling Vessel is dead") {
+                    game.findPermanent("Unwilling Vessel") shouldBe null
+                }
+
+                val token = game.findPermanent("Spirit Token")
+                    ?: error("expected a Spirit token to be created")
+                withClue("The token is a 2/2 (X = two counters) with flying") {
+                    game.state.projectedState.getPower(token) shouldBe 2
+                    game.state.projectedState.getToughness(token) shouldBe 2
+                    game.state.projectedState.hasKeyword(token, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("dying with no counters leaves a 0/0 token that dies as a state-based action") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Unwilling Vessel", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vessel = game.findPermanent("Unwilling Vessel")!!
+
+                game.castSpell(1, "Lightning Bolt", vessel)
+                game.resolveStack()
+
+                withClue("Unwilling Vessel is dead") {
+                    game.findPermanent("Unwilling Vessel") shouldBe null
+                }
+                // A 0/0 Spirit token is created but immediately dies to state-based actions, so no
+                // Spirit token survives on the battlefield.
+                withClue("No surviving Spirit token (a 0/0 dies immediately)") {
+                    game.findPermanent("Spirit Token") shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -113,4 +113,5 @@ export const counterManaClass: Record<string, string> = {
   NEST: 'counter-fungus',
   PAGE: 'counter-lore',
   REV: 'counter-bolt',
+  POSSESSION: 'counter-devotion',
 }

--- a/web-client/src/components/game/board/shared.ts
+++ b/web-client/src/components/game/board/shared.ts
@@ -670,6 +670,7 @@ export const PASSIVE_COUNTER_TYPES: readonly CounterType[] = [
   CounterType.NEST,
   CounterType.PAGE,
   CounterType.REV,
+  CounterType.POSSESSION,
   CounterType.PLUS_ONE_PLUS_ZERO,
   CounterType.PLUS_ZERO_PLUS_ONE,
   CounterType.MINUS_ONE_MINUS_ZERO,

--- a/web-client/src/components/game/board/styles.ts
+++ b/web-client/src/components/game/board/styles.ts
@@ -1783,6 +1783,7 @@ const passiveCounterPalette: Record<string, CounterBadgePalette> = {
   NEST: { bg: 'rgba(25, 55, 25, 0.95)', border: 'rgba(120, 200, 110, 0.65)', color: '#a8e090', glow: 'rgba(120, 200, 110, 0.55)' },
   PAGE: { bg: 'rgba(35, 30, 55, 0.95)', border: 'rgba(160, 150, 220, 0.65)', color: '#bcb4e8', glow: 'rgba(160, 150, 220, 0.5)' },
   REV: { bg: 'rgba(60, 30, 15, 0.95)', border: 'rgba(230, 140, 70, 0.7)', color: '#f0b070', glow: 'rgba(230, 140, 70, 0.55)' },
+  POSSESSION: { bg: 'rgba(45, 20, 60, 0.95)', border: 'rgba(180, 110, 220, 0.7)', color: '#cda0e8', glow: 'rgba(180, 110, 220, 0.55)' },
   PLUS_ONE_PLUS_ZERO: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   PLUS_ZERO_PLUS_ONE: { bg: 'rgba(20, 60, 25, 0.95)', border: 'rgba(120, 220, 130, 0.7)', color: '#9ce0a8' },
   MINUS_ONE_MINUS_ZERO: { bg: 'rgba(60, 20, 20, 0.95)', border: 'rgba(220, 120, 120, 0.7)', color: '#e09c9c' },

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -376,6 +376,7 @@ export enum CounterType {
   NEST = 'NEST',
   PAGE = 'PAGE',
   REV = 'REV',
+  POSSESSION = 'POSSESSION',
 }
 
 export const CounterTypeDisplayNames: Record<CounterType, string> = {
@@ -428,6 +429,7 @@ export const CounterTypeDisplayNames: Record<CounterType, string> = {
   [CounterType.NEST]: 'Nest',
   [CounterType.PAGE]: 'Page',
   [CounterType.REV]: 'Rev',
+  [CounterType.POSSESSION]: 'Possession',
 }
 
 /**


### PR DESCRIPTION
Implements three of the four requested Duskmourn: House of Horror (DSK) cards and skips one that needs new engine turn-tracking infrastructure (add-feature territory). Each implemented card is canonical in DSK (its earliest printing) and has a passing scenario test.

## Cards

| Card | # | Status | Notes |
|------|---|--------|-------|
| Reluctant Role Model | 26 | ✅ Implemented | Survival postcombat-main trigger → `Effects.ChooseAction` over a flying / lifelink / +1/+1 counter; dies trigger reuses `Conditions.TriggeringEntityHadCounters` + `Effects.MoveAllLastKnownCounters` (same shape as Host of the Hereafter) to move the dying creature's counters onto up to one target creature. |
| Orphans of the Wheat | 22 | ✅ Implemented | Attack-trigger Gather → Select(`ChooseAnyNumber`) → Tap pipeline (Minas Tirith Garrison shape), then `Effects.ModifyStats` +N/+N until end of turn where N is the `tapped_count` selection snapshot. |
| Unwilling Vessel | 81 | ✅ Implemented | Vigilance + two Eerie triggers (an enchantment you control enters / a Room is fully unlocked) add a new passive `possession` counter; dies trigger creates an X/X flying blue Spirit token via `Effects.CreateDynamicToken` sized by `LAST_KNOWN_TOTAL_COUNTER_COUNT`. |
| Oblivious Bookworm | 225 | ⏭️ Skipped | The "unless a permanent entered the battlefield face down under your control this turn **or** you turned a permanent face up this turn" clause needs two new per-turn `TurnTracker`s plus engine event-counting wiring — a new SDK/engine capability (add-feature), not single-card authoring. A lookalike would drop the edge case, so it's left unimplemented rather than approximated. |

## New SDK surface
- `Counters.POSSESSION` — a passive storage counter with no inherent rule (like `nest`/`rev`/`page`), wired through the frontend passive-counter renderer (`enums.ts`, icon `counterManaClass`, `passiveCounterPalette`, `PASSIVE_COUNTER_TYPES`) and documented in `docs/card-sdk-language-reference.md`.

## Testing
- New scenario tests: `ReluctantRoleModelScenarioTest`, `OrphansOfTheWheatScenarioTest`, `UnwillingVesselScenarioTest` — all green (counter choice, dies-counter-move with/without counters, tap-any-number with 2 and 0 selections, Eerie counter accrual, dies-token sizing).
- `:mtg-sets:test` passes (CardLint + snapshot); DSK card snapshot golden re-blessed (additive only).
- `web-client` typecheck passes.
- `just check-card-printing` confirms all three are canonical in their earliest real printing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)