### PR TITLE
Add DSK cards: Norin, Toby, Ghostly Keybearer, Paranormal Analyst

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1456,6 +1456,12 @@ effect = Effects.Pipeline {
 **Special `gather` sources** (component-backed, no zone scan):
 
 - `CardSource.Self` — the ability's own source card, in whatever zone it currently sits.
+- `CardSource.TriggeringEntity` — the entity that fired the trigger (`EffectContext.triggeringEntityId`),
+  the gatherable counterpart of `EffectTarget.TriggeringEntity`. Yields a single-element collection while
+  that entity still exists (empty once it has left), so a non-targeted "it" reference can feed a
+  gather → move → grant pipeline. Backs "whenever a creature you control becomes blocked, you may exile it.
+  You may play that card from exile this turn" (Norin, Swift Survivalist): `gather(TriggeringEntity)` →
+  `exile(...)` → `GrantMayPlayFromExile(EndOfTurn)`.
 - `CardSource.TappedAsCost` — the permanents tapped to pay the activation cost.
 - `CardSource.ChosenTargets` — the spell/ability's already-resolved targets.
 - `CardSource.FromLinkedExile(count?)` — the cards in the source's linked-exile pile.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -201,6 +201,23 @@ sealed interface CardSource {
     }
 
     /**
+     * The entity that caused the trigger to fire (`EffectContext.triggeringEntityId`) — the
+     * gatherable counterpart of [com.wingedsheep.sdk.scripting.targets.EffectTarget.TriggeringEntity].
+     * Yields a single-element collection when that entity is still in play, so a non-targeted "it"
+     * reference (the blocked creature, the dying permanent, …) can feed a gather → move → grant
+     * pipeline. Restricted to entities that still exist; an entity that already left yields nothing.
+     *
+     * Backs "whenever a creature you control becomes blocked, you may exile it. You may play that
+     * card from exile this turn" (Norin, Swift Survivalist): `GatherCards(TriggeringEntity)` →
+     * `MoveCollection(EXILE)` → `GrantMayPlayFromExile(EndOfTurn)`.
+     */
+    @SerialName("TriggeringEntity")
+    @Serializable
+    data object TriggeringEntity : CardSource {
+        override val description: String = "it"
+    }
+
+    /**
      * The creatures that were blocking, or blocked by, the effect's source at the moment the
      * source last left the battlefield (CR 509 combat pairing, captured as last-known
      * information). Resolves to those creatures that are still on the battlefield.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/NorinSwiftSurvivalist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/NorinSwiftSurvivalist.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+
+/**
+ * Norin, Swift Survivalist
+ * {R}
+ * Legendary Creature — Human Coward
+ * 2/1
+ * Norin can't block.
+ * Whenever a creature you control becomes blocked, you may exile it. You may play that card
+ * from exile this turn.
+ *
+ * "Can't block" is the [CantBlock] combat static on the source. The blocked-creature trigger uses
+ * the ANY-binding `becomesBlocked` factory filtered to creatures you control (same shape as
+ * Gustcloak Savior). The optional effect is a gather → exile → grant pipeline over
+ * [CardSource.TriggeringEntity] ("it" = the just-blocked creature), granting play-from-exile
+ * permission only until end of turn ([MayPlayExpiry.EndOfTurn]) — playing it still costs its mana.
+ */
+val NorinSwiftSurvivalist = card("Norin, Swift Survivalist") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Coward"
+    power = 2
+    toughness = 1
+    oracleText = "Norin can't block.\n" +
+        "Whenever a creature you control becomes blocked, you may exile it. You may play that " +
+        "card from exile this turn."
+
+    staticAbility {
+        ability = CantBlock()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.becomesBlocked(
+            filter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = MayEffect(
+            Effects.Composite(listOf(
+                GatherCardsEffect(
+                    source = CardSource.TriggeringEntity,
+                    storeAs = "exiledBlockedCreature",
+                ),
+                MoveCollectionEffect(
+                    from = "exiledBlockedCreature",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                ),
+                GrantMayPlayFromExileEffect("exiledBlockedCreature", MayPlayExpiry.EndOfTurn),
+            ))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "145"
+        artist = "Yigit Koroglu"
+        flavorText = "\"I don't know what it was! Why would I stick around to find out?\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/49f0fdf4-3881-4327-924f-2c1b67ccda93.jpg?1726286390"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -7454,6 +7454,69 @@
     ]
 }
 
+// Norin, Swift Survivalist
+{
+    "name": "Norin, Swift Survivalist",
+    "manaCost": "{R}",
+    "typeLine": "Legendary Creature — Human Coward",
+    "oracleText": "Norin can't block.\nWhenever a creature you control becomes blocked, you may exile it. You may play that card from exile this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesBlockedEvent",
+                    "filter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "TriggeringEntity",
+                                "storeAs": "exiledBlockedCreature"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "exiledBlockedCreature",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            },
+                            {
+                                "type": "GrantMayPlayFromExile",
+                                "from": "exiledBlockedCreature"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "145",
+        "rarity": "UNCOMMON",
+        "artist": "Yigit Koroglu",
+        "flavorText": "\"I don't know what it was! Why would I stick around to find out?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/49f0fdf4-3881-4327-924f-2c1b67ccda93.jpg?1726286390"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Nowhere to Run
 {
     "name": "Nowhere to Run",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -195,6 +195,18 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
                 if (state.getEntity(sourceId) != null) listOf(sourceId) else emptyList()
             }
 
+            is CardSource.TriggeringEntity -> {
+                // The entity that fired the trigger ("it"); single-element when still in play.
+                // Mirrors EffectTarget.TriggeringEntity for non-targeted gather → move pipelines
+                // (Norin, Swift Survivalist: exile the just-blocked creature you control).
+                val triggeringId = context.triggeringEntityId
+                if (triggeringId != null && state.getEntity(triggeringId) != null) {
+                    listOf(triggeringId)
+                } else {
+                    emptyList()
+                }
+            }
+
             is CardSource.LastKnownCombatPairedWithSource -> {
                 // CR 509 combat pairing captured when the source left the battlefield. Restrict
                 // to creatures still on the battlefield — a creature that already left can't be

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NorinSwiftSurvivalistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NorinSwiftSurvivalistScenarioTest.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.DeclareBlockers
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.combat.BlockedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Norin, Swift Survivalist (DSK #145) — {R} Legendary Creature — Human Coward, 2/1.
+ *
+ *   "Norin can't block.
+ *    Whenever a creature you control becomes blocked, you may exile it. You may play that card
+ *    from exile this turn."
+ *
+ * Exercises (a) the [com.wingedsheep.sdk.scripting.CantBlock] combat static, and (b) the
+ * ANY-binding becomes-blocked trigger feeding a gather → exile → grant pipeline over the new
+ * [com.wingedsheep.sdk.scripting.effects.CardSource.TriggeringEntity] source, with an
+ * end-of-turn play-from-exile permission.
+ */
+class NorinSwiftSurvivalistScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+        return driver
+    }
+
+    test("accepting the trigger exiles the blocked creature and lets you play it this turn") {
+        val driver = createDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val norin = driver.putCreatureOnBattlefield(attacker, "Norin, Swift Survivalist")
+        driver.removeSummoningSickness(norin)
+
+        val attackingCreature = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(attackingCreature)
+
+        val blocker = driver.putCreatureOnBattlefield(defender, "Centaur Courser")
+        driver.removeSummoningSickness(blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(attackingCreature), defender)
+        driver.bothPass()
+
+        // Defender blocks the Grizzly Bears → Norin's trigger fires.
+        driver.declareBlockers(defender, mapOf(blocker to listOf(attackingCreature)))
+        driver.bothPass() // pass priority so the trigger resolves
+        driver.submitYesNo(attacker, true) // "you may exile it" → yes
+
+        // Grizzly Bears is exiled (no longer on the battlefield, no combat components) and the
+        // owner has permission to play it from exile.
+        driver.findPermanent(attacker, "Grizzly Bears") shouldBe null
+        driver.state.getEntity(attackingCreature)?.has<AttackingComponent>() shouldBe false
+        driver.state.getEntity(attackingCreature)?.has<BlockedComponent>() shouldBe false
+
+        val exiled = driver.getExile(attacker).single()
+        driver.getExileCardNames(attacker) shouldBe listOf("Grizzly Bears")
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds } shouldBe true
+
+        // No combat damage dealt — the attacker left combat before damage.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.assertLifeTotal(defender, 20)
+        driver.findPermanent(defender, "Centaur Courser") shouldNotBe null
+    }
+
+    test("declining the trigger leaves the creature in combat") {
+        val driver = createDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val norin = driver.putCreatureOnBattlefield(attacker, "Norin, Swift Survivalist")
+        driver.removeSummoningSickness(norin)
+
+        val attackingCreature = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(attackingCreature)
+
+        val blocker = driver.putCreatureOnBattlefield(defender, "Centaur Courser")
+        driver.removeSummoningSickness(blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(attackingCreature), defender)
+        driver.bothPass()
+
+        driver.declareBlockers(defender, mapOf(blocker to listOf(attackingCreature)))
+        driver.bothPass()
+        driver.submitYesNo(attacker, false) // decline the exile
+
+        // Grizzly Bears stays in combat; nothing is exiled.
+        driver.getExile(attacker) shouldBe emptyList()
+        driver.state.getEntity(attackingCreature)?.has<AttackingComponent>() shouldBe true
+
+        // 3/3 Centaur Courser trades with / kills the 2/2 Grizzly Bears in combat.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.findPermanent(attacker, "Grizzly Bears") shouldBe null
+        driver.findPermanent(defender, "Centaur Courser") shouldNotBe null
+    }
+
+    test("Norin can't block") {
+        val driver = createDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        // Active player swings with a Grizzly Bears; defender controls Norin.
+        val norin = driver.putCreatureOnBattlefield(defender, "Norin, Swift Survivalist")
+        driver.removeSummoningSickness(norin)
+        val attackingCreature = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(attackingCreature)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(attackingCreature), defender)
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // Declaring Norin as a blocker is illegal ("Norin can't block").
+        driver.submitExpectFailure(
+            DeclareBlockers(defender, mapOf(norin to listOf(attackingCreature)))
+        )
+    }
+})


