### PR TITLE
Add three Duskmourn cards: Abandoned Campground, Bottomless Pool // Locker Room, Strangled Cemetery

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AbandonedCampground.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AbandonedCampground.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Abandoned Campground (DSK 255) — Duskmourn "horror" dual land cycle.
+ *
+ * Land
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {W} or {U}.
+ *
+ * The enters-tapped clause checks *any* player's life (not just the controller), modeled with
+ * [Conditions.APlayerLifeAtMost] (CR rules-faithful "a player has 13 or less life").
+ */
+val AbandonedCampground = card("Abandoned Campground") {
+    typeLine = "Land"
+    colorIdentity = "WU"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {W} or {U}."
+
+    replacementEffect(EntersTapped(unlessCondition = Conditions.APlayerLifeAtMost(13)))
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "255"
+        artist = "Cristi Balanescu"
+        flavorText = "They say every inhabitant vanished in a single night, leaving their belongings untouched but curiously covered in moths."
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/ee0565f5-ebdb-43f9-bbb4-0485b1968937.jpg?1726286826"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BottomlessPoolLockerRoom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BottomlessPoolLockerRoom.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.OneOrMoreDealCombatDamageToPlayerEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Bottomless Pool // Locker Room (DSK 43) — split-layout Room (CR 709.5).
+ *
+ * Bottomless Pool {U} — Enchantment — Room
+ *   When you unlock this door, return up to one target creature to its owner's hand.
+ *
+ * Locker Room {4}{U} — Enchantment — Room
+ *   Whenever one or more creatures you control deal combat damage to a player, draw a card.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ */
+val BottomlessPoolLockerRoom = card("Bottomless Pool // Locker Room") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "U"
+
+    face("Bottomless Pool") {
+        manaCost = "{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, return up to one target creature to its owner's hand."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            val creature = target("up to one target creature", Targets.UpToCreatures(1))
+            effect = Effects.ReturnToHand(creature)
+        }
+    }
+
+    face("Locker Room") {
+        manaCost = "{4}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Whenever one or more creatures you control deal combat damage to a player, draw a card."
+
+        triggeredAbility {
+            trigger = TriggerSpec(
+                OneOrMoreDealCombatDamageToPlayerEvent(
+                    sourceFilter = GameObjectFilter.Creature.youControl()
+                ),
+                TriggerBinding.ANY
+            )
+            effect = Effects.DrawCards(1)
+            description = "Whenever one or more creatures you control deal combat damage to a player, draw a card."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "43"
+        artist = "Diana Franco"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg?1726780385"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/StrangledCemetery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/StrangledCemetery.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Strangled Cemetery (DSK 268) — Duskmourn "horror" dual land cycle.
+ *
+ * Land
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {B} or {G}.
+ *
+ * The enters-tapped clause checks *any* player's life (not just the controller), modeled with
+ * [Conditions.APlayerLifeAtMost] ("a player has 13 or less life").
+ */
+val StrangledCemetery = card("Strangled Cemetery") {
+    typeLine = "Land"
+    colorIdentity = "BG"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {B} or {G}."
+
+    replacementEffect(EntersTapped(unlessCondition = Conditions.APlayerLifeAtMost(13)))
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "268"
+        artist = "Marco Gorlei"
+        flavorText = "They say that with each new moon, the buried dead rise and dance from dusk to dawn, and witnesses to the revelry must join them for eternity."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1ce9250-bdbe-4c77-9243-6db9ffffe69b.jpg?1726286874"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1,3 +1,54 @@
+// Abandoned Campground
+{
+    "name": "Abandoned Campground",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {W} or {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "255",
+        "artist": "Cristi Balanescu",
+        "flavorText": "They say every inhabitant vanished in a single night, leaving their belongings untouched but curiously covered in moths.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/ee0565f5-ebdb-43f9-bbb4-0485b1968937.jpg?1726286826"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Acrobatic Cheerleader
 {
     "name": "Acrobatic Cheerleader",
@@ -1001,6 +1052,82 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Bottomless Pool // Locker Room
+{
+    "name": "Bottomless Pool // Locker Room",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, return up to one target creature to its owner's hand.\n//\nWhenever one or more creatures you control deal combat damage to a player, draw a card.",
+    "metadata": {
+        "collectorNumber": "43",
+        "rarity": "UNCOMMON",
+        "artist": "Diana Franco",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/606fe87c-d17b-4fa7-8e82-e7002d8229ef.jpg?1726780385"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Bottomless Pool",
+            "manaCost": "{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, return up to one target creature to its owner's hand.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target creature"
+                            },
+                            "destination": "Hand"
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "up to one target creature"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Locker Room",
+            "manaCost": "{4}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Whenever one or more creatures you control deal combat damage to a player, draw a card.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": {
+                            "type": "OneOrMoreDealCombatDamageToPlayerEvent",
+                            "sourceFilter": "creature ctrl:you"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        "descriptionOverride": "Whenever one or more creatures you control deal combat damage to a player, draw a card."
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -11704,6 +11831,57 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Strangled Cemetery
+{
+    "name": "Strangled Cemetery",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {B} or {G}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "artist": "Marco Gorlei",
+        "flavorText": "They say that with each new moon, the buried dead rise and dance from dusk to dawn, and witnesses to the revelry must join them for eternity.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1ce9250-bdbe-4c77-9243-6db9ffffe69b.jpg?1726286874"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BottomlessPoolLockerRoomTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BottomlessPoolLockerRoomTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.BottomlessPoolLockerRoom
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario for `Bottomless Pool // Locker Room` (DSK 43), a split-layout Room (CR 709.5).
+ *
+ * Bottomless Pool {U}  — "When you unlock this door, return up to one target creature to its
+ *                         owner's hand." Casting the half enters it unlocked, firing the trigger.
+ * Locker Room {4}{U}   — "Whenever one or more creatures you control deal combat damage to a
+ *                         player, draw a card."
+ */
+class BottomlessPoolLockerRoomTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(BottomlessPoolLockerRoom)
+        d.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("casting Bottomless Pool unlocks its door and bounces a target creature to its owner's hand") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent has a creature in play to bounce.
+        val bears = d.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        // Cast Bottomless Pool ({U}, face 0). The cast face enters unlocked, firing the trigger.
+        val roomId = d.putCardInHand(p1, BottomlessPoolLockerRoom.name)
+        d.giveMana(p1, Color.BLUE, 1)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+
+        val room = d.state.getEntity(roomId)?.get<RoomComponent>()
+        room shouldNotBe null
+        room!!.unlocked shouldBe setOf(RoomFaceId("Bottomless Pool"))
+
+        // The "When you unlock this door" trigger asks for its (up-to-one) target.
+        val handBefore = d.getHand(p2).size
+        d.submitTargetSelection(p1, listOf(bears))
+        d.bothPass()
+
+        // The bear is returned to its owner's hand.
+        d.getCreatures(p2) shouldBe emptyList()
+        d.getHand(p2).size shouldBe handBefore + 1
+        d.getHand(p2) shouldContain bears
+    }
+
+    test("Locker Room draws a card when creatures you control deal combat damage to a player") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast Locker Room ({4}{U}, face 1).
+        val roomId = d.putCardInHand(p1, BottomlessPoolLockerRoom.name)
+        d.giveMana(p1, Color.BLUE, 5)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+        d.bothPass()
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe setOf(RoomFaceId("Locker Room"))
+
+        // An attacker connects with the opponent.
+        val attacker = d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        d.removeSummoningSickness(attacker)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(p1, listOf(attacker), p2)
+        d.bothPass()
+        d.declareNoBlockers(p2)
+
+        val handBefore = d.getHand(p1).size
+        // Combat damage resolves, then the "draw a card" trigger resolves.
+        d.bothPass()
+        d.bothPass()
+
+        d.getHand(p1).size shouldBe handBefore + 1
+        d.assertLifeTotal(p2, 18)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskHorrorLandsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskHorrorLandsScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.AbandonedCampground
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.StrangledCemetery
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for two Duskmourn: House of Horror common dual lands:
+ * Abandoned Campground (W/U) and Strangled Cemetery (B/G).
+ *
+ * Each: "This land enters tapped unless a player has 13 or less life. {T}: Add {C1} or {C2}."
+ * The enters-tapped condition is the existential [APlayerLifeAtMost(13)] — true when ANY
+ * player is at 13 life or below, distinct from a controller-only threshold.
+ */
+class DskHorrorLandsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + AbandonedCampground + StrangledCemetery)
+        return driver
+    }
+
+    test("Abandoned Campground enters tapped while both players are at full life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = driver.putCardInHand(p1, "Abandoned Campground")
+        driver.playLand(p1, land).isSuccess shouldBe true
+
+        driver.state.getEntity(land)?.has<TappedComponent>() shouldBe true
+    }
+
+    test("Abandoned Campground enters untapped when an opponent has 13 or less life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.setLifeTotal(driver.getOpponent(p1), 13)
+        val land = driver.putCardInHand(p1, "Abandoned Campground")
+        driver.playLand(p1, land).isSuccess shouldBe true
+
+        driver.state.getEntity(land)?.has<TappedComponent>() shouldBe false
+    }
+
+    test("Abandoned Campground taps for white and blue") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val white = driver.putPermanentOnBattlefield(p1, "Abandoned Campground")
+        driver.submit(ActivateAbility(p1, white, AbandonedCampground.activatedAbilities[0].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.white shouldBe 1
+
+        val blue = driver.putPermanentOnBattlefield(p1, "Abandoned Campground")
+        driver.submit(ActivateAbility(p1, blue, AbandonedCampground.activatedAbilities[1].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.blue shouldBe 1
+    }
+
+    test("Strangled Cemetery enters tapped at full life and taps for black and green") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val land = driver.putCardInHand(p1, "Strangled Cemetery")
+        driver.playLand(p1, land).isSuccess shouldBe true
+        driver.state.getEntity(land)?.has<TappedComponent>() shouldBe true
+
+        val black = driver.putPermanentOnBattlefield(p1, "Strangled Cemetery")
+        driver.submit(ActivateAbility(p1, black, StrangledCemetery.activatedAbilities[0].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.black shouldBe 1
+
+        val green = driver.putPermanentOnBattlefield(p1, "Strangled Cemetery")
+        driver.submit(ActivateAbility(p1, green, StrangledCemetery.activatedAbilities[1].id)).isSuccess shouldBe true
+        driver.state.getEntity(p1)?.get<ManaPoolComponent>()?.green shouldBe 1
+    }
+
+    test("Strangled Cemetery enters untapped when controller is low on life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.setLifeTotal(p1, 10)
+        val land = driver.putCardInHand(p1, "Strangled Cemetery")
+        driver.playLand(p1, land).isSuccess shouldBe true
+        driver.state.getEntity(land)?.has<TappedComponent>() shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

Implements three Duskmourn: House of Horror (DSK) cards. All three reuse existing SDK building blocks — no engine/SDK changes were required.

| Card | # | Details |
|------|---|---------|
| **Abandoned Campground** | 255 | W/U common dual land. "Enters tapped unless a player has 13 or less life. {T}: Add {W} or {U}." |
| **Strangled Cemetery** | 268 | B/G common dual land. Same enters-tapped clause; taps for {B} or {G}. |
| **Bottomless Pool // Locker Room** | 43 | Split-layout Room (CR 709.5). |

### Modeling notes
- The two lands use `EntersTapped(unlessCondition = Conditions.APlayerLifeAtMost(13))` — the existential "a player" threshold (any player at ≤13, not just the controller), matching the existing DSK dual-land cycle.
- **Bottomless Pool // Locker Room** is a Room split card:
  - *Bottomless Pool* `{U}` — "When you unlock this door, return up to one target creature to its owner's hand." The cast face enters unlocked, emitting `DoorUnlockedEvent`, so the trigger fires on cast (CR 709.5h). Modeled with `Triggers.OnDoorUnlocked` + up-to-one optional target + `Effects.ReturnToHand`.
  - *Locker Room* `{4}{U}` — "Whenever one or more creatures you control deal combat damage to a player, draw a card." Uses the existing `OneOrMoreDealCombatDamageToPlayerEvent` batching trigger.

### Tests
- `DskHorrorLandsScenarioTest` — enters tapped at full life, untapped when a player is at ≤13, and taps for both colors (both lands).
- `BottomlessPoolLockerRoomTest` — casting Bottomless Pool unlocks its door and bounces a target creature; Locker Room draws on combat damage to a player.
- `CardDefinitionSnapshotTest` golden re-blessed (only the three new cards added). `CardLintTest` passes.

No cards skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)