### PR TITLE
FIN: add Item Shopkeep, Magitek Infantry, and Namazu Trader

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ItemShopkeep.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ItemShopkeep.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Item Shopkeep
+ * {1}{R}
+ * Creature — Human Citizen
+ * 2/2
+ *
+ * Whenever you attack, target attacking equipped creature gains menace until end of turn.
+ * (It can't be blocked except by two or more creatures.)
+ */
+val ItemShopkeep = card("Item Shopkeep") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Citizen"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you attack, target attacking equipped creature gains menace until end of turn. " +
+        "(It can't be blocked except by two or more creatures.)"
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        val attacker = target(
+            "attacking equipped creature",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.attacking().equipped()))
+        )
+        effect = Effects.GrantKeyword(Keyword.MENACE, attacker)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "IWAO"
+        flavorText = "\"What can I do for you?\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd2db3f5-fd0d-4817-af90-6bea1f07e16b.jpg?1748706293"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagitekInfantry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagitekInfantry.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Magitek Infantry
+ * {W}
+ * Artifact Creature — Robot Soldier
+ * 1/1
+ *
+ * This creature gets +1/+0 as long as you control another artifact.
+ * {2}{W}: Search your library for a card named Magitek Infantry, put it onto the
+ * battlefield tapped, then shuffle.
+ */
+val MagitekInfantry = card("Magitek Infantry") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Robot Soldier"
+    power = 1
+    toughness = 1
+    oracleText = "This creature gets +1/+0 as long as you control another artifact.\n" +
+        "{2}{W}: Search your library for a card named Magitek Infantry, put it onto the battlefield tapped, then shuffle."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 1, toughnessBonus = 0, filter = GroupFilter.source()),
+            condition = Conditions.YouControl(GameObjectFilter.Artifact, excludeSelf = true)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{W}")
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Any.named("Magitek Infantry"),
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true,
+            shuffleAfter = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "John Tyler Christopher"
+        flavorText = "These cybersoldiers were specifically engineered to excel in combat, and serve as the powerhouse of the imperial infantry."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b64dc6d7-dd01-4e66-9099-4c90865448df.jpg?1748705847"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/NamazuTrader.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/NamazuTrader.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Namazu Trader
+ * {3}{B}
+ * Creature — Fish Citizen
+ * 3/4
+ *
+ * When this creature enters, you lose 1 life and create a Treasure token.
+ * Whenever this creature attacks, you may sacrifice another creature or artifact.
+ * If you do, surveil 2.
+ */
+val NamazuTrader = card("Namazu Trader") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Fish Citizen"
+    power = 3
+    toughness = 4
+    oracleText = "When this creature enters, you lose 1 life and create a Treasure token.\n" +
+        "Whenever this creature attacks, you may sacrifice another creature or artifact. If you do, surveil 2. " +
+        "(Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.LoseLife(1, EffectTarget.Controller) then Effects.CreateTreasure(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val sacrificeTarget = target(
+            "another creature or artifact",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.youControl().or(GameObjectFilter.Artifact.youControl())
+                ).other()
+            )
+        )
+        effect = MayEffect(
+            Effects.SacrificeTarget(sacrificeTarget) then Patterns.Library.surveil(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "107"
+        artist = "Andrea Tentori Montalto"
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9d25b34-990d-416c-aef7-1b5a73f19dd4.jpg?1748962390"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -3769,6 +3769,59 @@
     ]
 }
 
+// Item Shopkeep
+{
+    "name": "Item Shopkeep",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "Whenever you attack, target attacking equipped creature gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "MENACE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "attacking equipped creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "IsAttacking",
+                                "IsEquipped"
+                            ]
+                        }
+                    },
+                    "id": "attacking equipped creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "IWAO",
+        "flavorText": "\"What can I do for you?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd2db3f5-fd0d-4817-af90-6bea1f07e16b.jpg?1748706293"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Jecht, Reluctant Guardian
 {
     "name": "Jecht, Reluctant Guardian",
@@ -4795,6 +4848,98 @@
     ]
 }
 
