### PR TITLE
Add resolution-time "unlock a door" effect + Ghostly Keybearer

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1002,6 +1002,17 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `Effects.UntapEachTarget()` — the untap twin of `TapEachTarget`: untaps every object chosen as a
   target ("untap each of those creatures"). Composes `ForEachTargetEffect` over
   `Effects.Untap(ContextTarget(0))`, with the count owned by the spell's target requirement.
+- `UnlockDoorEffect(target = ContextTarget(0))` — facade `Effects.UnlockDoor(target)`. The resolution-time
+  **"unlock a door"** instruction (CR 709.5f): gives a locked half of the targeted Room the "unlocked"
+  designation. Distinct from the *unlock cost* special action (CR 709.5e, `ModifyUnlockCost` below) — the
+  resolving controller pays nothing. Routes through the same shared `RoomDoorUnlocker` the special action uses,
+  so it emits the identical `DoorUnlockedEvent`/`RoomFullyUnlockedEvent` and a face's "When you unlock this
+  door" trigger (`Triggers.OnDoorUnlocked`, CR 709.5h) fires either way. Pair with an **up-to-one** target
+  Room restricted to one with a locked door —
+  `TargetObject(optional = true, filter = TargetFilter(GameObjectFilter.Any.withSubtype(Subtype.ROOM).youControl()).hasLockedDoor())`
+  — so a fully-unlocked Room is never a legal target and the controller may choose no target. If the Room has
+  more than one locked door (it entered without being cast, CR 709.5d), its first locked door is unlocked.
+  Used by Ghostly Keybearer.
 - `PhaseOutEffect(target = Self)` — phase the target permanent out (Rule 702.26); facade `Effects.PhaseOut(target)`. While phased out it's treated as though it doesn't exist (excluded from `getBattlefield`, so from projection, triggers, combat, targeting, and SBAs) and phases back in before its controller's next untap step. Indirect phasing (attached Auras/Equipment) is handled automatically. Used as the `suffer` branch of a pay-or-phase trigger (Vaporous Djinn: "phases out unless you pay {U}{U}" = `PayOrSufferEffect(Costs.pay.Mana(...), Effects.PhaseOut())`), or as the reaction of a "becomes the target of a spell, it phases out" trigger (King of the Oathbreakers = `Triggers.BecomesTargetOfSpell(...)` + `Effects.PhaseOut(EffectTarget.TriggeringEntity)`). The matching phase-in moment is the `Triggers.PhasesIn(filter?)` trigger (see Triggers below).
 - `PhaseOutUntilLeavesEffect(target, tapOnPhaseIn)` / `Effects.PhaseOutUntilLeaves(target, tapOnPhaseIn)` — phase the target out **indefinitely, linked to the effect's source** (the phasing analogue of `ExileUntilLeaves`): it skips its untap-step phase-in and stays out until the source leaves the battlefield. Pair with `Effects.PhaseInLinkedToSource()` on the source's `LeavesBattlefield` trigger, which phases everything the source phased out this way back in (tapping those flagged `tapOnPhaseIn`). The link lives on the phased-out permanent (`PhasedOutComponent.phaseInOnSourceLeaves`); indirect phasing carries Auras/Equipment out with the creature. This is Oubliette (ETB phase-out + leaves-trigger phase-in, tapped).
 - `MarkExileOnDeathEffect(target)` — replace next "to graveyard" with "to exile".
@@ -1946,6 +1957,11 @@ work for abilities-on-stack (which carry no `CardComponent`).
 - `IsUntapped` — currently untapped.
 - `IsAttacking` — declared as attacker this combat.
 - `IsBlocking` — declared as blocker this combat.
