### PR TITLE
Add FIN cards: Adelbert Steiner, Al Bhed Salvagers, Balamb T-Rexaur, Cargo Ship

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AdelbertSteiner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AdelbertSteiner.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Adelbert Steiner
+ * {1}{W}
+ * Legendary Creature — Human Knight
+ * 2/1
+ * Lifelink
+ * Adelbert Steiner gets +1/+1 for each Equipment you control.
+ *
+ * Modeling: lifelink is an intrinsic keyword; the self-buff is a continuous static
+ * ([GrantDynamicStatsEffect] scoped to [GroupFilter.source]) whose bonus recomputes
+ * from a live count of Equipment you control ([DynamicAmount.Count]).
+ */
+val AdelbertSteiner = card("Adelbert Steiner") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Knight"
+    power = 2
+    toughness = 1
+    oracleText = "Lifelink\nAdelbert Steiner gets +1/+1 for each Equipment you control."
+
+    keywords(Keyword.LIFELINK)
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.Count(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).youControl()
+            ),
+            toughnessBonus = DynamicAmount.Count(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).youControl()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "3"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "\"Chivalry requires a knight to look after his comrades-in-arms. I will not abandon you!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a67a991-1e52-4676-a2e3-2bc7aa943ab3.jpg?1748705765"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AlBhedSalvagers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AlBhedSalvagers.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Al Bhed Salvagers
+ * {2}{B}
+ * Creature — Human Artificer Warrior
+ * 2/3
+ * Whenever this creature or another creature or artifact you control dies, target
+ * opponent loses 1 life and you gain 1 life.
+ *
+ * Modeling: an ANY-binding leaves-to-graveyard trigger filtered to creatures/artifacts
+ * you control — the filter matches the source itself, so "this creature or another"
+ * is covered without an explicit self clause (CR 603.2 / 700.4).
+ */
+val AlBhedSalvagers = card("Al Bhed Salvagers") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Artificer Warrior"
+    power = 2
+    toughness = 3
+    oracleText = "Whenever this creature or another creature or artifact you control dies, " +
+        "target opponent loses 1 life and you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.CreatureOrArtifact.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            listOf(
+                Effects.LoseLife(1, opponent),
+                Effects.GainLife(1)
+            )
+        )
+        description = "Whenever this creature or another creature or artifact you control dies, " +
+            "target opponent loses 1 life and you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "88"
+        artist = "Masateru Ikeda"
+        flavorText = "\"We found the airship! The records were right.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/8/58ccdcfc-a669-480f-bded-4273cfaf2045.jpg?1748706093"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BalambTRexaur.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BalambTRexaur.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Balamb T-Rexaur
+ * {4}{G}{G}
+ * Creature — Dinosaur
+ * 6/6
+ * Trample
+ * When this creature enters, you gain 3 life.
+ * Forestcycling {2} ({2}, Discard this card: Search your library for a Forest card,
+ * reveal it, put it into your hand, then shuffle.)
+ *
+ * Forestcycling is basic-land typecycling for Forest ([KeywordAbility.typecycling]).
+ */
+val BalambTRexaur = card("Balamb T-Rexaur") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 6
+    toughness = 6
+    oracleText = "Trample\nWhen this creature enters, you gain 3 life.\nForestcycling {2} " +
+        "({2}, Discard this card: Search your library for a Forest card, reveal it, " +
+        "put it into your hand, then shuffle.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Forest", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "173"
+        artist = "Fang Xinyu"
+        flavorText = "\"Sometimes it's better to run!\"\n—Quistis Trepe"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e5857b1b-73bc-458e-b26b-7ed8bef785f3.jpg?1748706407"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CargoShip.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CargoShip.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Cargo Ship
+ * {1}{U}
+ * Artifact — Vehicle
+ * 2/3
+ * Flying, vigilance
+ * {T}: Add {C}. Spend this mana only to cast an artifact spell or activate an ability of
+ *   an artifact source.
+ * Crew 1
+ *
+ * Modeling: a tap mana ability producing {C} restricted to artifact spells/abilities
+ * ([ManaRestriction.CardTypeSpellsOrAbilitiesOnly] with both spells and abilities allowed),
+ * plus the parameterized crew keyword ability.
+ */
+val CargoShip = card("Cargo Ship") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Vehicle"
+    power = 2
+    toughness = 3
+    oracleText = "Flying, vigilance\n" +
+        "{T}: Add {C}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)"
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(
+            1,
+            restriction = ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                cardType = CardType.ARTIFACT,
+                allowSpells = true,
+                allowAbilities = true,
+            ),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {C}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source."
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "47"
+        artist = "Thanh Tuấn"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/932b865c-bfe7-4bb7-82e9-2403cf0e0522.jpg?1748705931"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -34,6 +34,54 @@
     ]
 }
 