+// Magitek Infantry
+{
+    "name": "Magitek Infantry",
+    "manaCost": "{W}",
+    "typeLine": "Artifact Creature — Robot Soldier",
+    "oracleText": "This creature gets +1/+0 as long as you control another artifact.\n{2}{W}: Search your library for a card named Magitek Infantry, put it onto the battlefield tapped, then shuffle.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "name:Magitek Infantry"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "John Tyler Christopher",
+        "flavorText": "These cybersoldiers were specifically engineered to excel in combat, and serve as the powerhouse of the imperial infantry.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b64dc6d7-dd01-4e66-9099-4c90865448df.jpg?1748705847"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Midgar, City of Mako
 {
     "name": "Midgar, City of Mako",
@@ -5052,6 +5197,86 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Namazu Trader
+{
+    "name": "Namazu Trader",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Fish Citizen",
+    "oracleText": "When this creature enters, you lose 1 life and create a Treasure token.\nWhenever this creature attacks, you may sacrifice another creature or artifact. If you do, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": "Controller"
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "SacrificeTarget",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "another creature or artifact"
+                                }
+                            },
+                            {
+                                "type": "Surveil",
+                                "count": 2
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature|artifact ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another creature or artifact"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "artist": "Andrea Tentori Montalto",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9d25b34-990d-416c-aef7-1b5a73f19dd4.jpg?1748962390"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinMerchantsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinMerchantsScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Final Fantasy "merchants" batch:
+ *  - Item Shopkeep ({1}{R} 2/2): "Whenever you attack, target attacking equipped creature gains
+ *    menace until end of turn."
+ *  - Magitek Infantry ({W} 1/1 Artifact Creature): "+1/+0 as long as you control another artifact"
+ *    (conditional static buff) plus a search-for-another-copy activated ability (stock searchLibrary,
+ *    left to the snapshot net).
+ *  - Namazu Trader ({3}{B} 3/4): ETB "lose 1 life and create a Treasure token"; attack trigger
+ *    "you may sacrifice another creature or artifact. If you do, surveil 2."
+ */
+class FinMerchantsScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+
+        // -----------------------------------------------------------------------------------------
+        // Item Shopkeep
+        // -----------------------------------------------------------------------------------------
+
+        test("Item Shopkeep grants menace to an attacking equipped creature when you attack") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Item Shopkeep")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardAttachedTo(1, "Coral Sword", "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            projector.hasProjectedKeyword(game.state, bears, Keyword.MENACE) shouldBe false
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Item Shopkeep" to 2, "Grizzly Bears" to 2)).error shouldBe null
+
+            // The "whenever you attack" trigger targets the attacking equipped creature; the target
+            // decision may pend immediately or after the stack starts resolving.
+            if (game.state.pendingDecision == null) game.resolveStack()
+            if (game.state.pendingDecision != null) game.selectTargets(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            withClue("equipped attacker gains menace") {
+                projector.hasProjectedKeyword(game.state, bears, Keyword.MENACE) shouldBe true
+            }
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Magitek Infantry
+        // -----------------------------------------------------------------------------------------
+
+        test("Magitek Infantry is 1/1 with no other artifact") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Magitek Infantry")
+                .build()
+
+            val magitek = game.findPermanent("Magitek Infantry")!!
+            projector.getProjectedPower(game.state, magitek) shouldBe 1
+            projector.getProjectedToughness(game.state, magitek) shouldBe 1
+        }
+
+        test("Magitek Infantry gets +1/+0 while you control another artifact") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Magitek Infantry")
+                .withCardOnBattlefield(1, "Ornithopter")
+                .build()
+
+            val magitek = game.findPermanent("Magitek Infantry")!!
+            withClue("another artifact (Ornithopter) makes Magitek 2/1") {
+                projector.getProjectedPower(game.state, magitek) shouldBe 2
+                projector.getProjectedToughness(game.state, magitek) shouldBe 1
+            }
+        }
+
+        // -----------------------------------------------------------------------------------------
+        // Namazu Trader
+        // -----------------------------------------------------------------------------------------
+
+        test("Namazu Trader enters: you lose 1 life and create a Treasure token") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Namazu Trader")
+                .withLandsOnBattlefield(1, "Swamp", 4)
+                .withCardInLibrary(1, "Swamp")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.getLifeTotal(1) shouldBe 20
+            game.castSpell(1, "Namazu Trader").error shouldBe null
+            game.resolveStack()
+
+            withClue("controller lost 1 life") { game.getLifeTotal(1) shouldBe 19 }
+            withClue("a Treasure token was created") {
+                (game.findPermanent("Treasure") != null) shouldBe true
+            }
+        }
+
+        test("Namazu Trader attack trigger offers the optional sacrifice for surveil") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Namazu Trader")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Swamp")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Namazu Trader" to 2)).error shouldBe null
+            if (game.state.pendingDecision == null) game.resolveStack()
+
+            withClue("attacking presents the sacrifice/surveil decision") {
+                (game.state.pendingDecision != null) shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three Final Fantasy (FIN) commons, all composed from existing SDK primitives (no new engine features).

## Cards

- **Item Shopkeep** ({1}{R} 2/2 Human Citizen) — `Triggers.YouAttack` grants menace until end of turn to a *target attacking equipped creature* (`GameObjectFilter.Creature.attacking().equipped()`).
- **Magitek Infantry** ({W} 1/1 Artifact Creature — Robot Soldier) — `ConditionalStaticAbility` +1/+0 while you control another artifact (`Conditions.YouControl(Artifact, excludeSelf = true)`), plus `{2}{W}: Search your library for a card named Magitek Infantry, put it onto the battlefield tapped, then shuffle` via `Patterns.Library.searchLibrary(... destination = BATTLEFIELD, entersTapped = true)`.
- **Namazu Trader** ({3}{B} 3/4 Fish Citizen) — ETB: lose 1 life and create a Treasure; attack trigger: `MayEffect(SacrificeTarget(another creature or artifact) then surveil 2)`, following the Comet Crawler idiom.

## Tests

- `FinMerchantsScenarioTest` (5 cases): Item Shopkeep menace-on-attack to an equipped attacker; Magitek 1/1 base vs 2/1 with another artifact; Namazu ETB life-loss + Treasure; Namazu attack trigger offers the sacrifice/surveil decision. All passing.
- Re-blessed the FIN card snapshot golden (diff adds only the three new cards).
- `CardLintTest` passes.

## Deferred

- **Qiqirn Merchant** was skipped: its second ability ("{7}, {T}, Sacrifice this creature: Draw three cards. This ability costs {1} less to activate for each Town you control") needs activated-ability cost reduction by permanent count, which the engine does not yet support — that's `add-feature` territory, out of scope for a card PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)