### PR TITLE
Add additional-end-step support to the engine (FIN gap §9)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1017,6 +1017,17 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   (after the additional-combat-phase check), each remaining count redirecting into a fresh upkeep
   step in the beginning phase. Read "that many" from the triggering combat damage with
   `DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)`.
+- `Effects.AddAdditionalEndSteps(amount)` (`amount: DynamicAmount` or `Int`, default `1`) — insert
+  `amount` additional end step(s) directly after the current end step (Y'shtola Rhul: "there is an
+  additional end step after this step"). Per CR 500.9 a step is inserted directly after the
+  specified step; each added step is a full end step (CR 513) where the active player gets priority
+  and every "at the beginning of the end step" ability triggers again. Steps are always added to the
+  controller's own turn (CR 500.10a). Implemented by accumulating an `AdditionalEndStepsComponent`
+  count on the active player, drained by `TurnManager.advanceStep` when leaving the end step — each
+  remaining count redirects back into a fresh end step instead of advancing to the cleanup step. A
+  rider that adds an end step *and re-triggers in it* must guard against looping with
+  `Conditions.IsFirstEndStepOfTurn` (see Conditions below) — Y'shtola only spawns the extra end step
+  during the turn's first (natural) end step.
 - `GatedEffect(gate, then, otherwise?, decisionMaker?)` — **the unified resolution frame for the
   optional / gated-effect cluster** (phase-rs Lesson 1). A `Gate` decides whether `then` runs; if it
   fails, `otherwise` runs. One executor + one continuation/resumer own the canonical unwind order, so
@@ -4003,6 +4014,12 @@ that works in both resolution and static-ability (projection) contexts.
   (reads `state.step` + active player), so it evaluates identically at resolution and under projection,
   making it usable as a `ConditionalStaticAbility` gate. `yoursOnly` requires it to be the controller's
   turn ("during your end step"). Used by Zurgo, Thunder's Decree.
+- `IsFirstEndStepOfTurn` — it's the turn's first (natural) end step, i.e. *not* an extra end step
+  inserted by `Effects.AddAdditionalEndSteps`. Board-derived (reads `state.step` + the active
+  player's "in an inserted end step" marker), so it evaluates identically at resolution and under
+  projection. The loop guard for "there is an additional end step after this step" riders: gate the
+  `Effects.AddAdditionalEndSteps` call on it so the spawned end step doesn't spawn another (Y'shtola
+  Rhul).
 - `ControllerTurnsTakenAtMost(n)` — the controller has taken at most N turns so far
   (1-indexed once they're partway through their first turn). Reads
   `PlayerTurnsTakenComponent` set by `TurnManager.startTurn`. Used by Starting Town

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1229,6 +1229,14 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.SourcePlottedOnPriorTurn
 
     /**
+     * If it's the first end step of the turn (not an extra end step inserted by
+     * [Effects.AddAdditionalEndSteps]). The loop guard for "there is an additional end step
+     * after this step" riders — see Y'shtola Rhul.
+     */
+    val IsFirstEndStepOfTurn: ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.IsFirstEndStepOfTurn
+
+    /**
      * If it's your turn.
      */
     val IsYourTurn: ConditionInterface =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2972,6 +2972,21 @@ object Effects {
     fun AddAdditionalUpkeepSteps(amount: Int): Effect =
         com.wingedsheep.sdk.scripting.effects.AddAdditionalUpkeepStepsEffect(DynamicAmount.Fixed(amount))
 
+    /**
+     * Insert [amount] additional end step(s) directly after the current end step (Y'shtola Rhul:
+     * "there is an additional end step after this step"). Each is a full end step — priority and
+     * "at the beginning of the end step" triggers fire again (CR 500.9 / 513). Always added to the
+     * controller's own turn (CR 500.10a). Guard with [Conditions.IsFirstEndStepOfTurn] to avoid looping.
+     */
+    fun AddAdditionalEndSteps(amount: DynamicAmount): Effect =
+        com.wingedsheep.sdk.scripting.effects.AddAdditionalEndStepsEffect(amount)
+
+    /**
+     * Insert a fixed number of additional end steps directly after the current end step.
+     */
+    fun AddAdditionalEndSteps(amount: Int = 1): Effect =
+        com.wingedsheep.sdk.scripting.effects.AddAdditionalEndStepsEffect(DynamicAmount.Fixed(amount))
+
     // -------------------------------------------------------------------------
     // Damage Prevention (unified via PreventDamageEffect)
     // -------------------------------------------------------------------------

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
@@ -76,6 +76,23 @@ data class IsInStep(
     }
 }
 
+/**
+ * Condition: "If it's the first end step of the turn."
+ *
+ * True while the active player is in an end step that is *not* an extra end step inserted by
+ * [com.wingedsheep.sdk.scripting.effects.AddAdditionalEndStepsEffect]. This is the loop guard for
+ * "there is an additional end step after this step" riders (Y'shtola Rhul): the rider only adds an
+ * extra end step during the first one, so the additional end step it spawns doesn't spawn another.
+ *
+ * Board-derived (reads `state.step` and the active player's "in an additional end step" marker), so
+ * it evaluates identically at resolution and under projection.
+ */
+@SerialName("IsFirstEndStepOfTurn")
+@Serializable
+data object IsFirstEndStepOfTurn : Condition {
+    override val description: String = "if it's the first end step of the turn"
+}
+
 // =============================================================================
 // Combat Conditions
 // =============================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -119,6 +119,30 @@ data class AddAdditionalUpkeepStepsEffect(
 }
 
 /**
+ * Insert additional end step(s) directly after the current end step (Y'shtola Rhul:
+ * "there is an additional end step after this step").
+ *
+ * Per CR 500.9, an effect that adds a step inserts it directly after the specified step; if several
+ * are created after the same step, the most recently created occurs first. The extra end step is a
+ * full end step (CR 513) — the active player gets priority and every "at the beginning of the end
+ * step" ability triggers again (CR 513.1a) — followed eventually by the single cleanup step.
+ *
+ * The steps are always added to the controller's own turn (CR 500.10a — "there is an additional end
+ * step" riders only ever trigger on the controller's end step). Cards that must not loop guard the
+ * effect behind [com.wingedsheep.sdk.scripting.conditions.IsFirstEndStepOfTurn] so only the first
+ * end step spawns the extra one.
+ *
+ * @param amount The number of additional end steps to insert (usually a single one).
+ */
+@SerialName("AddAdditionalEndSteps")
+@Serializable
+data class AddAdditionalEndStepsEffect(
+    val amount: DynamicAmount
+) : Effect {
+    override val description: String = "There ${if (amount.description == "1") "is" else "are"} ${amount.description} additional end step(s) after this step"
+}
+
+/**
  * Take an extra turn after this one, with a consequence at end of turn.
  * Used for Last Chance: "Take an extra turn after this one. At the beginning of that turn's end step, you lose the game."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/YshtolaRhul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/YshtolaRhul.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Y'shtola Rhul
+ * {4}{U}{U}
+ * Legendary Creature — Cat Druid
+ * 3/5
+ *
+ * At the beginning of your end step, exile target creature you control, then return it to the
+ * battlefield under its owner's control. Then if it's the first end step of the turn, there is an
+ * additional end step after this step.
+ *
+ * The blink is the standard immediate exile-then-return ([Effects.Move] to exile, then back to the
+ * battlefield — cards return under their owner's control by default). The "additional end step"
+ * rider is gated behind [Conditions.IsFirstEndStepOfTurn] (CR 500.9 / 513): the trigger fires again
+ * during the extra end step it creates, but by then the active player is flagged as being in an
+ * inserted end step, so the condition is false and no further end step is spawned — exactly one
+ * extra end step per turn.
+ */
+val YshtolaRhul = card("Y'shtola Rhul") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Cat Druid"
+    power = 3
+    toughness = 5
+    oracleText = "At the beginning of your end step, exile target creature you control, then " +
+        "return it to the battlefield under its owner's control. Then if it's the first end step " +
+        "of the turn, there is an additional end step after this step."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        val creature = target("creature you control", Targets.CreatureYouControl)
+        effect = Effects.Move(creature, Zone.EXILE)
+            .then(Effects.Move(creature, Zone.BATTLEFIELD))
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.IsFirstEndStepOfTurn,
+                    effect = Effects.AddAdditionalEndSteps(1)
+                )
+            )
+        description = "At the beginning of your end step, exile target creature you control, then " +
+            "return it to the battlefield under its owner's control. Then if it's the first end " +
+            "step of the turn, there is an additional end step after this step."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "86"
+        artist = "Immanuela Crovius"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aef218fa-13a4-4653-95d6-6b3ef1b33a92.jpg?1748706086"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -8546,6 +8546,82 @@
     "colorIdentityOverride": []
 }
 