+- `HasLockedDoor` (filter builder `hasLockedDoor()`) — a Room permanent (CR 709.5) with at least one locked
+  door, i.e. a half lacking its "unlocked" designation (CR 709.5c). Reads the engine's
+  `RoomComponent.lockedFaces`; false for non-Rooms and fully-unlocked Rooms. The targeting restriction for
+  "unlock a locked door of target Room you control" (Ghostly Keybearer) — a Room with nothing to unlock isn't a
+  legal target. Pairs with `UnlockDoorEffect`/`Effects.UnlockDoor`.
 - `InSameBandAsSource` (filter builder `inSameBandAsSource()`) — source-relative (CR 702.22):
   matches the effect's source creature itself and any creature sharing its combat band id.
   Resolves against `PredicateContext.sourceId`, so it only matches while that source is attacking

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2745,6 +2745,15 @@ object Effects {
         TapUntapEffect(target, tap = false)
 
     /**
+     * Unlock a locked door of a target Room (CR 709.5f) — the resolution-time "unlock" instruction.
+     * Pairs with an "up to one target Room you control with a locked door" `TargetObject`
+     * (`TargetFilter.…hasLockedDoor()`). Emits the same door-unlock events as the unlock-cost
+     * special action, so "When you unlock this door" triggers fire. Used by Ghostly Keybearer.
+     */
+    fun UnlockDoor(target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
+        com.wingedsheep.sdk.scripting.effects.UnlockDoorEffect(target)
+
+    /**
      * Tap every creature/permanent chosen as a target ("tap up to N target creatures").
      *
      * Composes [ForEachTargetEffect] over [Effects.Tap], so the number of targets is owned

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RoomEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RoomEffects.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.sdk.scripting.effects
+
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// =============================================================================
+// Room / Door Effects (CR 709.5)
+// =============================================================================
+
+/**
+ * Resolution-time "unlock a door" effect (CR 709.5f).
+ *
+ * "To unlock half of a permanent, a player chooses a locked half of that permanent, and that
+ * permanent is given the appropriate unlocked designation." This is the spell/ability form of
+ * unlocking — distinct from the [unlock cost] special action (CR 709.5e), which pays a half's
+ * mana cost. The resolving controller pays nothing.
+ *
+ * The [target] is the Room whose door is unlocked. Model it with an "up to one target Room you
+ * control with a locked door" `TargetObject` (`TargetFilter.…hasLockedDoor()`) so a fully-unlocked
+ * Room is never a legal target and the optional ("up to one") form lets the controller choose no
+ * target. If the target Room still has a single locked door at resolution it is unlocked; if it has
+ * more than one locked door (a Room that entered without being cast, CR 709.5d), one of them is
+ * unlocked.
+ *
+ * Unlocking emits the same `DoorUnlockedEvent` (and `RoomFullyUnlockedEvent` when it completes the
+ * Room) the unlock-cost special action emits, so face-scoped "When you unlock this door" triggers
+ * (CR 709.5h) and "fully unlock" / Eerie triggers fire identically.
+ *
+ * Authored via [com.wingedsheep.sdk.dsl.Effects.UnlockDoor].
+ */
+@SerialName("UnlockDoor")
+@Serializable
+data class UnlockDoorEffect(
+    val target: EffectTarget = EffectTarget.ContextTarget(0)
+) : Effect {
+    override val description: String = "unlock a locked door of ${target.description} Room"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -540,6 +540,11 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.IsUntapped
     )
 
+    /** Must be a Room with at least one locked door (CR 709.5c). */
+    fun hasLockedDoor() = copy(
+        statePredicates = statePredicates + StatePredicate.HasLockedDoor
+    )
+
     /** Must be attacking */
     fun attacking() = copy(
         statePredicates = statePredicates + StatePredicate.IsAttacking

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -332,6 +332,9 @@ data class TargetFilter(
     /** Must be untapped */
     fun untapped() = copy(baseFilter = baseFilter.untapped())
 
+    /** Must be a Room with at least one locked door (CR 709.5c). */
+    fun hasLockedDoor() = copy(baseFilter = baseFilter.hasLockedDoor())
+
     /** Must be attacking */
     fun attacking() = copy(baseFilter = baseFilter.attacking())
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -389,6 +389,26 @@ sealed interface StatePredicate {
     }
 
     // =============================================================================
+    // Rooms (Entity)
+    // =============================================================================
+
+    /**
+     * A Room permanent (CR 709.5) that currently has at least one locked door — i.e. at least
+     * one half without its "unlocked" designation (CR 709.5c). Reads the engine's
+     * `RoomComponent.lockedFaces`; false for any permanent that isn't a Room or whose doors are
+     * all unlocked.
+     *
+     * Used as a targeting restriction for "unlock a locked door of target Room you control"
+     * (Ghostly Keybearer): a fully-unlocked Room has no door left to unlock, so it isn't a legal
+     * target.
+     */
+    @SerialName("HasLockedDoor")
+    @Serializable
+    data object HasLockedDoor : Entity {
+        override val description: String = "with a locked door"
+    }
+
+    // =============================================================================
     // Saddle (Entity)
     // =============================================================================
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GhostlyKeybearer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GhostlyKeybearer.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ghostly Keybearer — Duskmourn: House of Horror #61
+ * {3}{U}
+ * Creature — Spirit
+ * 3/3
+ *
+ * Flying
+ * Whenever this creature deals combat damage to a player, unlock a locked door of up to one
+ * target Room you control.
+ *
+ * The combat-damage trigger uses the resolution-time "unlock a door" effect (CR 709.5f): it gives
+ * a locked half of the targeted Room the "unlocked" designation, firing that face's "When you
+ * unlock this door" triggers (CR 709.5h) exactly as the unlock-cost special action would. "Up to
+ * one target Room you control" is an optional `TargetObject` restricted to a Room with a locked
+ * door — a fully-unlocked Room has nothing left to unlock, so it isn't a legal target, and the
+ * controller may also choose no target.
+ */
+val GhostlyKeybearer = card("Ghostly Keybearer") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\nWhenever this creature deals combat damage to a player, unlock a locked " +
+        "door of up to one target Room you control."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val room = target(
+            "room",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.Any.withSubtype(Subtype.ROOM).youControl()
+                ).hasLockedDoor()
+            )
+        )
+        effect = Effects.UnlockDoor(room)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "61"
+        artist = "Marco Gorlei"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11d04a98-6997-4653-9719-e6b215567599.jpg?1726286080"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -4895,6 +4895,68 @@
     "colorIdentityOverride": []
 }
 
+// Ghostly Keybearer
+{
+    "name": "Ghostly Keybearer",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhenever this creature deals combat damage to a player, unlock a locked door of up to one target Room you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "UnlockDoor",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "room"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "HasSubtype",
+                                    "subtype": "Room"
+                                }
+                            ],
+                            "statePredicates": [
+                                "HasLockedDoor"
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    },
+                    "id": "room"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "61",
+        "rarity": "UNCOMMON",
+        "artist": "Marco Gorlei",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11d04a98-6997-4653-9719-e6b215567599.jpg?1726286080"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Give In to Violence
 {
     "name": "Give In to Violence",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -460,6 +460,7 @@ class BeginningPhaseManager(
         StatePredicate.IsEquipped,
         StatePredicate.IsModified,
         StatePredicate.IsSaddled,
+        StatePredicate.HasLockedDoor,
         StatePredicate.CrewedOrSaddledSourceThisTurn,
         StatePredicate.IsWarpExiled,
         StatePredicate.NotTargetedByAbilityFromSameNamedSource,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1594,6 +1594,7 @@ class TriggerMatcher(
         // *trigger-gating* filters (those evaluate the triggering entity, not the source
         // state). Returning true preserves the prior "don't gate" behavior, but listing
         // every variant forces a compile-time choice when a new predicate is added.
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.HasLockedDoor,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsTapped,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsUntapped,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttacking,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -24,6 +24,7 @@ import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnCom
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
@@ -1087,6 +1088,11 @@ class PredicateEvaluator {
                     ?: return false
                 entityPower <= minPower
             }
+
+            // Rooms: has at least one locked door (CR 709.5c). The unlock-a-door targeting
+            // restriction — a fully-unlocked Room (or any non-Room) has no door to unlock.
+            StatePredicate.HasLockedDoor ->
+                container.get<RoomComponent>()?.lockedFaces?.isNotEmpty() == true
 
             // Composite / logical combinators
             is StatePredicate.Or -> predicate.predicates.any { matchesStatePredicate(state, entityId, it, context) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/RoomDoorUnlocker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/RoomDoorUnlocker.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.handlers.actions.room
+
+import com.wingedsheep.engine.core.DoorUnlockedEvent
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.RoomFullyUnlockedEvent
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Shared door-unlock primitive (CR 709.5f/h). Gives a single locked face of a Room permanent the
+ * appropriate "unlocked" designation and emits the resulting events.
+ *
+ * This is the one place that mutates [RoomComponent.unlocked]. Both paths that can unlock a door —
+ * the unlock-cost special action ([UnlockRoomDoorHandler], CR 709.5e) and the resolution-time
+ * "unlock a door" effect (`UnlockDoorEffect`, CR 709.5f) — funnel through here so they emit
+ * identical [DoorUnlockedEvent] / [RoomFullyUnlockedEvent] events. That keeps "When you unlock this
+ * door" (CR 709.5h) and "fully unlock" / Eerie triggers firing the same way regardless of how the
+ * door was unlocked.
+ *
+ * Trigger detection is the caller's responsibility: the special-action handler runs it inline
+ * (special actions don't use the stack), while the effect executor returns the events for the
+ * normal effect-resolution trigger pass to pick up.
+ */
+object RoomDoorUnlocker {
+
+    /**
+     * Unlock [faceId] of the Room [roomId] controlled by [controllerId]. Returns the new state with
+     * that face designated unlocked, plus a [DoorUnlockedEvent] (and a [RoomFullyUnlockedEvent] when
+     * this transition completes the Room). If the face is already unlocked or the entity isn't a
+     * Room, returns the state unchanged with no events.
+     */
+    fun unlock(
+        state: GameState,
+        roomId: EntityId,
+        faceId: RoomFaceId,
+        controllerId: EntityId,
+    ): Pair<GameState, List<GameEvent>> {
+        val container = state.getEntity(roomId) ?: return state to emptyList()
+        val room = container.get<RoomComponent>() ?: return state to emptyList()
+        val face = room.faces.find { it.id == faceId } ?: return state to emptyList()
+        if (room.isUnlocked(faceId)) return state to emptyList()
+
+        val roomName = container.get<CardComponent>()?.name ?: face.name
+        val updatedRoom = room.copy(unlocked = room.unlocked + faceId)
+        val newState = state.updateEntity(roomId) { c -> c.with(updatedRoom) }
+
+        val events = mutableListOf<GameEvent>()
+        val nowFullyUnlocked = updatedRoom.isFullyUnlocked
+        events.add(
+            DoorUnlockedEvent(
+                roomId = roomId,
+                roomName = roomName,
+                faceId = faceId,
+                faceName = face.name,
+                controllerId = controllerId,
+                becameFullyUnlocked = nowFullyUnlocked,
+            )
+        )
+        if (nowFullyUnlocked) {
+            events.add(
+                RoomFullyUnlockedEvent(
+                    roomId = roomId,
+                    roomName = roomName,
+                    controllerId = controllerId,
+                )
+            )
+        }
+        return newState to events
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/room/UnlockRoomDoorHandler.kt
@@ -20,7 +20,6 @@ import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
 import com.wingedsheep.engine.mechanics.mana.UnlockCostReducer
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
@@ -274,34 +273,13 @@ class UnlockRoomDoorHandler(
             }
         }
 
-        // Apply the unlock to the RoomComponent.
-        val roomName = state.getEntity(action.roomId)?.get<CardComponent>()?.name ?: face.name
-        val newUnlocked = room.unlocked + action.faceId
-        val updatedRoom = room.copy(unlocked = newUnlocked)
-        currentState = currentState.updateEntity(action.roomId) { c ->
-            c.with(updatedRoom)
-        }
-
-        val nowFullyUnlocked = updatedRoom.isFullyUnlocked
-        events.add(
-            DoorUnlockedEvent(
-                roomId = action.roomId,
-                roomName = roomName,
-                faceId = action.faceId,
-                faceName = face.name,
-                controllerId = action.playerId,
-                becameFullyUnlocked = nowFullyUnlocked
-            )
+        // Apply the unlock to the RoomComponent via the shared primitive, so the unlock-cost
+        // special action and the resolution-time "unlock a door" effect emit identical events.
+        val (stateAfterUnlock, unlockEvents) = RoomDoorUnlocker.unlock(
+            currentState, action.roomId, action.faceId, action.playerId
         )
-        if (nowFullyUnlocked) {
-            events.add(
-                RoomFullyUnlockedEvent(
-                    roomId = action.roomId,
-                    roomName = roomName,
-                    controllerId = action.playerId
-                )
-            )
-        }
+        currentState = stateAfterUnlock
+        events.addAll(unlockEvents)
 
         // Detect and process triggers from the door-unlock events.
         val triggers = triggerDetector.detectTriggers(currentState, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -53,6 +53,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.phasing.PhaseOutExecuto
 import com.wingedsheep.engine.handlers.effects.permanent.phasing.PhaseOutUntilLeavesExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.phasing.PhaseInLinkedToSourceExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.tapping.TapUntapCollectionExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.room.UnlockDoorExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.tapping.TapUntapExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.AddCardTypeExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.AddColorExecutor
@@ -189,6 +190,8 @@ class PermanentExecutors(
         // tapping
         TapUntapExecutor(),
         TapUntapCollectionExecutor(),
+        // rooms / doors
+        UnlockDoorExecutor(),
         // phasing
         PhaseOutExecutor(),
         PhaseOutUntilLeavesExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/room/UnlockDoorExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/room/UnlockDoorExecutor.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.engine.handlers.effects.permanent.room
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.actions.room.RoomDoorUnlocker
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.sdk.scripting.effects.UnlockDoorEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [UnlockDoorEffect] — the resolution-time "unlock a door" instruction (CR 709.5f).
+ *
+ * Resolves the targeted Room and unlocks one of its locked doors via the shared
+ * [RoomDoorUnlocker], so it emits the same `DoorUnlockedEvent` / `RoomFullyUnlockedEvent` the
+ * unlock-cost special action emits and "When you unlock this door" triggers (CR 709.5h) fire
+ * normally off the returned events.
+ *
+ * The target is "up to one" (optional): a fully-unlocked Room is never offered as a target
+ * (the `hasLockedDoor()` targeting restriction), and choosing no target resolves as a harmless
+ * no-op. When the Room has more than one locked door (it entered without being cast, CR 709.5d),
+ * its first locked face is unlocked — CR 709.5f leaves the choice of which door to the controller,
+ * which this models deterministically since the single-locked-door case (a normally-cast Room)
+ * carries no real choice.
+ */
+class UnlockDoorExecutor : EffectExecutor<UnlockDoorEffect> {
+
+    override val effectType: KClass<UnlockDoorEffect> = UnlockDoorEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: UnlockDoorEffect,
+        context: EffectContext
+    ): EffectResult {
+        // "Up to one target": no chosen target → nothing to unlock (not an error).
+        val roomId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.success(state, emptyList())
+
+        val container = state.getEntity(roomId)
+            ?: return EffectResult.success(state, emptyList())
+        val room = container.get<RoomComponent>()
+            ?: return EffectResult.success(state, emptyList())
+
+        // Choose a locked door to unlock (CR 709.5f). May be empty if the Room was unlocked in
+        // response to the trigger going on the stack — then this resolves as a no-op.
+        val lockedFace = room.lockedFaces.firstOrNull()
+            ?: return EffectResult.success(state, emptyList())
+
+        val controllerId = container.get<ControllerComponent>()?.playerId ?: context.controllerId
+        val (newState, events) = RoomDoorUnlocker.unlock(state, roomId, lockedFace.id, controllerId)
+        return EffectResult.success(newState, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnCom
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.identity.HasMorphAbilityComponent
 import com.wingedsheep.engine.state.components.identity.MorphDataComponent
 import com.wingedsheep.sdk.core.CounterType
@@ -460,6 +461,8 @@ internal class AffectsFilterResolver {
             val counterType = parseCounterType(predicate.counterType)
             counters != null && counterType != null && counters.getCount(counterType) > 0
         }
+        StatePredicate.HasLockedDoor ->
+            container.get<RoomComponent>()?.lockedFaces?.isNotEmpty() == true
         is StatePredicate.Or -> predicate.predicates.any {
             matchesStatePredicateForProjection(state, entityId, it, container, isFaceDown, projectedValues)
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostlyKeybearerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostlyKeybearerTest.kt
@@ -1,0 +1,179 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ghostly Keybearer ({3}{U} 3/3 Spirit, flying): "Whenever this creature deals combat damage to a
+ * player, unlock a locked door of up to one target Room you control."
+ *
+ * Exercises the resolution-time "unlock a door" effect (CR 709.5f) and its "up to one target Room
+ * you control with a locked door" targeting:
+ *  - a locked Room is a legal target and its door is unlocked, firing the face's
+ *    "When you unlock this door" trigger (CR 709.5h);
+ *  - with no Room to unlock, the optional trigger resolves harmlessly (up-to-one);
+ *  - a fully-unlocked Room is not a legal target (the locked-door restriction).
+ */
+class GhostlyKeybearerTest : FunSpec({
+
+    // A Room whose locked face (Test Vault) draws a card when unlocked, so we can observe the
+    // "When you unlock this door" trigger firing off the resolution-time unlock.
+    val testRoom = card("Keybearer Hall // Keybearer Vault") {
+        layout = CardLayout.SPLIT
+        face("Keybearer Hall") {
+            manaCost = "{2}{B}"
+            typeLine = "Enchantment — Room"
+            oracleText = "At the beginning of your end step, draw a card."
+            triggeredAbility {
+                trigger = Triggers.YourEndStep
+                effect = Effects.DrawCards(1)
+            }
+        }
+        face("Keybearer Vault") {
+            manaCost = "{3}{B}{B}"
+            typeLine = "Enchantment — Room"
+            oracleText = "When you unlock this door, draw a card."
+            triggeredAbility {
+                trigger = Triggers.OnDoorUnlocked
+                effect = Effects.DrawCards(1)
+            }
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(testRoom)
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            startingLife = 20,
+            skipMulligans = true,
+        )
+        return driver
+    }
+
+    /** Cast the left face so the Room is on the battlefield with the right door locked. */
+    fun GameTestDriver.castLockedRoom(player: com.wingedsheep.sdk.model.EntityId): com.wingedsheep.sdk.model.EntityId {
+        val roomId = putCardInHand(player, testRoom.name)
+        giveMana(player, Color.BLACK, 3)
+        submitSuccess(CastSpell(player, roomId, faceIndex = 0))
+        bothPass()
+        return roomId
+    }
+
+    test("combat damage unlocks a locked door of the target Room and fires its unlock trigger") {
+        val driver = createDriver()
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val roomId = driver.castLockedRoom(attacker)
+        driver.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe
+            setOf(RoomFaceId("Keybearer Hall"))
+
+        val keybearer = driver.putCreatureOnBattlefield(attacker, "Ghostly Keybearer")
+        driver.removeSummoningSickness(keybearer)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(keybearer), defender)
+        driver.bothPass()
+        driver.declareNoBlockers(defender)
+        driver.bothPass()
+
+        // The combat-damage trigger asks for its (up-to-one) target. The locked Room is legal.
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        decision.legalTargets[0]!! shouldContain roomId
+
+        val handBefore = driver.getHand(attacker).size
+        driver.submitTargetSelection(attacker, listOf(roomId))
+        // Resolve the unlock trigger, then the "When you unlock this door, draw a card" trigger.
+        driver.bothPass()
+        driver.bothPass()
+
+        // The locked door is now unlocked (the Room is fully unlocked).
+        val room = driver.state.getEntity(roomId)!!.get<RoomComponent>()!!
+        room.isUnlocked(RoomFaceId("Keybearer Vault")) shouldBe true
+        room.isFullyUnlocked shouldBe true
+
+        // The face's unlock trigger drew a card.
+        driver.getHand(attacker).size shouldBe handBefore + 1
+        driver.assertLifeTotal(defender, 17)
+    }
+
+    test("up to one: with no Room to unlock, the trigger resolves harmlessly") {
+        val driver = createDriver()
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        val keybearer = driver.putCreatureOnBattlefield(attacker, "Ghostly Keybearer")
+        driver.removeSummoningSickness(keybearer)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(keybearer), defender)
+        driver.bothPass()
+        driver.declareNoBlockers(defender)
+        driver.bothPass()
+
+        // No Room with a locked door exists, so the optional trigger has no legal target.
+        // It must not get stuck demanding a target; if a decision is offered it allows zero.
+        (driver.pendingDecision as? ChooseTargetsDecision)?.let { decision ->
+            decision.legalTargets[0].orEmpty().shouldBe(emptyList())
+            driver.submitTargetSelection(attacker, emptyList())
+        }
+        driver.bothPass()
+
+        // Combat damage still landed; nothing else happened.
+        driver.assertLifeTotal(defender, 17)
+    }
+
+    test("a fully-unlocked Room is not a legal target (locked-door restriction)") {
+        val driver = createDriver()
+        val attacker = driver.player1
+        val defender = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val roomId = driver.castLockedRoom(attacker)
+
+        // Unlock the second door via the special action so the Room is fully unlocked.
+        driver.giveMana(attacker, Color.BLACK, 5)
+        driver.submitSuccess(UnlockRoomDoor(attacker, roomId, RoomFaceId("Keybearer Vault")))
+        driver.bothPass() // resolve the unlock-triggered draw
+        driver.state.getEntity(roomId)!!.get<RoomComponent>()!!.isFullyUnlocked shouldBe true
+
+        val keybearer = driver.putCreatureOnBattlefield(attacker, "Ghostly Keybearer")
+        driver.removeSummoningSickness(keybearer)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(keybearer), defender)
+        driver.bothPass()
+        driver.declareNoBlockers(defender)
+        driver.bothPass()
+
+        // The fully-unlocked Room is not offered as a target.
+        (driver.pendingDecision as? ChooseTargetsDecision)?.let { decision ->
+            decision.legalTargets[0].orEmpty() shouldNotContain roomId
+            driver.submitTargetSelection(attacker, emptyList())
+        }
+        driver.bothPass()
+
+        // The Room is unchanged and combat damage landed.
+        driver.state.getEntity(roomId)!!.get<RoomComponent>()!!.isFullyUnlocked shouldBe true
+        driver.assertLifeTotal(defender, 17)
+    }
+})


### PR DESCRIPTION
## What

Adds the engine capability to **unlock a Room's locked door at resolution** (CR 709.5f), and implements **Ghostly Keybearer** (DSK 61) on top of it.

Until now every "unlock" SDK surface was triggers / cost-modifiers *reacting* to unlocks; the only thing that actually unlocked a door was the pay-cost special action (CR 709.5e, `UnlockRoomDoorHandler`). There was no `Effect` that performs an unlock at resolution. Ghostly Keybearer needs exactly that.

## Engine / SDK feature

- **`UnlockDoorEffect(target)`** + facade **`Effects.UnlockDoor(target)`** — the resolution-time "unlock a door" instruction (CR 709.5f); the resolving controller pays nothing.
- **`UnlockDoorExecutor`** resolves the targeted Room and unlocks one locked door via a new shared **`RoomDoorUnlocker`** — now the single place that mutates `RoomComponent.unlocked` and emits `DoorUnlockedEvent` / `RoomFullyUnlockedEvent`. `UnlockRoomDoorHandler` (the special action) was refactored to funnel through the same helper, so **both** unlock paths emit identical events and a face's "When you unlock this door" trigger (CR 709.5h) fires either way.
- **`StatePredicate.HasLockedDoor`** (+ `hasLockedDoor()` builders on `GameObjectFilter` / `TargetFilter`) — the targeting restriction so a **fully-unlocked Room is never a legal target**. Wired into every exhaustive `StatePredicate` dispatch (`PredicateEvaluator`, `AffectsFilterResolver`, `BeginningPhaseManager`, `TriggerMatcher`).

The target is modeled as an **up-to-one** `TargetObject(optional = true)` filtered to a *Room you control with a locked door*, so the controller may also choose no target. No new `GameEvent` and no new player-facing decision type are introduced — it reuses the existing door-unlock events and the standard target-selection decision, so there is no new client/DTO wiring.

## Card

**Ghostly Keybearer** — `{3}{U}` 3/3 Creature — Spirit, Flying. "Whenever this creature deals combat damage to a player, unlock a locked door of up to one target Room you control." (Oracle verified via Scryfall — the trigger is combat-damage-to-player, not ETB.)

## Tests

`GhostlyKeybearerTest` (rules-engine scenarios):
- combat damage unlocks the locked door of the target Room and fires that face's "When you unlock this door" trigger;
- up-to-one optionality — with no Room to unlock the trigger resolves harmlessly;
- a fully-unlocked Room is not a legal target (the locked-door restriction).

Full `:rules-engine`, `:mtg-sdk`, `:mtg-sets` suites pass; `CardLintTest` green; DSK card snapshot re-blessed (adds only Ghostly Keybearer). `docs/card-sdk-language-reference.md` updated for the new effect and predicate.

## Notes

- CR rule numbers (709.5e/f/h/j) verified against the official Comprehensive Rules text.
- mtgish generator (add-feature Step 8b): skipped as a justified best-effort — there is no existing Room/unlock-*effect* IR tag in the bridge to extend and no DSK corpus present to verify a tag name against; guessing one would risk emitting a wrong shape.
- When a Room has more than one locked door (it entered without being cast, CR 709.5d), the executor unlocks its first locked door deterministically; CR 709.5f leaves the choice to the controller, but the common single-locked-door case carries no real choice. Documented in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)