### PR TITLE
Add Fear of Abduction and Violent Urge (DSK); Fear of Missing Out deferred

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfAbduction.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfAbduction.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostZone
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Fear of Abduction
+ * {4}{W}{W}
+ * Enchantment Creature — Nightmare
+ * 5/5
+ * As an additional cost to cast this spell, exile a creature you control.
+ * Flying
+ * When this creature enters, exile target creature an opponent controls.
+ * When this creature leaves the battlefield, put each card exiled with it into its owner's hand.
+ *
+ * The ETB exile is linked to the source (CR 603.6e-style "until ~ leaves" exile pile), so the
+ * leaves trigger returns exactly the card this creature exiled — to its owner's HAND, not the
+ * battlefield. The additional-cost exile of your own creature is a permanent exile (not linked),
+ * so it is never returned.
+ */
+val FearOfAbduction = card("Fear of Abduction") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment Creature — Nightmare"
+    power = 5
+    toughness = 5
+    oracleText = "As an additional cost to cast this spell, exile a creature you control.\n" +
+        "Flying\n" +
+        "When this creature enters, exile target creature an opponent controls.\n" +
+        "When this creature leaves the battlefield, put each card exiled with it into its owner's hand."
+
+    keywords(Keyword.FLYING)
+
+    additionalCost(
+        Costs.additional.ExileCards(
+            count = 1,
+            filter = GameObjectFilter.Creature.youControl(),
+            fromZone = CostZone.BATTLEFIELD
+        )
+    )
+
+    // ETB: exile target creature an opponent controls until this creature leaves the battlefield.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "creature an opponent controls",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.opponentControls()))
+        )
+        effect = Effects.ExileUntilLeaves(creature)
+    }
+
+    // LTB: return each linked-exiled card to its owner's hand.
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ReturnLinkedExileToHand()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "9"
+        artist = "Fernando Falcone"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc9374be-5e4b-4c23-8b6e-94c03d4f5ef1.jpg?1726285889"
+
+        ruling("2024-09-20", "If Fear of Abduction leaves the battlefield before its third ability resolves, the ability still exiles the target creature.")
+        ruling("2024-09-20", "If there are no exiled cards when Fear of Abduction's last ability resolves (most likely because its third ability hasn't resolved yet), the ability won't do anything.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ViolentUrge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ViolentUrge.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Violent Urge
+ * {R}
+ * Instant
+ * Target creature gets +1/+0 and gains first strike until end of turn.
+ * Delirium — If there are four or more card types among cards in your graveyard, that creature
+ * gains double strike until end of turn.
+ */
+val ViolentUrge = card("Violent Urge") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +1/+0 and gains first strike until end of turn.\n" +
+        "Delirium — If there are four or more card types among cards in your graveyard, that creature gains double strike until end of turn."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, t),
+            Effects.GrantKeyword(Keyword.FIRST_STRIKE, t),
+            ConditionalEffect(
+                condition = Conditions.Delirium(4),
+                effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, t)
+            )
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "164"
+        artist = "Mirko Failoni"
+        flavorText = "Rage can be a potent antidote to fear."
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a47c968b-1edd-45ac-a67c-311647e7e2fc.jpg?1726286465"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -3697,6 +3697,100 @@
     ]
 }
 