+// Y'shtola Rhul
+{
+    "name": "Y'shtola Rhul",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Legendary Creature — Cat Druid",
+    "oracleText": "At the beginning of your end step, exile target creature you control, then return it to the battlefield under its owner's control. Then if it's the first end step of the turn, there is an additional end step after this step.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature you control"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature you control"
+                            },
+                            "destination": "Battlefield"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": "IsFirstEndStepOfTurn"
+                            },
+                            "then": {
+                                "type": "AddAdditionalEndSteps",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "creature you control"
+                },
+                "descriptionOverride": "At the beginning of your end step, exile target creature you control, then return it to the battlefield under its owner's control. Then if it's the first end step of the turn, there is an additional end step after this step."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "MYTHIC",
+        "artist": "Immanuela Crovius",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aef218fa-13a4-4653-95d6-6b3ef1b33a92.jpg?1748706086"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Zanarkand, Ancient Metropolis
 {
     "name": "Zanarkand, Ancient Metropolis",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -32,6 +32,8 @@ import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostCom
 import com.wingedsheep.engine.state.components.identity.RevertCopyAtEndOfTurnComponent
 import com.wingedsheep.engine.state.components.identity.TextReplacementComponent
 import com.wingedsheep.engine.state.components.player.AdditionalCombatPhasesComponent
+import com.wingedsheep.engine.state.components.player.AdditionalEndStepsComponent
+import com.wingedsheep.engine.state.components.player.InAdditionalEndStepComponent
 import com.wingedsheep.engine.state.components.player.CantActivateLoyaltyAbilitiesComponent
 import com.wingedsheep.engine.state.components.player.CantCastSpellsComponent
 import com.wingedsheep.engine.state.components.player.CantGainLifeComponent
@@ -572,6 +574,16 @@ class CleanupPhaseManager(
                 var result = container
                 if (result.has<AdditionalCombatPhasesComponent>()) {
                     result = result.without<AdditionalCombatPhasesComponent>()
+                }
+                // Clear any leftover additional-end-step state. The count is normally drained by the
+                // TurnManager, but a turn could end with the marker still set (it persists across the
+                // extra end steps so IsFirstEndStepOfTurn keeps reading false); reset both so the next
+                // turn's first end step is genuinely "first" again.
+                if (result.has<AdditionalEndStepsComponent>()) {
+                    result = result.without<AdditionalEndStepsComponent>()
+                }
+                if (result.has<InAdditionalEndStepComponent>()) {
+                    result = result.without<InAdditionalEndStepComponent>()
                 }
                 // Drop a Mindslaver-style hijack at end of the controlled turn (ACTIVE state).
                 // Scheduled hijacks (SCHEDULED) survive cleanup so they fire on the player's

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -459,6 +459,8 @@ val engineSerializersModule = SerializersModule {
         subclass(AdditionalCombatPhasesComponent::class)
         subclass(AdditionalUpkeepStepsComponent::class)
         subclass(InAdditionalUpkeepStepComponent::class)
+        subclass(AdditionalEndStepsComponent::class)
+        subclass(InAdditionalEndStepComponent::class)
         subclass(CantCastSpellsComponent::class)
         subclass(CantGainLifeComponent::class)
         subclass(CantActivateLoyaltyAbilitiesComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -14,6 +14,8 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.player.AdditionalCombatPhasesComponent
 import com.wingedsheep.engine.state.components.player.AdditionalUpkeepStepsComponent
 import com.wingedsheep.engine.state.components.player.InAdditionalUpkeepStepComponent
+import com.wingedsheep.engine.state.components.player.AdditionalEndStepsComponent
+import com.wingedsheep.engine.state.components.player.InAdditionalEndStepComponent
 import com.wingedsheep.engine.state.components.player.CardsDrawnThisTurnComponent
 import com.wingedsheep.engine.state.components.player.CardsPutIntoExileThisTurnComponent
 import com.wingedsheep.engine.state.components.player.EquipActivationsThisTurnComponent
@@ -271,6 +273,41 @@ class TurnManager(
                     StepChangedEvent(Step.UPKEEP)
                 )
 
+                redirectedState = redirectedState.withPriority(activePlayer)
+                return ExecutionResult.success(redirectedState, events)
+            }
+        }
+
+        // Drain any additional end steps (Y'shtola Rhul). Per CR 500.9 an "additional end step
+        // after this step" is inserted directly after the current end step; each is a full end step
+        // (CR 513) where the active player gets priority and "at the beginning of the end step"
+        // abilities trigger again. So instead of advancing from the end step to the cleanup step, we
+        // re-enter a fresh end step, decrementing the count, until it's exhausted. The
+        // InAdditionalEndStepComponent marker (set on the first redirect, cleared at end-of-turn
+        // cleanup) lets IsFirstEndStepOfTurn distinguish these extra steps from the natural one, so
+        // the rider that created them doesn't loop.
+        if (currentStep == Step.END) {
+            val additionalEndSteps = state.getEntity(activePlayer)?.get<AdditionalEndStepsComponent>()
+            if (additionalEndSteps != null && additionalEndSteps.count > 0) {
+                var redirectedState = if (additionalEndSteps.count <= 1) {
+                    state.updateEntity(activePlayer) { it.without<AdditionalEndStepsComponent>() }
+                } else {
+                    state.updateEntity(activePlayer) { container ->
+                        container.with(AdditionalEndStepsComponent(additionalEndSteps.count - 1))
+                    }
+                }
+
+                redirectedState = redirectedState
+                    .updateEntity(activePlayer) { it.with(InAdditionalEndStepComponent) }
+                    .copy(
+                        step = Step.END,
+                        phase = Phase.ENDING,
+                        priorityPassedBy = emptySet()
+                    )
+
+                // Phase is unchanged (END and CLEANUP both live in the ending phase), so only the
+                // step-changed event is emitted — that re-fires the end-step triggers.
+                val events = mutableListOf<GameEvent>(StepChangedEvent(Step.END))
                 redirectedState = redirectedState.withPriority(activePlayer)
                 return ExecutionResult.success(redirectedState, events)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -34,12 +34,14 @@ import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.RingBearerComponent
+import com.wingedsheep.engine.state.components.player.InAdditionalEndStepComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.player.PlayerTurnsTakenComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageThisTurnComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.*
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
@@ -60,6 +62,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.conditions.Exists
 import com.wingedsheep.sdk.scripting.conditions.IsInPhase
 import com.wingedsheep.sdk.scripting.conditions.IsInStep
+import com.wingedsheep.sdk.scripting.conditions.IsFirstEndStepOfTurn
 import com.wingedsheep.sdk.scripting.conditions.IsNotYourTurn
 import com.wingedsheep.sdk.scripting.conditions.IsYourTurn
 import com.wingedsheep.sdk.scripting.conditions.NotCondition
@@ -189,6 +192,16 @@ class ConditionEvaluator(
                 val notYourTurn = cid == null || !state.isActiveTurnFor(cid)
                 if (condition.yoursOnly && notYourTurn) false
                 else state.step in condition.steps
+            }
+
+            // True while we're in the turn's *natural* end step — i.e. an end step the active player
+            // hasn't yet marked as an inserted extra (AddAdditionalEndStepsEffect). Board-derived, so
+            // it reads the same at resolution and under projection. The loop guard for Y'shtola Rhul.
+            is IsFirstEndStepOfTurn -> {
+                state.step == Step.END &&
+                    state.activePlayerId?.let {
+                        state.getEntity(it)?.has<InAdditionalEndStepComponent>()
+                    } != true
             }
 
             // Reads the controller's PlayerTurnsTakenComponent (incremented in

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AddAdditionalEndStepsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/AddAdditionalEndStepsExecutor.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.AdditionalEndStepsComponent
+import com.wingedsheep.sdk.scripting.effects.AddAdditionalEndStepsEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [AddAdditionalEndStepsEffect] (Y'shtola Rhul).
+ *
+ * "There is an additional end step after this step." Per CR 500.9 the step is inserted directly
+ * after the current end step; per CR 500.10a these "there is an additional end step" riders are
+ * always added to the controller's own turn (they only ever trigger on the controller's end step,
+ * so the active player when this resolves is that controller). Accumulates the resolved amount onto
+ * an [AdditionalEndStepsComponent] on the active player; the TurnManager drains it when advancing
+ * out of the end step, redirecting back into a fresh end step (CR 513) instead of the cleanup step.
+ */
+class AddAdditionalEndStepsExecutor(
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
+) : EffectExecutor<AddAdditionalEndStepsEffect> {
+
+    override val effectType: KClass<AddAdditionalEndStepsEffect> =
+        AddAdditionalEndStepsEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: AddAdditionalEndStepsEffect,
+        context: EffectContext
+    ): EffectResult {
+        val activePlayer = state.activePlayerId
+            ?: return EffectResult.error(state, "No active player for AddAdditionalEndStepsEffect")
+
+        val amount = amountEvaluator.evaluate(state, effect.amount, context)
+        if (amount <= 0) {
+            return EffectResult.success(state)
+        }
+
+        val existing = state.getEntity(activePlayer)?.get<AdditionalEndStepsComponent>()
+        val newCount = (existing?.count ?: 0) + amount
+
+        val newState = state.updateEntity(activePlayer) { container ->
+            container.with(AdditionalEndStepsComponent(count = newCount))
+        }
+
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -40,6 +40,7 @@ class PlayerExecutors(
     override fun executors(): List<EffectExecutor<*>> = listOf(
         AmassExecutor(effectExecutor),
         AddAdditionalUpkeepStepsExecutor(),
+        AddAdditionalEndStepsExecutor(),
         AddCombatPhaseExecutor(),
         AnyPlayerMayPayExecutor(executeEffect = effectExecutor),
         CantActivateLoyaltyAbilitiesExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -305,6 +305,34 @@ data class AdditionalUpkeepStepsComponent(
 data object InAdditionalUpkeepStepComponent : Component
 
 /**
+ * Component tracking additional end steps to be inserted into the current turn (Y'shtola Rhul).
+ * Per CR 500.9, adding a step after a step inserts it directly after that step; if several are
+ * created after the same step the most recently created occurs first. Each is a full end step
+ * (CR 513) — the active player gets priority and "at the beginning of the end step" abilities
+ * trigger again.
+ *
+ * The TurnManager drains this when advancing out of the end step, redirecting back into a fresh
+ * end step instead of proceeding to the cleanup step, decrementing the count each time. Always
+ * added to the active player's own turn (CR 500.10a).
+ *
+ * @param count Number of additional end steps remaining to insert
+ */
+@Serializable
+data class AdditionalEndStepsComponent(
+    val count: Int = 1
+) : Component
+
+/**
+ * Marker placed on the active player once at least one [AdditionalEndStepsComponent] end step has
+ * begun this turn. It distinguishes an *extra* end step from the turn's first (natural) end step,
+ * which is what [com.wingedsheep.sdk.scripting.conditions.IsFirstEndStepOfTurn] reads to keep
+ * "there is an additional end step after this step" riders from looping. Cleared at end-of-turn
+ * cleanup so the next turn's first end step is "first" again.
+ */
+@Serializable
+data object InAdditionalEndStepComponent : Component
+
+/**
  * Marker component indicating that a player should skip all combat phases
  * during their next turn. Applied by effects like False Peace.
  *

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YshtolaRhulScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YshtolaRhulScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.YshtolaRhul
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Y'shtola Rhul (FIN) — {4}{U}{U} Legendary Creature — Cat Druid 3/5
+ *
+ * "At the beginning of your end step, exile target creature you control, then return it to the
+ *  battlefield under its owner's control. Then if it's the first end step of the turn, there is an
+ *  additional end step after this step."
+ *
+ * Exercises the new [Effects.AddAdditionalEndSteps] / `AdditionalEndStepsComponent` turn-structure
+ * path and the [com.wingedsheep.sdk.dsl.Conditions.IsFirstEndStepOfTurn] loop guard.
+ *
+ * The blink target is a creature whose only ability is "when it enters, you gain 1 life", so each
+ * time Y'shtola's end-step trigger resolves the target re-enters and the controller gains 1 life.
+ * That makes the life swing a direct count of how many end steps actually happened:
+ *  - Without the feature, Y'shtola would trigger once → +1 life.
+ *  - With one additional end step (and exactly one — the rider is gated to the *first* end step),
+ *    Y'shtola triggers twice → +2 life, and the turn still ends (no infinite loop).
+ */
+class YshtolaRhulScenarioTest : FunSpec({
+
+    // Blink target: a creature that gains its controller 1 life whenever it enters the battlefield.
+    val lifebloomSpirit = card("Lifebloom Spirit") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Spirit"
+        power = 1
+        toughness = 1
+        oracleText = "When Lifebloom Spirit enters the battlefield, you gain 1 life."
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(YshtolaRhul)
+        driver.registerCard(lifebloomSpirit)
+        driver.initMirrorMatch(Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Drive the rest of the active player's turn, choosing [blinkTargetName] whenever Y'shtola's
+     * end-step trigger asks for a target. Stops once the turn has passed to the opponent (which
+     * proves the additional end step terminated instead of looping).
+     */
+    fun GameTestDriver.finishMyTurn(me: com.wingedsheep.sdk.model.EntityId, blinkTargetName: String) {
+        var guard = 0
+        while (activePlayer == me && !state.gameOver && guard++ < 200) {
+            val decision = pendingDecision
+            when {
+                decision is ChooseTargetsDecision -> {
+                    val target = findPermanent(me, blinkTargetName)
+                        ?: error("No '$blinkTargetName' on the battlefield to target")
+                    submitTargetSelection(me, listOf(target))
+                }
+                decision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> passPriority(state.priorityPlayerId!!)
+                else -> error("Stuck at step ${state.step} with no priority and no decision")
+            }
+        }
+        if (guard >= 200) error("Turn never ended — additional end step appears to be looping")
+    }
+
+    test("Y'shtola adds exactly one additional end step and blinks her target each time") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        driver.putCreatureOnBattlefield(me, "Y'shtola Rhul")
+        driver.putCreatureOnBattlefield(me, "Lifebloom Spirit")
+
+        val lifeBefore = driver.getLifeTotal(me)
+
+        driver.finishMyTurn(me, blinkTargetName = "Lifebloom Spirit")
+
+        // Two end steps happened (the natural one plus exactly one inserted by the rider), so the
+        // blink — and its enters-the-battlefield life gain — resolved twice. A third end step would
+        // mean the loop guard failed; +2 (not +3) pins down "exactly one extra end step".
+        driver.getLifeTotal(me) shouldBe lifeBefore + 2
+
+        // The turn actually ended — control passed to the opponent (further proof there was no loop).
+        driver.activePlayer shouldBe driver.player2
+    }
+})


### PR DESCRIPTION
## Summary

Implements the **"there is an additional end step after this step"** turn-structure primitive — FIN engine gap **§9** (Y'shtola Rhul) — and ships Y'shtola Rhul as its first consumer. Mirrors the existing `AddAdditionalUpkeepSteps` (Obeka) / `AddCombatPhase` (Aggravated Assault) step-insertion pattern.

## New SDK vocabulary
- **`Effects.AddAdditionalEndSteps(amount)`** (`DynamicAmount` or `Int`, default `1`) — inserts extra end step(s) directly after the current end step. Per **CR 500.9** a step is inserted directly after the specified step; each is a full end step (**CR 513**) where the active player gets priority and every "at the beginning of the end step" ability triggers again. Always added to the controller's own turn (**CR 500.10a**).
- **`Conditions.IsFirstEndStepOfTurn`** — board-derived loop guard. A rider that adds an end step *and re-triggers in it* gates the add on this so the spawned end step doesn't spawn another. Evaluates identically at resolution and under projection.

## Engine wiring
- `AdditionalEndStepsComponent` (pending count) + `InAdditionalEndStepComponent` (marker distinguishing an inserted end step from the natural one).
- `AddAdditionalEndStepsExecutor` accumulates the count on the active player.
- `TurnManager.advanceStep` drains it when leaving the end step — re-entering a fresh end step (re-emitting `StepChangedEvent(END)` so end-step triggers re-fire) until the count is exhausted, then proceeds to cleanup.
- `ConditionEvaluator` evaluates `IsFirstEndStepOfTurn` from `state.step` + the marker.
- Both components registered for serialization and cleared at end-of-turn cleanup.

No new `GameEvent` (reuses `StepChangedEvent`) and the components are internal player markers with no client-visible state, so no server DTO / masking / client changes are needed.

## Proof card — Y'shtola Rhul (FIN, {4}{U}{U}, 3/5)
*"At the beginning of your end step, exile target creature you control, then return it to the battlefield under its owner's control. Then if it's the first end step of the turn, there is an additional end step after this step."* — built from the existing immediate-blink primitives + the new effect gated by `IsFirstEndStepOfTurn`.

## Tests
- **`YshtolaRhulScenarioTest`** (`rules-engine`, `GameTestDriver`): the blink target gains 1 life on each enter, so the life swing counts end steps. Asserts **exactly +2** (natural + one inserted; not +3 → the loop guard holds) and that the turn actually passes to the opponent.
- Green: `rules-engine` + `mtg-sets` full suites, `EffectExecutorCoverageTest`, `CardLintTest`, serialization polymorphic-registration, FIN card snapshot (re-blessed — only the new card added), full `build`.

## mtgish
Skipped (Step 8b): these step-insertion turn-structure effects map to no mtgish IR tag — the directly analogous `AddAdditionalUpkeepSteps` has no bridge/emitter entry either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)