### PR TITLE
FIN: Cloudbound Moogle, Delivery Moogle, Ice Flan, Gran Pulse Ochu

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1270,7 +1270,7 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 **Library search & reveal**
 
 - `searchLibrary(filter, destination?, tapped?, shuffle?)` — search library, pick matching, move, shuffle.
-- `searchMultipleZones(filters, ...)` — search multiple zones in one effect.
+- `searchMultipleZones(zones, filter, count?, destination?, tapped?, reveal?)` — search several zones (e.g. library and/or graveyard) in one effect; shuffles automatically if `LIBRARY` is among the zones. Pass `reveal = true` for "reveal it" tutors (Delivery Moogle).
 
 **Top-deck manipulation**
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -422,7 +422,8 @@ object LibraryPatterns {
         filter: GameObjectFilter = GameObjectFilter.Any,
         count: Int = 1,
         destination: SearchDestination = SearchDestination.BATTLEFIELD,
-        entersTapped: Boolean = false
+        entersTapped: Boolean = false,
+        reveal: Boolean = false
     ): CompositeEffect {
         val effects = mutableListOf<Effect>()
 
@@ -452,7 +453,8 @@ object LibraryPatterns {
         effects.add(
             MoveCollectionEffect(
                 from = "found",
-                destination = CardDestination.ToZone(zone, placement = placement)
+                destination = CardDestination.ToZone(zone, placement = placement),
+                revealed = reveal
             )
         )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CloudboundMoogle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CloudboundMoogle.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Cloudbound Moogle
+ * {3}{W}{W}
+ * Creature — Moogle
+ * 2/3
+ * Flying
+ * When this creature enters, put a +1/+1 counter on target creature.
+ * Plainscycling {2}
+ */
+val CloudboundMoogle = card("Cloudbound Moogle") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Moogle"
+    power = 2
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, put a +1/+1 counter on target creature.\n" +
+        "Plainscycling {2} ({2}, Discard this card: Search your library for a Plains card, " +
+        "reveal it, put it into your hand, then shuffle.)"
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("creature", TargetCreature(filter = TargetFilter.Creature))
+        effect = AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Plains", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Andrea Radeck"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/7387bca7-f496-45da-a0ac-6be049303a8f.jpg?1748705792"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DeliveryMoogle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DeliveryMoogle.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Delivery Moogle
+ * {3}{W}
+ * Creature — Moogle
+ * 3/2
+ * Flying
+ * When this creature enters, search your library and/or graveyard for an artifact card
+ * with mana value 2 or less, reveal it, and put it into your hand. If you search your
+ * library this way, shuffle.
+ */
+val DeliveryMoogle = card("Delivery Moogle") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Moogle"
+    power = 3
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this creature enters, search your library and/or graveyard for an artifact card " +
+        "with mana value 2 or less, reveal it, and put it into your hand. If you search your " +
+        "library this way, shuffle."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchMultipleZones(
+            zones = listOf(Zone.LIBRARY, Zone.GRAVEYARD),
+            filter = GameObjectFilter.Artifact.manaValueAtMost(2),
+            count = 1,
+            destination = SearchDestination.HAND,
+            reveal = true,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "15"
+        artist = "Joseph Weston"
+        flavorText = "\"A new letter has arrived just for you, kupo!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f58840dc-c641-4092-8b67-9c0d449af715.jpg?1748705812"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GranPulseOchu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GranPulseOchu.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gran Pulse Ochu
+ * {G}
+ * Creature — Plant Beast
+ * 1/1
+ * Deathtouch
+ * {8}: Until end of turn, this creature gets +1/+1 for each permanent card in your graveyard.
+ */
+val GranPulseOchu = card("Gran Pulse Ochu") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Plant Beast"
+    power = 1
+    toughness = 1
+    oracleText = "Deathtouch\n" +
+        "{8}: Until end of turn, this creature gets +1/+1 for each permanent card in your graveyard."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    activatedAbility {
+        cost = Costs.Mana("{8}")
+        val permanentCards = DynamicAmounts.zone(Player.You, Zone.GRAVEYARD, GameObjectFilter.Permanent).count()
+        effect = Effects.ModifyStats(permanentCards, permanentCards, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "189"
+        artist = "Domenico Cava"
+        flavorText = "A mysterious beast that has grown large on its journey across Gran Pulse. " +
+            "Its children, known as microchus, accompany the ochu in combat against adventurers."
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4dced21f-478c-4500-9484-af5864dea5cc.jpg?1748706468"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IceFlan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IceFlan.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Ice Flan
+ * {4}{U}{U}
+ * Creature — Elemental Ooze
+ * 5/4
+ * When this creature enters, tap target artifact or creature an opponent controls.
+ * Put a stun counter on it.
+ * Islandcycling {2}
+ */
+val IceFlan = card("Ice Flan") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Elemental Ooze"
+    power = 5
+    toughness = 4
+    oracleText = "When this creature enters, tap target artifact or creature an opponent controls. " +
+        "Put a stun counter on it. (If a permanent with a stun counter would become untapped, " +
+        "remove one from it instead.)\n" +
+        "Islandcycling {2} ({2}, Discard this card: Search your library for an Island card, " +
+        "reveal it, put it into your hand, then shuffle.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "target",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.CreatureOrArtifact.opponentControls()))
+        )
+        effect = Effects.Composite(
+            Effects.Tap(t),
+            Effects.AddCounters(Counters.STUN, 1, t),
+        )
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Island", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "SHOSUKE"
+        imageUri = "https://cards.scryfall.io/normal/front/a/d/ad304c9c-943f-442f-bb82-ff378ad7d7ba.jpg?1748705958"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1943,6 +1943,71 @@
     ]
 }
 
+// Cloudbound Moogle
+{
+    "name": "Cloudbound Moogle",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Moogle",
+    "oracleText": "Flying\nWhen this creature enters, put a +1/+1 counter on target creature.\nPlainscycling {2} ({2}, Discard this card: Search your library for a Plains card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Plains"
+                    }
+                ]
+            },
+            "displayPrefix": "Plainscycling"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Andrea Radeck",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/7387bca7-f496-45da-a0ac-6be049303a8f.jpg?1748705792"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Coeurl
 {
     "name": "Coeurl",
@@ -2336,6 +2401,81 @@
         "imageUri": "https://cards.scryfall.io/normal/front/6/4/64db46d4-f91f-49cc-971c-b8e19f0c4ea9.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Delivery Moogle
+{
+    "name": "Delivery Moogle",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Moogle",
+    "oracleText": "Flying\nWhen this creature enters, search your library and/or graveyard for an artifact card with mana value 2 or less, reveal it, and put it into your hand. If you search your library this way, shuffle.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromMultipleZones",
+                                "zones": [
+                                    "Library",
+                                    "Graveyard"
+                                ],
+                                "filter": "artifact mv<=2"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "UNCOMMON",
+        "artist": "Joseph Weston",
+        "flavorText": "\"A new letter has arrived just for you, kupo!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f58840dc-c641-4092-8b67-9c0d449af715.jpg?1748705812"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Demon Wall
@@ -3231,6 +3371,60 @@
     ]
 }
 
