### PR TITLE
Add the wish mechanic (fetch from sideboard / outside the game)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1261,7 +1261,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 ---
 
-## 5. Effect patterns (`Patterns.Library.*` / `Patterns.Hand.*` / `Patterns.Group.*` / `Patterns.Exile.*` / `Patterns.CreatureType.*` / `Patterns.Mechanic.*`)
+## 5. Effect patterns (`Patterns.Library.*` / `Patterns.Hand.*` / `Patterns.Group.*` / `Patterns.Exile.*` / `Patterns.Sideboard.*` / `Patterns.CreatureType.*` / `Patterns.Mechanic.*`)
 
 Composed pipelines (`GatherCards → SelectFromCollection → MoveCollection` shapes and similar).
 Named entries here are for named MTG mechanics and shapes with a demonstrated second user — a
@@ -1271,6 +1271,28 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 
 - `searchLibrary(filter, destination?, tapped?, shuffle?)` — search library, pick matching, move, shuffle.
 - `searchMultipleZones(filters, ...)` — search multiple zones in one effect.
+
+**Sideboard / wish (`Patterns.Sideboard.*`)**
+
+- `wish(filter = Any, count = 1, destination = HAND)` — the **wish** mechanic (Burning Wish,
+  Living Wish, Cunning Wish, Death Wish, Glittering Wish, Wish, …): "you may [reveal] a [type] card
+  you own from outside the game and put it into your hand." A player's sideboard is modelled as the
+  private per-player `Zone.SIDEBOARD` ("outside the game", CR 100.4 / 400.11a; strictly not a zone
+  per CR 400.11, but a pseudo-zone lets the wish reuse the ordinary pipeline). The recipe composes
+  `GatherCards(FromZone(SIDEBOARD, You, filter)) → SelectFromCollection(ChooseUpTo(count)) →
+  MoveCollection(→ destination, revealed = true)` — **no shuffle** (the sideboard is unordered) and
+  reveal always on. The "may" and "a card" are both the `ChooseUpTo(count)`: declining or having no
+  legal choice simply moves nothing. The varying axis across the cycle is `filter`
+  (`Filters.Sorcery` for Burning Wish, `Filters.Instant` for Cunning Wish, creature-or-land for
+  Living Wish, `Any` for Death Wish/Wish); `destination` is `HAND` for every printed wish but is
+  parameterized for the rare future "from outside the game onto the battlefield"/Karn-style case.
+  Pair with `spell { selfExile() }` for the cards (Burning/Cunning/Living Wish) that exile
+  themselves on resolution instead of going to the graveyard (CR 608.2g). The sideboard is private
+  to its owner — masked from opponents and spectators by `ClientStateTransformer` (like the library
+  and hand) — and, consistent with CR 400.11c, no effect other than a wish should ever gather from
+  it. Sideboards are populated at deck-build: an explicit ≤15-card list in constructed (CR 100.4a),
+  `pool − maindeck` in Limited (CR 100.4b). Example — **Burning Wish**:
+  `spell { selfExile(); effect = Patterns.Sideboard.wish(Filters.Sorcery) }`.
 
 **Top-deck manipulation**
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Zone.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Zone.kt
@@ -11,13 +11,26 @@ enum class Zone(val displayName: String) {
     @SerialName("Graveyard") GRAVEYARD("a graveyard"),
     @SerialName("Stack") STACK("the stack"),
     @SerialName("Exile") EXILE("exile"),
-    @SerialName("Command") COMMAND("the command zone");
+    @SerialName("Command") COMMAND("the command zone"),
+
+    /**
+     * A player's sideboard — the cards they own *outside the game* (CR 100.4, 400.11a). Strictly,
+     * "outside the game is not a zone" (CR 400.11), but the engine models the sideboard as a
+     * private per-player pseudo-zone so the "wish" mechanic (Burning Wish, Living Wish, …) can
+     * reach it with the ordinary Gather → Select → Move pipeline instead of bespoke machinery.
+     *
+     * It is private to its owner (masked from opponents, like [LIBRARY]/[HAND]) and, consistent
+     * with CR 400.11c ("cards outside the game can't be affected by spells or abilities"), nothing
+     * but a wish effect should ever gather from it. In constructed it is an explicit list (≤15,
+     * CR 100.4a); in Limited it is every card in the player's pool not in their deck (CR 100.4b).
+     */
+    @SerialName("Sideboard") SIDEBOARD("a sideboard");
 
     val isPublic: Boolean
         get() = this in listOf(BATTLEFIELD, GRAVEYARD, STACK, EXILE, COMMAND)
 
     val isHidden: Boolean
-        get() = this in listOf(LIBRARY, HAND)
+        get() = this in listOf(LIBRARY, HAND, SIDEBOARD)
 
     val isShared: Boolean
         get() = this in listOf(BATTLEFIELD, STACK, EXILE)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Patterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Patterns.kt
@@ -23,6 +23,9 @@ object Patterns {
     /** Exile mechanics: exile-and-return, linked exile, exile-and-replace-with-token, … */
     val Exile = ExilePatterns
 
+    /** Sideboard / "outside the game": the wish mechanic (Burning/Living/Cunning/Death Wish, …). */
+    val Sideboard = SideboardPatterns
+
     /** "Choose a creature type, then …" recipes. */
     val CreatureType = CreatureTypePatterns
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/SideboardPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/SideboardPatterns.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sideboard / "outside the game" recipes — the **wish** mechanic (Burning Wish, Living Wish,
+ * Cunning Wish, Death Wish, Glittering Wish, Wish, …).
+ *
+ * A wish lets the controller bring a card they own from *outside the game* — modelled as the
+ * private per-player [Zone.SIDEBOARD] (CR 100.4 / 400.11a) — into a zone in the game. Mechanically
+ * it is the ordinary Gather → Select → Move pipeline (see `LibraryPatterns.searchLibrary`), pointed
+ * at the sideboard instead of the library, with **no shuffle** (the sideboard is unordered and
+ * stays outside the game) and **reveal on** (the chosen card is shown — CR 701.19j / the wish
+ * cycle's "reveal that card"). The "may" and "a card" of "you may choose a [type] card" are both
+ * expressed by `ChooseUpTo(1)`: declining or having no legal choice simply moves nothing.
+ *
+ * The varying axis across the whole wish cycle is the [filter] (Burning Wish → sorcery, Cunning
+ * Wish → instant, Living Wish → creature or land, Death Wish / Wish → any); the destination is
+ * [SearchDestination.HAND] for every printed wish, but is parameterized for the rare future case
+ * (e.g. a Karn-style "from outside the game" that goes elsewhere).
+ *
+ * Reached through the single index as `Patterns.Sideboard.wish(...)`.
+ */
+object SideboardPatterns {
+
+    /**
+     * "You may choose a card you own from outside the game [matching [filter]], reveal it, and put
+     * it into your hand." Gathers the controller's [Zone.SIDEBOARD], lets them choose up to [count]
+     * (default 1) matching cards, reveals the choice, and moves it to [destination] (default hand).
+     *
+     * No shuffle — the sideboard is not a library. Reveal is always on, per the wish cycle's
+     * "reveal that card" clause and CR 701.19j.
+     */
+    fun wish(
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        count: DynamicAmount = DynamicAmount.Fixed(1),
+        destination: SearchDestination = SearchDestination.HAND,
+        storeAs: String = "wishable",
+    ): CompositeEffect {
+        val (zone, placement) = when (destination) {
+            SearchDestination.HAND -> Zone.HAND to ZonePlacement.Default
+            SearchDestination.BATTLEFIELD -> Zone.BATTLEFIELD to ZonePlacement.Default
+            SearchDestination.GRAVEYARD -> Zone.GRAVEYARD to ZonePlacement.Default
+            SearchDestination.TOP_OF_LIBRARY -> Zone.LIBRARY to ZonePlacement.Top
+        }
+        val selected = "${storeAs}Found"
+        return CompositeEffect(
+            listOf<Effect>(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.SIDEBOARD, Player.You, filter),
+                    storeAs = storeAs,
+                ),
+                SelectFromCollectionEffect(
+                    from = storeAs,
+                    selection = SelectionMode.ChooseUpTo(count),
+                    storeSelected = selected,
+                ),
+                MoveCollectionEffect(
+                    from = selected,
+                    destination = CardDestination.ToZone(zone, Player.You, placement),
+                    revealed = true,
+                ),
+            )
+        )
+    }
+
+    /** Convenience overload for the common fixed-count wish. */
+    fun wish(
+        filter: GameObjectFilter,
+        count: Int,
+        destination: SearchDestination = SearchDestination.HAND,
+    ): CompositeEffect = wish(filter, DynamicAmount.Fixed(count), destination)
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/Deck.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/Deck.kt
@@ -65,9 +65,22 @@ data class Deck(
      * Optional commander printing reference. Honoured only when [commander] is non-null.
      */
     val commanderPrinting: PrintingRef? = null,
+    /**
+     * The player's sideboard — cards they own *outside the game* (CR 100.4). These begin the
+     * game in [com.wingedsheep.sdk.core.Zone.SIDEBOARD] and are reachable only by "wish" effects
+     * (Burning Wish, Living Wish, …). Empty for the vast majority of decks, so it does not count
+     * toward [size] or [isEmpty] (those describe the in-game deck).
+     *
+     * Populated differently per format, but the engine consumes the same flat list either way:
+     * constructed decks carry an explicit, player-curated sideboard (≤15, CR 100.4a); Limited
+     * decks derive it as `pool − maindeck` at deck submission (CR 100.4b) — there is no separate
+     * Limited sideboard editor, every opened/drafted card not in the deck is automatically here.
+     */
+    val sideboard: List<CardEntry> = emptyList(),
 ) {
     /**
-     * Total number of cards in the deck (library + command zone).
+     * Total number of cards in the deck (library + command zone). Excludes the sideboard, which
+     * is outside the game.
      */
     val size: Int get() = cards.size + (if (commander != null) 1 else 0)
 
@@ -129,11 +142,13 @@ data class Deck(
             entries: List<CardEntry>,
             commander: String? = null,
             commanderPrinting: PrintingRef? = null,
+            sideboard: List<CardEntry> = emptyList(),
         ): Deck = Deck(
             cards = entries.map { it.name },
             commander = commander,
             cardEntries = entries,
             commanderPrinting = commanderPrinting,
+            sideboard = sideboard,
         )
 
         /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -128,6 +128,9 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
                     Zone.LIBRARY -> append("be put into a library")
                     Zone.STACK -> append("be put on the stack")
                     Zone.COMMAND -> append("be put into the command zone")
+                    // No card is ever moved *to* the sideboard mid-game (it is "outside the game",
+                    // CR 400.11); this branch only exists for `when` exhaustiveness.
+                    Zone.SIDEBOARD -> append("be put into a sideboard")
                 }
                 if (from != null && to != Zone.GRAVEYARD) {
                     append(" from ${from.displayName}")

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jud/cards/BurningWish.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jud/cards/BurningWish.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.jud.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Burning Wish {1}{R}
+ * Sorcery
+ *
+ * You may reveal a sorcery card you own from outside the game and put it into your hand.
+ * Exile Burning Wish.
+ *
+ * The archetypal "wish" (CR 100.4 / 400.11a — "outside the game" = the player's sideboard,
+ * modelled as the private [com.wingedsheep.sdk.core.Zone.SIDEBOARD]). It is pure composition over
+ * the Gather → Select → Move pipeline via [Patterns.Sideboard.wish]: gather the sorcery cards in
+ * the controller's sideboard, let them choose up to one (the "may"), reveal it, and put it into
+ * their hand. No new effect or executor.
+ *
+ * "Exile Burning Wish." is [selfExile] — the spell goes to exile instead of the graveyard on
+ * resolution (CR 608.2g routes the spell to exile; the engine flag is `CardScript.selfExileOnResolve`).
+ */
+val BurningWish = card("Burning Wish") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "You may reveal a sorcery card you own from outside the game and put it into " +
+        "your hand. Exile Burning Wish."
+
+    spell {
+        selfExile()
+        effect = Patterns.Sideboard.wish(Filters.Sorcery)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "83"
+        artist = "Scott M. Fischer"
+        flavorText = "She wished for a weapon, but not for the skill to wield it."
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1c9b692a-e832-4612-a6ec-93b52f6a0410.jpg?1562628871"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/JUD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JUD.json
@@ -116,6 +116,62 @@
     ]
 }
 
+// Burning Wish
+{
+    "name": "Burning Wish",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "You may reveal a sorcery card you own from outside the game and put it into your hand. Exile Burning Wish.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Sideboard",
+                        "filter": "sorcery"
+                    },
+                    "storeAs": "wishable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "wishable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "wishableFound"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "wishableFound",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                }
+            ]
+        },
+        "selfExileOnResolve": true
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "RARE",
+        "artist": "Scott M. Fischer",
+        "flavorText": "She wished for a weapon, but not for the skill to wield it.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1c9b692a-e832-4612-a6ec-93b52f6a0410.jpg?1562628871"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cabal Trainee
 {
     "name": "Cabal Trainee",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameInitializer.kt
@@ -342,6 +342,19 @@ class GameInitializer(
                 state = state.addToZone(ZoneKey(playerId, Zone.LIBRARY), cardId)
             }
 
+            // Sideboard: the cards this player owns *outside the game* (CR 100.4). They begin in
+            // the private [Zone.SIDEBOARD] and are reachable only by "wish" effects. They are not
+            // shuffled (the sideboard is unordered) and never drawn into the opening hand. Empty
+            // for almost every deck.
+            for (entry in playerConfig.deck.sideboard) {
+                val cardDef = cardRegistry.requireCard(entry.name)
+                val (cardId, stateWithId) = state.newEntity()
+                state = stateWithId
+                val cardContainer = createCardEntity(cardDef, playerId, entry.printing)
+                state = state.withEntity(cardId, cardContainer)
+                state = state.addToZone(ZoneKey(playerId, Zone.SIDEBOARD), cardId)
+            }
+
             if (commanderEntityIds.isNotEmpty()) {
                 state = state.updateEntity(playerId) { c ->
                     c.with(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -395,6 +395,14 @@ class ClientStateTransformer(
                 (!isSpectator && state.teammatesOf(viewingPlayerId).contains(zoneKey.ownerId)) ||
                 (!isSpectator && zoneKey.ownerId != viewingPlayerId &&
                     revealsOpponentHandsTo(state, viewingPlayerId))
+            // The sideboard is private "outside the game" knowledge (CR 100.4 / 400.11a): only its
+            // owner ever sees it, never opponents or spectators. (The wish *choice* itself is driven
+            // by the SelectFromCollection decision, which sends the deciding player the gathered
+            // cards directly — it doesn't depend on this passive zone visibility.) The actorFor
+            // clause keeps a Mindslaver-style controller able to see the sideboard of the player
+            // whose turn they're piloting.
+            Zone.SIDEBOARD -> debugMode || zoneKey.ownerId == viewingPlayerId ||
+                (!isSpectator && state.actorFor(zoneKey.ownerId) == viewingPlayerId)
             Zone.BATTLEFIELD,
             Zone.GRAVEYARD,
             Zone.STACK,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BurningWishScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BurningWishScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for the **wish** mechanic, exercised through Burning Wish.
+ *
+ * Burning Wish {1}{R} — Sorcery:
+ * "You may reveal a sorcery card you own from outside the game and put it into your hand.
+ *  Exile Burning Wish."
+ *
+ * "Outside the game" is modelled as the private [com.wingedsheep.sdk.core.Zone.SIDEBOARD]
+ * (CR 100.4 / 400.11a). Each clause of the card is pinned by a test below:
+ * - the fetch moves a chosen *sorcery* from the sideboard to hand, leaving the sideboard;
+ * - the filter excludes non-sorcery sideboard cards (only sorceries are offered);
+ * - "you may" — the controller can decline and fetch nothing;
+ * - an empty/no-matching sideboard fetches nothing (no error);
+ * - "Exile Burning Wish" — the spell is exiled on resolution, not put into the graveyard
+ *   (CR 608.2g), in every branch.
+ */
+class BurningWishScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Burning Wish fetches a sorcery from the sideboard") {
+            test("chosen sorcery goes to hand, leaves the sideboard, and Burning Wish is exiled") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Burning Wish")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInSideboard(1, "Swelter")        // a sorcery — wish-eligible
+                    .withCardInSideboard(1, "Grizzly Bears")  // a creature — NOT eligible
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Burning Wish")
+                withClue("Burning Wish should be castable: ${cast.error}") { cast.error shouldBe null }
+
+                game.resolveStack()
+
+                withClue("Should pause to choose a sorcery from the sideboard") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision() as? SelectCardsDecision
+                decision.shouldNotBeNull()
+                val offered = decision.cardInfo!!
+
+                withClue("Only the sorcery should be offered — the creature is filtered out") {
+                    offered.values.any { it.name == "Swelter" } shouldBe true
+                    offered.values.any { it.name == "Grizzly Bears" } shouldBe false
+                }
+
+                val swelterId = offered.entries.first { it.value.name == "Swelter" }.key
+                game.selectCards(listOf(swelterId))
+
+                withClue("Swelter should now be in player 1's hand") {
+                    game.isInHand(1, "Swelter") shouldBe true
+                }
+                withClue("Swelter should have left the sideboard") {
+                    game.isInSideboard(1, "Swelter") shouldBe false
+                }
+                withClue("Grizzly Bears should remain in the sideboard (not fetched)") {
+                    game.isInSideboard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Burning Wish should be exiled, not in the graveyard (CR 608.2g)") {
+                    game.isInExile(1, "Burning Wish") shouldBe true
+                    game.isInGraveyard(1, "Burning Wish") shouldBe false
+                }
+            }
+        }
+
+        context("\"you may\" — declining fetches nothing") {
+            test("skipping the choice leaves the sideboard intact and still exiles Burning Wish") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Burning Wish")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInSideboard(1, "Swelter")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Burning Wish")
+                game.resolveStack()
+
+                withClue("Should offer the optional sideboard choice") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.skipSelection()
+
+                withClue("Swelter should stay in the sideboard when the wish is declined") {
+                    game.isInSideboard(1, "Swelter") shouldBe true
+                }
+                withClue("Player 1 should not have fetched anything into hand") {
+                    game.isInHand(1, "Swelter") shouldBe false
+                }
+                withClue("Burning Wish is still exiled even when nothing is fetched") {
+                    game.isInExile(1, "Burning Wish") shouldBe true
+                    game.isInGraveyard(1, "Burning Wish") shouldBe false
+                }
+            }
+        }
+
+        context("no eligible card in the sideboard") {
+            test("a sideboard with no sorcery fetches nothing and still exiles Burning Wish") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Burning Wish")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInSideboard(1, "Grizzly Bears") // no sorcery anywhere in the sideboard
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Burning Wish")
+                game.resolveStack()
+
+                // With nothing eligible to gather, the choice may resolve with no decision at all;
+                // if a (necessarily empty) decision is presented, decline it.
+                if (game.hasPendingDecision()) game.skipSelection()
+
+                withClue("Nothing should be fetched into hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe false
+                }
+                withClue("The creature stays in the sideboard") {
+                    game.isInSideboard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Burning Wish is exiled regardless of whether a card was fetched") {
+                    game.isInExile(1, "Burning Wish") shouldBe true
+                    game.isInGraveyard(1, "Burning Wish") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/ScenarioTestBase.kt
@@ -306,6 +306,17 @@ abstract class ScenarioTestBase : FunSpec() {
         }
 
         /**
+         * Add a card to a player's sideboard ("outside the game", CR 100.4 / 400.11a). Used to
+         * set up "wish" effects (Burning Wish, …) that fetch from the sideboard.
+         */
+        fun withCardInSideboard(playerNumber: Int, cardName: String): ScenarioBuilder {
+            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            val cardId = createCard(cardName, playerId)
+            state = state.addToZone(ZoneKey(playerId, Zone.SIDEBOARD), cardId)
+            return this
+        }
+
+        /**
          * Add a card to a player's command zone (e.g. a commander or a Momir Basic Vanguard
          * avatar). The card gets a [VanguardAvatarComponent] when its type line is Vanguard so
          * the command-zone activated-ability path treats it as an avatar.
@@ -900,6 +911,32 @@ abstract class ScenarioTestBase : FunSpec() {
          */
         fun isOnBattlefield(cardName: String): Boolean {
             return findPermanent(cardName) != null
+        }
+
+        /**
+         * Check if a card with the given name is in a player's sideboard ("outside the game").
+         */
+        fun isInSideboard(playerNumber: Int, cardName: String): Boolean {
+            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            return state.getZone(playerId, Zone.SIDEBOARD).any { entityId ->
+                state.getEntity(entityId)?.get<CardComponent>()?.name == cardName
+            }
+        }
+
+        /** Number of cards in a player's sideboard. */
+        fun sideboardSize(playerNumber: Int): Int {
+            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            return state.getZone(playerId, Zone.SIDEBOARD).size
+        }
+
+        /**
+         * Check if a card with the given name is in a player's exile zone.
+         */
+        fun isInExile(playerNumber: Int, cardName: String): Boolean {
+            val playerId = if (playerNumber == 1) player1Id!! else player2Id!!
+            return state.getExile(playerId).any { entityId ->
+                state.getEntity(entityId)?.get<CardComponent>()?.name == cardName
+            }
         }
 
         /**

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -309,6 +309,9 @@ export enum ZoneType {
   STACK = 'Stack',
   EXILE = 'Exile',
   COMMAND = 'Command',
+  // Cards owned "outside the game" (CR 100.4 / 400.11a) — a player's sideboard, reachable in-game
+  // only by wish effects. Private to its owner; opponents never see it.
+  SIDEBOARD = 'Sideboard',
 }
 
 export function isPublicZone(zoneType: ZoneType): boolean {
@@ -316,7 +319,7 @@ export function isPublicZone(zoneType: ZoneType): boolean {
 }
 
 export function isHiddenZone(zoneType: ZoneType): boolean {
-  return [ZoneType.LIBRARY, ZoneType.HAND].includes(zoneType)
+  return [ZoneType.LIBRARY, ZoneType.HAND, ZoneType.SIDEBOARD].includes(zoneType)
 }
 
 export function isSharedZone(zoneType: ZoneType): boolean {


### PR DESCRIPTION
## What

Adds the **wish** mechanic — fetching a card you own *outside the game* (your sideboard) into hand — and proves it with **Burning Wish**. This is the engine/SDK half: a player's sideboard becomes a first-class private zone, and a single composed recipe expresses the whole wish cycle.

The mechanic composes entirely from existing pipeline primitives — **no new `Effect`, `CardSource`, or executor**. `CardSource.FromZone` already accepts any zone, so a wish is just `searchLibrary` pointed at the sideboard with no shuffle and reveal on.

## Rules grounding

- **CR 100.4 / 400.11a** — the sideboard is "outside the game". CR 400.11 notes it isn't technically a zone; we model it as a private pseudo-zone (like MTG Arena's wishboard) so the wish reuses the ordinary pipeline.
- **CR 400.11c** — cards outside the game can't be affected by anything except effects that bring them in. Honoured: nothing but a wish gathers from `SIDEBOARD`, and it's masked from opponents.
- **CR 100.4a/b** — constructed sideboard ≤ 15; in Limited it's `pool − maindeck`. (Relevant to the follow-up that *populates* sideboards.)
- **CR 608.2g** — "Exile Burning Wish" routes the spell to exile instead of the graveyard (`spell { selfExile() }`).

## Changes

**SDK**
- `Zone.SIDEBOARD` — hidden, owner-private (not public/shared).
- `Deck.sideboard: List<CardEntry>`.
- `Patterns.Sideboard.wish(filter, count = 1, destination = HAND)` — `GatherCards(FromZone(SIDEBOARD, You, filter)) → SelectFromCollection(ChooseUpTo(count)) → MoveCollection(→ hand, revealed = true)`. The `ChooseUpTo` is both the "may" and "a card"; `filter` is the only axis that varies across the cycle (`Filters.Sorcery` for Burning Wish, instant for Cunning, creature-or-land for Living, `Any` for Death/Wish).

**Engine**
- `GameInitializer` seeds each player's `SIDEBOARD` zone from `Deck.sideboard` (not shuffled, never drawn).
- `ClientStateTransformer.isZoneVisibleTo` gives `SIDEBOARD` owner-only visibility — opponents and spectators never see it. The wish choice reuses the existing `SelectFromCollection` → `SelectCardsDecision` overlay (same flow as a library tutor), so there's **no new decision type or client component**.

**Content** — Burning Wish (JUD), the archetypal wish, with self-exile on resolve.

**Tests** — `BurningWishScenarioTest` pins each clause of the card:
- fetch a sorcery to hand + it leaves the sideboard;
- the type filter excludes non-sorcery sideboard cards (only sorceries offered);
- "you may" — declining fetches nothing;
- empty / no-matching sideboard fetches nothing without error;
- Burning Wish is exiled, **not** in the graveyard, in every branch.

`ScenarioTestBase` gains `withCardInSideboard` / `isInSideboard` / `sideboardSize` / `isInExile`.

**Docs** — `card-sdk-language-reference.md` §5 documents `Patterns.Sideboard.wish`.

## Verified green

- `BurningWishScenarioTest` (3/3)
- full `:rules-engine:test` + `:mtg-sets:test` (incl. `CardDefinitionSnapshotTest` — JUD golden re-blessed, Burning Wish only; `CardLintTest`; `FacadeBoundaryTest`)
- `:game-server:compileKotlin`, `:mtg-sdk`/`:rules-engine` compile
- `web-client` `tsc --noEmit`

## Scope / follow-up

This PR is the **engine mechanic, end-to-end and fully tested**. The wish works in-game today wherever a `Deck.sideboard` is supplied (scenarios/dev).

What it deliberately **does not** include — a separate, mostly-mechanical PR that spans the whole deck subsystem and needs manual/E2E verification + screenshots:
- **populating** sideboards from the deckbuilders: an explicit sideboard editor in the constructed deckbuilder, and deriving `pool − maindeck` at submission for sealed/draft (CR 100.4b — no separate editor needed there);
- threading `sideboard` through the server deck DTOs (`DeckRequestConverter.toDeck`, request/persistence DTOs) and the ~6 `Deck`-construction sites (`TournamentMatchHandler`, `FreeForAllHandler`, `SealedSession`, `LobbyHandler`).

Splitting here keeps this PR a tight, reviewable, correctness-critical unit; the population layer lands next as its own reviewable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)