### PR TITLE
Add 14 TMNT cards + dynamic pay-life and distinct-card-type-count SDK primitives

### DIFF
--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,7 +10,7 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-161 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+163 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist (the authoritative status); the per-card
 commits all carry `flavorText` in metadata.
 
@@ -32,13 +32,20 @@ commits all carry `flavorText` in metadata.
 > `LoseAllAbilities` aura), Kitsune (`ExchangeControl`), Venus (`TakesDamage` +
 > `dealsDamage` factory + `MayPayMana`), and Everything Pizza (multi-target composite).
 >
-> The remaining 29 cards each need a genuinely new engine feature (each verified
+> Also debunked after that note: **Grounded for Life** (`ModifySpellCost` +
+> `CostReductionSource.FixedIfAnyTargetMatches(Creature.tapped())`, Quicksand
+> Whirlpool shape) and **Ray Fillet** (`Costs.RemovePlusOnePlusOneCounters` — the
+> counter-typed cost already existed). 27 cards remain.
+>
+> The remaining 27 cards each need a genuinely new engine feature (each verified
 > individually this run — none is "just authoring"): dynamic pay-life (Madame Null),
-> target-state cost reduction (Grounded for Life), card-types-cast-this-turn amount
-> (April O'Neil Hacktivist), permanent-entered-this-turn condition (Fugitive Droid),
+> card-types-cast-this-turn amount
+> (April O'Neil Hacktivist), counter-spell-that-targets-a-filter (Fugitive Droid —
+> its can't-be-blocked half is `ConditionalStaticAbility` +
+> `PermanentTypeEnteredBattlefieldThisTurn`),
 > grant-affinity-to-next-spell (Don & Raph), any-ability mana restriction (Purple
-> Dragon Punks), crewed-this-turn filter (Turtle Van), counter-typed activated-ability
-> cost (Ray Fillet), remove-one-counter-of-any-kind action (Leatherhead), last-known
+> Dragon Punks), crewed-this-turn filter (Turtle Van),
+> remove-one-counter-of-any-kind action (Leatherhead), last-known
 > counter transfer (Donatello Mutant Mechanic), cast-from-GY/top *with a counter rider*
 > (Leonardo Sewer Samurai, Mikey & Don, Ninja Teen L3), total-mana-value-budget select
 > (Michelangelo's Technique), "opponents are attacked" trigger (Party Dude), UEOT grant

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,7 +10,7 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-157 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+161 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist (the authoritative status); the per-card
 commits all carry `flavorText` in metadata.
 
@@ -26,7 +26,32 @@ commits all carry `flavorText` in metadata.
 > plus the Mutagen cost-reduction static (`ReduceActivatedAbilityCost`), `+1`
 > counter rider (`ModifyCounterPlacement`), Chrome Dome
 > (`CreateTokenCopyOfTarget(addedKeywords, sacrificeAtStep)`), and the three Class
-> cards (Does Machines, Cool but Rude, Leader's Talent). Debunked gaps (now shipped composably):
+> cards (Does Machines, Cool but Rude, Leader's Talent). Final sweep also shipped:
+> **Gap II** (tap-or-untap choice = `MayEffect(ModalEffect(tap, untap))`, Sewer-veillance
+> Cam), Retro-Mutation (`TransformPermanent`+`SetBasePowerToughnessStatic`+`CantAttack`+
+> `LoseAllAbilities` aura), Kitsune (`ExchangeControl`), Venus (`TakesDamage` +
+> `dealsDamage` factory + `MayPayMana`), and Everything Pizza (multi-target composite).
+>
+> The remaining 29 cards each need a genuinely new engine feature (each verified
+> individually this run — none is "just authoring"): dynamic pay-life (Madame Null),
+> target-state cost reduction (Grounded for Life), card-types-cast-this-turn amount
+> (April O'Neil Hacktivist), permanent-entered-this-turn condition (Fugitive Droid),
+> grant-affinity-to-next-spell (Don & Raph), any-ability mana restriction (Purple
+> Dragon Punks), crewed-this-turn filter (Turtle Van), counter-typed activated-ability
+> cost (Ray Fillet), remove-one-counter-of-any-kind action (Leatherhead), last-known
+> counter transfer (Donatello Mutant Mechanic), cast-from-GY/top *with a counter rider*
+> (Leonardo Sewer Samurai, Mikey & Don, Ninja Teen L3), total-mana-value-budget select
+> (Michelangelo's Technique), "opponents are attacked" trigger (Party Dude), UEOT grant
+> of play-from-linked-exile (Raphael Most Attitude), persistent mana / Enrage display
+> (Raphael Ninja Destroyer), mode-not-chosen-this-turn (Lita), same-name reanimate (Rat
+> King), reveal-until + cast-from-exile (Krang & Shredder), linked-exile copy across
+> Saga chapters (The Cloning of Shredder), attacks-alone + mill-then-do (The Last Ronin),
+> mana-spent-< -MV trigger (Tokka & Rahzar), linked-exile land (Northampton Farm),
+> delayed-target ransom return (Koya), become-chosen-color + colors-among-permanents
+> (Mondo Gecko), and wishboard (North Wind Avatar, Turtles Forever), plus the
+> mass-bounce/shuffle/draw-7 Turtles in Time.
+>
+> Debunked gaps (now shipped composably):
 > - **Gap B (Disappear)** — `Conditions.YouHadPermanentLeaveBattlefieldThisTurn`
 >   + the per-controller all-permanent leave tracker already existed (LTR Shortcut
 >   to Mushrooms). NO engine change. Shipped Foot Mystic, Insectoid Exterminator,

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,9 +10,42 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-167 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+171 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist (the authoritative status); the per-card
 commits all carry `flavorText` in metadata.
+
+> **2026-06-25 sweep — six more "feature-gated" cards were actually composable.**
+> Re-verifying each supposed gap against real primitives debunked: **Turtle Van**
+> (`crewedOrSaddledSourceThisTurn()` filter + `DoubleCounters`), **Michelangelo's
+> Technique** (`SelectionRestriction.TotalManaValueAtMost`), **Fugitive Droid**
+> (`CardPredicate.TargetsMatching` — counter target spell that targets your stuff,
+> the Teferi's Response idiom), **Northampton Farm** + **Raphael, Most Attitude** +
+> **Koya, Death from Above** (the `CardSource.FromLinkedExile` / `MoveCollection(linkToSource)`
+> / `GrantMayPlayFromExile` / `PayOrSuffer` linked-exile family — all already built).
+>
+> **The genuinely-remaining 19 each need a real new engine primitive** (oracle text
+> re-read 2026-06-25; none is "just authoring"):
+> - **Leatherhead, Swamp Stalker** — remove *one counter of any kind* (chooser picks) +
+>   reflexive "when you do" (HEXPROOF counter + entersWith already exist).
+> - **Purple Dragon Punks** — *any*-ability mana ("artifact spell or activate an ability";
+>   `CardTypeSpellsOrAbilitiesOnly` ties abilities to the card type, too narrow).
+> - **The Last Ronin** — a Saga chapter that installs a *this-turn* triggered ability
+>   ("whenever a creature attacks alone this turn …"; the attacks-alone trigger exists).
+> - **Tokka & Rahzar** — "mana spent to cast it was less than its mana value" trigger condition.
+> - **Lita, Little Orphan Amphibian** — modal where each mode is once-per-turn ("hasn't been chosen this turn").
+> - **Mondo Gecko** — become-chosen-color + "draw a card for each color among permanents you control" dynamic.
+> - **Donatello, Mutant Mechanic** — move a dying artifact's last-known counters to a target.
+> - **Krang & Shredder** — each opponent exiles from top until a nonland (reveal-until).
+> - **Party Dude** — "your opponents are attacked" trigger (+ each-player Food).
+> - **Raphael, Ninja Destroyer** — Enrage mana that persists past step/phase cleanup.
+> - **Rat King** — return target creature card + all same-named cards from your graveyard.
+> - **Leonardo, Sewer Samurai** — cast creatures from GY (static), entering with a finality counter.
+> - **Ninja Teen L3** — grant Sneak to graveyard creature cards + cast them from GY via Sneak.
+> - **Mikey & Don** — cast from top of library; creatures cast this way enter with a +1/+1 counter.
+> - **The Cloning of Shredder** — token copy of a card in this Saga's linked exile.
+> - **Don & Raph** — grant the next noncreature spell you cast affinity for artifacts.
+> - **North Wind Avatar** + **Turtles Forever** — wishboard (cards from outside the game).
+> - **Turtles in Time** — each-player-MAY Timetwister (per-player shuffle-hand+gy / draw 7).
 
 > **2026-06-24 run — the gap list below was badly overestimated.** A sweep added
 > 38 cards by discovering that most "blocking gaps" were *already supported* and

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,7 +10,7 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-163 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+167 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist (the authoritative status); the per-card
 commits all carry `flavorText` in metadata.
 

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,13 +2,13 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 164 / 190
+**Implemented:** 165 / 190
 ---
 
 - [x] Action News Crew
 - [x] Agent Bishop, Man in Black
 - [x] Anchovy & Banana Pizza
-- [ ] April O'Neil, Hacktivist
+- [x] April O'Neil, Hacktivist
 - [x] April O'Neil, Kunoichi Trainee
 - [x] April, Reporter of the Weird
 - [x] Armaggon, Future Shark

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 156 / 190
+**Implemented:** 157 / 190
 ---
 
 - [x] Action News Crew
@@ -149,7 +149,7 @@
 - [x] Sally Pride, Lioness Leader
 - [x] Savanti Romero, Time's Exile
 - [x] Saved by the Shell
-- [ ] Sewer-veillance Cam
+- [x] Sewer-veillance Cam
 - [x] Shark Shredder, Killer Clone
 - [x] Shredder's Armor
 - [x] Shredder's Revenge

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 166 / 190
+**Implemented:** 167 / 190
 ---
 
 - [x] Action News Crew
@@ -90,7 +90,7 @@
 - [x] Manhole Missile
 - [x] Mechanized Ninja Cavalry
 - [x] Metalhead
-- [ ] Michelangelo's Technique
+- [x] Michelangelo's Technique
 - [x] Michelangelo, Game Master
 - [x] Michelangelo, Improviser
 - [x] Michelangelo, Mutant BFF

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 158 / 190
+**Implemented:** 159 / 190
 ---
 
 - [x] Action News Crew
@@ -142,7 +142,7 @@
 - [x] Ravenous Robots
 - [ ] Ray Fillet, Man Ray
 - [x] Renet, Temporal Apprentice
-- [ ] Retro-Mutation
+- [x] Retro-Mutation
 - [x] Return to the Sewers
 - [x] Rock Soldiers
 - [x] Rocksteady, Crash Courser

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 161 / 190
+**Implemented:** 162 / 190
 ---
 
 - [x] Action News Crew
@@ -140,7 +140,7 @@
 - [x] Raphael, Tough Turtle
 - [ ] Rat King, Verminister
 - [x] Ravenous Robots
-- [ ] Ray Fillet, Man Ray
+- [x] Ray Fillet, Man Ray
 - [x] Renet, Temporal Apprentice
 - [x] Retro-Mutation
 - [x] Return to the Sewers

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 157 / 190
+**Implemented:** 158 / 190
 ---
 
 - [x] Action News Crew
@@ -70,7 +70,7 @@
 - [x] Karai's Technique
 - [x] Karai, Future of the Foot
 - [x] Kitsune's Technique
-- [ ] Kitsune, Dragon's Daughter
+- [x] Kitsune, Dragon's Daughter
 - [ ] Koya, Death from Above
 - [ ] Krang & Shredder
 - [x] Krang, Master Mind

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 167 / 190
+**Implemented:** 168 / 190
 ---
 
 - [x] Action News Crew
@@ -50,7 +50,7 @@
 - [x] Foot Mystic
 - [x] Foot Ninjas
 - [x] Frog Butler
-- [ ] Fugitive Droid
+- [x] Fugitive Droid
 - [x] General Traag, Heart of Stone
 - [x] Genghis Frog
 - [x] Go Ninja Go

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 163 / 190
+**Implemented:** 164 / 190
 ---
 
 - [x] Action News Crew
@@ -85,7 +85,7 @@
 - [x] Lessons from Life
 - [ ] Lita, Little Orphan Amphibian
 - [x] Lord Dregg, Insect Invader
-- [ ] Madame Null, Power Broker
+- [x] Madame Null, Power Broker
 - [x] Make Your Move
 - [x] Manhole Missile
 - [x] Mechanized Ninja Cavalry

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 162 / 190
+**Implemented:** 163 / 190
 ---
 
 - [x] Action News Crew
@@ -55,7 +55,7 @@
 - [x] Genghis Frog
 - [x] Go Ninja Go
 - [x] Groundchuck & Dirtbag
-- [ ] Grounded for Life
+- [x] Grounded for Life
 - [x] Guac & Marshmallow Pizza
 - [x] Hamato Guardian Stance
 - [x] Hard-Won Jitte

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 159 / 190
+**Implemented:** 160 / 190
 ---
 
 - [x] Action News Crew
@@ -189,7 +189,7 @@
 - [ ] Turtles in Time
 - [x] Uneasy Alliance
 - [x] Utrom Scientists
-- [ ] Venus, Torn Between Worlds
+- [x] Venus, Torn Between Worlds
 - [x] Weather Maker
 - [x] West Wind Avatar
 - [x] Wingnut, Bat on the Belfry

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 168 / 190
+**Implemented:** 169 / 190
 ---
 
 - [x] Action News Crew
@@ -113,7 +113,7 @@
 - [ ] Ninja Teen
 - [x] Nobody
 - [ ] North Wind Avatar
-- [ ] Northampton Farm
+- [x] Northampton Farm
 - [x] Novel Nunchaku
 - [x] Null Group Biological Assets
 - [x] Old Hob, Alleycat Blues

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 160 / 190
+**Implemented:** 161 / 190
 ---
 
 - [x] Action News Crew
@@ -43,7 +43,7 @@
 - [x] East Wind Avatar
 - [x] EPF Point Squad
 - [x] Escape Tunnel
-- [ ] Everything Pizza
+- [x] Everything Pizza
 - [x] Featherbrained Filcher
 - [x] Foot Elite
 - [x] Foot Headquarters

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 169 / 190
+**Implemented:** 170 / 190
 ---
 
 - [x] Action News Crew
@@ -134,7 +134,7 @@
 - [x] Raph & Leo, Sibling Rivals
 - [x] Raph & Mikey, Troublemakers
 - [x] Raphael's Technique
-- [ ] Raphael, Most Attitude
+- [x] Raphael, Most Attitude
 - [ ] Raphael, Ninja Destroyer
 - [x] Raphael, the Nightwatcher
 - [x] Raphael, Tough Turtle

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 170 / 190
+**Implemented:** 171 / 190
 ---
 
 - [x] Action News Crew
@@ -71,7 +71,7 @@
 - [x] Karai, Future of the Foot
 - [x] Kitsune's Technique
 - [x] Kitsune, Dragon's Daughter
-- [ ] Koya, Death from Above
+- [x] Koya, Death from Above
 - [ ] Krang & Shredder
 - [x] Krang, Master Mind
 - [x] Krang, Utrom Warlord

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 165 / 190
+**Implemented:** 166 / 190
 ---
 
 - [x] Action News Crew
@@ -184,7 +184,7 @@
 - [x] Turtle Blimp
 - [x] Turtle Lair
 - [x] Turtle Power!
-- [ ] Turtle Van
+- [x] Turtle Van
 - [ ] Turtles Forever
 - [ ] Turtles in Time
 - [x] Uneasy Alliance

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -341,6 +341,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 ### Life
 
 - `GainLife(amount, target?)` — target gains life (default: controller).
+- `PayDynamicLife(amount: DynamicAmount, payer?)` — pay life equal to a `DynamicAmount` (e.g.
+  "pay life equal to its power" via `EntityProperty(Triggering, Power)`), evaluated at resolution.
+  The dynamic, payer-parametric twin of the fixed `PayLifeEffect`; use it as the `cost` of an
+  `OptionalCostEffect` (`Gate.MayPay`) so the same amount can also feed the `ifPaid` effect. A
+  non-positive evaluated amount pays nothing and still counts as paid (CR 119.4).
 - `LoseLife(amount, target)` — target loses life.
 - `SetLifeTotal(amount, target)` — set target's life total to N.
 - `ExchangeLifeAndPower(target)` — swap target's power with controller's life total.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4423,6 +4423,11 @@ Numbers computed at resolution time.
     `Add(Fixed(2), SpellsCastThisTurn(Player.You, excludeSelf = true))`.
   - Magebane Lizard ("the number of noncreature spells they've cast this turn"):
     `SpellsCastThisTurn(Player.TriggeringPlayer, GameObjectFilter.Noncreature)`.
+  - `countDistinctCardTypes` (default `false`) switches the aggregation from *count of spells* to
+    *count of distinct card types among them* — April O'Neil, Hacktivist ("draw a card for each card
+    type among spells you've cast this turn"): `SpellsCastThisTurn(Player.You, countDistinctCardTypes
+    = true)`. An artifact creature spell contributes both Artifact and Creature; types are unioned
+    across the matching records (and across every player the ref resolves to).
   - Pairs with the `YouCastSpellsThisTurn` **condition** (§ conditions) — that gates a yes/no
     threshold, this yields the count.
 - `CraftedMaterialsTotalPower` — total printed power of the cards exiled to craft the source

--- a/manual-scenarios/cards/c/courier-of-comestibles.json
+++ b/manual-scenarios/cards/c/courier-of-comestibles.json
@@ -1,0 +1,36 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Courier of Comestibles", "Grizzly Bears", "Grizzly Bears", "Grizzly Bears"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Everything Pizza", "Everything Pizza", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -285,6 +285,17 @@ object Effects {
         GainLifeEffect(amount, target)
 
     /**
+     * Pay life equal to a [DynamicAmount] (e.g. "pay life equal to its power"). Used as the
+     * `cost` effect inside a [com.wingedsheep.sdk.scripting.effects.Gate.MayPay] gate — pair with
+     * `Effects.OptionalCost` / `MayPayManaEffect`-style gating so the same dynamic amount can
+     * also feed the `ifPaid` effect. A non-positive evaluated amount pays nothing (still "paid").
+     */
+    fun PayDynamicLife(
+        amount: DynamicAmount,
+        payer: Player = Player.You
+    ): Effect = com.wingedsheep.sdk.scripting.effects.PayDynamicLifeEffect(amount, payer)
+
+    /**
      * Lose life. Default target is target opponent.
      */
     fun LoseLife(amount: Int, target: EffectTarget = EffectTarget.PlayerRef(Player.TargetOpponent)): Effect =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LifeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LifeEffects.kt
@@ -73,6 +73,25 @@ data class PayLifeEffect(
 }
 
 /**
+ * Pay life equal to a [DynamicAmount], evaluated at payment/resolution time (e.g. "pay life
+ * equal to its power"). The dynamic, payer-parametric twin of [PayLifeEffect]; mirrors
+ * [PayDynamicManaCostEffect]. A non-positive evaluated amount pays nothing and still succeeds,
+ * so a gating [Gate.MayPay] proceeds to its `then`.
+ */
+@SerialName("PayDynamicLife")
+@Serializable
+data class PayDynamicLifeEffect(
+    val amount: DynamicAmount,
+    val payer: Player = Player.You
+) : Effect {
+    override val description: String = "pay ${amount.description} life"
+    override fun applyTextReplacement(replacer: TextReplacer): Effect {
+        val newAmount = amount.applyTextReplacement(replacer)
+        return if (newAmount !== amount) copy(amount = newAmount) else this
+    }
+}
+
+/**
  * Target player's owner gains life equal to a fixed amount.
  * Used for effects like "Its owner gains 4 life" (Path of Peace).
  * This targets the owner of the previously targeted permanent.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -1110,6 +1110,7 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
             append("the number of ")
             if (countDistinctCardTypes) {
                 append("card types among ")
+                if (excludeSelf) append("other ")
                 if (filter != GameObjectFilter.Any) append("${filter.description} ")
                 append("spells")
             } else {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -1088,6 +1088,10 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
      * @param filter Spell characteristics to match (default [GameObjectFilter.Any])
      * @param excludeSelf Exclude the resolving spell's own cast record (default false)
      * @param fromZone Restrict to spells cast from this zone, independently of [filter] (default any zone)
+     * @param countDistinctCardTypes When true, instead of counting matching spells, count the
+     *   *distinct card types* among them (April O'Neil, Hacktivist: "for each card type among
+     *   spells you've cast this turn"). An artifact creature spell contributes both Artifact and
+     *   Creature. Card types are unioned across every player resolved by [player].
      */
     @SerialName("SpellsCastThisTurn")
     @Serializable
@@ -1095,7 +1099,8 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         val player: Player = Player.You,
         val filter: GameObjectFilter = GameObjectFilter.Any,
         val excludeSelf: Boolean = false,
-        val fromZone: Zone? = null
+        val fromZone: Zone? = null,
+        val countDistinctCardTypes: Boolean = false
     ) : DynamicAmount {
         override fun applyTextReplacement(replacer: TextReplacer): DynamicAmount {
             val newFilter = filter.applyTextReplacement(replacer)
@@ -1103,9 +1108,15 @@ sealed interface DynamicAmount : TextReplaceable<DynamicAmount> {
         }
         override val description: String = buildString {
             append("the number of ")
-            if (excludeSelf) append("other ")
-            if (filter == GameObjectFilter.Any) append("spells")
-            else append("${filter.description} spells")
+            if (countDistinctCardTypes) {
+                append("card types among ")
+                if (filter != GameObjectFilter.Any) append("${filter.description} ")
+                append("spells")
+            } else {
+                if (excludeSelf) append("other ")
+                if (filter == GameObjectFilter.Any) append("spells")
+                else append("${filter.description} spells")
+            }
             append(" ")
             when (player) {
                 Player.You -> append("you've cast")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AprilONeilHacktivist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/AprilONeilHacktivist.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * April O'Neil, Hacktivist
+ * {3}{U}
+ * Legendary Creature — Human Scientist
+ * 1/5
+ *
+ * At the beginning of your end step, draw a card for each card type among spells
+ * you've cast this turn.
+ */
+val AprilONeilHacktivist = card("April O'Neil, Hacktivist") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Scientist"
+    oracleText = "At the beginning of your end step, draw a card for each card type among spells you've cast this turn."
+    power = 1
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.DrawCards(
+            DynamicAmount.SpellsCastThisTurn(Player.You, countDistinctCardTypes = true)
+        )
+        description = "At the beginning of your end step, draw a card for each card type among spells you've cast this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "29"
+        artist = "Xabi Gaztelua"
+        flavorText = "In the fight between mutants, ninjas, and aliens, don't underestimate a resourceful human."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f0147f6d-b797-4d5e-aca2-a9d309896eca.jpg?1760102651"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/EverythingPizza.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/EverythingPizza.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Everything Pizza
+ * {2}
+ * Artifact — Food
+ *
+ * When this artifact enters, search your library for a basic land card, reveal it,
+ * put it into your hand, then shuffle.
+ * {2}{W}{U}{B}{R}{G}, {T}, Sacrifice this artifact: Target player gains 3 life and
+ * draws a card. Each of your opponents discards a card. This artifact deals 3 damage
+ * to any target. Put three +1/+1 counters on up to one target creature.
+ */
+val EverythingPizza = card("Everything Pizza") {
+    manaCost = "{2}"
+    typeLine = "Artifact — Food"
+    oracleText = "When this artifact enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{2}{W}{U}{B}{R}{G}, {T}, Sacrifice this artifact: Target player gains 3 life and draws a card. Each of your opponents discards a card. This artifact deals 3 damage to any target. Put three +1/+1 counters on up to one target creature."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            count = 1,
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+        description = "When this artifact enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle."
+    }
+
+    activatedAbility {
+        val player = target("target player", Targets.Player)
+        val anyTarget = target("any target", Targets.Any)
+        val creature = target("up to one target creature", TargetCreature(optional = true))
+        cost = Costs.Composite(
+            Costs.Mana("{2}{W}{U}{B}{R}{G}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.Composite(
+            Effects.GainLife(3, player),
+            Effects.DrawCards(1, player),
+            Effects.EachOpponentDiscards(1),
+            Effects.DealDamage(3, anyTarget, damageSource = EffectTarget.Self),
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "173"
+        artist = "James Bousema"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df2cdaa5-9ea0-4aa5-89d3-9edf40fa2a39.jpg?1771476702"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FugitiveDroid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/FugitiveDroid.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlocked
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Fugitive Droid
+ * {U}
+ * Artifact Creature — Robot Scientist
+ * 1/1
+ *
+ * This creature can't be blocked if an artifact entered the battlefield under
+ * your control this turn.
+ * {U}, Sacrifice this creature: Counter target spell that targets an artifact or
+ * creature you control.
+ */
+val FugitiveDroid = card("Fugitive Droid") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Robot Scientist"
+    oracleText = "This creature can't be blocked if an artifact entered the battlefield under your control this turn.\n{U}, Sacrifice this creature: Counter target spell that targets an artifact or creature you control."
+    power = 1
+    toughness = 1
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = CantBeBlocked(),
+            condition = Conditions.PermanentTypeEnteredBattlefieldThisTurn(CardType.ARTIFACT, Player.You)
+        )
+    }
+
+    activatedAbility {
+        // "target spell that targets an artifact or creature you control" — a stack spell at
+        // least one of whose chosen targets matches the subfilter (CardPredicate.TargetsMatching).
+        val spell = target(
+            "target spell that targets an artifact or creature you control",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter(
+                        cardPredicates = listOf(
+                            CardPredicate.TargetsMatching(GameObjectFilter.CreatureOrArtifact.youControl())
+                        )
+                    ),
+                    zone = Zone.STACK
+                )
+            )
+        )
+        cost = Costs.Composite(Costs.Mana("{U}"), Costs.SacrificeSelf)
+        effect = Effects.CounterSpell()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "40"
+        artist = "Narendra Bintara Adi"
+        flavorText = "\"A freak accident transferred Professor Honeycutt's mind into his robot assistant. Blamed for his own death, he fled . . . as the FUGITOID!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/0/50c4e65f-00dc-4fc5-bd5c-8482c2848f4c.jpg?1771586801"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GroundedForLife.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GroundedForLife.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Grounded for Life
+ * {4}{W}
+ * Instant
+ *
+ * This spell costs {3} less to cast if it targets a tapped creature.
+ * Destroy target creature.
+ */
+val GroundedForLife = card("Grounded for Life") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "This spell costs {3} less to cast if it targets a tapped creature.\nDestroy target creature."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(amount = 3, filter = GameObjectFilter.Creature.tapped())
+            )
+        )
+    }
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Destroy(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "7"
+        artist = "Andrea Tentori Montalto"
+        flavorText = "\"Of course I know what you did! You always do precisely what I told you not to do!\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72388199-85fa-4eba-9a9c-c2904e6da9ed.jpg?1771502482"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KitsuneDragonsDaughter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KitsuneDragonsDaughter.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Kitsune, Dragon's Daughter
+ * {4}{U}{U}
+ * Legendary Creature — Fox Warlock Avatar
+ * 6/6
+ *
+ * Vigilance
+ * Whenever Kitsune enters or deals combat damage to a player, you may exchange
+ * control of two other target creatures controlled by different players.
+ *
+ * In the engine's two-player game, "controlled by different players" is exactly
+ * one creature you control and one an opponent controls.
+ */
+val KitsuneDragonsDaughter = card("Kitsune, Dragon's Daughter") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Fox Warlock Avatar"
+    oracleText = "Vigilance\nWhenever Kitsune enters or deals combat damage to a player, you may exchange control of two other target creatures controlled by different players."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val yours = target(
+            "target creature you control",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.youControl(), excludeSelf = true))
+        )
+        val theirs = target(
+            "target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.CreatureOpponentControls)
+        )
+        effect = MayEffect(Effects.ExchangeControl(yours, theirs))
+        description = "When Kitsune enters, you may exchange control of two other target creatures controlled by different players."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val yours = target(
+            "target creature you control",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.youControl(), excludeSelf = true))
+        )
+        val theirs = target(
+            "target creature an opponent controls",
+            TargetCreature(filter = TargetFilter.CreatureOpponentControls)
+        )
+        effect = MayEffect(Effects.ExchangeControl(yours, theirs))
+        description = "Whenever Kitsune deals combat damage to a player, you may exchange control of two other target creatures controlled by different players."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "41"
+        artist = "Robin Har"
+        flavorText = "\"You hunger for retribution, I know. And so I come to you with an offering . . .\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a87a9257-4535-4286-8b59-a842ac45d05e.jpg?1769005699"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KoyaDeathFromAbove.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KoyaDeathFromAbove.kt
@@ -57,7 +57,10 @@ val KoyaDeathFromAbove = card("Koya, Death from Above") {
                             GatherCardsEffect(source = CardSource.FromLinkedExile(), storeAs = "koyaExile"),
                             MoveCollectionEffect(
                                 from = "koyaExile",
-                                destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                                destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                                // The exiled creature returns under its *owner's* control, not Koya's
+                                // controller's — it may be a creature an opponent owns.
+                                underOwnersControl = true
                             )
                         )
                     )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KoyaDeathFromAbove.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KoyaDeathFromAbove.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Koya, Death from Above
+ * {2}{W}
+ * Legendary Creature — Mutant Ninja Bird
+ * 2/1
+ *
+ * Flying
+ * When Koya enters, exile up to one other target creature. At the beginning of the
+ * next end step, you may pay {3}{B}. If you don't, return that card to the
+ * battlefield under its owner's control.
+ */
+val KoyaDeathFromAbove = card("Koya, Death from Above") {
+    manaCost = "{2}{W}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Mutant Ninja Bird"
+    oracleText = "Flying\nWhen Koya enters, exile up to one other target creature. At the beginning of the next end step, you may pay {3}{B}. If you don't, return that card to the battlefield under its owner's control."
+    power = 2
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    // Exile the creature linked to Koya; at the next end step, pay to keep it gone, otherwise
+    // return the linked-exiled card to its owner's control (read by Koya's linked exile).
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "up to one other target creature",
+            TargetCreature(optional = true, filter = TargetFilter(GameObjectFilter.Creature, excludeSelf = true))
+        )
+        effect = Effects.Move(creature, Zone.EXILE, linkToSource = true)
+            .then(
+                CreateDelayedTriggerEffect(
+                    step = Step.END,
+                    effect = PayOrSufferEffect(
+                        cost = Costs.pay.Mana("{3}{B}"),
+                        suffer = Effects.Composite(
+                            GatherCardsEffect(source = CardSource.FromLinkedExile(), storeAs = "koyaExile"),
+                            MoveCollectionEffect(
+                                from = "koyaExile",
+                                destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+                            )
+                        )
+                    )
+                )
+            )
+        description = "When Koya enters, exile up to one other target creature. At the beginning of the next end step, you may pay {3}{B}. If you don't, return that card to the battlefield under its owner's control."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "11"
+        artist = "Irina Nordsol"
+        flavorText = "\"Hello, prey.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a4f1ccc-2225-4cd0-abef-0eb7a8eae9cf.jpg?1771586885"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MadameNullPowerBroker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MadameNullPowerBroker.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Madame Null, Power Broker
+ * {2}{B}
+ * Legendary Creature — Demon Advisor
+ * 1/3
+ *
+ * Deathtouch
+ * Whenever another creature you control enters, you may pay life equal to its
+ * power. If you do, put that many +1/+1 counters on it.
+ */
+val MadameNullPowerBroker = card("Madame Null, Power Broker") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Demon Advisor"
+    oracleText = "Deathtouch\nWhenever another creature you control enters, you may pay life equal to its power. If you do, put that many +1/+1 counters on it."
+    power = 1
+    toughness = 3
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        // "its power" / "that many" — the entering creature's power, used for both the life
+        // payment and the counters (Effects.PayDynamicLife is the dynamic pay-life cost).
+        val enteringPower = DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Power)
+        effect = OptionalCostEffect(
+            cost = Effects.PayDynamicLife(enteringPower),
+            ifPaid = Effects.AddDynamicCounters(Counters.PLUS_ONE_PLUS_ONE, enteringPower, EffectTarget.TriggeringEntity)
+        )
+        description = "Whenever another creature you control enters, you may pay life equal to its power. If you do, put that many +1/+1 counters on it."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "66"
+        artist = "Irina Nordsol"
+        flavorText = "\"We suffered a bit of a setback tonight, but rest assured: We'll have the planet purged and primed for you right on schedule.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/e/4e712d5c-d6fe-40bb-b8e5-5f50c6ea8d4f.jpg?1769005736"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangelosTechnique.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MichelangelosTechnique.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SelectionRestriction
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Michelangelo's Technique
+ * {4}{G}
+ * Sorcery
+ *
+ * Sneak {3}{G}
+ * Look at the top eight cards of your library. Put up to two creature cards with
+ * total mana value 6 or less from among them onto the battlefield and the rest on
+ * the bottom of your library in a random order.
+ */
+val MichelangelosTechnique = card("Michelangelo's Technique") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Sneak {3}{G} (You may cast this spell for {3}{G} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nLook at the top eight cards of your library. Put up to two creature cards with total mana value 6 or less from among them onto the battlefield and the rest on the bottom of your library in a random order."
+
+    sneak("{3}{G}")
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(count = DynamicAmount.Fixed(8), player = Player.You),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    filter = GameObjectFilter.Creature,
+                    restrictions = listOf(SelectionRestriction.TotalManaValueAtMost(6)),
+                    showAllCards = true,
+                    storeSelected = "toBattlefield",
+                    storeRemainder = "toBottom",
+                    prompt = "Put up to two creature cards with total mana value 6 or less onto the battlefield",
+                    selectedLabel = "Put onto the battlefield",
+                    remainderLabel = "Put on the bottom of your library"
+                ),
+                MoveCollectionEffect(
+                    from = "toBattlefield",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You)
+                ),
+                MoveCollectionEffect(
+                    from = "toBottom",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "122"
+        artist = "Dominik Mayer"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a63c06a-7c59-4b72-b916-e5b6ad78c684.jpg?1769006772"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NorthamptonFarm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NorthamptonFarm.kt
@@ -56,7 +56,9 @@ val NorthamptonFarm = card("Northampton Farm") {
                 GatherCardsEffect(source = CardSource.FromLinkedExile(), storeAs = "exiled"),
                 SelectFromCollectionEffect(
                     from = "exiled",
-                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    // "Return a creature card" is mandatory when one is available (ChooseExactly clamps
+                    // to the eligible cards: auto-selects the lone creature, no-ops on an empty pile).
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
                     filter = GameObjectFilter.Creature,
                     showAllCards = true,
                     storeSelected = "toBattlefield",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NorthamptonFarm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/NorthamptonFarm.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Northampton Farm
+ * Land
+ *
+ * {T}: Add {C}.
+ * {1}, {T}: Exile target creature you own.
+ * {2}, {T}, Sacrifice this land: Return a creature card exiled with this land to
+ * the battlefield under your control. Return each other card exiled with this land
+ * to its owner's hand.
+ */
+val NorthamptonFarm = card("Northampton Farm") {
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n{1}, {T}: Exile target creature you own.\n{2}, {T}, Sacrifice this land: Return a creature card exiled with this land to the battlefield under your control. Return each other card exiled with this land to its owner's hand."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+    }
+
+    // Exile a creature you own, linked to this land so the sacrifice ability can find it later.
+    activatedAbility {
+        val creature = target(
+            "target creature you own",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.ownedByYou()))
+        )
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.Move(creature, Zone.EXILE, linkToSource = true)
+    }
+
+    // Sacrifice: return one creature card from this land's linked exile to the battlefield under
+    // your control; everything else exiled with it goes to its owner's hand.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(source = CardSource.FromLinkedExile(), storeAs = "exiled"),
+                SelectFromCollectionEffect(
+                    from = "exiled",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Creature,
+                    showAllCards = true,
+                    storeSelected = "toBattlefield",
+                    storeRemainder = "toHand",
+                    prompt = "Return a creature card to the battlefield under your control",
+                    selectedLabel = "Return to the battlefield",
+                    remainderLabel = "Return to owner's hand"
+                ),
+                MoveCollectionEffect(
+                    from = "toBattlefield",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You)
+                ),
+                MoveCollectionEffect(
+                    from = "toHand",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "188"
+        artist = "Marina Ortega Lorente"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbca168e-095f-4fbc-88f8-3048d83caf94.jpg?1769006600"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelMostAttitude.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelMostAttitude.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Raphael, Most Attitude
+ * {3}{R}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 4/3
+ *
+ * Menace
+ * Alliance — Whenever another creature you control enters, you may exile the top
+ * card of your library.
+ * Whenever Raphael attacks, until end of turn, you may play a card exiled with
+ * Raphael.
+ */
+val RaphaelMostAttitude = card("Raphael, Most Attitude") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Menace\nAlliance — Whenever another creature you control enters, you may exile the top card of your library.\nWhenever Raphael attacks, until end of turn, you may play a card exiled with Raphael."
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.MENACE)
+
+    // Alliance: exile the top card linked to Raphael (accumulates the impulse pile).
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = MayEffect(
+            Effects.Composite(
+                listOf(
+                    GatherCardsEffect(source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)), storeAs = "raphaelTop"),
+                    MoveCollectionEffect(
+                        from = "raphaelTop",
+                        destination = CardDestination.ToZone(Zone.EXILE),
+                        linkToSource = true
+                    )
+                )
+            )
+        )
+        description = "Alliance — Whenever another creature you control enters, you may exile the top card of your library."
+    }
+
+    // Attack: grant permission to play any card exiled with Raphael until end of turn.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(source = CardSource.FromLinkedExile(), storeAs = "raphaelExile"),
+                GrantMayPlayFromExileEffect("raphaelExile", MayPlayExpiry.EndOfTurn)
+            )
+        )
+        description = "Whenever Raphael attacks, until end of turn, you may play a card exiled with Raphael."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "101"
+        artist = "Thomas Chamberlain-Keen"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/88385a87-f931-409f-8a21-250f0866d63d.jpg?1771502673"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RayFilletManRay.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RayFilletManRay.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Ray Fillet, Man Ray
+ * {3}{U}
+ * Legendary Creature — Fish Mutant
+ * 3/3
+ *
+ * Flying
+ * When Ray Fillet enters, create a Mutagen token.
+ * {2}, Remove a +1/+1 counter from a creature you control: Draw a card.
+ */
+val RayFilletManRay = card("Ray Fillet, Man Ray") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Fish Mutant"
+    oracleText = "Flying\nWhen Ray Fillet enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")\n{2}, Remove a +1/+1 counter from a creature you control: Draw a card."
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMutagenToken()
+        description = "When Ray Fillet enters, create a Mutagen token."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.RemovePlusOnePlusOneCounters(GameObjectFilter.Creature.youControl(), 1)
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "49"
+        artist = "Mirko Failoni"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14e0892c-a556-43c3-974f-6be44188da2e.jpg?1771502589"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RetroMutation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RetroMutation.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttack
+import com.wingedsheep.sdk.scripting.LoseAllAbilities
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.TransformPermanent
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Retro-Mutation
+ * {2}{U}
+ * Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature is a Turtle with base power and toughness 0/1. It can't
+ * attack and loses all abilities. (It also loses all other creature types.)
+ */
+val RetroMutation = card("Retro-Mutation") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\nEnchant creature\nEnchanted creature is a Turtle with base power and toughness 0/1. It can't attack and loses all abilities. (It also loses all other creature types.)"
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    // "is a Turtle" — set its only creature subtype to Turtle (keeps the Creature type).
+    staticAbility {
+        ability = TransformPermanent(setCardTypes = setOf("CREATURE"), setSubtypes = setOf("Turtle"))
+    }
+    staticAbility {
+        ability = SetBasePowerToughnessStatic(0, 1)
+    }
+    staticAbility {
+        ability = CantAttack(filter = GroupFilter.attachedCreature())
+    }
+    staticAbility {
+        ability = LoseAllAbilities()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "51"
+        artist = "Leonardo Santanna"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4af284ba-fa54-43c5-8c76-3e1128957452.jpg?1771586820"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SewerVeillanceCam.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/SewerVeillanceCam.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.TapUntapEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sewer-veillance Cam
+ * {U}
+ * Artifact
+ *
+ * Flash
+ * When this artifact enters or leaves the battlefield, you may tap or untap target creature.
+ * {3}{U}, Sacrifice this artifact: Draw two cards.
+ */
+val SewerVeillanceCam = card("Sewer-veillance Cam") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "Flash\nWhen this artifact enters or leaves the battlefield, you may tap or untap target creature.\n{3}{U}, Sacrifice this artifact: Draw two cards."
+
+    keywords(Keyword.FLASH)
+
+    // "you may tap or untap target creature" — a 2-mode modal (tap / untap) over the
+    // declared target, made optional with MayEffect (Wingnut's countsAsModalSpell=false idiom).
+    fun tapOrUntapTarget(target: EffectTarget) = MayEffect(
+        ModalEffect(
+            modes = listOf(
+                Mode.noTarget(TapUntapEffect(target, tap = true), "Tap that creature"),
+                Mode.noTarget(TapUntapEffect(target, tap = false), "Untap that creature")
+            ),
+            chooseCount = 1,
+            countsAsModalSpell = false
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = tapOrUntapTarget(creature)
+        description = "When this artifact enters, you may tap or untap target creature."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        val creature = target("target creature", Targets.Creature)
+        effect = tapOrUntapTarget(creature)
+        description = "When this artifact leaves the battlefield, you may tap or untap target creature."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}{U}"),
+            Costs.SacrificeSelf
+        )
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Nicholas Gregory"
+        flavorText = "No one in New York was going to notice one more cockroach."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab47a37b-b66d-4f70-9bf0-4d5ed6b518f3.jpg?1779102308"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtleVan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtleVan.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Turtle Van
+ * {3}
+ * Artifact — Vehicle
+ * 4/4
+ *
+ * Whenever this Vehicle attacks, put a +1/+1 counter on target creature that
+ * crewed it this turn. Then if that creature is a Mutant, Ninja, or Turtle,
+ * double the number of +1/+1 counters on it.
+ * Crew 1
+ */
+val TurtleVan = card("Turtle Van") {
+    manaCost = "{3}"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Whenever this Vehicle attacks, put a +1/+1 counter on target creature that crewed it this turn. Then if that creature is a Mutant, Ninja, or Turtle, double the number of +1/+1 counters on it.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)"
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val crewer = target(
+            "target creature that crewed it this turn",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.crewedOrSaddledSourceThisTurn()))
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, crewer)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.TargetMatchesFilter(
+                        GameObjectFilter.Creature.withAnyOfSubtypes(
+                            listOf(Subtype("Mutant"), Subtype("Ninja"), Subtype("Turtle"))
+                        )
+                    ),
+                    effect = Effects.DoubleCounters(Counters.PLUS_ONE_PLUS_ONE, crewer)
+                )
+            )
+        description = "Whenever this Vehicle attacks, put a +1/+1 counter on target creature that crewed it this turn. Then if that creature is a Mutant, Ninja, or Turtle, double the number of +1/+1 counters on it."
+    }
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 1))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "181"
+        artist = "Jakob Eirich"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fce6a8b6-b43c-4045-9378-97b2463f9b4d.jpg?1769006474"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/VenusTornBetweenWorlds.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/VenusTornBetweenWorlds.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Venus, Torn Between Worlds
+ * {4}{G}
+ * Legendary Creature — Mutant Frog Turtle
+ * 5/5
+ *
+ * Whenever Venus is dealt damage, put that many +1/+1 counters on her. (She must
+ * survive the damage to get the counters.)
+ * Whenever a creature you control with a counter on it deals combat damage to a
+ * player, you may pay {U}. If you do, draw a card.
+ */
+val VenusTornBetweenWorlds = card("Venus, Torn Between Worlds") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Mutant Frog Turtle"
+    oracleText = "Whenever Venus is dealt damage, put that many +1/+1 counters on her. (She must survive the damage to get the counters.)\nWhenever a creature you control with a counter on it deals combat damage to a player, you may pay {U}. If you do, draw a card."
+    power = 5
+    toughness = 5
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT),
+            EffectTarget.Self
+        )
+        description = "Whenever Venus is dealt damage, put that many +1/+1 counters on her."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl().withAnyCounter(),
+            binding = TriggerBinding.ANY
+        )
+        effect = MayPayManaEffect(ManaCost.parse("{U}"), Effects.DrawCards(1))
+        description = "Whenever a creature you control with a counter on it deals combat damage to a player, you may pay {U}. If you do, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "April Prime"
+        flavorText = "Built from scraps. Defined by self."
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fcb59b16-3d76-478e-9306-969dd2cb1b5a.jpg?1771586980"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -460,6 +460,10 @@ object PredefinedTokens {
             effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
             timing = TimingRule.SorcerySpeed
         }
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/6/5/6559c423-449c-4e8e-8384-3ce78183e317.jpg?1760102885"
+        }
     }
 
     /**

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -7881,6 +7881,147 @@
     ]
 }
 
+// Sewer-veillance Cam
+{
+    "name": "Sewer-veillance Cam",
+    "manaCost": "{U}",
+    "typeLine": "Artifact",
+    "oracleText": "Flash\nWhen this artifact enters or leaves the battlefield, you may tap or untap target creature.\n{3}{U}, Sacrifice this artifact: Draw two cards.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature"
+                                    }
+                                },
+                                "description": "Tap that creature"
+                            },
+                            {
+                                "effect": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature"
+                                    },
+                                    "tap": false
+                                },
+                                "description": "Untap that creature"
+                            }
+                        ],
+                        "countsAsModalSpell": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this artifact enters, you may tap or untap target creature."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Modal",
+                        "modes": [
+                            {
+                                "effect": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature"
+                                    }
+                                },
+                                "description": "Tap that creature"
+                            },
+                            {
+                                "effect": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature"
+                                    },
+                                    "tap": false
+                                },
+                                "description": "Untap that creature"
+                            }
+                        ],
+                        "countsAsModalSpell": false
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "descriptionOverride": "When this artifact leaves the battlefield, you may tap or untap target creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Nicholas Gregory",
+        "flavorText": "No one in New York was going to notice one more cockroach.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab47a37b-b66d-4f70-9bf0-4d5ed6b518f3.jpg?1779102308"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shark Shredder, Killer Clone
 {
     "name": "Shark Shredder, Killer Clone",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -197,6 +197,48 @@
     ]
 }
 
+// April O'Neil, Hacktivist
+{
+    "name": "April O'Neil, Hacktivist",
+    "manaCost": "{3}{U}",
+    "typeLine": "Legendary Creature — Human Scientist",
+    "oracleText": "At the beginning of your end step, draw a card for each card type among spells you've cast this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "SpellsCastThisTurn",
+                        "countDistinctCardTypes": true
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, draw a card for each card type among spells you've cast this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "RARE",
+        "artist": "Xabi Gaztelua",
+        "flavorText": "In the fight between mutants, ninjas, and aliens, don't underestimate a resourceful human.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f0147f6d-b797-4d5e-aca2-a9d309896eca.jpg?1760102651"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // April O'Neil, Kunoichi Trainee
 {
     "name": "April O'Neil, Kunoichi Trainee",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4538,7 +4538,8 @@
                                             "destination": {
                                                 "type": "ToZone",
                                                 "zone": "Battlefield"
-                                            }
+                                            },
+                                            "underOwnersControl": true
                                         }
                                     ]
                                 }
@@ -6746,7 +6747,7 @@
                             "type": "SelectFromCollection",
                             "from": "exiled",
                             "selection": {
-                                "type": "ChooseUpTo",
+                                "type": "ChooseExactly",
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 1

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5361,6 +5361,92 @@
     ]
 }
 
+// Michelangelo's Technique
+{
+    "name": "Michelangelo's Technique",
+    "manaCost": "{4}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Sneak {3}{G} (You may cast this spell for {3}{G} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nLook at the top eight cards of your library. Put up to two creature cards with total mana value 6 or less from among them onto the battlefield and the rest on the bottom of your library in a random order.",
+    "keywords": [
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{3}{G}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 8
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "filter": "creature",
+                    "storeSelected": "toBattlefield",
+                    "storeRemainder": "toBottom",
+                    "prompt": "Put up to two creature cards with total mana value 6 or less onto the battlefield",
+                    "selectedLabel": "Put onto the battlefield",
+                    "remainderLabel": "Put on the bottom of your library",
+                    "showAllCards": true,
+                    "restrictions": [
+                        {
+                            "type": "TotalManaValueAtMost",
+                            "max": 6
+                        }
+                    ]
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toBattlefield",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toBottom",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "Random"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "RARE",
+        "artist": "Dominik Mayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a63c06a-7c59-4b72-b916-e5b6ad78c684.jpg?1769006772"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Michelangelo, Game Master
 {
     "name": "Michelangelo, Game Master",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -7615,6 +7615,57 @@
     ]
 }
 
+// Retro-Mutation
+{
+    "name": "Retro-Mutation",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature is a Turtle with base power and toughness 0/1. It can't attack and loses all abilities. (It also loses all other creature types.)",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "TransformPermanent",
+                "setCardTypes": [
+                    "CREATURE"
+                ],
+                "setSubtypes": [
+                    "Turtle"
+                ]
+            },
+            {
+                "type": "SetBasePowerToughnessStatic",
+                "power": 0,
+                "toughness": 1
+            },
+            {
+                "type": "CantAttack",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            "LoseAllAbilities"
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "artist": "Leonardo Santanna",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4af284ba-fa54-43c5-8c76-3e1128957452.jpg?1771586820"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Return to the Sewers
 {
     "name": "Return to the Sewers",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4007,6 +4007,116 @@
     ]
 }
 
+// Kitsune, Dragon's Daughter
+{
+    "name": "Kitsune, Dragon's Daughter",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Legendary Creature — Fox Warlock Avatar",
+    "oracleText": "Vigilance\nWhenever Kitsune enters or deals combat damage to a player, you may exchange control of two other target creatures controlled by different players.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ExchangeControl",
+                        "target1": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        },
+                        "target2": {
+                            "type": "BoundVariable",
+                            "name": "target creature an opponent controls"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target creature you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "target creature an opponent controls"
+                    }
+                ],
+                "descriptionOverride": "When Kitsune enters, you may exchange control of two other target creatures controlled by different players."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "ExchangeControl",
+                        "target1": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        },
+                        "target2": {
+                            "type": "BoundVariable",
+                            "name": "target creature an opponent controls"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target creature you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "target creature an opponent controls"
+                    }
+                ],
+                "descriptionOverride": "Whenever Kitsune deals combat damage to a player, you may exchange control of two other target creatures controlled by different players."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "RARE",
+        "artist": "Robin Har",
+        "flavorText": "\"You hunger for retribution, I know. And so I come to you with an offering . . .\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a87a9257-4535-4286-8b59-a842ac45d05e.jpg?1769005699"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Krang, Master Mind
 {
     "name": "Krang, Master Mind",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -7744,6 +7744,75 @@
     ]
 }
 
+// Ray Fillet, Man Ray
+{
+    "name": "Ray Fillet, Man Ray",
+    "manaCost": "{3}{U}",
+    "typeLine": "Legendary Creature — Fish Mutant",
+    "oracleText": "Flying\nWhen Ray Fillet enters, create a Mutagen token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Put a +1/+1 counter on target creature. Activate only as a sorcery.\")\n{2}, Remove a +1/+1 counter from a creature you control: Draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Mutagen"
+                },
+                "descriptionOverride": "When Ray Fillet enters, create a Mutagen token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostRemovePlusOnePlusOneCounters",
+                            "filter": "creature ctrl:you",
+                            "count": 1
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "49",
+        "rarity": "UNCOMMON",
+        "artist": "Mirko Failoni",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14e0892c-a556-43c3-974f-6be44188da2e.jpg?1771502589"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Renet, Temporal Apprentice
 {
     "name": "Renet, Temporal Apprentice",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -3033,6 +3033,87 @@
     ]
 }
 
+// Fugitive Droid
+{
+    "name": "Fugitive Droid",
+    "manaCost": "{U}",
+    "typeLine": "Artifact Creature — Robot Scientist",
+    "oracleText": "This creature can't be blocked if an artifact entered the battlefield under your control this turn.\n{U}, Sacrifice this creature: Counter target spell that targets an artifact or creature you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{U}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": "Counter",
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "TargetsMatching",
+                                        "subfilter": {
+                                            "cardPredicates": [
+                                                {
+                                                    "type": "Or",
+                                                    "predicates": [
+                                                        "IsCreature",
+                                                        "IsArtifact"
+                                                    ]
+                                                }
+                                            ],
+                                            "controllerPredicate": "ControlledByYou"
+                                        }
+                                    }
+                                ]
+                            },
+                            "zone": "Stack"
+                        },
+                        "id": "target spell that targets an artifact or creature you control"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": "CantBeBlocked",
+                "condition": {
+                    "type": "PermanentTypeEnteredBattlefieldThisTurn",
+                    "cardType": "ARTIFACT"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "UNCOMMON",
+        "artist": "Narendra Bintara Adi",
+        "flavorText": "\"A freak accident transferred Professor Honeycutt's mind into his robot assistant. Blamed for his own death, he fled . . . as the FUGITOID!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/0/50c4e65f-00dc-4fc5-bd5c-8482c2848f4c.jpg?1771586801"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // General Traag, Heart of Stone
 {
     "name": "General Traag, Heart of Stone",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4987,6 +4987,69 @@
     ]
 }
 
+// Madame Null, Power Broker
+{
+    "name": "Madame Null, Power Broker",
+    "manaCost": "{2}{B}",
+    "typeLine": "Legendary Creature — Demon Advisor",
+    "oracleText": "Deathtouch\nWhenever another creature you control enters, you may pay life equal to its power. If you do, put that many +1/+1 counters on it.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayDynamicLife",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Triggering",
+                                "numericProperty": "Power"
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "AddDynamicCounters",
+                        "counterType": "+1/+1",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Triggering",
+                            "numericProperty": "Power"
+                        },
+                        "target": "TriggeringEntity"
+                    }
+                },
+                "descriptionOverride": "Whenever another creature you control enters, you may pay life equal to its power. If you do, put that many +1/+1 counters on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "RARE",
+        "artist": "Irina Nordsol",
+        "flavorText": "\"We suffered a bit of a setback tonight, but rest assured: We'll have the planet purged and primed for you right on schedule.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/e/4e712d5c-d6fe-40bb-b8e5-5f50c6ea8d4f.jpg?1769005736"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Make Your Move
 {
     "name": "Make Your Move",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -3228,6 +3228,57 @@
     ]
 }
 
+// Grounded for Life
+{
+    "name": "Grounded for Life",
+    "manaCost": "{4}{W}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {3} less to cast if it targets a tapped creature.\nDestroy target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 3,
+                        "filter": "creature tapped"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "artist": "Andrea Tentori Montalto",
+        "flavorText": "\"Of course I know what you did! You always do precisely what I told you not to do!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72388199-85fa-4eba-9a9c-c2904e6da9ed.jpg?1771502482"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Guac & Marshmallow Pizza
 {
     "name": "Guac & Marshmallow Pizza",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -10453,6 +10453,82 @@
     ]
 }
 
+// Venus, Torn Between Worlds
+{
+    "name": "Venus, Torn Between Worlds",
+    "manaCost": "{4}{G}",
+    "typeLine": "Legendary Creature — Mutant Frog Turtle",
+    "oracleText": "Whenever Venus is dealt damage, put that many +1/+1 counters on her. (She must survive the damage to get the counters.)\nWhenever a creature you control with a counter on it deals combat damage to a player, you may pay {U}. If you do, draw a card.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever Venus is dealt damage, put that many +1/+1 counters on her."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            "HasAnyCounter"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{U}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "descriptionOverride": "Whenever a creature you control with a counter on it deals combat damage to a player, you may pay {U}. If you do, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "UNCOMMON",
+        "artist": "April Prime",
+        "flavorText": "Built from scraps. Defined by self.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fcb59b16-3d76-478e-9306-969dd2cb1b5a.jpg?1771586980"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Weather Maker
 {
     "name": "Weather Maker",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -6571,6 +6571,131 @@
     ]
 }
 
+// Northampton Farm
+{
+    "name": "Northampton Farm",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{1}, {T}: Exile target creature you own.\n{2}, {T}, Sacrifice this land: Return a creature card exiled with this land to the battlefield under your control. Return each other card exiled with this land to its owner's hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you own"
+                    },
+                    "destination": "Exile",
+                    "linkToSource": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature own:you"
+                        },
+                        "id": "target creature you own"
+                    }
+                ]
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "exiled"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "exiled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature",
+                            "storeSelected": "toBattlefield",
+                            "storeRemainder": "toHand",
+                            "prompt": "Return a creature card to the battlefield under your control",
+                            "selectedLabel": "Return to the battlefield",
+                            "remainderLabel": "Return to owner's hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBattlefield",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "RARE",
+        "artist": "Marina Ortega Lorente",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbca168e-095f-4fbc-88f8-3048d83caf94.jpg?1769006600"
+    }
+}
+
 // Novel Nunchaku
 {
     "name": "Novel Nunchaku",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -8019,6 +8019,92 @@
     ]
 }
 
+// Raphael, Most Attitude
+{
+    "name": "Raphael, Most Attitude",
+    "manaCost": "{3}{R}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "Menace\nAlliance — Whenever another creature you control enters, you may exile the top card of your library.\nWhenever Raphael attacks, until end of turn, you may play a card exiled with Raphael.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeAs": "raphaelTop"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "raphaelTop",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Alliance — Whenever another creature you control enters, you may exile the top card of your library."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "raphaelExile"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "raphaelExile"
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Raphael attacks, until end of turn, you may play a card exiled with Raphael."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "rarity": "UNCOMMON",
+        "artist": "Thomas Chamberlain-Keen",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/88385a87-f931-409f-8a21-250f0866d63d.jpg?1771502673"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Raphael, Tough Turtle
 {
     "name": "Raphael, Tough Turtle",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -10723,6 +10723,104 @@
     ]
 }
 
+// Turtle Van
+{
+    "name": "Turtle Van",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Whenever this Vehicle attacks, put a +1/+1 counter on target creature that crewed it this turn. Then if that creature is a Mutant, Ninja, or Turtle, double the number of +1/+1 counters on it.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature that crewed it this turn"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": {
+                                        "cardPredicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasAnyOfSubtypes",
+                                                "subtypes": [
+                                                    "Mutant",
+                                                    "Ninja",
+                                                    "Turtle"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "DoubleCounters",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature that crewed it this turn"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "CrewedOrSaddledSourceThisTurn"
+                            ]
+                        }
+                    },
+                    "id": "target creature that crewed it this turn"
+                },
+                "descriptionOverride": "Whenever this Vehicle attacks, put a +1/+1 counter on target creature that crewed it this turn. Then if that creature is a Mutant, Ninja, or Turtle, double the number of +1/+1 counters on it."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "RARE",
+        "artist": "Jakob Eirich",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fce6a8b6-b43c-4045-9378-97b2463f9b4d.jpg?1769006474"
+    }
+}
+
 // Uneasy Alliance
 {
     "name": "Uneasy Alliance",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2489,6 +2489,194 @@
     ]
 }
 
+// Everything Pizza
+{
+    "name": "Everything Pizza",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Food",
+    "oracleText": "When this artifact enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle.\n{2}{W}{U}{B}{R}{G}, {T}, Sacrifice this artifact: Target player gains 3 life and draws a card. Each of your opponents discards a card. This artifact deals 3 damage to any target. Put three +1/+1 counters on up to one target creature.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary"
+                    ]
+                },
+                "descriptionOverride": "When this artifact enters, search your library for a basic land card, reveal it, put it into your hand, then shuffle."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}{U}{B}{R}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target player"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": "EachOpponent"
+                            },
+                            "body": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "any target"
+                            },
+                            "damageSource": "Self"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetPlayer",
+                        "id": "target player"
+                    },
+                    {
+                        "type": "AnyTarget",
+                        "id": "any target"
+                    },
+                    {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "up to one target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "rarity": "UNCOMMON",
+        "artist": "James Bousema",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df2cdaa5-9ea0-4aa5-89d3-9edf40fa2a39.jpg?1771476702"
+    }
+}
+
 // Featherbrained Filcher
 {
     "name": "Featherbrained Filcher",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4479,6 +4479,99 @@
     ]
 }
 
+// Koya, Death from Above
+{
+    "name": "Koya, Death from Above",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Mutant Ninja Bird",
+    "oracleText": "Flying\nWhen Koya enters, exile up to one other target creature. At the beginning of the next end step, you may pay {3}{B}. If you don't, return that card to the battlefield under its owner's control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one other target creature"
+                            },
+                            "destination": "Exile",
+                            "linkToSource": true
+                        },
+                        {
+                            "type": "CreateDelayedTrigger",
+                            "step": "END",
+                            "effect": {
+                                "type": "PayOrSuffer",
+                                "cost": {
+                                    "type": "PayAtom",
+                                    "atom": {
+                                        "type": "AtomMana",
+                                        "cost": "{3}{B}"
+                                    }
+                                },
+                                "suffer": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": "FromLinkedExile",
+                                            "storeAs": "koyaExile"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "koyaExile",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Battlefield"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature",
+                        "excludeSelf": true
+                    },
+                    "id": "up to one other target creature"
+                },
+                "descriptionOverride": "When Koya enters, exile up to one other target creature. At the beginning of the next end step, you may pay {3}{B}. If you don't, return that card to the battlefield under its owner's control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "rarity": "UNCOMMON",
+        "artist": "Irina Nordsol",
+        "flavorText": "\"Hello, prey.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a4f1ccc-2225-4cd0-abef-0eb7a8eae9cf.jpg?1771586885"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Krang, Master Mind
 {
     "name": "Krang, Master Mind",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -513,13 +513,23 @@ class DynamicAmountEvaluator(
                 // excludeSelf drops the resolving spell's own record, matched by the spell's
                 // stack entity id (CastSpellRecord.sourceEntityId == context.sourceId).
                 val selfId = if (amount.excludeSelf) context.sourceId else null
-                playerIds.sumOf { playerId ->
-                    val records = state.spellsCastThisTurnByPlayer[playerId] ?: emptyList()
-                    records.count { record ->
-                        (selfId == null || record.sourceEntityId != selfId) &&
-                            // Zone qualifier is checked independently of the filter (see condition note).
-                            (amount.fromZone == null || record.castFromZone == amount.fromZone) &&
-                            predicateEvaluator.matchesFilter(record, amount.filter)
+                fun matches(record: com.wingedsheep.engine.state.CastSpellRecord) =
+                    (selfId == null || record.sourceEntityId != selfId) &&
+                        // Zone qualifier is checked independently of the filter (see condition note).
+                        (amount.fromZone == null || record.castFromZone == amount.fromZone) &&
+                        predicateEvaluator.matchesFilter(record, amount.filter)
+                if (amount.countDistinctCardTypes) {
+                    // "for each card type among spells you've cast this turn" — union the card types
+                    // across every matching record (an artifact creature spell counts for both).
+                    playerIds
+                        .flatMap { state.spellsCastThisTurnByPlayer[it] ?: emptyList() }
+                        .filter { matches(it) }
+                        .flatMap { it.typeLine.cardTypes }
+                        .toSet()
+                        .size
+                } else {
+                    playerIds.sumOf { playerId ->
+                        (state.spellsCastThisTurnByPlayer[playerId] ?: emptyList()).count { matches(it) }
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -26,6 +26,7 @@ import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.MoveToZoneEffect
+import com.wingedsheep.sdk.scripting.effects.PayDynamicLifeEffect
 import com.wingedsheep.sdk.scripting.effects.PayDynamicManaCostEffect
 import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
 import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
@@ -370,6 +371,11 @@ class GatedEffectExecutor(
                 val amount = dynamicAmountEvaluator.evaluate(state, cost.amount, context).coerceAtLeast(0)
                 "Pay ${PayDynamicManaCostExecutor.dynamicManaCost(amount, cost.color)}"
             }
+            is PayLifeEffect -> "Pay ${cost.amount} life"
+            is PayDynamicLifeEffect -> {
+                val amount = dynamicAmountEvaluator.evaluate(state, cost.amount, context).coerceAtLeast(0)
+                "Pay $amount life"
+            }
             else -> null
         }
 
@@ -391,6 +397,14 @@ class GatedEffectExecutor(
             is PayLifeEffect -> {
                 val life = state.lifeTotal(playerId) // CR 810.9a — team's shared total
                 life >= cost.amount
+            }
+            is PayDynamicLifeEffect -> {
+                // Resolve the cost's own payer; a computed amount of <= 0 is free (CR 119.4).
+                val amount = dynamicAmountEvaluator.evaluate(state, cost.amount, context)
+                val payerId = TargetResolutionUtils
+                    .resolvePlayerTarget(EffectTarget.PlayerRef(cost.payer), context, state)
+                    ?: playerId
+                amount <= 0 || state.lifeTotal(payerId) >= amount
             }
             is CompositeEffect -> cost.effects.all { canAfford(state, playerId, it, context) }
             // "You may sacrifice [filter]" — payable only if the player controls enough matching

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/LifeExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/LifeExecutors.kt
@@ -16,6 +16,7 @@ class LifeExecutors(
         LoseLifeExecutor(amountEvaluator),
         OwnerGainsLifeExecutor(),
         PayLifeEffectExecutor(),
+        PayDynamicLifeEffectExecutor(amountEvaluator),
         SetLifeTotalExecutor(amountEvaluator)
     )
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/PayDynamicLifeEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/life/PayDynamicLifeEffectExecutor.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.handlers.effects.life
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
+import com.wingedsheep.engine.core.LifeChangedEvent
+import com.wingedsheep.engine.core.LifeChangeReason
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.DamageUtils
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.sdk.scripting.effects.PayDynamicLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [PayDynamicLifeEffect] — the dynamic, payer-parametric twin of
+ * [PayLifeEffectExecutor]. Evaluates [PayDynamicLifeEffect.amount] at resolution, resolves
+ * [PayDynamicLifeEffect.payer] (defaulting to the ability controller), then deducts that much life.
+ *
+ * A computed amount of `<= 0` pays nothing and succeeds (CR 119.4 — paying 0 life is legal), so a
+ * gating [com.wingedsheep.sdk.scripting.effects.Gate.MayPay] still proceeds to its `then`.
+ */
+class PayDynamicLifeEffectExecutor(
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
+) : EffectExecutor<PayDynamicLifeEffect> {
+
+    override val effectType: KClass<PayDynamicLifeEffect> = PayDynamicLifeEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: PayDynamicLifeEffect,
+        context: EffectContext
+    ): EffectResult {
+        val amount = amountEvaluator.evaluate(state, effect.amount, context)
+        if (amount <= 0) {
+            return EffectResult.success(state)
+        }
+
+        val playerId = TargetResolutionUtils
+            .resolvePlayerTarget(EffectTarget.PlayerRef(effect.payer), context, state)
+            ?: context.controllerId
+
+        if (state.getEntity(playerId)?.get<LifeTotalComponent>() == null) {
+            return EffectResult.error(state, "Player not found for life payment")
+        }
+
+        // CR 810.9a — life paid as a cost comes out of the team's shared total.
+        val currentLife = state.lifeTotal(playerId)
+        val newLife = currentLife - amount
+        val newState = state.withLifeTotal(playerId, newLife)
+
+        val events = listOf<EngineGameEvent>(
+            LifeChangedEvent(playerId, currentLife, newLife, LifeChangeReason.PAYMENT)
+        )
+
+        val finalState = DamageUtils.markLifeLostThisTurn(newState, playerId)
+        return EffectResult.success(finalState, events)
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AprilONeilHacktivistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AprilONeilHacktivistScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for April O'Neil, Hacktivist (TMT) — the proving card for
+ * `DynamicAmount.SpellsCastThisTurn(countDistinctCardTypes = true)`.
+ *
+ * "At the beginning of your end step, draw a card for each card type among spells you've cast
+ *  this turn."
+ *
+ * Proves the distinct-card-types aggregation:
+ *  - casting one artifact creature spell (two card types from a single spell) draws 2, showing the
+ *    amount counts card *types* (unioned across a spell's type line), not the number of spells,
+ *  - casting nothing draws 0.
+ */
+class AprilONeilHacktivistScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("April O'Neil, Hacktivist end step") {
+
+            test("one artifact creature spell (Artifact + Creature) draws two cards") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "April O'Neil, Hacktivist")
+                    .withCardInHand(1, "Ornithopter") // {0} Artifact Creature
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Island") }
+                val game = builder.build()
+
+                game.castSpell(1, "Ornithopter")
+                game.resolveStack()
+
+                // Hand is now empty (Ornithopter left for the battlefield).
+                game.handSize(1) shouldBe 0
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Artifact + Creature = 2 card types → draw 2") {
+                    game.handSize(1) shouldBe 2
+                }
+            }
+
+            test("casting no spells this turn draws nothing") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "April O'Neil, Hacktivist")
+                    .withCardInHand(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Island") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("No spells cast → 0 card types → draw 0") {
+                    game.handSize(1) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KoyaDeathFromAboveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KoyaDeathFromAboveScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Koya, Death from Above (TMT).
+ *
+ * "When Koya enters, exile up to one other target creature. At the beginning of the next end step,
+ *  you may pay {3}{B}. If you don't, return that card to the battlefield under its owner's control."
+ *
+ * Regression guard for the return's controller: when Koya exiles an *opponent's* creature and the
+ * {3}{B} isn't paid, the creature must come back under its **owner's** control (player 2), not under
+ * Koya's controller's (player 1). The exile/return uses a linked exile with
+ * `MoveCollectionEffect(underOwnersControl = true)`; without that flag the controller would default
+ * to `Player.You` and Koya would steal the creature.
+ */
+class KoyaDeathFromAboveScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Koya, Death from Above end-step return") {
+
+            test("an opponent's exiled creature returns under its owner's control when {3}{B} isn't paid") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Koya, Death from Above")
+                    .withLandsOnBattlefield(1, "Plains", 3) // pays {2}{W}; no black source for {3}{B}
+                    .withCardOnBattlefield(2, "Centaur Courser") // opponent's 3/3
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentCreature = game.findPermanent("Centaur Courser")
+                    ?: error("Centaur Courser should start on player 2's battlefield")
+
+                // Koya enters; its ETB trigger targets and exiles the opponent's creature.
+                game.castSpell(1, "Koya, Death from Above")
+                game.resolveStack()
+                game.selectTargets(listOf(opponentCreature))
+                game.resolveStack()
+
+                withClue("Centaur Courser is exiled by Koya's ETB") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                }
+
+                // Next end step: player 1 has no black mana, so {3}{B} can't be paid — the "if you
+                // don't" branch returns the creature to the battlefield.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                val returned = game.findPermanent("Centaur Courser")
+                    ?: error("Centaur Courser should have returned to the battlefield")
+                withClue("Returned under its owner's (player 2's) control, not Koya's controller's") {
+                    game.state.getEntity(returned)?.get<ControllerComponent>()?.playerId shouldBe game.player2Id
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MadameNullScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MadameNullScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Madame Null, Power Broker (TMT) — the proving card for the dynamic
+ * pay-life cost (`Effects.PayDynamicLife`).
+ *
+ * "Whenever another creature you control enters, you may pay life equal to its power. If you
+ *  do, put that many +1/+1 counters on it."
+ *
+ * Exercises the `OptionalCostEffect(PayDynamicLife(power), AddDynamicCounters(power))` gate:
+ *  - pay → life drops by the entering creature's power and it gets that many +1/+1 counters,
+ *  - decline → no life paid, no counters,
+ *  - a 0-power creature → "pay 0 life" is a no-op payment (CR 119.4) that still adds 0 counters.
+ */
+class MadameNullScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Madame Null, Power Broker") {
+
+            test("paying life equal to the entering creature's power adds that many +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Madame Null, Power Broker")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInHand(1, "Centaur Courser") // {2}{G} 3/3
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Centaur Courser")
+                game.resolveStack() // Centaur enters; Madame Null's trigger resolves to the may-pay prompt
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Paid 3 life (Centaur Courser's power)") {
+                    game.getLifeTotal(1) shouldBe 17
+                }
+                withClue("Centaur Courser gained 3 +1/+1 counters") {
+                    game.plusOneCounters(game.findOnBattlefield("Centaur Courser")) shouldBe 3
+                }
+            }
+
+            test("declining the payment adds no counters and costs no life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Madame Null, Power Broker")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withCardInHand(1, "Centaur Courser")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Centaur Courser")
+                game.resolveStack()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("No life paid when declined") { game.getLifeTotal(1) shouldBe 20 }
+                withClue("No counters when declined") {
+                    game.plusOneCounters(game.findOnBattlefield("Centaur Courser")) shouldBe 0
+                }
+            }
+
+            test("a 0-power creature: paying 0 life is a no-op and adds no counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Madame Null, Power Broker")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, "Taunting Elf") // {G} 0/1
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Taunting Elf")
+                game.resolveStack()
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Paying life equal to 0 power costs no life") { game.getLifeTotal(1) shouldBe 20 }
+                withClue("0 power → 0 +1/+1 counters") {
+                    game.plusOneCounters(game.findOnBattlefield("Taunting Elf")) shouldBe 0
+                }
+            }
+        }
+    }
+
+    private fun TestGame.findOnBattlefield(cardName: String): EntityId =
+        state.getBattlefield().first { state.getEntity(it)?.get<CardComponent>()?.name == cardName }
+
+    private fun TestGame.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+}


### PR DESCRIPTION
Adds 14 cards to Teenage Mutant Ninja Turtles (TMT) plus two new SDK
primitives that unblock them. Brings TMT to 171/190.

### New SDK primitives
- **`Effects.PayDynamicLife(amount, payer?)`** — pay life equal to a
  `DynamicAmount`, the payer-parametric twin of `PayLifeEffect` (mirrors
  `PayDynamicManaCostEffect`). Lowers through `OptionalCostEffect` /
  `Gate.MayPay`; a non-positive amount pays nothing and still counts as
  paid (CR 119.4b). Proven by Madame Null, Power Broker.
- **`SpellsCastThisTurn(countDistinctCardTypes = true)`** — counts the
  distinct card types among matching cast spells (unioned per record and
  across players) instead of the spell count. Proven by April O'Neil,
  Hacktivist.

### Cards
April O'Neil, Madame Null, Koya, Raphael, Northampton Farm, Fugitive
Droid, Michelangelo's Technique, Turtle Van, Everything Pizza, Venus,
Retro-Mutation, Kitsune, Ray Fillet, Sewer-veillance Cam. Mutagen token
gets art.

### Tests
New scenario tests for Madame Null (pay / decline / 0-power), April
O'Neil (distinct types / zero), and Koya (owner-control return
regression). Card snapshot + lint nets re-blessed. `docs/card-sdk-
language-reference.md` updated for both primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)