### PR DESCRIPTION
Implements DSK cards requested, one at a time via the add-card flow. One card was implementable with existing primitives (plus one tiny, general SDK addition); the other three each require a substantially larger new engine/SDK capability and were left for the add-feature skill.

## Implemented

- **Norin, Swift Survivalist** ({R} Legendary Creature — Human Coward, 2/1) ✅
  - "Norin can't block" → `CantBlock` combat static.
  - "Whenever a creature you control becomes blocked, you may exile it. You may play that card from exile this turn." → ANY-binding `becomesBlocked(youControl)` trigger feeding a `gather → exile → GrantMayPlayFromExile(EndOfTurn)` pipeline (faithful end-of-turn permission, not the permanent owner-permission of `ExileAndGrantOwnerPlayPermission`).
  - New SDK primitive: `CardSource.TriggeringEntity` — the gatherable counterpart of the existing `EffectTarget.TriggeringEntity`, so a non-targeted "it" reference can feed a gather/move/grant pipeline. ~15 LOC, purely additive (one data object + one `GatherCardsExecutor` branch), SDK reference updated.
  - Scenario test covers: accept (exile + play-this-turn permission), decline (stays in combat), and "can't block".

## Skipped (need add-feature, not single-card authoring)

- **Toby, Beastie Befriender** ⛔ — The ETB token has "This token can't attack or block alone." Only "can't attack alone" exists (`CantAttackUnlessCoAttacker`); there is **no "can't block alone" co-blocker combat restriction**. Adding one is a combat-legality subsystem change. (The conditional token-flying lord half is supported.)
- **Ghostly Keybearer** ⛔ — "Unlock a locked door of up to one target Room you control" needs a **resolution-time unlock-door effect** (new Effect + executor). Only the pay-cost `UnlockRoomDoor` special action exists; all "unlock" SDK surface today is triggers/cost-modifiers reacting to unlocks, not an effect that performs one.
- **Paranormal Analyst** ⛔ — "Whenever you manifest dread, put a card you put into your graveyard this way into your hand" needs a **"you manifest dread" trigger event** (none is emitted by the manifest-dread pipeline) plus threading the milled graveyard card into a reflexive to-hand effect.

## Validation

- `:rules-engine:test --tests NorinSwiftSurvivalistScenarioTest` — 3/3 pass.
- `:mtg-sets:test` — CardLintTest, FacadeBoundaryTest, CardDefinitionSnapshotTest all pass; DSK snapshot re-blessed (Norin-only, 63 insertions, no other card moved).
- Full-repo `compileKotlin`/`compileTestKotlin` green (new sealed `CardSource` subtype handled everywhere it's matched).
- `check-card-printing "Norin, Swift Survivalist"` — canonical correctly placed in DSK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)