### PR TITLE
Add "whenever you manifest dread" trigger + Paranormal Analyst

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1268,16 +1268,20 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `manifest(count = 1)` — manifest the top N cards (CR 701.40): each is put onto the battlefield
   face down as a 2/2 creature (one at a time). A manifested creature card can be turned face up for
   its mana cost; a manifested non-creature can't.
-- `manifestDread(markEntered = false)` — "Manifest dread" (CR 701.62, Duskmourn): look at the top
+- `manifestDread(markEntered = false)` — "Manifest dread" (CR 701.60, Duskmourn): look at the top
   two cards of your library, manifest one of them (your choice), and put the other into your
-  graveyard. Composes gather → select → move-face-down(MANIFEST) → move-to-graveyard. Pass
-  `markEntered = true` to stamp each manifested permanent with `EnteredViaAbilityComponent(this
-  source)`, so wrapping it in `RepeatDynamicTimes(X, manifestDread(markEntered = true))` lets a later
+  graveyard. Composes gather → select → move-face-down(MANIFEST) → move-to-graveyard →
+  emit-`ManifestedDreadEvent`. Pass `markEntered = true` to stamp each manifested permanent with
+  `EnteredViaAbilityComponent(this source)`, so wrapping it in
+  `RepeatDynamicTimes(X, manifestDread(markEntered = true))` lets a later
   `GatherCards(CardSource.EnteredViaThisResolution)` re-collect every creature this spell manifested
   (across all X iterations and the per-iteration manifest-dread pick pauses) and reference "each of
   those creatures" — e.g. **Valgavoth's Onslaught**: `RepeatDynamicTimes(XValue, manifestDread(true))`
   → `GatherCards(EnteredViaThisResolution, "manifested")` → `AddCountersToCollection("manifested",
-  +1/+1, XValue)`.
+  +1/+1, XValue)`. The trailing `EmitManifestedDreadEventEffect` tail (internal — not for card
+  authors) fires `Triggers.WheneverYouManifestDread` (see Triggers) once per manifest-dread,
+  carrying the card put into the graveyard this way so a "this way" payoff can pull it back out
+  (**Paranormal Analyst**).
 
 **Reveal patterns**
 
@@ -2580,6 +2584,18 @@ Triggers.youCastSpell(
   ("cards looked at"). Used by Golbez.
 - `WheneverYouScryOrSurveil` — the combined look-at-top trigger; fires once per scry **and**
   once per surveil (Matoya, Archon Elder).
+
+### Manifest Dread
+
+- `WheneverYouManifestDread` — fires once per manifest-dread resolution (CR 701.60), after the
+  chosen card is manifested face down and the other put into your graveyard. Automatically emitted
+  by `Patterns.Library.manifestDread()`; no card has to opt in. Per CR 701.60b it fires even when
+  the library held fewer than two cards. The card(s) put into the graveyard this way are seeded into
+  the payoff's pipeline under `IterationSpace.TRIGGER_CAPTURED_COLLECTION` (the same engine-seeded
+  slot batch ETB payoffs read), so a payoff that references "a card you put into your graveyard this
+  way" can move it out of the graveyard — e.g. **Paranormal Analyst**:
+  `MoveCollection(from = TRIGGER_CAPTURED_COLLECTION, destination = ToZone(HAND))`. The collection is
+  empty when nothing was binned, making the payoff a safe no-op.
 - A literal "scry 0" / "surveil 0" produces no event and fires no trigger (CR 701.18b / 701.42c);
   the trigger still fires when the library was empty and zero cards were looked at (CR 701.18d /
   701.42d).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.EmitManifestedDreadEventEffect
 import com.wingedsheep.sdk.scripting.effects.EmitScriedEventEffect
 import com.wingedsheep.sdk.scripting.effects.EmitSurveiledEventEffect
 import com.wingedsheep.sdk.scripting.effects.ForEachEffect
@@ -155,7 +156,12 @@ object LibraryPatterns {
             MoveCollectionEffect(
                 from = "manifestDreadGraveyard",
                 destination = CardDestination.ToZone(Zone.GRAVEYARD)
-            )
+            ),
+            // Fire "Whenever you manifest dread" triggers (CR 701.60) after the pick resolves,
+            // carrying the cards put into the graveyard this way so a payoff can pull one back out
+            // (Paranormal Analyst). Per CR 701.60b the trigger fires even when the library held
+            // fewer than two cards (the graveyard collection is then empty).
+            EmitManifestedDreadEventEffect()
         )
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1766,6 +1766,25 @@ object Triggers {
     )
 
     // =========================================================================
+    // Manifest Dread Triggers (CR 701.60)
+    // =========================================================================
+
+    /**
+     * Whenever you manifest dread (CR 701.60). Fires once per manifest-dread, after the chosen
+     * card has been manifested and the other put into your graveyard. Per CR 701.60b it fires even
+     * when the library held fewer than two cards.
+     *
+     * The card(s) put into the graveyard this way are seeded into the payoff's pipeline under
+     * [com.wingedsheep.sdk.scripting.effects.IterationSpace.TRIGGER_CAPTURED_COLLECTION], so a
+     * payoff can move "a card you put into your graveyard this way" out of the graveyard
+     * (Paranormal Analyst).
+     */
+    val WheneverYouManifestDread: TriggerSpec = TriggerSpec(
+        event = ManifestedDreadEvent(Player.You),
+        binding = TriggerBinding.ANY
+    )
+
+    // =========================================================================
     // Saga Chapter Resolution Triggers (CR 714)
     // =========================================================================
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -381,6 +381,26 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
         override val description: String = "${player.description} scries or surveils"
     }
 
+    /**
+     * Whenever a player manifests dread (CR 701.60). Fires once per manifest-dread, after the
+     * chosen card has been manifested and the other card(s) put into the graveyard. Per CR
+     * 701.60b the trigger fires "even if some or all of those actions were impossible" (an empty
+     * or one-card library), exactly like scry/surveil.
+     *
+     * The card(s) put into the graveyard this way are exposed to the payoff as the pipeline
+     * collection [com.wingedsheep.sdk.scripting.effects.IterationSpace.TRIGGER_CAPTURED_COLLECTION],
+     * so a payoff that references "a card you put into your graveyard this way" (Paranormal
+     * Analyst) can move it out of the graveyard. The collection is empty when the library held
+     * fewer than two cards.
+     */
+    @SerialName("ManifestedDreadEvent")
+    @Serializable
+    data class ManifestedDreadEvent(
+        val player: Player = Player.You
+    ) : EventPattern {
+        override val description: String = "${player.description} manifest dread"
+    }
+
     // =========================================================================
     // Extra Turn Events
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
@@ -78,6 +78,31 @@ data class EmitSurveiledEventEffect(
     override val description: String = ""
 }
 
+/**
+ * Emit a `ManifestedDreadEvent` after a manifest-dread pipeline finishes resolving — the
+ * manifest-dread twin of [EmitScriedEventEffect]. Appended internally by
+ * [com.wingedsheep.sdk.dsl.LibraryPatterns.manifestDread] so "Whenever you manifest dread"
+ * triggers ([com.wingedsheep.sdk.dsl.Triggers.WheneverYouManifestDread]) fire exactly once per
+ * manifest-dread (CR 701.60), after the chosen card has been manifested and the other put into
+ * the graveyard.
+ *
+ * The executor reads [graveyardCollection] — the named pipeline collection of cards put into the
+ * graveyard this way — and carries those entity ids on the event so the resolving trigger can
+ * pull "a card you put into your graveyard this way" back out (Paranormal Analyst). The collection
+ * is empty when the library held fewer than two cards; the event still fires (CR 701.60b), the
+ * payoff simply finds nothing to return.
+ *
+ * Card authors should not use this directly; it is wired into the manifest-dread primitive.
+ */
+@SerialName("EmitManifestedDreadEvent")
+@Serializable
+data class EmitManifestedDreadEventEffect(
+    val graveyardCollection: String = "manifestDreadGraveyard"
+) : Effect {
+    // Intentionally blank: this is an internal pipeline tail with no player-facing text.
+    override val description: String = ""
+}
+
 
 /**
  * "Scry [count]" (CR 701.18) as a single compact node.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ParanormalAnalyst.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ParanormalAnalyst.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.IterationSpace
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+
+/**
+ * Paranormal Analyst
+ * {1}{U}
+ * Creature — Human Detective
+ * 1/3
+ *
+ * Whenever you manifest dread, put a card you put into your graveyard this way into your hand.
+ *
+ * Implementation notes:
+ * - Listens for [Triggers.WheneverYouManifestDread] (CR 701.60). Every manifest dread emits a
+ *   `ManifestedDreadEvent` carrying the card(s) put into the graveyard this way; the engine seeds
+ *   those into the resolving trigger's pipeline under
+ *   [IterationSpace.TRIGGER_CAPTURED_COLLECTION] (the same engine-seeded slot Kambal's batch payoff
+ *   reads). The payoff is a single [MoveCollectionEffect] moving that captured card out of the
+ *   graveyard and into your hand.
+ * - Manifest dread puts at most one card into the graveyard, so the captured collection holds 0 or
+ *   1 cards — moving the whole collection realises "put **a** card … into your hand". When the
+ *   library held fewer than two cards there is nothing to put in the graveyard; the trigger still
+ *   fires (CR 701.60b) and the move is a safe no-op on the empty collection.
+ */
+val ParanormalAnalyst = card("Paranormal Analyst") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Detective"
+    power = 1
+    toughness = 3
+    oracleText = "Whenever you manifest dread, put a card you put into your graveyard this way " +
+        "into your hand."
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouManifestDread
+        effect = MoveCollectionEffect(
+            from = IterationSpace.TRIGGER_CAPTURED_COLLECTION,
+            destination = CardDestination.ToZone(Zone.HAND)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "69"
+        artist = "James Ryman"
+        flavorText = "\"If I've done this right, it should immobilize all spirits in the area. " +
+            "If I've done this wrong... you know what, let's just hope I did it right.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/60cf954a-5503-460c-8720-8960842eea47.jpg?1726286109"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -611,7 +611,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 }
             }
@@ -1099,7 +1100,8 @@
                                     "type": "ToZone",
                                     "zone": "Graveyard"
                                 }
-                            }
+                            },
+                            "EmitManifestedDreadEvent"
                         ]
                     },
                     "description": "Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)"
@@ -1814,7 +1816,8 @@
                                         "type": "ToZone",
                                         "zone": "Graveyard"
                                     }
-                                }
+                                },
+                                "EmitManifestedDreadEvent"
                             ]
                         },
                         {
@@ -2505,7 +2508,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 },
                 "triggerCondition": {
@@ -2700,7 +2704,8 @@
                                         "type": "ToZone",
                                         "zone": "Graveyard"
                                     }
-                                }
+                                },
+                                "EmitManifestedDreadEvent"
                             ]
                         },
                         {
@@ -2867,7 +2872,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 }
             }
@@ -4020,7 +4026,8 @@
                                             "type": "ToZone",
                                             "zone": "Graveyard"
                                         }
-                                    }
+                                    },
+                                    "EmitManifestedDreadEvent"
                                 ]
                             }
                         }
@@ -5500,7 +5507,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 }
             },
@@ -5719,7 +5727,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 }
             }
@@ -6237,7 +6246,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 }
             }
@@ -6727,7 +6737,8 @@
                                         "type": "ToZone",
                                         "zone": "Graveyard"
                                     }
-                                }
+                                },
+                                "EmitManifestedDreadEvent"
                             ]
                         },
                         {
@@ -7089,7 +7100,8 @@
                         "type": "ToZone",
                         "zone": "Graveyard"
                     }
-                }
+                },
+                "EmitManifestedDreadEvent"
             ]
         }
     },
@@ -8689,6 +8701,45 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Paranormal Analyst
+{
+    "name": "Paranormal Analyst",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Detective",
+    "oracleText": "Whenever you manifest dread, put a card you put into your graveyard this way into your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "ManifestedDreadEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveCollection",
+                    "from": "trigger.captured",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "rarity": "UNCOMMON",
+        "artist": "James Ryman",
+        "flavorText": "\"If I've done this right, it should immobilize all spirits in the area. If I've done this wrong... you know what, let's just hope I did it right.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/60cf954a-5503-460c-8720-8960842eea47.jpg?1726286109"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -11259,7 +11310,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 }
             },
@@ -11597,7 +11649,8 @@
                                     "type": "ToZone",
                                     "zone": "Graveyard"
                                 }
-                            }
+                            },
+                            "EmitManifestedDreadEvent"
                         ]
                     },
                     "trigger": {
@@ -11704,7 +11757,8 @@
                                     "type": "ToZone",
                                     "zone": "Graveyard"
                                 }
-                            }
+                            },
+                            "EmitManifestedDreadEvent"
                         ]
                     },
                     "description": "Manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)"
@@ -12052,7 +12106,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 },
                 {
@@ -12290,7 +12345,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 }
             ]
@@ -12380,7 +12436,8 @@
                                 "type": "ToZone",
                                 "zone": "Graveyard"
                             }
-                        }
+                        },
+                        "EmitManifestedDreadEvent"
                     ]
                 }
             }
@@ -12736,7 +12793,8 @@
                                     "type": "ToZone",
                                     "zone": "Graveyard"
                                 }
-                            }
+                            },
+                            "EmitManifestedDreadEvent"
                         ]
                     }
                 },

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -353,6 +353,29 @@ data class SurveiledEvent(
 ) : GameEvent
 
 /**
+ * A player just finished a `manifest dread` (CR 701.60). Fires once per manifest-dread, after the
+ * chosen card has been manifested face down and the other card(s) put into the graveyard. Drives
+ * "Whenever you manifest dread" triggers; see
+ * [com.wingedsheep.sdk.scripting.EventPattern.ManifestedDreadEvent]. Per CR 701.60b it fires even
+ * when the library held fewer than two cards.
+ *
+ * @property playerId The player who manifested dread.
+ * @property graveyardCardIds The card(s) put into the graveyard this way (the looked-at cards that
+ *   were not manifested). Carried so a payoff that references "a card you put into your graveyard
+ *   this way" (Paranormal Analyst) can move it out — seeded into the trigger's pipeline under
+ *   `PipelineState.TRIGGER_CAPTURED_COLLECTION` via [TriggerContext.capturedEntityIds]. Empty when
+ *   the library held fewer than two cards.
+ * @property sourceName The card/ability that caused the manifest dread (for display).
+ */
+@Serializable
+@SerialName("ManifestedDreadEvent")
+data class ManifestedDreadEvent(
+    val playerId: EntityId,
+    val graveyardCardIds: List<EntityId>,
+    val sourceName: String
+) : GameEvent
+
+/**
  * A player chose a creature type (e.g., "Choose a creature type" for Walking Desecration).
  * This is a public announcement visible to all players.
  */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -123,6 +123,7 @@ val engineSerializersModule = SerializersModule {
         subclass(RingTemptedEvent::class)
         subclass(ScriedEvent::class)
         subclass(SurveiledEvent::class)
+        subclass(ManifestedDreadEvent::class)
         subclass(LibraryReorderedEvent::class)
         subclass(LookedAtCardsEvent::class)
         subclass(LoyaltyChangedEvent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -207,6 +207,15 @@ data class TriggerContext(
                     triggeringPlayerId = event.playerId,
                     scryCount = event.count
                 )
+                // Manifest dread (CR 701.60): the cards put into the graveyard this way are
+                // carried as capturedEntityIds, seeded into the resolving trigger's pipeline under
+                // TRIGGER_CAPTURED_COLLECTION so "a card you put into your graveyard this way"
+                // payoffs (Paranormal Analyst) can move it out. Empty when the library held fewer
+                // than two cards (the trigger still fires per CR 701.60b).
+                is com.wingedsheep.engine.core.ManifestedDreadEvent -> TriggerContext(
+                    triggeringPlayerId = event.playerId,
+                    capturedEntityIds = event.graveyardCardIds.takeIf { it.isNotEmpty() }
+                )
                 is CardsDiscardedEvent -> TriggerContext(triggeringPlayerId = event.playerId)
                 is CardRevealedFromDrawEvent -> TriggerContext(
                     triggeringEntityId = event.cardEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -75,6 +75,7 @@ enum class TriggerCategory {
     RING_TEMPTED,
     SCRIED,
     SURVEILED,
+    MANIFESTED_DREAD,
     BECAME_SADDLED,
     BECOMES_ATTACHED,
     SAGA_CHAPTER_RESOLVED,
@@ -246,6 +247,7 @@ class TriggerIndex(
                 // "Whenever you scry or surveil" indexes under both buckets so either engine event
                 // finds it; the matcher confirms the event is a scry or a surveil.
                 is SdkGameEvent.ScriedOrSurveiledEvent -> SCRIED_OR_SURVEILED_LIST
+                is SdkGameEvent.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
                 is SdkGameEvent.BecameSaddledEvent -> BECAME_SADDLED_LIST
                 is SdkGameEvent.BecomesAttachedEvent -> BECOMES_ATTACHED_LIST
                 is SdkGameEvent.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
@@ -286,6 +288,7 @@ class TriggerIndex(
             is com.wingedsheep.engine.core.RingTemptedEvent -> RING_TEMPTED_LIST
             is com.wingedsheep.engine.core.ScriedEvent -> SCRIED_LIST
             is com.wingedsheep.engine.core.SurveiledEvent -> SURVEILED_LIST
+            is com.wingedsheep.engine.core.ManifestedDreadEvent -> MANIFESTED_DREAD_LIST
             is com.wingedsheep.engine.core.BecameSaddledEvent -> BECAME_SADDLED_LIST
             is com.wingedsheep.engine.core.PermanentAttachedEvent -> BECOMES_ATTACHED_LIST
             is com.wingedsheep.engine.core.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
@@ -319,6 +322,7 @@ class TriggerIndex(
         private val SCRIED_LIST = listOf(TriggerCategory.SCRIED)
         private val SURVEILED_LIST = listOf(TriggerCategory.SURVEILED)
         private val SCRIED_OR_SURVEILED_LIST = listOf(TriggerCategory.SCRIED, TriggerCategory.SURVEILED)
+        private val MANIFESTED_DREAD_LIST = listOf(TriggerCategory.MANIFESTED_DREAD)
         private val BECAME_SADDLED_LIST = listOf(TriggerCategory.BECAME_SADDLED)
         private val BECOMES_ATTACHED_LIST = listOf(TriggerCategory.BECOMES_ATTACHED)
         private val SAGA_CHAPTER_RESOLVED_LIST = listOf(TriggerCategory.SAGA_CHAPTER_RESOLVED)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -457,6 +457,10 @@ class TriggerMatcher(
                     matchesPlayer(trigger.player, event.playerId, controllerId)
                 else -> false
             }
+            is EventPattern.ManifestedDreadEvent -> {
+                event is com.wingedsheep.engine.core.ManifestedDreadEvent &&
+                    matchesPlayer(trigger.player, event.playerId, controllerId)
+            }
             is EventPattern.BecomesTargetEvent -> {
                 event is BecomesTargetEvent && matchesBecomesTargetTrigger(trigger, binding, event, sourceId, controllerId, state)
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/EmitManifestedDreadEventExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/EmitManifestedDreadEventExecutor.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.ManifestedDreadEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.EmitManifestedDreadEventEffect
+import kotlin.reflect.KClass
+
+/**
+ * Tail of the [com.wingedsheep.sdk.dsl.Patterns.Library.manifestDread] composite: emits a
+ * [ManifestedDreadEvent] so "Whenever you manifest dread" triggers (CR 701.60) fire exactly once
+ * per manifest-dread, after the manifest/graveyard moves have all resolved.
+ *
+ * The carried [ManifestedDreadEvent.graveyardCardIds] are the cards put into the graveyard this
+ * way — read from the named graveyard collection (`"manifestDreadGraveyard"` by default) at
+ * resolution time. They are threaded onto the resolving trigger's pipeline via
+ * [com.wingedsheep.engine.event.TriggerContext.capturedEntityIds] so a payoff can pull "a card you
+ * put into your graveyard this way" back out (Paranormal Analyst).
+ *
+ * The collection (and thus the event's id list) is empty when the library held fewer than two
+ * cards; the event is still emitted, because CR 701.60b fires "whenever you manifest dread"
+ * triggers "even if some or all of those actions were impossible."
+ */
+class EmitManifestedDreadEventExecutor : EffectExecutor<EmitManifestedDreadEventEffect> {
+
+    override val effectType: KClass<EmitManifestedDreadEventEffect> = EmitManifestedDreadEventEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: EmitManifestedDreadEventEffect,
+        context: EffectContext
+    ): EffectResult {
+        val graveyardCardIds = context.pipeline.storedCollections[effect.graveyardCollection].orEmpty()
+
+        val playerId = context.controllerId
+        val sourceName = context.sourceId
+            ?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+            ?: "Manifest Dread"
+
+        return EffectResult.success(
+            state,
+            listOf(
+                ManifestedDreadEvent(
+                    playerId = playerId,
+                    graveyardCardIds = graveyardCardIds,
+                    sourceName = sourceName
+                )
+            )
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -97,6 +97,7 @@ class LibraryExecutors(
         StoreNumberExecutor(),
         StoreCardNameExecutor(),
         EmitScriedEventExecutor(),
-        EmitSurveiledEventExecutor()
+        EmitSurveiledEventExecutor(),
+        EmitManifestedDreadEventExecutor()
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1183,6 +1183,7 @@ is PermanentsSacrificedEvent -> {
             is RingTemptedEvent,
             is ScriedEvent,
             is SurveiledEvent,
+            is ManifestedDreadEvent,
             is TurnedFaceDownEvent,
             is CreatureTypeChangedEvent,
             is BecomesTargetEvent,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ParanormalAnalystScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ParanormalAnalystScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Paranormal Analyst (DSK) — "Whenever you manifest dread, put a card you put into your graveyard
+ * this way into your hand."
+ *
+ * Exercises the manifest-dread trigger (CR 701.60): manifesting dread emits a `ManifestedDreadEvent`
+ * carrying the card put into the graveyard this way, which the engine threads onto the resolving
+ * trigger's pipeline (`TRIGGER_CAPTURED_COLLECTION`). Paranormal Analyst's payoff moves that card
+ * from the graveyard back to its controller's hand.
+ *
+ * Per CR 701.60b the trigger fires even when the library held fewer than two cards (nothing to put
+ * in the graveyard); the payoff is then a safe no-op.
+ */
+class ParanormalAnalystScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    /** Cast Manifest Dread from hand, paying {1}{G} from the pool, and resolve until the pick pauses. */
+    fun GameTestDriver.castManifestDread(you: EntityId) {
+        val spell = putCardInHand(you, "Manifest Dread")
+        giveMana(you, Color.GREEN, 2)
+        castSpell(you, spell)
+        while (!isPaused && state.stack.isNotEmpty()) bothPass()
+    }
+
+    test("returns the binned card from the graveyard to hand when you manifest dread") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putPermanentOnBattlefield(you, "Paranormal Analyst")
+
+        // Stack the top two: creature on top, a land beneath it.
+        val land = d.putCardOnTopOfLibrary(you, "Forest")
+        val creature = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        d.castManifestDread(you)
+
+        // Manifest dread pauses to choose which of the two looked-at cards to manifest.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pick.options.toSet() shouldBe setOf(creature, land)
+
+        // Manifest the creature; the land is the one put into the graveyard this way.
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+
+        // The manifest-dread trigger now resolves: move the binned land to hand.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getPermanents(you) shouldContain creature
+        d.getHand(you) shouldContain land
+        d.getGraveyard(you) shouldNotContain land
+    }
+
+    test("trigger fires safely and returns nothing when the library has too few cards to bin") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putPermanentOnBattlefield(you, "Paranormal Analyst")
+
+        // Empty the library down to a single creature on top — manifest dread looks at one card,
+        // manifests it, and has nothing to put into the graveyard.
+        d.replaceState(d.state.copy(zones = d.state.zones + (ZoneKey(you, Zone.LIBRARY) to emptyList())))
+        val creature = d.putCardOnTopOfLibrary(you, "Centaur Courser")
+        val handBefore = d.getHand(you).toSet()
+
+        d.castManifestDread(you)
+
+        // A forced 1-of-1 pick may still prompt; satisfy it if so.
+        if (d.isPaused) {
+            val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+        }
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The creature is manifested; the trigger fired but found nothing to return — hand is
+        // unchanged (only the resolved sorcery sits in the graveyard).
+        d.getPermanents(you) shouldContain creature
+        d.getHand(you).toSet() shouldBe handBefore
+        d.getGraveyardCardNames(you) shouldBe listOf("Manifest Dread")
+    }
+})


### PR DESCRIPTION
## Summary

Adds engine support for the **"you manifest dread" trigger** (CR 701.60) and threads the milled graveyard card into a reflexive payoff, then implements **Paranormal Analyst** (DSK 69) on top of it.

Two capabilities were missing:
1. The manifest-dread pipeline emitted **no event** a trigger could listen for.
2. There was **no way to reference the card put into the graveyard "this way"** from a separate, reflexive triggered ability.

## What's added

**Trigger event + facade**
- `EventPattern.ManifestedDreadEvent` + `Triggers.WheneverYouManifestDread` — the manifest-dread twin of the scry/surveil trigger family.
- New internal `EmitManifestedDreadEventEffect` pipeline tail, appended to `Patterns.Library.manifestDread()`, so **every** manifest dread fires the trigger exactly once — even with fewer than two cards in the library (CR 701.60b: fires "even if some or all of those actions were impossible").

**Threading the binned card (compose, don't build a monolith)**
- The engine `ManifestedDreadEvent` carries `graveyardCardIds` (the looked-at cards not manifested).
- `TriggerContext.fromEvent` maps those onto `capturedEntityIds`, which the existing `TriggerProcessor` → `AbilityComponent` → `StackResolver` path already seeds into the resolving ability's pipeline under `TRIGGER_CAPTURED_COLLECTION` — **the same engine-seeded collection slot Kambal's batch-ETB payoff reads.** No new threading mechanism, no bespoke executor.

**Cross-layer wiring:** GameEvent + Serialization, executor + `LibraryExecutors` registry, `TriggerContext` / `TriggerMatcher` / `TriggerIndex`, `ClientEvent` (internal event → no client animation, like ScriedEvent).

**Card**
- Paranormal Analyst (DSK 69): "Whenever you manifest dread, put a card you put into your graveyard this way into your hand." The payoff is a single `MoveCollection(from = TRIGGER_CAPTURED_COLLECTION, to = HAND)`.

## Tests
- `ParanormalAnalystScenarioTest`: happy path (binned card returns from graveyard to hand) + edge case (≤1-card library — trigger fires safely and returns nothing).
- Existing `ManifestDreadScenarioTest`, `ValgavothsOnslaughtScenarioTest`, `HauntwoodsShriekerScenarioTest` still pass.
- Full `:rules-engine`, `:mtg-sdk`, `:mtg-sets` suites green. `EffectExecutorCoverageTest`, `CardLintTest`, `FacadeBoundaryTest` pass.
- DSK snapshot golden re-blessed (new manifestDread pipeline tail + new card).

## Docs
- `docs/card-sdk-language-reference.md` updated: new `WheneverYouManifestDread` trigger, the manifestDread emit tail, and a correction of the manifest-dread CR reference to **701.60** (verified against the Comprehensive Rules).

## Notes
- **mtgish generator (Step 8b):** skipped deliberately. The payoff's effect side (`MoveCollection` from an engine-seeded collection) already composes primitives the emitter renders, and the manifest-dread effect tag is already bridged. The only candidate addition is the "whenever you manifest dread" trigger-condition tag, but the mtgish corpus isn't present in this checkout (no DSK data) and I can't verify the exact IR tag spelling — rather than guess an identifier, I left it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)