+// Adelbert Steiner
+{
+    "name": "Adelbert Steiner",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "Lifelink\nAdelbert Steiner gets +1/+1 for each Equipment you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact Equipment ctrl:you"
+                },
+                "toughnessBonus": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact Equipment ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "UNCOMMON",
+        "artist": "Lorenzo Mastroianni",
+        "flavorText": "\"Chivalry requires a knight to look after his comrades-in-arms. I will not abandon you!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a67a991-1e52-4676-a2e3-2bc7aa943ab3.jpg?1748705765"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Adventurer's Airship
 {
     "name": "Adventurer's Airship",
@@ -219,6 +267,70 @@
         "artist": "Kevin Sidharta",
         "flavorText": "\"The Wrath of Dark has nearly reached its zenith! No one can stop it! Least of all you!\"",
         "imageUri": "https://cards.scryfall.io/normal/front/1/6/162a415c-5465-497e-8f4e-c6f09681641d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Al Bhed Salvagers
+{
+    "name": "Al Bhed Salvagers",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Human Artificer Warrior",
+    "oracleText": "Whenever this creature or another creature or artifact you control dies, target opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature|artifact ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                },
+                "descriptionOverride": "Whenever this creature or another creature or artifact you control dies, target opponent loses 1 life and you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "UNCOMMON",
+        "artist": "Masateru Ikeda",
+        "flavorText": "\"We found the airship! The records were right.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/8/58ccdcfc-a669-480f-bded-4273cfaf2045.jpg?1748706093"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -464,6 +576,63 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Balamb T-Rexaur
+{
+    "name": "Balamb T-Rexaur",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Trample\nWhen this creature enters, you gain 3 life.\nForestcycling {2} ({2}, Discard this card: Search your library for a Forest card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Forest"
+                    }
+                ]
+            },
+            "displayPrefix": "Forestcycling"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "173",
+        "artist": "Fang Xinyu",
+        "flavorText": "\"Sometimes it's better to run!\"\n—Quistis Trepe",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5857b1b-73bc-458e-b26b-7ed8bef785f3.jpg?1748706407"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -1183,6 +1352,62 @@
         "imageUri": "https://cards.scryfall.io/normal/front/f/7/f73ce8ec-c916-48eb-ae20-c0d6d03d7145.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Cargo Ship
+{
+    "name": "Cargo Ship",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Flying, vigilance\n{T}: Add {C}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "restriction": {
+                        "type": "CardTypeSpellsOrAbilitiesOnly",
+                        "cardType": "ARTIFACT",
+                        "allowAbilities": true
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {C}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "rarity": "UNCOMMON",
+        "artist": "Thanh Tuấn",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/932b865c-bfe7-4bb7-82e9-2403cf0e0522.jpg?1748705931"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // Cecil, Dark Knight

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinBatchSteinerSalvagersTRexaurCargoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinBatchSteinerSalvagersTRexaurCargoScenarioTest.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.AdelbertSteiner
+import com.wingedsheep.mtg.sets.definitions.fin.cards.AlBhedSalvagers
+import com.wingedsheep.mtg.sets.definitions.fin.cards.BalambTRexaur
+import com.wingedsheep.mtg.sets.definitions.fin.cards.CargoShip
+import com.wingedsheep.mtg.sets.definitions.fin.cards.LionHeart
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for the FIN batch: Adelbert Steiner (+1/+1 per Equipment you control),
+ * Al Bhed Salvagers (drain on a creature/artifact you control dying), Balamb T-Rexaur
+ * (ETB gain 3 life), and Cargo Ship (Flying/vigilance + tap mana ability).
+ */
+class FinBatchSteinerSalvagersTRexaurCargoScenarioTest : FunSpec({
+
+    fun createDriver(vararg cards: com.wingedsheep.sdk.model.CardDefinition): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        cards.forEach { driver.registerCard(it) }
+        return driver
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Adelbert Steiner
+    // -----------------------------------------------------------------------------------------
+
+    test("Adelbert Steiner gets +1/+1 for each Equipment you control") {
+        val driver = createDriver(AdelbertSteiner, LionHeart)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingLife = 20)
+        val active = driver.activePlayer!!
+
+        val steiner = driver.putCreatureOnBattlefield(active, "Adelbert Steiner")
+
+        // No Equipment: base 2/1.
+        driver.state.projectedState.getPower(steiner) shouldBe 2
+        driver.state.projectedState.getToughness(steiner) shouldBe 1
+
+        // One Equipment (unattached) you control: 3/2.
+        driver.putPermanentOnBattlefield(active, "Lion Heart")
+        driver.state.projectedState.getPower(steiner) shouldBe 3
+        driver.state.projectedState.getToughness(steiner) shouldBe 2
+
+        // Two Equipment: 4/3.
+        driver.putPermanentOnBattlefield(active, "Lion Heart")
+        driver.state.projectedState.getPower(steiner) shouldBe 4
+        driver.state.projectedState.getToughness(steiner) shouldBe 3
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Al Bhed Salvagers
+    // -----------------------------------------------------------------------------------------
+
+    test("Al Bhed Salvagers drains when a creature you control dies") {
+        val driver = createDriver(AlBhedSalvagers)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youLifeBefore = driver.getLifeTotal(you)
+        val oppLifeBefore = driver.getLifeTotal(opponent)
+
+        driver.putCreatureOnBattlefield(you, "Al Bhed Salvagers")
+        val fodder = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+
+        // Opponent bolts your creature; it dies and triggers the drain.
+        driver.giveMana(opponent, Color.RED, 1)
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.passPriority(you)
+        driver.castSpellWithTargets(opponent, bolt, listOf(ChosenTarget.Permanent(fodder))).error shouldBe null
+
+        // Resolve the bolt, then the drain trigger (targeting the lone opponent).
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 30) {
+            val pending = driver.state.pendingDecision
+            if (pending != null) {
+                driver.submitTargetSelection(pending.playerId, listOf(opponent))
+            } else {
+                driver.bothPass()
+            }
+            safety++
+        }
+
+        driver.getLifeTotal(opponent) shouldBe (oppLifeBefore - 1)
+        driver.getLifeTotal(you) shouldBe (youLifeBefore + 1)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Balamb T-Rexaur
+    // -----------------------------------------------------------------------------------------
+
+    test("Balamb T-Rexaur gains 3 life when it enters") {
+        val driver = createDriver(BalambTRexaur)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+        val lifeBefore = driver.getLifeTotal(active)
+
+        val trex = driver.putCardInHand(active, "Balamb T-Rexaur")
+        driver.giveMana(active, Color.GREEN, 6)
+        driver.castSpell(active, trex).error shouldBe null
+
+        // Resolve the spell, then the ETB life-gain trigger.
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            driver.bothPass(); safety++
+        }
+
+        driver.getLifeTotal(active) shouldBe (lifeBefore + 3)
+        driver.state.getBattlefield().contains(trex) shouldBe true
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Cargo Ship
+    // -----------------------------------------------------------------------------------------
+
+    test("Cargo Ship has flying and vigilance and taps for restricted mana") {
+        val driver = createDriver(CargoShip)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        val ship = driver.putPermanentOnBattlefield(active, "Cargo Ship")
+
+        driver.state.projectedState.hasKeyword(ship, Keyword.FLYING).shouldBeTrue()
+        driver.state.projectedState.hasKeyword(ship, Keyword.VIGILANCE).shouldBeTrue()
+
+        // Activating the {T}: Add {C} mana ability taps the Vehicle.
+        val manaAbility = CargoShip.activatedAbilities.first { it.isManaAbility }
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = active,
+                sourceId = ship,
+                abilityId = manaAbility.id,
+            )
+        )
+        result.isSuccess shouldBe true
+        driver.isTapped(ship) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements four Final Fantasy (FIN) cards using existing SDK primitives — no new effects, triggers, conditions, or keywords required.

## Cards

- **Adelbert Steiner** `{1}{W}` Legendary Creature — Human Knight (2/1)
  Lifelink. `GrantDynamicStatsEffect` on the source with a live `DynamicAmount.Count` of Equipment you control → +1/+1 each.
- **Al Bhed Salvagers** `{2}{B}` Creature — Human Artificer Warrior (2/3)
  ANY-binding leaves-to-graveyard trigger filtered to `CreatureOrArtifact.youControl()` (matches the source itself, so "this creature or another" needs no special clause). Target opponent loses 1, you gain 1. Same shape as Susurian Voidborn.
- **Balamb T-Rexaur** `{4}{G}{G}` Creature — Dinosaur (6/6)
  Trample, ETB gain 3 life, Forestcycling {2} via `KeywordAbility.typecycling("Forest", {2})`.
- **Cargo Ship** `{1}{U}` Artifact — Vehicle (2/3)
  Flying, vigilance, Crew 1, and `{T}: Add {C}` restricted to artifact spells/abilities via `ManaRestriction.CardTypeSpellsOrAbilitiesOnly(ARTIFACT, allowSpells = true, allowAbilities = true)`.

## Testing

- New `FinBatchSteinerSalvagersTRexaurCargoScenarioTest` covers all four: Equipment-count buff, drain-on-death, ETB life gain, and Flying/vigilance + tapping the mana ability. All pass.
- Card snapshot golden re-blessed (FIN.json — additions only, no other card moved).
- `CardLintTest` and `check-card-printing` for all four pass (FIN is the canonical/earliest printing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)