+// Gran Pulse Ochu
+{
+    "name": "Gran Pulse Ochu",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Plant Beast",
+    "oracleText": "Deathtouch\n{8}: Until end of turn, this creature gets +1/+1 for each permanent card in your graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "toughnessModifier": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "189",
+        "artist": "Domenico Cava",
+        "flavorText": "A mysterious beast that has grown large on its journey across Gran Pulse. Its children, known as microchus, accompany the ochu in combat against adventurers.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4dced21f-478c-4500-9484-af5864dea5cc.jpg?1748706468"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Guadosalam, Farplane Gateway
 {
     "name": "Guadosalam, Farplane Gateway",
@@ -3447,6 +3641,80 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Ice Flan
+{
+    "name": "Ice Flan",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Elemental Ooze",
+    "oracleText": "When this creature enters, tap target artifact or creature an opponent controls. Put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nIslandcycling {2} ({2}, Discard this card: Search your library for an Island card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Island"
+                    }
+                ]
+            },
+            "displayPrefix": "Islandcycling"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|artifact ctrl:opponent"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "SHOSUKE",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/d/ad304c9c-943f-442f-bb82-ff378ad7d7ba.jpg?1748705958"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudboundMoogleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudboundMoogleScenarioTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Cloudbound Moogle (FIN #11).
+ *
+ * Cloudbound Moogle {3}{W} {W} Creature — Moogle 2/3
+ * Flying
+ * When this creature enters, put a +1/+1 counter on target creature.
+ * Plainscycling {2}
+ */
+class CloudboundMoogleScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("ETB puts a +1/+1 counter on a target creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+
+        val moogle = driver.putCardInHand(active, "Cloudbound Moogle")
+        driver.giveMana(active, Color.WHITE, 2)
+        driver.giveColorlessMana(active, 3)
+
+        driver.castSpell(active, moogle).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature; ETB trigger goes on the stack and asks for a target
+
+        val moogleId = driver.findPermanent(active, "Cloudbound Moogle")
+        moogleId shouldNotBe null
+
+        val decision = driver.pendingDecision
+        (decision is ChooseTargetsDecision) shouldBe true
+        driver.submitTargetSelection(active, listOf(bears))
+        driver.bothPass() // resolve the ETB trigger
+
+        plusCounters(driver, bears) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeliveryMoogleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeliveryMoogleScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Delivery Moogle (FIN #15).
+ *
+ * Delivery Moogle {3}{W} Creature — Moogle 3/2
+ * Flying
+ * When this creature enters, search your library and/or graveyard for an artifact card
+ * with mana value 2 or less, reveal it, and put it into your hand. If you search your
+ * library this way, shuffle.
+ */
+class DeliveryMoogleScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("ETB searches both library and graveyard for a cheap artifact to hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A cheap artifact in each of the two searchable zones.
+        val ornithopterInLibrary = driver.putCardOnTopOfLibrary(active, "Ornithopter") // MV 0
+        val bonesplitterInGraveyard = driver.putCardInGraveyard(active, "Bonesplitter")  // MV 1
+
+        val moogle = driver.putCardInHand(active, "Delivery Moogle")
+        driver.giveMana(active, Color.WHITE, 1)
+        driver.giveColorlessMana(active, 3)
+
+        driver.castSpell(active, moogle).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature; ETB trigger goes on the stack
+
+        driver.bothPass() // resolve the ETB trigger -> presents the multi-zone search
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        // Both the library artifact and the graveyard artifact are valid choices.
+        decision.options shouldContain ornithopterInLibrary
+        decision.options shouldContain bonesplitterInGraveyard
+
+        driver.submitDecision(active, CardsSelectedResponse(decision.id, listOf(bonesplitterInGraveyard)))
+
+        driver.findCardInHand(active, "Bonesplitter") shouldBe bonesplitterInGraveyard
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GranPulseOchuScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GranPulseOchuScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.GranPulseOchu
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Gran Pulse Ochu (FIN #189).
+ *
+ * Gran Pulse Ochu {G} Creature — Plant Beast 1/1
+ * Deathtouch
+ * {8}: Until end of turn, this creature gets +1/+1 for each permanent card in your graveyard.
+ */
+class GranPulseOchuScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GranPulseOchu)
+        return driver
+    }
+
+    test("activated ability pumps +1/+1 for each permanent card in your graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ochu = driver.putCreatureOnBattlefield(active, "Gran Pulse Ochu")
+
+        // Three permanent cards in the graveyard (creature cards are permanent cards).
+        driver.putCardInGraveyard(active, "Grizzly Bears")
+        driver.putCardInGraveyard(active, "Grizzly Bears")
+        driver.putCardInGraveyard(active, "Grizzly Bears")
+
+        // Base stats before activation.
+        projector.project(driver.state).getPower(ochu) shouldBe 1
+
+        driver.giveColorlessMana(active, 8)
+        val abilityId = GranPulseOchu.script.activatedAbilities[0].id
+        driver.submit(ActivateAbility(playerId = active, sourceId = ochu, abilityId = abilityId))
+        driver.bothPass() // resolve the activated ability
+
+        val projected = projector.project(driver.state)
+        projected.getPower(ochu) shouldBe 4
+        projected.getToughness(ochu) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IceFlanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IceFlanScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Ice Flan (FIN #55).
+ *
+ * Ice Flan {4}{U}{U} Creature — Elemental Ooze 5/4
+ * When this creature enters, tap target artifact or creature an opponent controls.
+ * Put a stun counter on it.
+ * Islandcycling {2}
+ */
+class IceFlanScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun stunCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    test("ETB taps an opponent's creature and puts a stun counter on it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val flan = driver.putCardInHand(active, "Ice Flan")
+        driver.giveMana(active, Color.BLUE, 2)
+        driver.giveColorlessMana(active, 4)
+
+        driver.castSpell(active, flan).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature; ETB trigger goes on the stack and asks for a target
+
+        val decision = driver.pendingDecision
+        (decision is ChooseTargetsDecision) shouldBe true
+        driver.submitTargetSelection(active, listOf(victim))
+        driver.bothPass() // resolve the ETB trigger
+
+        driver.isTapped(victim) shouldBe true
+        stunCounters(driver, victim) shouldBe 1
+    }
+})


### PR DESCRIPTION
Implements four Final Fantasy (FIN) cards using existing SDK primitives.

## Cards

| Card | Cost | P/T | Behavior |
|------|------|-----|----------|
| Cloudbound Moogle | {3}{W}{W} | 2/3 | Flying; ETB put a +1/+1 counter on target creature; Plainscycling {2} |
| Delivery Moogle | {3}{W} | 3/2 | Flying; ETB search library and/or graveyard for an artifact card with mana value 2 or less, reveal it, to hand |
| Ice Flan | {4}{U}{U} | 5/4 | ETB tap target artifact or creature an opponent controls and put a stun counter on it; Islandcycling {2} |
| Gran Pulse Ochu | {G} | 1/1 | Deathtouch; {8}: until end of turn, gets +1/+1 for each permanent card in your graveyard |

## SDK change

Added an optional `reveal` flag to `LibraryPatterns.searchMultipleZones` so "reveal it" multi-zone tutors render faithfully (used by Delivery Moogle). Updated `docs/card-sdk-language-reference.md` to match. No behavior change for existing callers (default `reveal = false`).

## Tests

Each card has a passing rules-engine scenario test:
- `CloudboundMoogleScenarioTest` — ETB +1/+1 counter on chosen target
- `DeliveryMoogleScenarioTest` — multi-zone search offers both a library and graveyard artifact, chosen card goes to hand
- `IceFlanScenarioTest` — ETB taps opponent's creature and applies a stun counter
- `GranPulseOchuScenarioTest` — {8} activation pumps to 4/4 with 3 permanent cards in graveyard

FIN card snapshot golden re-blessed (additions only). All four cards auto-register via `CardDiscovery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)