### PR TITLE
Add unary numeric-predicate condition (prime/even/odd/multiple) + Zimone, All-Questioning

### DIFF
--- a/backlog/dsk-engine-gaps.md
+++ b/backlog/dsk-engine-gaps.md
@@ -177,11 +177,14 @@ to a **player** that have no home yet.
     → **Toby, Beastie Befriender** (its Beast token "can't attack or block alone" — the attack half
       already maps to `CantAttackUnlessCoAttacker`).
 
-12. **Prime-number count condition.** All count conditions are threshold comparisons
-    (`AtLeast`/`AtMost`/`Exactly`). Needs a numeric-predicate condition (e.g. `CountIsPrime(filter)`
-    or a general `NumericPredicate` over a count). The "make a Fractal with X +1/+1 counters where
-    X = land count" half is already buildable.
-    → **Zimone, All-Questioning**.
+12. **Prime-number count condition.** ✅ **Done.** Added the unary numeric-predicate condition
+    `NumberMatches(amount, NumberProperty.{Prime,Even,Odd,MultipleOf})` (facades
+    `Conditions.AmountIsPrime/Even/Odd/MultipleOf`) — the counterpart to the threshold-only `Compare`
+    family. The arithmetic lives in `ConditionEvaluator` so `NumberProperty` stays pure data
+    (mirroring `ComparisonOperator`); dual-mode (resolution + projection). The "make a Fractal with X
+    +1/+1 counters where X = land count" half composes the existing `CREATED_TOKENS` +
+    `AddDynamicCounters(PipelineTarget)` shape.
+    → **Zimone, All-Questioning** (implemented).
 
 13. **Opponent routes the caster's chosen targets.** The caster targets two creatures one opponent
     controls; *that opponent* then chooses which takes 5 damage and which can't block. This differs

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3783,6 +3783,15 @@ answer it and would silently return `false`.
   entry point for any "if amount X (relation) amount Y" intervening-if or static gate. Used by Taii
   Wakeen, Perfect Shot's intervening-if: `CompareAmounts(ContextProperty(TRIGGER_DAMAGE_AMOUNT), EQ,
   ContextProperty(TRIGGER_RECIPIENT_TOUGHNESS))`.
+- `AmountIsPrime(amount)` / `AmountIsEven(amount)` / `AmountIsOdd(amount)` /
+  `AmountIsMultipleOf(amount, divisor)` — the **unary** numeric-predicate family, the counterpart to
+  `CompareAmounts` for properties a two-sided threshold can't express (primality, parity,
+  divisibility). Each desugars to `NumberMatches(amount, NumberProperty.{Prime,Even,Odd,MultipleOf})`;
+  the arithmetic lives in the engine's `ConditionEvaluator` (the SDK `NumberProperty` is pure data,
+  exactly like `ComparisonOperator`). Dual-mode (resolution + projection), so it gates either a
+  triggered ability's intervening-if or an "as long as" static. `0` and `1` are not prime; `0` is
+  even and a multiple of every nonzero divisor. Used by Zimone, All-Questioning ("if … you control a
+  prime number of lands": `AmountIsPrime(AggregateBattlefield(You, Land))`).
 - `DifferentCounterKindsAtLeast(count, filter = Creature)` — true when `count` or more *different
   kinds* of counters are among permanents you control matching `filter` (default: creatures). A
   +1/+1 and a finality counter is two kinds; the same kind on several permanents counts once.
@@ -4154,6 +4163,8 @@ default to "you" so card authors don't need to pass it explicitly.
 - `Any(c1, c2, ...)` — OR.
 - `Not(c)` — negate.
 - `Compare(v1, op, v2)` — numeric comparison between `DynamicAmount`s.
+- `NumberMatches(amount, NumberProperty.{Prime,Even,Odd,MultipleOf(n)})` — unary numeric predicate
+  over one `DynamicAmount` (primality/parity/divisibility); facades `AmountIsPrime/Even/Odd/MultipleOf`.
 - `Exists(player, zone, filter)` — at least one matching object exists.
 
 To gate a spell-cost reduction on a condition, use `CostGating.OnlyIf(condition)` on the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -14,6 +14,8 @@ import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
 import com.wingedsheep.sdk.scripting.conditions.Exists
 import com.wingedsheep.sdk.scripting.conditions.NotCondition
+import com.wingedsheep.sdk.scripting.conditions.NumberMatches
+import com.wingedsheep.sdk.scripting.conditions.NumberProperty
 import com.wingedsheep.sdk.scripting.conditions.WasCast as WasCastCondition
 import com.wingedsheep.sdk.scripting.conditions.NoManaSpentToCast as NoManaSpentToCastCondition
 import com.wingedsheep.sdk.scripting.conditions.NoManaSpentToCastEntered as NoManaSpentToCastEnteredCondition
@@ -111,6 +113,28 @@ object Conditions {
         operator: ComparisonOperator,
         right: DynamicAmount,
     ): ConditionInterface = Compare(left, operator, right)
+
+    /**
+     * If [amount] is a prime number (2, 3, 5, 7, …). 0 and 1 are not prime.
+     *
+     * The unary counterpart to [CompareAmounts] — used for "if you control a prime number of
+     * lands" (Zimone, All-Questioning). Compose the count with any [DynamicAmount], e.g.
+     * `Conditions.AmountIsPrime(DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land))`.
+     */
+    fun AmountIsPrime(amount: DynamicAmount): ConditionInterface =
+        NumberMatches(amount, NumberProperty.Prime)
+
+    /** If [amount] is even (0 counts as even). */
+    fun AmountIsEven(amount: DynamicAmount): ConditionInterface =
+        NumberMatches(amount, NumberProperty.Even)
+
+    /** If [amount] is odd. */
+    fun AmountIsOdd(amount: DynamicAmount): ConditionInterface =
+        NumberMatches(amount, NumberProperty.Odd)
+
+    /** If [amount] is a multiple of [divisor] (must be non-zero). */
+    fun AmountIsMultipleOf(amount: DynamicAmount, divisor: Int): ConditionInterface =
+        NumberMatches(amount, NumberProperty.MultipleOf(divisor))
 
     /**
      * If an opponent controls more lands than you.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
@@ -105,6 +105,78 @@ data class Compare(
 }
 
 /**
+ * A unary arithmetic property a single number can satisfy, tested by [NumberMatches].
+ *
+ * Distinct from [ComparisonOperator], which is *binary* (compares two amounts). These are
+ * *unary* predicates over one evaluated [DynamicAmount] — "is the count prime / even / odd /
+ * a multiple of N" — shapes a threshold comparison can't express. The arithmetic itself lives
+ * in the engine's `ConditionEvaluator` (these stay pure data, mirroring how `ComparisonOperator`
+ * carries no comparison logic), so this type only names the property and supplies its wording.
+ */
+@Serializable
+sealed interface NumberProperty {
+    /** Adjective phrase for condition descriptions, e.g. "prime", "even", "a multiple of 3". */
+    val description: String
+
+    /** A prime number (CR has no notion of this — it's a card-defined property; 0 and 1 are not prime). */
+    @SerialName("Prime")
+    @Serializable
+    data object Prime : NumberProperty {
+        override val description: String get() = "prime"
+    }
+
+    /** An even number (0 is even). */
+    @SerialName("Even")
+    @Serializable
+    data object Even : NumberProperty {
+        override val description: String get() = "even"
+    }
+
+    /** An odd number. */
+    @SerialName("Odd")
+    @Serializable
+    data object Odd : NumberProperty {
+        override val description: String get() = "odd"
+    }
+
+    /** A multiple of [divisor] (0 counts as a multiple of every nonzero divisor). */
+    @SerialName("MultipleOf")
+    @Serializable
+    data class MultipleOf(val divisor: Int) : NumberProperty {
+        init { require(divisor != 0) { "MultipleOf divisor must be non-zero" } }
+        override val description: String get() = "a multiple of $divisor"
+    }
+}
+
+/**
+ * Unary numeric-predicate condition: evaluates [amount] and tests whether the resulting number
+ * satisfies [property].
+ *
+ * The counterpart to [Compare] for properties that aren't a two-sided threshold — primality,
+ * parity, divisibility. Like [Compare] it evaluates identically at resolution and under
+ * projection, so it can gate either a triggered ability's intervening-if or an "as long as"
+ * static ability.
+ *
+ * Example:
+ * ```kotlin
+ * // "you control a prime number of lands" (Zimone, All-Questioning)
+ * NumberMatches(AggregateBattlefield(Player.You, GameObjectFilter.Land), NumberProperty.Prime)
+ * ```
+ */
+@SerialName("NumberMatches")
+@Serializable
+data class NumberMatches(
+    val amount: DynamicAmount,
+    val property: NumberProperty
+) : Condition {
+    override val description: String = "${amount.description} is ${property.description}"
+    override fun applyTextReplacement(replacer: TextReplacer): Condition {
+        val newAmount = amount.applyTextReplacement(replacer)
+        return if (newAmount !== amount) copy(amount = newAmount) else this
+    }
+}
+
+/**
  * Generic zone-presence condition.
  * Checks whether any matching object exists in a player's zone.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ZimoneAllQuestioning.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ZimoneAllQuestioning.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Zimone, All-Questioning
+ * {1}{G}{U}
+ * Legendary Creature — Human Wizard
+ * 1/1
+ *
+ * At the beginning of your end step, if a land entered the battlefield under your control this turn
+ * and you control a prime number of lands, create Primo, the Indivisible, a legendary 0/0 green and
+ * blue Fractal creature token, then put that many +1/+1 counters on it.
+ *
+ * The "prime number of lands" gate is the engine's new unary numeric-predicate condition,
+ * [Conditions.AmountIsPrime], over `AggregateBattlefield(You, Land)` — the counterpart to the
+ * threshold-only `Compare` family. The "a land entered this turn" half reuses the existing
+ * `LANDS_ENTERED_UNDER_CONTROL` turn tracker (≥ 1), and the two are ANDed as the intervening-if
+ * (re-checked at resolution per CR 603.4 — if you no longer control a prime number of lands when
+ * the ability resolves, it does nothing).
+ *
+ * The token half is a pure composition: a named legendary 0/0 GU Fractal is created and published
+ * to the [CREATED_TOKENS] pipeline collection, then "that many" (= the prime land count) +1/+1
+ * counters land on exactly that token via `PipelineTarget(CREATED_TOKENS, 0)` — the same shape as
+ * Wild Hypothesis / Applied Geometry.
+ */
+val ZimoneAllQuestioning = card("Zimone, All-Questioning") {
+    manaCost = "{1}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "At the beginning of your end step, if a land entered the battlefield under your " +
+        "control this turn and you control a prime number of lands, create Primo, the Indivisible, " +
+        "a legendary 0/0 green and blue Fractal creature token, then put that many +1/+1 counters " +
+        "on it. (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, and 31 are prime numbers.)"
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.All(
+            // "a land entered the battlefield under your control this turn"
+            Conditions.CompareAmounts(
+                DynamicAmounts.landsEnteredUnderControlThisTurn(Player.You),
+                com.wingedsheep.sdk.scripting.conditions.ComparisonOperator.GTE,
+                DynamicAmount.Fixed(1),
+            ),
+            // "and you control a prime number of lands"
+            Conditions.AmountIsPrime(
+                DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land),
+            ),
+        )
+        effect = CreateTokenEffect(
+            count = DynamicAmount.Fixed(1),
+            power = 0,
+            toughness = 0,
+            colors = setOf(Color.GREEN, Color.BLUE),
+            creatureTypes = setOf("Fractal"),
+            name = "Primo, the Indivisible",
+            legendary = true,
+            imageUri = "https://cards.scryfall.io/normal/front/c/9/c990db6b-e1f2-4802-b8b1-80a8b768be0e.jpg?1775827823",
+        ).then(
+            Effects.AddDynamicCounters(
+                Counters.PLUS_ONE_PLUS_ONE,
+                DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land),
+                EffectTarget.PipelineTarget(CREATED_TOKENS, 0),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "241"
+        artist = "Ekaterina Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/7722f4f7-fe38-4107-a715-7b27b6a4e341.jpg?1726597486"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -13504,3 +13504,97 @@
         "BLACK"
     ]
 }
+
+// Zimone, All-Questioning
+{
+    "name": "Zimone, All-Questioning",
+    "manaCost": "{1}{G}{U}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "At the beginning of your end step, if a land entered the battlefield under your control this turn and you control a prime number of lands, create Primo, the Indivisible, a legendary 0/0 green and blue Fractal creature token, then put that many +1/+1 counters on it. (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, and 31 are prime numbers.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 0,
+                            "toughness": 0,
+                            "colors": [
+                                "GREEN",
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Fractal"
+                            ],
+                            "name": "Primo, the Indivisible",
+                            "imageUri": "https://cards.scryfall.io/normal/front/c/9/c990db6b-e1f2-4802-b8b1-80a8b768be0e.jpg?1775827823",
+                            "legendary": true
+                        },
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "land"
+                            },
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "All",
+                    "conditions": [
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "TurnTracking",
+                                "player": "You",
+                                "tracker": "LANDS_ENTERED_UNDER_CONTROL"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "NumberMatches",
+                            "amount": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": "land"
+                            },
+                            "property": "Prime"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "RARE",
+        "artist": "Ekaterina Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/7722f4f7-fe38-4107-a715-7b27b6a4e341.jpg?1726597486"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -49,6 +49,8 @@ import com.wingedsheep.sdk.scripting.conditions.AllConditions
 import com.wingedsheep.sdk.scripting.conditions.AnyCondition
 import com.wingedsheep.sdk.scripting.conditions.APlayerLifeAtMost
 import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.NumberMatches
+import com.wingedsheep.sdk.scripting.conditions.NumberProperty
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureHasSubtype
@@ -176,6 +178,7 @@ class ConditionEvaluator(
             // Dual-mode primitives (work in both resolution and projection)
             // ============================================================
             is Compare -> evaluateCompareCtx(state, condition, ctx)
+            is NumberMatches -> evaluateNumberMatchesCtx(state, condition, ctx)
             is Exists -> evaluateExistsCtx(state, condition, ctx)
 
             // CR 805 — "your turn" is the active team's turn for every member of that team.
@@ -451,6 +454,43 @@ class ConditionEvaluator(
             ComparisonOperator.GT -> left > right
             ComparisonOperator.GTE -> left >= right
         }
+    }
+
+    /**
+     * Evaluates [NumberMatches] in both resolution and projection: resolves the amount via the
+     * same effect-context plumbing as [evaluateCompareCtx], then applies the unary numeric
+     * predicate. The arithmetic lives here (not on the SDK type) so [NumberProperty] stays pure
+     * data, mirroring how [ComparisonOperator]'s comparison logic lives in [evaluateCompareCtx].
+     */
+    private fun evaluateNumberMatchesCtx(
+        state: GameState,
+        condition: NumberMatches,
+        ctx: ConditionEvaluationContext
+    ): Boolean {
+        val effectCtx = when (ctx) {
+            is Resolution -> ctx.effectContext
+            is Projection -> syntheticEffectContext(state, ctx) ?: return false
+        }
+        val value = dynamicAmountEvaluator.evaluate(state, condition.amount, effectCtx)
+        return when (val property = condition.property) {
+            NumberProperty.Prime -> isPrime(value)
+            NumberProperty.Even -> value % 2 == 0
+            NumberProperty.Odd -> value % 2 != 0
+            is NumberProperty.MultipleOf -> property.divisor != 0 && value % property.divisor == 0
+        }
+    }
+
+    /** Standard primality test: 0 and 1 are not prime; 2 is the only even prime (CR-agnostic). */
+    private fun isPrime(n: Int): Boolean {
+        if (n < 2) return false
+        if (n < 4) return true
+        if (n % 2 == 0) return false
+        var d = 3
+        while (d.toLong() * d <= n) {
+            if (n % d == 0) return false
+            d += 2
+        }
+        return true
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NumberMatchesConditionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NumberMatchesConditionTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.conditions.NumberMatches
+import com.wingedsheep.sdk.scripting.conditions.NumberProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit coverage for the unary numeric-predicate condition `NumberMatches(amount, property)`.
+ * Drives the evaluator over a `DynamicAmount.Fixed(n)` so each [NumberProperty] arithmetic branch
+ * (prime / even / odd / multiple-of) is pinned independently of any card. The prime edge cases
+ * (0 and 1 are not prime; 2 is the smallest prime) back the Zimone ruling.
+ */
+class NumberMatchesConditionTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 20), skipMulligans = true)
+        return d
+    }
+
+    fun GameTestDriver.eval(n: Int, property: NumberProperty): Boolean {
+        val context = EffectContext(sourceId = null, controllerId = activePlayer!!, xValue = 0)
+        return ConditionEvaluator().evaluate(state, NumberMatches(DynamicAmount.Fixed(n), property), context)
+    }
+
+    test("Prime: 0 and 1 are not prime; 2, 3, 5, 7, 11 are; 4, 6, 9 are not") {
+        val d = driver()
+        d.eval(0, NumberProperty.Prime) shouldBe false
+        d.eval(1, NumberProperty.Prime) shouldBe false
+        d.eval(2, NumberProperty.Prime) shouldBe true
+        d.eval(3, NumberProperty.Prime) shouldBe true
+        d.eval(4, NumberProperty.Prime) shouldBe false
+        d.eval(5, NumberProperty.Prime) shouldBe true
+        d.eval(6, NumberProperty.Prime) shouldBe false
+        d.eval(7, NumberProperty.Prime) shouldBe true
+        d.eval(9, NumberProperty.Prime) shouldBe false
+        d.eval(11, NumberProperty.Prime) shouldBe true
+        d.eval(25, NumberProperty.Prime) shouldBe false // 5*5 — past the early-prime shortcut
+        d.eval(31, NumberProperty.Prime) shouldBe true
+    }
+
+    test("Even: 0 is even; parity alternates") {
+        val d = driver()
+        d.eval(0, NumberProperty.Even) shouldBe true
+        d.eval(1, NumberProperty.Even) shouldBe false
+        d.eval(2, NumberProperty.Even) shouldBe true
+        d.eval(7, NumberProperty.Even) shouldBe false
+    }
+
+    test("Odd: complement of Even") {
+        val d = driver()
+        d.eval(0, NumberProperty.Odd) shouldBe false
+        d.eval(1, NumberProperty.Odd) shouldBe true
+        d.eval(2, NumberProperty.Odd) shouldBe false
+        d.eval(7, NumberProperty.Odd) shouldBe true
+    }
+
+    test("MultipleOf: divisibility, with 0 a multiple of everything") {
+        val d = driver()
+        d.eval(0, NumberProperty.MultipleOf(3)) shouldBe true
+        d.eval(3, NumberProperty.MultipleOf(3)) shouldBe true
+        d.eval(6, NumberProperty.MultipleOf(3)) shouldBe true
+        d.eval(4, NumberProperty.MultipleOf(3)) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZimoneAllQuestioningTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZimoneAllQuestioningTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.ZimoneAllQuestioning
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Zimone, All-Questioning ({1}{G}{U}, 1/1):
+ * "At the beginning of your end step, if a land entered the battlefield under your control this
+ *  turn and you control a prime number of lands, create Primo, the Indivisible, a legendary 0/0
+ *  green and blue Fractal creature token, then put that many +1/+1 counters on it."
+ *
+ * Exercises the new unary numeric-predicate condition `NumberMatches(amount, NumberProperty.Prime)`
+ * (`Conditions.AmountIsPrime`) as the prime half of the trigger's intervening-if, ANDed with the
+ * existing `LANDS_ENTERED_UNDER_CONTROL` tracker. Every clause of the oracle + the "1 is not prime"
+ * ruling has a paired assertion:
+ *  - prime count + land entered → Primo with `count` +1/+1 counters,
+ *  - non-prime count → no token,
+ *  - no land entered this turn → trigger doesn't fire even at a prime count,
+ *  - 1 land (entered) → not prime, no token,
+ *  - 2 lands (smallest prime) → Primo with two counters.
+ *
+ * `putLandOnBattlefield` adds lands without firing the entry tracker, so only the single land
+ * played via `playLand` counts as "entered this turn" — letting each test pin the land count and
+ * the entered-this-turn flag independently.
+ */
+class ZimoneAllQuestioningTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(ZimoneAllQuestioning)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun advanceToEndStep(d: GameTestDriver, me: EntityId) {
+        d.passPriorityUntil(Step.END, maxPasses = 300)
+        d.activePlayer shouldBe me
+        d.currentStep shouldBe Step.END
+    }
+
+    /** Plays one Forest from hand this turn (records the entered-this-turn tracker). */
+    fun playOneLand(d: GameTestDriver, me: EntityId) {
+        val forest = d.putCardInHand(me, "Forest")
+        d.playLand(me, forest)
+    }
+
+    fun primoCounters(d: GameTestDriver, me: EntityId): Int? {
+        val primo = d.findPermanent(me, "Primo, the Indivisible") ?: return null
+        return d.state.getEntity(primo)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    test("prime land count (5) with a land entered this turn: create Primo with five +1/+1 counters") {
+        val d = driver()
+        val me = d.activePlayer!!
+        d.putCreatureOnBattlefield(me, ZimoneAllQuestioning.name)
+        repeat(4) { d.putLandOnBattlefield(me, "Forest") } // 4 pre-placed (not "entered this turn")
+        playOneLand(d, me)                                  // +1 played → 5 lands, entered this turn
+
+        advanceToEndStep(d, me)
+        d.bothPass() // resolve the end-step trigger
+
+        primoCounters(d, me) shouldBe 5
+        // 0/0 base + five +1/+1 counters = 5/5, and it is the only Primo (legendary, named token).
+        val primo = d.findPermanent(me, "Primo, the Indivisible")!!
+        d.state.projectedState.getPower(primo) shouldBe 5
+        d.state.projectedState.getToughness(primo) shouldBe 5
+    }
+
+    test("non-prime land count (4): the prime gate fails, no token") {
+        val d = driver()
+        val me = d.activePlayer!!
+        d.putCreatureOnBattlefield(me, ZimoneAllQuestioning.name)
+        repeat(3) { d.putLandOnBattlefield(me, "Forest") }
+        playOneLand(d, me) // 4 lands total, entered this turn
+
+        advanceToEndStep(d, me)
+        d.bothPass()
+
+        d.findPermanent(me, "Primo, the Indivisible") shouldBe null
+    }
+
+    test("prime land count (5) but no land entered this turn: trigger does not fire") {
+        val d = driver()
+        val me = d.activePlayer!!
+        d.putCreatureOnBattlefield(me, ZimoneAllQuestioning.name)
+        repeat(5) { d.putLandOnBattlefield(me, "Forest") } // 5 lands, none "entered this turn"
+
+        advanceToEndStep(d, me)
+        d.bothPass()
+
+        d.findPermanent(me, "Primo, the Indivisible") shouldBe null
+    }
+
+    test("1 land that entered this turn: 1 is not prime, so no token") {
+        val d = driver()
+        val me = d.activePlayer!!
+        d.putCreatureOnBattlefield(me, ZimoneAllQuestioning.name)
+        playOneLand(d, me) // exactly 1 land, entered this turn
+
+        advanceToEndStep(d, me)
+        d.bothPass()
+
+        d.findPermanent(me, "Primo, the Indivisible") shouldBe null
+    }
+
+    test("2 lands (smallest prime) with a land entered: Primo with two +1/+1 counters") {
+        val d = driver()
+        val me = d.activePlayer!!
+        d.putCreatureOnBattlefield(me, ZimoneAllQuestioning.name)
+        d.putLandOnBattlefield(me, "Forest")
+        playOneLand(d, me) // 2 lands total, entered this turn
+
+        advanceToEndStep(d, me)
+        d.bothPass()
+
+        primoCounters(d, me) shouldBe 2
+    }
+})


### PR DESCRIPTION
Closes **DSK engine gap #12** (`backlog/dsk-engine-gaps.md`). All count conditions in the engine were threshold comparisons (`AtLeast`/`AtMost`/`Exactly` over `Compare`); **Zimone, All-Questioning** needs *"you control a prime number of lands"* — a unary predicate over a count, which the two-sided `Compare` family cannot express.

## What's new

**SDK**
- `NumberMatches(amount: DynamicAmount, property: NumberProperty)` condition + sealed `NumberProperty.{Prime, Even, Odd, MultipleOf(divisor)}`. `NumberProperty` is **pure data** (carries only its wording) — the arithmetic lives in the engine, exactly like `ComparisonOperator` keeps its comparison logic in `evaluateCompareCtx`.
- DSL facades: `Conditions.AmountIsPrime / AmountIsEven / AmountIsOdd / AmountIsMultipleOf`.
- Designed for the next card, not just Zimone: parity and divisibility ride the same primitive.

**Engine**
- `ConditionEvaluator.evaluateNumberMatchesCtx` — **dual-mode** (resolution + projection, via the same effect-context plumbing as `Compare`), so the condition gates a triggered ability's intervening-if *or* an "as long as" static identically. Standard `isPrime` helper (0/1 not prime).

**Card**
- **Zimone, All-Questioning** (DSK 241). The end-step token half is a pure composition — a named legendary 0/0 GU Fractal published to `CREATED_TOKENS`, then `AddDynamicCounters(PipelineTarget(CREATED_TOKENS, 0))` puts *that many* (= the prime land count) +1/+1 counters on it (same shape as Wild Hypothesis / Applied Geometry). The *"a land entered this turn"* clause reuses the existing `LANDS_ENTERED_UNDER_CONTROL` tracker; the two are ANDed as the intervening-if (re-checked at resolution per CR 603.4).

## Tests
- `NumberMatchesConditionTest` — pins each arithmetic branch (prime/even/odd/multiple) and the rulings' edge cases (0 and 1 are not prime; 2 is the smallest prime; 25 past the early-prime shortcut).
- `ZimoneAllQuestioningTest` — full card through `GameTestDriver`: prime count + land entered → Primo with N counters (and 5/5 projected P/T); non-prime → no token; prime but no land entered → trigger doesn't fire; 1 land → not prime, no token; 2 lands → Primo with two counters.
- Docs (`card-sdk-language-reference.md`) + DSK snapshot golden updated. `mtg-sdk`, `mtg-sets` (snapshot + lint), and full `rules-engine` suites green.

**mtgish (Step 8b):** no-op — primality has no mtgish IR tag and Zimone isn't in the corpus, so there is nothing to bridge or render (genuinely card-specific mechanic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)