### PR TITLE
Add "can't block alone" combat restriction + Toby, Beastie Befriender

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2983,8 +2983,17 @@ staticAbility {
 - `CantAttackUnlessCoAttacker(coAttackerFilter, filter = source)` — "This creature can't attack
   unless [a creature matching coAttackerFilter] also attacks" (Scarred Puma). Unlike
   `CantAttackUnless` (which is defender-relative), this depends on the whole proposed attacker
-  group, so it's validated against the other declared attackers at declaration time (projected
-  state; self never counts as its own co-attacker).
+  group, so it's validated against the other declared attackers at declaration time (CR 508.1c,
+  projected state; self never counts as its own co-attacker).
+- `CantBlockUnlessCoBlocker(coBlockerFilter, filter = source)` — the blocking sibling: "This
+  creature can't block unless [a creature matching coBlockerFilter] also blocks." Validated against
+  the whole proposed blocker group at declaration time (CR 509.1b, `BlockPhaseManager`); the
+  co-blocker need not block the same attacker, and self never counts as its own co-blocker. Pass
+  `GameObjectFilter.Creature` for the bare "can't block alone" form. Combined with
+  `CantAttackUnlessCoAttacker` it models "can't attack or block alone" (Toby, Beastie Befriender's
+  Beast token). Both restriction families are read from the card definition *and* from
+  `grantedStaticAbilities`, so they work on tokens (which have no `CardDefinition`) —
+  `CreateTokenEffect.staticAbilities` are granted per-token for exactly this reason.
 - `AttackerCountLimit(maxAttackers)` / `BlockerCountLimit(maxBlockers)` — global combat caps
   (Dueling Grounds — "No more than one creature can attack/block each combat"). Constrain the
   *total* declared attacker/blocker set across all players, not a single creature, so they are

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -252,6 +252,34 @@ data class CantBlockUnless(
 }
 
 /**
+ * This creature can't block unless another creature being declared as a blocker in the same
+ * declaration matches [coBlockerFilter]. The blocking sibling of [CantAttackUnlessCoAttacker];
+ * together they model "can't attack or block alone" (Toby's Beast token — pass
+ * [com.wingedsheep.sdk.scripting.GameObjectFilter.Creature] for the bare "alone" form, where any
+ * other declared blocker satisfies it).
+ *
+ * Like [CantAttackUnlessCoAttacker], this restriction depends on the set of co-blockers rather
+ * than on the attacking player, so it is checked against the full proposed blocker group at
+ * declaration time (CR 509.1b). The co-blocker need not block the same attacker — it only has to
+ * be declared as a blocker this combat. The creature itself is never counted as its own co-blocker.
+ *
+ * @property coBlockerFilter The filter a *different* blocking creature must match.
+ * @property filter What this ability applies to.
+ */
+@SerialName("CantBlockUnlessCoBlocker")
+@Serializable
+data class CantBlockUnlessCoBlocker(
+    val coBlockerFilter: com.wingedsheep.sdk.scripting.GameObjectFilter,
+    val filter: GroupFilter = GroupFilter.source()
+) : StaticAbility {
+    override val description: String = "can't block unless ${coBlockerFilter.description} also blocks"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Creatures can't attack you unless their controller pays generic mana for each
  * attacking creature. Used for Ghostly Prison, Propaganda, Windborn Muse, and
  * Domain-scaled variants like Collective Restraint.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TobyBeastieBefriender.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TobyBeastieBefriender.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnlessCoAttacker
+import com.wingedsheep.sdk.scripting.CantBlockUnlessCoBlocker
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Toby, Beastie Befriender
+ * {2}{W}
+ * Legendary Creature — Human Wizard
+ * 1/1
+ *
+ * When Toby enters, create a 4/4 white Beast creature token with "This token can't attack or
+ * block alone."
+ * As long as you control four or more creature tokens, creature tokens you control have flying.
+ */
+val TobyBeastieBefriender = card("Toby, Beastie Befriender") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "When Toby enters, create a 4/4 white Beast creature token with \"This token can't " +
+        "attack or block alone.\"\n" +
+        "As long as you control four or more creature tokens, creature tokens you control have flying."
+
+    // "can't attack or block alone" = the co-attacker restriction (existing) plus the new
+    // co-blocker restriction; both filter on any creature, so any other declared attacker/blocker
+    // satisfies the requirement.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 4,
+            toughness = 4,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Beast"),
+            name = "Beast",
+            staticAbilities = listOf(
+                CantAttackUnlessCoAttacker(coAttackerFilter = GameObjectFilter.Creature),
+                CantBlockUnlessCoBlocker(coBlockerFilter = GameObjectFilter.Creature),
+            ),
+            imageUri = "https://cards.scryfall.io/normal/front/f/4/f43e18d8-529d-4d63-b627-b9d9fa4f3f38.jpg?1726236338",
+        )
+    }
+
+    // "As long as you control four or more creature tokens, creature tokens you control have flying."
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(
+                Keyword.FLYING,
+                GroupFilter(GameObjectFilter.Creature.youControl().token()),
+            ),
+            condition = Conditions.YouControlAtLeast(
+                4,
+                GameObjectFilter.Creature.youControl().token(),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "35"
+        artist = "Jehan Choo"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f33d3948-fe7b-4c3b-ab67-1022623fbb2b.jpg?1726285986"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -11322,6 +11322,94 @@
     ]
 }
 
