### PR TITLE
Add first-time-each-turn attack trigger flag (#136a)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2195,9 +2195,12 @@ sealed set for attack-time facts beyond the basics.
 **Attacks (per-attacker `AttackEvent`)**
 
 - `Attacks` — SELF, no filter. ("When this creature attacks.")
+- `AttacksFirstTimeEachTurn` — SELF sugar for
+  `attacks(requires = setOf(AttackPredicate.FirstTimeEachTurn))`. ("Whenever this
+  creature attacks for the first time each turn.")
 - `attacks(filter?, requires?, binding?)` — factory. Covers ANY-binding scopes,
   type-filtered scopes (creature-you-control, nontoken-creature-you-control),
-  and attack-time predicates (alone, future Battalion-style count gates).
+  and attack-time predicates (alone, Battalion-style count gates, first-attack-each-turn).
 
 **Attacks (player-level)**
 
@@ -2239,12 +2242,24 @@ Adding a new attack-time mechanic is one new sealed-case + one matcher branch
 - `AttackPredicate.AttackerCountAtLeast(n)` — at least N creatures total were
   declared as attackers (counting the trigger's attacker). Battalion shape:
   `attacks(requires = setOf(AttackerCountAtLeast(3)))` on a `SELF` binding.
+- `AttackPredicate.FirstTimeEachTurn` — the trigger's own attacker is attacking for
+  the **first time this turn** (it had not been declared as an attacker in an earlier
+  combat phase this turn). Per-attacker, so use it on a `SELF` binding. Fires once on
+  the first attack and not again if the creature attacks in a later combat phase the
+  same turn (extra-combat effects like Fear of Missing Out); the window resets each
+  turn. The "first time" fact is captured on `AttackersDeclaredEvent.firstTimeAttackers`
+  at declaration — post-declaration state can't tell, since the per-turn attacker set
+  already includes the just-declared attacker. Prefer the `AttacksFirstTimeEachTurn`
+  sugar.
 
 Examples:
 
 ```kotlin
 // "Whenever this creature attacks alone"
 Triggers.attacks(requires = setOf(AttackPredicate.Alone))
+
+// "Whenever this creature attacks for the first time each turn" (prefer the sugar)
+Triggers.AttacksFirstTimeEachTurn
 
 // "Whenever a nontoken creature you control attacks"
 Triggers.attacks(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -240,6 +240,19 @@ object Triggers {
     )
 
     /**
+     * When this creature attacks for the first time each turn. (SELF.)
+     *
+     * Fires the first time the source is declared as an attacker in a turn and not
+     * again if it attacks in a later combat phase that turn (extra-combat effects
+     * like Fear of Missing Out). The window resets each turn. Sugar for
+     * `attacks(requires = setOf(AttackPredicate.FirstTimeEachTurn))`.
+     */
+    val AttacksFirstTimeEachTurn: TriggerSpec = TriggerSpec(
+        event = AttackEvent(requires = setOf(AttackPredicate.FirstTimeEachTurn)),
+        binding = TriggerBinding.SELF
+    )
+
+    /**
      * Generic "attacks" trigger factory. Use [Attacks] for the SELF-only
      * unfiltered case; reach for this factory for any other combination.
      *
@@ -261,6 +274,9 @@ object Triggers {
      *            binding = TriggerBinding.ANY)`
      * - "Battalion — whenever ~ and at least two other creatures attack":
      *   `attacks(requires = setOf(AttackPredicate.AttackerCountAtLeast(3)))`
+     * - "Whenever this creature attacks for the first time each turn"
+     *   (prefer the [AttacksFirstTimeEachTurn] sugar):
+     *   `attacks(requires = setOf(AttackPredicate.FirstTimeEachTurn))`
      */
     fun attacks(
         filter: GameObjectFilter? = null,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -488,7 +488,8 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
          * matcher branch, not a new field here.
          *
          * Current cases: [AttackPredicate.Alone],
-         * [AttackPredicate.AttackerCountAtLeast].
+         * [AttackPredicate.AttackerCountAtLeast],
+         * [AttackPredicate.FirstTimeEachTurn].
          */
         val requires: Set<AttackPredicate> = emptySet(),
     ) : EventPattern {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -516,6 +516,24 @@ sealed interface AttackPredicate {
     data class AttackerCountAtLeast(val n: Int) : AttackPredicate {
         override val description = "with $n or more attackers"
     }
+
+    /**
+     * The attacker is attacking *for the first time this turn* — it had not been
+     * declared as an attacker in any earlier combat phase this turn. The matcher
+     * consults the per-turn attacker set (the same union that backs raid / "you
+     * attacked with N creatures this turn"), so a creature that attacks again in a
+     * second combat phase (extra-combat effects like Fear of Missing Out) does not
+     * re-fire. The window resets at the start of each turn.
+     *
+     * Per-attacker by design: it gates against the trigger's own source, so use it
+     * with a `SELF` binding — "Whenever this creature attacks for the first time
+     * each turn, …".
+     */
+    @SerialName("AttacksFirstTimeEachTurn")
+    @Serializable
+    data object FirstTimeEachTurn : AttackPredicate {
+        override val description = "for the first time each turn"
+    }
 }
 
 // =============================================================================

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -17,6 +17,10 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // declines -> SCAFFOLD.
     supported("WhenAnyNumberOfCountersOfTypeArePutOnAPermanent", "trigger: one or more counters of a type put on this permanent (CountersPlacedEvent, SELF)")
     supported("WhenACreatureAttacks", "trigger: attacks")
+    // "Whenever this creature attacks for the first time each turn, …" — SELF attack trigger gated on
+    // the per-turn attacker set (AttackPredicate.FirstTimeEachTurn / Triggers.AttacksFirstTimeEachTurn,
+    // Fear of Missing Out). Fires once on the first attack and not on a later combat phase the same turn.
+    supported("WhenACreatureAttacksForTheFirstTimeEachTurn", "trigger: this creature attacks for the first time each turn (Triggers.AttacksFirstTimeEachTurn)")
     // "Whenever you attack with one or more creatures [matching a filter]" — the batched declare-attackers
     // trigger that fires once per combat when at least one attacker matches (Triggers.YouAttackWithFilter,
     // Jolene Plundering Pugilist's "with power 4 or greater"). You scope only; the emitter recovers the

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -1740,6 +1740,7 @@ private val TRIGGER_SPEC = mapOf(
     "WhenAPermanentEntersTheBattlefield" to "Triggers.EntersBattlefield",
     "WhenACreatureOrPlaneswalkerDies" to "Triggers.Dies",
     "WhenACreatureAttacks" to "Triggers.Attacks",
+    "WhenACreatureAttacksForTheFirstTimeEachTurn" to "Triggers.AttacksFirstTimeEachTurn",
     "WhenACreatureBlocks" to "Triggers.Blocks",
     "WhenACreatureDealsCombatDamageToAPlayer" to "Triggers.DealsCombatDamageToPlayer",
     "WhenACreatureBecomesBlocked" to "Triggers.BecomesBlocked",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -645,13 +645,22 @@ data class TargetsChosenEvent(
 
 /**
  * Attackers were declared.
+ *
+ * [firstTimeAttackers] is the subset of [attackers] that were declared as an attacker
+ * *for the first time this turn* — i.e. they had not attacked in an earlier combat phase
+ * this turn. It backs `AttackPredicate.FirstTimeEachTurn` ("attacks for the first time
+ * each turn"): the matcher cannot derive this from post-declaration state because the
+ * per-turn attacker set already includes the just-declared attacker by detection time, so
+ * the "first time" fact is captured on the event at declaration (mirroring
+ * `LifeChangeEvent.firstThisTurn` / `BecomesTargetEvent.firstTimeByThisController`).
  */
 @Serializable
 @SerialName("AttackersDeclaredEvent")
 data class AttackersDeclaredEvent(
     val attackers: List<EntityId>,
     val attackerNames: List<String> = emptyList(),
-    val attackingPlayerId: EntityId? = null
+    val attackingPlayerId: EntityId? = null,
+    val firstTimeAttackers: Set<EntityId> = emptySet()
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -117,7 +117,7 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
                     // Apply the trigger's attack-time predicates (e.g. AttackPredicate.Alone for
                     // Bilbo's Ring) — the same conjunctive check the main loop runs at declaration,
                     // which the ATTACHED path must not skip.
-                    trigger.requires.all { matcher.matchesAttackPredicate(it, event) }
+                    trigger.requires.all { matcher.matchesAttackPredicate(it, event, attachedEntityId) }
             }
             is EventPattern.TapEvent -> {
                 event is TappedEvent && event.entityId == attachedEntityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -121,7 +121,7 @@ class TriggerMatcher(
             is EventPattern.AttackEvent -> {
                 event is AttackersDeclaredEvent &&
                     checkBinding(binding, sourceId, event.attackers) &&
-                    trigger.requires.all { matchesAttackPredicate(it, event) }
+                    trigger.requires.all { matchesAttackPredicate(it, event, sourceId) }
             }
             is EventPattern.YouAttackEvent -> {
                 if (event !is AttackersDeclaredEvent) return false
@@ -1380,10 +1380,15 @@ class TriggerMatcher(
      */
     internal fun matchesAttackPredicate(
         predicate: AttackPredicate,
-        event: AttackersDeclaredEvent
+        event: AttackersDeclaredEvent,
+        boundEntityId: EntityId
     ): Boolean = when (predicate) {
         AttackPredicate.Alone -> event.attackers.size == 1
         is AttackPredicate.AttackerCountAtLeast -> event.attackers.size >= predicate.n
+        // Per-attacker: the trigger's own source (SELF / the attached creature) is among the
+        // creatures attacking for the first time this turn. Stamped on the event at declaration
+        // (post-declaration state can't tell, since the per-turn attacker set already includes it).
+        AttackPredicate.FirstTimeEachTurn -> boundEntityId in event.firstTimeAttackers
     }
 
     private fun matchesSpellCastPredicate(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -210,6 +210,14 @@ internal class AttackPhaseManager(
             }
         }.toSet()
 
+        // Attackers seen earlier this turn (across prior combat phases) — read before the per-turn
+        // set is unioned below so we can flag which of these attackers are attacking for the *first
+        // time this turn*. Backs AttackPredicate.FirstTimeEachTurn; this fact can't be derived after
+        // the union (the just-declared attacker would already be a member).
+        val previousAttackersThisTurn = state.getEntity(attackingPlayer)
+            ?.get<PlayerAttackersThisTurnComponent>()?.attackerIds ?: emptySet()
+        val firstTimeAttackers = attackers.keys - previousAttackersThisTurn
+
         newState = newState.updateEntity(attackingPlayer) { container ->
             var updated = container.with(AttackersDeclaredThisCombatComponent)
             if (attackers.isNotEmpty()) {
@@ -233,7 +241,14 @@ internal class AttackPhaseManager(
         val attackerNames = attackers.keys.map { state.getEntity(it)?.get<CardComponent>()?.name ?: "Creature" }
         return ExecutionResult.success(
             newState,
-            taxEvents + tapEvents + listOf(AttackersDeclaredEvent(attackers.keys.toList(), attackerNames, attackingPlayer))
+            taxEvents + tapEvents + listOf(
+                AttackersDeclaredEvent(
+                    attackers.keys.toList(),
+                    attackerNames,
+                    attackingPlayer,
+                    firstTimeAttackers = firstTimeAttackers
+                )
+            )
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AttacksFirstTimeEachTurnScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AttacksFirstTimeEachTurnScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * `AttackPredicate.FirstTimeEachTurn` — "Whenever this creature attacks for the first time each
+ * turn, …" (engine gap #136a, the trigger half of Fear of Missing Out).
+ *
+ * The flag gates a SELF attack trigger on the per-turn attacker set: it fires the first time the
+ * source is declared as an attacker in a turn, does NOT fire if it attacks again later that same
+ * turn (an extra combat phase — the *other* half of Fear of Missing Out), and fires again on a
+ * later turn because the window resets each turn. The "first time" fact is captured on the
+ * `AttackersDeclaredEvent` at declaration, so the second-combat case can't be papered over by
+ * post-declaration state.
+ */
+class AttacksFirstTimeEachTurnScenarioTest : FunSpec({
+
+    // Proof creature: a 2/2 that draws a card the first time it attacks each turn.
+    val firstStriker = CardDefinition.creature(
+        name = "First-Strike Scout",
+        manaCost = ManaCost.parse("{1}{R}"),
+        subtypes = setOf(Subtype("Scout")),
+        power = 2,
+        toughness = 2,
+        oracleText = "Whenever this creature attacks for the first time each turn, draw a card.",
+        script = CardScript.creature(
+            TriggeredAbility.create(
+                trigger = EventPattern.AttackEvent(
+                    requires = setOf(AttackPredicate.FirstTimeEachTurn)
+                ),
+                binding = TriggerBinding.SELF,
+                effect = DrawCardsEffect(1)
+            )
+        )
+    )
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(
+            TestCards.all +
+                com.wingedsheep.mtg.sets.tokens.PredefinedTokens.allTokens +
+                listOf(firstStriker)
+        )
+        return d
+    }
+
+    test("fires on the first attack each turn, and again the next turn") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val scout = d.putCreatureOnBattlefield(active, "First-Strike Scout")
+        d.removeSummoningSickness(scout)
+
+        // Turn 1: first attack of the turn -> draw.
+        val handTurn1 = d.getHandSize(active)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(active, listOf(scout), opp)
+        repeat(6) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.getHandSize(active) shouldBe handTurn1 + 1
+
+        // Advance whole turns until it is the active player's turn again (their next turn).
+        do {
+            d.passPriorityUntil(Step.END)            // current turn's end step
+            d.passPriorityUntil(Step.PRECOMBAT_MAIN) // next turn's precombat main
+        } while (d.activePlayer != active)
+
+        // Turn 3 (active again): the window has reset -> draw again.
+        val handTurn3 = d.getHandSize(active)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(active, listOf(scout), opp)
+        repeat(6) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+        d.getHandSize(active) shouldBe handTurn3 + 1
+    }
+
+    test("does NOT fire on a second attack the same turn (extra combat)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val scout = d.putCreatureOnBattlefield(active, "First-Strike Scout")
+        d.removeSummoningSickness(scout)
+
+        // Simulate that the Scout already attacked earlier this turn (the state an extra combat
+        // phase produces): seed the per-turn attacker set with it before declaring this combat.
+        d.replaceState(
+            d.state.updateEntity(active) { container ->
+                val prev = container.get<PlayerAttackersThisTurnComponent>()?.attackerIds ?: emptySet()
+                container.with(PlayerAttackersThisTurnComponent(prev + scout))
+            }
+        )
+
+        val handBefore = d.getHandSize(active)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(active, listOf(scout), opp)
+        repeat(6) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Not the first attack this turn -> no draw.
+        d.getHandSize(active) shouldBe handBefore
+    }
+})


### PR DESCRIPTION
## Capability

Adds **`AttackPredicate.FirstTimeEachTurn`** — a SELF attack trigger that fires only the *first* time its source is declared as an attacker each turn ("Whenever this creature attacks for the first time each turn, …"). This is the **trigger half of Fear of Missing Out** (engine gap #136a). The card's *other* half — granting an extra combat phase — is being implemented separately; this PR does not touch it.

This follows the engine's existing extensible `AttackPredicate` design: a new attack-time mechanic is **one new sealed-case + one matcher branch**, never a new boolean/field on `AttackEvent` (same pattern as `Alone` and `AttackerCountAtLeast`).

## Where it plugs into the trigger system

- **SDK** (`mtg-sdk`):
  - `AttackPredicate.FirstTimeEachTurn` (a `data object`, no payload).
  - `Triggers.AttacksFirstTimeEachTurn` sugar; `attacks(requires = setOf(AttackPredicate.FirstTimeEachTurn))` also works.
- **Engine** (`rules-engine`):
  - `AttackersDeclaredEvent.firstTimeAttackers` — the subset of attackers **not** seen in an earlier combat phase this turn, stamped at declaration time in `AttackPhaseManager.commitAttackDeclaration` (read from the per-turn `PlayerAttackersThisTurnComponent` *before* it is unioned with the new attackers). The matcher can't derive "first time" from post-declaration state, since by detection time the attacker is already a member — so the fact rides the event, mirroring `LifeChangeEvent.firstThisTurn` / `BecomesTargetEvent.firstTimeByThisController`.
  - `TriggerMatcher.matchesAttackPredicate` now takes the bound attacker; the `FirstTimeEachTurn` branch checks `boundEntityId in event.firstTimeAttackers`. Both call sites updated — the main matcher (`sourceId`) and `AttachmentTriggerDetector` (`attachedEntityId`).
  - The per-turn window resets via the existing cleanup that clears `PlayerAttackersThisTurnComponent` at end of turn — no new cleanup needed.
- **mtgish tooling**: bridge + emitter entries for the `WhenACreatureAttacksForTheFirstTimeEachTurn` IR tag (SELF shape renders `Triggers.AttacksFirstTimeEachTurn`), so the corpus scores those cards as coverable and auto-drafts them.

## Test

`AttacksFirstTimeEachTurnScenarioTest` (rules-engine, `GameTestDriver`) with a proof creature that draws on its first attack each turn:
- fires on the first attack of the turn;
- fires **again** on the active player's next turn (window resets);
- does **not** fire on a second attack the same turn (simulating an extra combat phase by pre-seeding the per-turn attacker set).

## Verification

- `:rules-engine:test --tests "*AttacksFirstTimeEachTurn*"` — green.
- Combat / attachment / raid / serialization regressions (BilbosRing, Battalion, Combat, Raid) — green.
- `CardDefinitionSnapshotTest` + `CardLintTest` — green (no compiled-card diffs; the new event field defaults to empty).
- `:mtgish-tooling:test` (emitter goldens) — green.
- `:game-server` / `:ai` / `:mtg-sets` compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)