+// Fear of Abduction
+{
+    "name": "Fear of Abduction",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Enchantment Creature — Nightmare",
+    "oracleText": "As an additional cost to cast this spell, exile a creature you control.\nFlying\nWhen this creature enters, exile target creature an opponent controls.\nWhen this creature leaves the battlefield, put each card exiled with it into its owner's hand.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature an opponent controls"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "linked_return_hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "linked_return_hand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomExileFrom",
+                    "zone": "Battlefield",
+                    "filter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "9",
+        "rarity": "UNCOMMON",
+        "artist": "Fernando Falcone",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc9374be-5e4b-4c23-8b6e-94c03d4f5ef1.jpg?1726285889",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "If Fear of Abduction leaves the battlefield before its third ability resolves, the ability still exiles the target creature."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If there are no exiled cards when Fear of Abduction's last ability resolves (most likely because its third ability hasn't resolved yet), the ability won't do anything."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Fear of Being Hunted
 {
     "name": "Fear of Being Hunted",
@@ -13952,6 +14046,91 @@
         "artist": "Johann Bodin",
         "flavorText": "\"Surprise! Aaahahahahah! You should see the look on your face. Here, let's peel it off so you can!\"",
         "imageUri": "https://cards.scryfall.io/normal/front/1/2/12649f73-9d29-4eed-bc89-cc0d1a8969e3.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Violent Urge
+{
+    "name": "Violent Urge",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +1/+0 and gains first strike until end of turn.\nDelirium — If there are four or more card types among cards in your graveyard, that creature gains double strike until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateZone",
+                                "player": "You",
+                                "zone": "Graveyard",
+                                "aggregation": "DISTINCT_TYPES"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "GrantKeyword",
+                        "keyword": "DOUBLE_STRIKE",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "rarity": "UNCOMMON",
+        "artist": "Mirko Failoni",
+        "flavorText": "Rage can be a potent antidote to fear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a47c968b-1edd-45ac-a67c-311647e7e2fc.jpg?1726286465"
     },
     "colorIdentityOverride": [
         "RED"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfAbductionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfAbductionScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fear of Abduction (DSK #9) — {4}{W}{W} Enchantment Creature — Nightmare, 5/5, flying.
+ *
+ * "As an additional cost to cast this spell, exile a creature you control.
+ *  When this creature enters, exile target creature an opponent controls.
+ *  When this creature leaves the battlefield, put each card exiled with it into its owner's hand."
+ *
+ * Exercises:
+ *  - the `ExileCards(fromZone = BATTLEFIELD)` additional cost (exile a creature you control as the
+ *    spell is cast — this exile is NOT linked, so it never returns), and
+ *  - the linked ETB exile (`ExileUntilLeaves`) + leaves-trigger `ReturnLinkedExileToHand`, which
+ *    returns the exiled opponent's creature to its owner's HAND (not the battlefield).
+ */
+class FearOfAbductionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Fear of Abduction — additional-cost exile + linked ETB exile returned to hand") {
+
+            test("cost exiles your creature, ETB exiles an opponent's creature, leaving returns it to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fear of Abduction")
+                    .withCardInHand(1, "Doom Blade")
+                    // {4}{W}{W} for Fear of Abduction, plus {1}{B} for Doom Blade afterward.
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    // The creature exiled to pay the additional cost.
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    // The opponent's creature the ETB will exile.
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spellId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Fear of Abduction"
+                }
+                val courser = game.findPermanent("Centaur Courser")!!
+                val opponentBears = game.findPermanent("Grizzly Bears")!!
+
+                // Cast, exiling our own Centaur Courser as the additional cost.
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id, spellId, emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(exiledCards = listOf(courser))
+                    )
+                )
+                withClue("cast should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                withClue("the additional-cost creature is exiled immediately as the spell is cast") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe false
+                }
+
+                // Resolve the spell; its ETB trigger pauses to choose the opponent's creature.
+                var guard = 0
+                while (game.state.pendingDecision !is ChooseTargetsDecision && guard < 20) {
+                    game.resolveStack(); guard++
+                }
+                val td = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected ChooseTargetsDecision for the ETB exile; got ${game.state.pendingDecision}")
+                game.submitDecision(TargetsResponse(td.id, mapOf(0 to listOf(opponentBears))))
+                game.resolveStack()
+
+                withClue("Fear of Abduction resolved onto the battlefield") {
+                    game.isOnBattlefield("Fear of Abduction") shouldBe true
+                }
+                withClue("the opponent's creature is exiled by the ETB") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                    game.isInHand(2, "Grizzly Bears") shouldBe false
+                }
+
+                // Destroy Fear of Abduction (Doom Blade — sorcery speed, active player has priority).
+                val cast2 = game.castSpell(1, "Doom Blade", game.findPermanent("Fear of Abduction")!!)
+                withClue("Doom Blade cast should succeed: ${cast2.error}") { cast2.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Fear of Abduction is destroyed") {
+                    game.isOnBattlefield("Fear of Abduction") shouldBe false
+                    game.isInGraveyard(1, "Fear of Abduction") shouldBe true
+                }
+                withClue("the linked-exiled creature returns to its OWNER's hand, not the battlefield") {
+                    game.isInHand(2, "Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("the additional-cost creature stays exiled (it was never linked)") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe false
+                    game.isInHand(1, "Centaur Courser") shouldBe false
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ViolentUrgeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ViolentUrgeScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Violent Urge (DSK #164) — {R} Instant.
+ *
+ * "Target creature gets +1/+0 and gains first strike until end of turn.
+ *  Delirium — If there are four or more card types among cards in your graveyard, that creature
+ *  gains double strike until end of turn."
+ *
+ * Exercises the [com.wingedsheep.sdk.dsl.Conditions.Delirium] gate on a resolution-time
+ * [com.wingedsheep.sdk.scripting.effects.ConditionalEffect] that grants an extra keyword to the
+ * same targeted creature.
+ */
+class ViolentUrgeScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Violent Urge — pump + first strike, Delirium double strike") {
+
+            test("without Delirium: +1/+0 and first strike, no double strike") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Violent Urge")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    // Only three card types in graveyard.
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withCardInGraveyard(1, "Doom Blade")
+                    .withCardInGraveyard(1, "Test Enchantment")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Violent Urge", bears)
+                withClue("cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val p = projector.project(game.state)
+                withClue("base 2/2 + 1/0 = 3/2") {
+                    p.getPower(bears) shouldBe 3
+                    p.getToughness(bears) shouldBe 2
+                }
+                p.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+                withClue("Delirium not active — no double strike") {
+                    p.hasKeyword(bears, Keyword.DOUBLE_STRIKE) shouldBe false
+                }
+            }
+
+            test("with Delirium (four card types): also gains double strike") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Violent Urge")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    // Four card types: creature, instant, sorcery, enchantment.
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withCardInGraveyard(1, "Doom Blade")
+                    .withCardInGraveyard(1, "Test Enchantment")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cast = game.castSpell(1, "Violent Urge", bears)
+                withClue("cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val p = projector.project(game.state)
+                withClue("base 2/2 + 1/0 = 3/2") {
+                    p.getPower(bears) shouldBe 3
+                    p.getToughness(bears) shouldBe 2
+                }
+                p.hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+                withClue("Delirium active — double strike granted") {
+                    p.hasKeyword(bears, Keyword.DOUBLE_STRIKE) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements two of three assigned Duskmourn: House of Horror (DSK) cards. The third, **Fear of Missing Out**, is deferred because it requires new engine/SDK capability (an add-feature, not an add-card).

### Implemented

- **Fear of Abduction** (#9, `{4}{W}{W}` Enchantment Creature — Nightmare, 5/5, flying)
  - "As an additional cost to cast this spell, exile a creature you control" → `Costs.additional.ExileCards(fromZone = BATTLEFIELD)`. This exile is **not** linked to the source, so it never returns (matches the rules).
  - ETB "exile target creature an opponent controls" → `Effects.ExileUntilLeaves` (linked exile).
  - Leaves trigger "put each card exiled with it into its owner's hand" → `Effects.ReturnLinkedExileToHand()` (returns to **hand**, not the battlefield).
  - Added the two mechanically-relevant Scryfall rulings.

- **Violent Urge** (#164, `{R}` Instant)
  - "+1/+0 and first strike until end of turn" → `Effects.ModifyStats` + `Effects.GrantKeyword(FIRST_STRIKE)`.
  - "Delirium — … double strike" → `ConditionalEffect(Conditions.Delirium(4), GrantKeyword(DOUBLE_STRIKE))` on the same target.

Both use only existing SDK primitives. Added rules-engine scenario tests for each and reblessed the DSK card-snapshot golden (additive only — no other card's tree changed). `CardLintTest` and `check-card-printing` both pass; canonical placement is DSK (earliest printing) for both.

### Deferred — Fear of Missing Out (#136)

Its Delirium combat ability is *"Whenever this creature attacks **for the first time each turn**, if there are four or more card types among cards in your graveyard, untap target creature. **After this phase, there is an additional combat phase.**"* Two capabilities don't exist yet:

1. **"attacks for the first time each turn" trigger** — `AttackEvent`/`AttackPredicate` only support `Alone` and `AttackerCountAtLeast`; there is no `firstTimeEachTurn` flag (other events like `LifeGainEvent`/`BecomesTargetEvent` have one, but the wiring + per-creature attack tracking + `TriggerMatcher` branch would all be new).
2. **combat-only extra-combat-phase effect** — the existing `AddCombatPhaseEffect` adds a combat phase *plus an additional main phase* (Aggravated Assault); this card adds combat only (Aurelia/Combat Celebrant shape).

Shipping it with the mtgish SCAFFOLD draft would silently drop the combat trigger, so it was left out per the "a card that resolves wrong is worse than an unimplemented one" principle. It should go through the `add-feature` skill.

## Test status

- `:rules-engine:test` — `ViolentUrgeScenarioTest`, `FearOfAbductionScenarioTest` pass.
- `:mtg-sets:test` — `CardDefinitionSnapshotTest` (reblessed), `CardLintTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)