+// Toby, Beastie Befriender
+{
+    "name": "Toby, Beastie Befriender",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "When Toby enters, create a 4/4 white Beast creature token with \"This token can't attack or block alone.\"\nAs long as you control four or more creature tokens, creature tokens you control have flying.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 4,
+                    "toughness": 4,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Beast"
+                    ],
+                    "name": "Beast",
+                    "imageUri": "https://cards.scryfall.io/normal/front/f/4/f43e18d8-529d-4d63-b627-b9d9fa4f3f38.jpg?1726236338",
+                    "staticAbilities": [
+                        {
+                            "type": "CantAttackUnlessCoAttacker",
+                            "coAttackerFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "CantBlockUnlessCoBlocker",
+                            "coBlockerFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "creature token ctrl:you"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature token ctrl:you"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "rarity": "RARE",
+        "artist": "Jehan Choo",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f33d3948-fe7b-4c3b-ab67-1022623fbb2b.jpg?1726285986"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Trapped in the Screen
 {
     "name": "Trapped in the Screen",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -28,6 +28,7 @@ import com.wingedsheep.sdk.model.CreatureStats
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.event.GrantedActivatedAbility
+import com.wingedsheep.engine.event.GrantedStaticAbility
 import com.wingedsheep.engine.event.GrantedTriggeredAbility
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
@@ -314,6 +315,28 @@ class CreateTokenExecutor(
                     )
                     newState = newState.copy(
                         grantedActivatedAbilities = newState.grantedActivatedAbilities + grant
+                    )
+                }
+            }
+        }
+
+        // Static abilities also live on the token entity for the layer system
+        // (ContinuousEffectSourceComponent, attached above). But combat-restriction statics like
+        // CantAttackUnlessCoAttacker / CantBlockUnlessCoBlocker are read directly by the combat
+        // legality managers from the card definition or grantedStaticAbilities — never projected —
+        // and a token has no CardDefinition. So grant them per-token here, mirroring the triggered/
+        // activated-ability paths above, so those managers can find a token's "can't attack/block
+        // alone"-style restrictions (Toby's Beast token).
+        if (effect.staticAbilities.isNotEmpty()) {
+            for (tokenId in createdTokens) {
+                for (ability in effect.staticAbilities) {
+                    val grant = GrantedStaticAbility(
+                        entityId = tokenId,
+                        ability = ability,
+                        duration = Duration.Permanent
+                    )
+                    newState = newState.copy(
+                        grantedStaticAbilities = newState.grantedStaticAbilities + grant
                     )
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -362,8 +362,15 @@ internal class AttackPhaseManager(
     ): String? {
         for (attackerId in attackerIds) {
             val cardComponent = state.getEntity(attackerId)?.get<CardComponent>() ?: continue
-            val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: continue
-            val restrictions = cardDef.staticAbilities
+            // Tokens have no CardDefinition, so their restrictions arrive via grantedStaticAbilities
+            // (CreateTokenExecutor). Union both sources so the "can't attack alone" half of Toby's
+            // Beast token is enforced alongside printed restrictions (Scarred Puma).
+            val printed = cardRegistry.getCard(cardComponent.cardDefinitionId)
+                ?.staticAbilities.orEmpty()
+            val granted = state.grantedStaticAbilities
+                .filter { it.entityId == attackerId }
+                .map { it.ability }
+            val restrictions = (printed + granted)
                 .filterIsInstance<CantAttackUnlessCoAttacker>()
                 .filter { it.filter.scope is Scope.Self }
             for (restriction in restrictions) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -25,6 +25,8 @@ import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PredicateContext
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.sdk.scripting.BlockTax
 import com.wingedsheep.sdk.scripting.BlockerCountLimit
 import com.wingedsheep.sdk.scripting.CanBlockAnyNumber
@@ -33,6 +35,8 @@ import com.wingedsheep.sdk.scripting.MustBeBlocked
 import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
 import com.wingedsheep.sdk.scripting.CantBlock
 import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnlessCoBlocker
+import com.wingedsheep.sdk.scripting.filters.unified.Scope
 import java.util.UUID
 
 /**
@@ -55,6 +59,7 @@ internal class BlockPhaseManager(
 ) {
     private val conditionEvaluator = ConditionEvaluator()
     private val dynamicAmountEvaluator = DynamicAmountEvaluator()
+    private val predicateEvaluator = PredicateEvaluator()
 
     /**
      * Validate and declare blockers.
@@ -97,6 +102,14 @@ internal class BlockPhaseManager(
         val blockerCountValidation = validateGlobalBlockerCount(state, blockers.keys)
         if (blockerCountValidation != null) {
             return ExecutionResult.error(state, blockerCountValidation)
+        }
+
+        // Check co-blocker requirements (CR 509.1b — "can't block alone" / "can't block unless an
+        // X also blocks"). Depends on the whole proposed blocker group, not the attacker, so it's
+        // validated here rather than per-blocker. Mirrors the co-attacker check in declare-attackers.
+        val coBlockerValidation = validateCoBlockerRequirements(state, state.projectedState, blockers.keys)
+        if (coBlockerValidation != null) {
+            return ExecutionResult.error(state, coBlockerValidation)
         }
 
         // Check "must be blocked" requirements (Alluring Scent, etc.)
@@ -625,6 +638,50 @@ internal class BlockPhaseManager(
         }
         if (cap != null && blockerIds.size > cap) {
             return capDescription
+        }
+        return null
+    }
+
+    /**
+     * Validate "can't block unless [X] also blocks" restrictions ([CantBlockUnlessCoBlocker], CR
+     * 509.1b). The blocking sibling of [com.wingedsheep.engine.mechanics.combat.AttackPhaseManager]'s
+     * co-attacker check.
+     *
+     * For each proposed blocker carrying the restriction, at least one *other* blocker in the same
+     * declaration must match the restriction's filter (evaluated with projected state so
+     * color/type-changing effects are honored). The co-blocker need not block the same attacker —
+     * it just has to be declared as a blocker this combat. Self never counts as its own co-blocker.
+     *
+     * Restrictions are read from both the card definition (printed) and grantedStaticAbilities, so
+     * the form arrives on a token without a CardDefinition (Toby's Beast token — "This token can't
+     * attack or block alone").
+     */
+    private fun validateCoBlockerRequirements(
+        state: GameState,
+        projected: ProjectedState,
+        blockerIds: Set<EntityId>
+    ): String? {
+        for (blockerId in blockerIds) {
+            val cardComponent = state.getEntity(blockerId)?.get<CardComponent>() ?: continue
+            if (state.getEntity(blockerId)?.has<FaceDownComponent>() == true) continue
+            val printed = cardRegistry.getCard(cardComponent.cardDefinitionId)
+                ?.staticAbilities.orEmpty()
+            val granted = state.grantedStaticAbilities
+                .filter { it.entityId == blockerId }
+                .map { it.ability }
+            val restrictions = (printed + granted)
+                .filterIsInstance<CantBlockUnlessCoBlocker>()
+                .filter { it.filter.scope is Scope.Self }
+            for (restriction in restrictions) {
+                val context = PredicateContext(controllerId = projected.getController(blockerId) ?: blockerId)
+                val satisfied = blockerIds.any { otherId ->
+                    otherId != blockerId &&
+                        predicateEvaluator.matches(state, projected, otherId, restriction.coBlockerFilter, context)
+                }
+                if (!satisfied) {
+                    return "${cardComponent.name} ${restriction.description}"
+                }
+            }
         }
         return null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -90,6 +90,7 @@ import com.wingedsheep.sdk.scripting.CantBeBlockedIfCastSpellType
 import com.wingedsheep.sdk.scripting.CantBeBlockedUnlessDefenderSharesCreatureType
 import com.wingedsheep.sdk.scripting.CantBlockCreaturesWithGreaterPower
 import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnlessCoBlocker
 import com.wingedsheep.sdk.scripting.CantCastSpellsSharingColorWithLastCast
 import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
 import com.wingedsheep.sdk.scripting.DampLandManaProduction
@@ -725,6 +726,7 @@ class StaticAbilityHandler(
             is CantBeBlockedUnlessDefenderSharesCreatureType,
             is CantBlockCreaturesWithGreaterPower,
             is CantBlockUnless,
+            is CantBlockUnlessCoBlocker,
 
             // Combat: damage assignment (CombatDamageManager / CombatDamageUtils / DamageUtils):
             is AssignCombatDamageAsUnblocked,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TobyBeastieBefrienderTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TobyBeastieBefrienderTest.kt
@@ -1,0 +1,232 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CantBlockUnlessCoBlocker
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Toby, Beastie Befriender (DSK #35) and the new "can't block alone" combat restriction
+ * ([CantBlockUnlessCoBlocker], CR 509.1b — the blocking sibling of `CantAttackUnlessCoAttacker`,
+ * CR 508.1c).
+ *
+ * Toby:
+ * - ETB: create a 4/4 white Beast token with "This token can't attack or block alone."
+ * - Static: "As long as you control four or more creature tokens, creature tokens you control
+ *   have flying."
+ */
+class TobyBeastieBefrienderTest : FunSpec({
+
+    // A vanilla creature used as a co-attacker / co-blocker partner.
+    val TestWarrior = CardDefinition.creature(
+        name = "Test Warrior",
+        manaCost = ManaCost.parse("{1}{R}"),
+        subtypes = setOf(Subtype("Human"), Subtype("Warrior")),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    // A bare-bones "can't block alone" creature CARD, so the restriction is exercised through the
+    // card-registry path (CR 509.1b) independently of token plumbing.
+    val LonelySentinel = card("Lonely Sentinel") {
+        manaCost = "{W}"
+        typeLine = "Creature — Soldier"
+        power = 2
+        toughness = 2
+        oracleText = "This creature can't block alone."
+        staticAbility {
+            ability = CantBlockUnlessCoBlocker(coBlockerFilter = GameObjectFilter.Creature)
+        }
+    }
+
+    // Token makers, used to drive Toby's "four or more creature tokens" static ability.
+    val MakeThreeSaprolings = card("Make Three Saprolings") {
+        manaCost = "{G}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.CreateToken(
+                power = 1, toughness = 1, colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Saproling"), count = 3
+            )
+        }
+    }
+    val MakeFourSaprolings = card("Make Four Saprolings") {
+        manaCost = "{G}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.CreateToken(
+                power = 1, toughness = 1, colors = setOf(Color.GREEN),
+                creatureTypes = setOf("Saproling"), count = 4
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(TestWarrior, LonelySentinel, MakeThreeSaprolings, MakeFourSaprolings)
+        )
+        return driver
+    }
+
+    fun GameTestDriver.beastTokenOf(playerId: EntityId): EntityId? =
+        state.getBattlefield().firstOrNull { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == "Beast" && getController(id) == playerId
+        }
+
+    fun GameTestDriver.saprolingOf(playerId: EntityId): EntityId? =
+        state.getBattlefield().firstOrNull { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name?.contains("Saproling") == true &&
+                getController(id) == playerId
+        }
+
+    fun GameTestDriver.castTobyAndResolve(playerId: EntityId): EntityId {
+        giveMana(playerId, Color.WHITE, 3)
+        val toby = putCardInHand(playerId, "Toby, Beastie Befriender")
+        val cast = castSpell(playerId, toby)
+        withClue("Casting Toby should succeed") { cast.error shouldBe null }
+        // Resolve Toby itself, then its ETB trigger.
+        bothPass()
+        bothPass()
+        return beastTokenOf(playerId) ?: error("Toby's ETB Beast token was not created")
+    }
+
+    // -------------------------------------------------------------------------
+    // can't block alone (CR 509.1b) — card-registry path
+    // -------------------------------------------------------------------------
+
+    test("a 'can't block alone' creature cannot be the only blocker") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // p2 is the defender; give it the lonely blocker plus a partner.
+        val sentinel = driver.putCreatureOnBattlefield(p2, "Lonely Sentinel")
+        val partner = driver.putCreatureOnBattlefield(p2, "Test Warrior")
+        // p1 attacks with a creature it has controlled since before this turn.
+        val attacker = driver.putCreatureOnBattlefield(p1, "Test Warrior")
+        driver.removeSummoningSickness(attacker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(attacker), p2)
+        driver.bothPass()
+
+        withClue("Lonely Sentinel can't block alone") {
+            driver.declareBlockers(p2, mapOf(sentinel to listOf(attacker))).error shouldNotBe null
+        }
+        withClue("…but can block alongside another blocker") {
+            driver.declareBlockers(
+                p2, mapOf(sentinel to listOf(attacker), partner to listOf(attacker))
+            ).error shouldBe null
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Toby's Beast token — restriction arrives via grantedStaticAbilities (no CardDefinition)
+    // -------------------------------------------------------------------------
+
+    test("Toby's Beast token can't attack alone but can with a co-attacker") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val beast = driver.castTobyAndResolve(p1)
+        driver.removeSummoningSickness(beast)
+        val ally = driver.putCreatureOnBattlefield(p1, "Test Warrior")
+        driver.removeSummoningSickness(ally)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        withClue("Beast token can't attack alone") {
+            driver.declareAttackers(p1, listOf(beast), p2).error shouldNotBe null
+        }
+        withClue("…but can attack alongside another attacker") {
+            driver.declareAttackers(p1, listOf(beast, ally), p2).error shouldBe null
+        }
+    }
+
+    test("Toby's Beast token can't block alone but can with a co-blocker") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val beast = driver.castTobyAndResolve(p1)
+        val ally = driver.putCreatureOnBattlefield(p1, "Test Warrior")
+        // p2's attacker, controlled since before p2's turn.
+        val attacker = driver.putCreatureOnBattlefield(p2, "Test Warrior")
+
+        // Advance to p2's declare-attackers (past p1's own combat, which auto-submits empty).
+        driver.passPriorityUntil(Step.END)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p2, listOf(attacker), p1)
+        driver.bothPass()
+
+        withClue("Beast token can't block alone") {
+            driver.declareBlockers(p1, mapOf(beast to listOf(attacker))).error shouldNotBe null
+        }
+        withClue("…but can block alongside another blocker") {
+            driver.declareBlockers(
+                p1, mapOf(beast to listOf(attacker), ally to listOf(attacker))
+            ).error shouldBe null
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Toby's flying static ability (gated on four or more creature tokens)
+    // -------------------------------------------------------------------------
+
+    test("creature tokens you control don't have flying with only three creature tokens") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(p1, "Toby, Beastie Befriender") // static source (no ETB token)
+        driver.giveMana(p1, Color.GREEN, 1)
+        driver.castSpell(p1, driver.putCardInHand(p1, "Make Three Saprolings"))
+        driver.bothPass()
+
+        val token = driver.saprolingOf(p1) ?: error("No Saproling token")
+        withClue("3 creature tokens < 4 → no flying") {
+            driver.state.projectedState.hasKeyword(token, Keyword.FLYING) shouldBe false
+        }
+    }
+
+    test("creature tokens you control gain flying with four or more creature tokens") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(p1, "Toby, Beastie Befriender") // static source (no ETB token)
+        driver.giveMana(p1, Color.GREEN, 1)
+        driver.castSpell(p1, driver.putCardInHand(p1, "Make Four Saprolings"))
+        driver.bothPass()
+
+        val token = driver.saprolingOf(p1) ?: error("No Saproling token")
+        withClue("4 creature tokens ≥ 4 → flying") {
+            driver.state.projectedState.hasKeyword(token, Keyword.FLYING) shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
## Summary

Adds engine support for a **"can't block alone" combat restriction** and implements **Toby, Beastie Befriender** (DSK #35), whose Beast token needs it.

### New SDK type
`CantBlockUnlessCoBlocker(coBlockerFilter, filter = source)` — the declare-blockers sibling of the existing `CantAttackUnlessCoAttacker`. Validated against the whole proposed blocker group at declaration time (**CR 509.1b**) in `BlockPhaseManager`: a creature carrying it can't be the only declared blocker; the co-blocker need not block the same attacker. Parameterized over a `GameObjectFilter` (pass `GameObjectFilter.Creature` for the bare "alone" form, or any filter for "can't block unless an X also blocks"). Together with `CantAttackUnlessCoAttacker` (**CR 508.1c**) it expresses "can't attack or block alone".

### Token plumbing (designed for the next card too)
Combat-restriction statics are read directly by the combat managers, never projected — so a token (no `CardDefinition`) previously couldn't carry them. `CreateTokenEffect.staticAbilities` are now also granted per-token into `grantedStaticAbilities` (mirroring the existing triggered/activated-ability token paths), and **both** the co-attacker and co-blocker validators union the card definition with `grantedStaticAbilities`. This fixes co-attacker-on-token too, not just the new co-blocker.

### Card
**Toby, Beastie Befriender** `{2}{W}` 1/1 — ETB makes the 4/4 white Beast token with "can't attack or block alone" (existing co-attacker half + new co-blocker half), plus the conditional flying lord composed entirely from existing primitives (`ConditionalStaticAbility` + `GrantKeyword` + `Conditions.YouControlAtLeast` over a `creature tokens you control` filter).

## Files
- `mtg-sdk/.../scripting/CombatStaticAbilities.kt` — new `CantBlockUnlessCoBlocker`
- `rules-engine/.../combat/BlockPhaseManager.kt` — `validateCoBlockerRequirements` (CR 509.1b)
- `rules-engine/.../combat/AttackPhaseManager.kt` — co-attacker check now unions `grantedStaticAbilities`
- `rules-engine/.../effects/token/CreateTokenExecutor.kt` — grant token statics into `grantedStaticAbilities`
- `rules-engine/.../layers/StaticAbilityHandler.kt` — classify the new (non-projected) static
- `mtg-sets/.../dsk/cards/TobyBeastieBefriender.kt` + re-blessed `DSK.json` golden
- `docs/card-sdk-language-reference.md` — documented both restrictions + CR numbers
- `rules-engine/.../scenarios/TobyBeastieBefrienderTest.kt` — 5 scenario tests

## Tests
- can't-block-alone via the card-registry path (CR 509.1b)
- Toby's token can't-attack-alone and can't-block-alone (grantedStaticAbilities path)
- flying lord gated at the 4-creature-token threshold (no flying at 3, flying at 4)
- Full suite green: `rules-engine` 5418 / `mtg-sdk` 302 / DSK snapshot + CardLint pass

CR rule numbers verified against the official Comprehensive Rules (508.1c attack restrictions, 509.1b block restrictions).

mtgish Step 8b intentionally skipped: this static maps to no mtgish IR tag and the co-attacker sibling has no bridge/emitter entry either; "can't block alone" is too card-specific to render, so coverage scoring is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)