### PR TITLE
Implement Qiqirn Merchant; prove activated-ability cost reduction by permanent count

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3453,6 +3453,23 @@ activatedAbility {
 }
 ```
 
+**`genericCostReduction` — "this ability costs {N} less to activate for each …".** The
+`activatedAbility { }` builder exposes `genericCostReduction: DynamicAmount?`. When set, the engine
+reduces the generic-mana portion of the ability's `cost` by that amount at activation time (floored
+at {0}; colored pips are never touched — CR 118.9a), and both the legal-action enumerator and
+`ActivateAbilityHandler` apply the same reduction so the displayed/affordable cost matches what's
+paid. It accepts **any** `DynamicAmount`, so the reduction can read:
+- a **per-source property** — `DynamicAmount.EntityProperty(Source, Power)` for "costs {X} less,
+  where X is this creature's power" (The Dominion Bracelet);
+- the **chosen target** — `DynamicAmounts.targetColorCount()` for "costs {1} less for each color of
+  the creature it targets" (Dragonfire Blade; the enumerator gates affordability on the largest
+  reduction over the legal targets, since the target isn't picked until activation);
+- a **battlefield count** — `DynamicAmounts.battlefield(Player.You, GameObjectFilter.Land.withSubtype("Town")).count()`
+  for "costs {1} less to activate for each Town you control" (Qiqirn Merchant).
+
+No new vocabulary is needed for a "costs {N} less per «permanents you control matching a filter»"
+ability — feed the matching count `DynamicAmount` to `genericCostReduction`.
+
 **`TimingRule`**
 
 - `Normal` — at instant speed (default for most abilities).

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/QiqirnMerchant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/QiqirnMerchant.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Qiqirn Merchant
+ * {2}{U}
+ * Creature — Beast Citizen
+ * 1/4
+ * {1}, {T}: Draw a card, then discard a card.
+ * {7}, {T}, Sacrifice this creature: Draw three cards. This ability costs {1} less to
+ *   activate for each Town you control.
+ *
+ * The second ability's cost reduction rides the existing
+ * [com.wingedsheep.sdk.scripting.ActivatedAbility.genericCostReduction] field: any
+ * [com.wingedsheep.sdk.scripting.values.DynamicAmount] reduces the generic-mana portion of the cost
+ * at activation time, evaluated once before costs are paid (enumerator + handler stay in sync). Here
+ * it's a battlefield count of Towns you control, so the {7} drops by {1} per Town (floored at {0}).
+ */
+val QiqirnMerchant = card("Qiqirn Merchant") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Beast Citizen"
+    power = 1
+    toughness = 4
+    oracleText = "{1}, {T}: Draw a card, then discard a card.\n" +
+        "{7}, {T}, Sacrifice this creature: Draw three cards. This ability costs {1} less to " +
+        "activate for each Town you control."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
+        effect = Effects.Composite(
+            DrawCardsEffect(1),
+            Patterns.Hand.discardCards(1)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = DrawCardsEffect(3)
+        genericCostReduction =
+            DynamicAmounts.battlefield(Player.You, GameObjectFilter.Land.withSubtype("Town")).count()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Andrea Tentori Montalto"
+        imageUri = "https://cards.scryfall.io/normal/front/a/7/a75a6ecc-a6a5-462c-bd92-ae57dde9b965.jpg?1748705999"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -5592,6 +5592,122 @@
     ]
 }
 
+// Qiqirn Merchant
+{
+    "name": "Qiqirn Merchant",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Beast Citizen",
+    "oracleText": "{1}, {T}: Draw a card, then discard a card.\n{7}, {T}, Sacrifice this creature: Draw three cards. This ability costs {1} less to activate for each Town you control.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "genericCostReduction": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land Town"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Andrea Tentori Montalto",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/7/a75a6ecc-a6a5-462c-bd92-ae57dde9b965.jpg?1748705999"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Queen Brahne
 {
     "name": "Queen Brahne",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QiqirnMerchantTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QiqirnMerchantTest.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.QiqirnMerchant
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Qiqirn Merchant (FIN) — proves activated-ability cost reduction *by permanent count*.
+ *
+ * "{7}, {T}, Sacrifice this creature: Draw three cards. This ability costs {1} less to activate for
+ * each Town you control." rides the engine's per-activation
+ * [com.wingedsheep.sdk.scripting.ActivatedAbility.genericCostReduction] field fed
+ * `DynamicAmounts.battlefield(You, Land — Town).count()`. The same field already powers
+ * The Dominion Bracelet (X = creature's power) and Dragonfire Blade (X = target's color count);
+ * here the [com.wingedsheep.sdk.scripting.values.DynamicAmount] is a battlefield count, so no new
+ * engine vocabulary is required — these tests pin that the reduction lowers the displayed/affordable
+ * and paid generic cost, floors at {0}, and never goes negative.
+ *
+ * A Town here is an inert "Land — Town" with no mana ability, so the only mana available is what the
+ * test grants — exact-cost assertions stay clean.
+ */
+class QiqirnMerchantTest : FunSpec({
+
+    // The cost-reduced "draw three" ability is the one carrying genericCostReduction; the looter is the other.
+    val drawThreeAbilityId = QiqirnMerchant.activatedAbilities.first { it.genericCostReduction != null }.id
+    val looterAbilityId = QiqirnMerchant.activatedAbilities.first { it.genericCostReduction == null }.id
+
+    // Inert Land — Town (no mana ability) used purely as a "Town you control" for the count.
+    val town = CardDefinition(
+        name = "Test Town",
+        manaCost = ManaCost.ZERO,
+        typeLine = TypeLine(cardTypes = setOf(CardType.LAND), subtypes = setOf(Subtype("Town"))),
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(QiqirnMerchant)
+        driver.registerCard(town)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Put a ready (no summoning sickness) Qiqirn Merchant onto [player]'s battlefield. */
+    fun GameTestDriver.readyMerchant(player: com.wingedsheep.sdk.model.EntityId): com.wingedsheep.sdk.model.EntityId {
+        val merchant = putCreatureOnBattlefield(player, "Qiqirn Merchant")
+        removeSummoningSickness(merchant)
+        return merchant
+    }
+
+    /**
+     * Add [count] Towns to [player]'s battlefield, tapped. The engine grants every land an intrinsic
+     * mana ability, so untapped Towns would help pay the very cost we're metering. Tapped Towns still
+     * satisfy the "Town you control" count (the filter has no untapped requirement), so the only mana
+     * the test affords is what it explicitly grants.
+     */
+    fun GameTestDriver.addTowns(player: com.wingedsheep.sdk.model.EntityId, count: Int) {
+        repeat(count) { tapPermanent(putLandOnBattlefield(player, "Test Town")) }
+    }
+
+    test("draw-three costs the full {7} with no Towns in play") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val merchant = driver.readyMerchant(player)
+        val handBefore = driver.getHandSize(player)
+
+        // {6} is one short of the unreduced {7}.
+        driver.giveColorlessMana(player, 6)
+        driver.submitExpectFailure(ActivateAbility(player, merchant, drawThreeAbilityId))
+        driver.state.getBattlefield(player) shouldContain merchant // not yet sacrificed
+
+        // The seventh mana covers it; the ability resolves and draws three.
+        driver.giveColorlessMana(player, 1)
+        driver.submit(ActivateAbility(player, merchant, drawThreeAbilityId)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getHandSize(player) shouldBe handBefore + 3
+        driver.state.getBattlefield(player) shouldNotContain merchant // sacrificed as a cost
+        driver.getGraveyard(player) shouldContain merchant
+    }
+
+    test("each Town you control reduces the cost by {1} — three Towns make it {4}") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val merchant = driver.readyMerchant(player)
+        driver.addTowns(player, 3)
+        val handBefore = driver.getHandSize(player)
+
+        // {7} - 3 Towns = {4}. Three mana is not enough...
+        driver.giveColorlessMana(player, 3)
+        driver.submitExpectFailure(ActivateAbility(player, merchant, drawThreeAbilityId))
+        driver.state.getBattlefield(player) shouldContain merchant
+
+        // ...the fourth mana is.
+        driver.giveColorlessMana(player, 1)
+        driver.submit(ActivateAbility(player, merchant, drawThreeAbilityId)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getHandSize(player) shouldBe handBefore + 3
+        driver.getGraveyard(player) shouldContain merchant
+    }
+
+    test("the reduction floors at {0} and never goes negative with more Towns than generic mana") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val merchant = driver.readyMerchant(player)
+        driver.addTowns(player, 8) // 8 > the {7} generic; tapped, so they afford no mana themselves
+        val handBefore = driver.getHandSize(player)
+
+        // {7} - 8 Towns floors at {0}: activatable with no mana at all (CR 118.9a — never below zero).
+        driver.submit(ActivateAbility(player, merchant, drawThreeAbilityId)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getHandSize(player) shouldBe handBefore + 3
+        driver.getGraveyard(player) shouldContain merchant
+    }
+
+    test("the looter ability is unaffected by Towns and loots one card") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        val merchant = driver.readyMerchant(player)
+        driver.addTowns(player, 5) // must not discount this ability
+        val toDiscard = driver.putCardInHand(player, "Mountain")
+        val handBefore = driver.getHandSize(player)
+
+        // The Town count must not reduce the looter's {1} — zero mana fails, one mana succeeds.
+        driver.submitExpectFailure(ActivateAbility(player, merchant, looterAbilityId))
+        driver.giveColorlessMana(player, 1)
+        driver.submit(ActivateAbility(player, merchant, looterAbilityId)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Drew one, then discard the card we planted: net hand unchanged, Merchant still in play.
+        driver.submitCardSelection(player, listOf(toDiscard))
+        driver.getHandSize(player) shouldBe handBefore
+        driver.getGraveyard(player) shouldContain toDiscard
+        driver.state.getBattlefield(player) shouldContain merchant
+    }
+})


### PR DESCRIPTION
## Summary

Qiqirn Merchant (FIN) was skipped during triage as *"add-feature territory"* — its second ability

> {7}, {T}, Sacrifice this creature: Draw three cards. **This ability costs {1} less to activate for each Town you control.**

was thought to need new engine support for **activated-ability cost reduction by permanent count**.

**It doesn't.** The engine already supports this. `ActivatedAbility.genericCostReduction: DynamicAmount?` is a *general* per-activation reduction that both the legal-action enumerator and `ActivateAbilityHandler` apply identically (so the displayed, affordable, and paid generic cost all match). The same field already powers **The Dominion Bracelet** (X = creature's power) and **Dragonfire Blade** (X = the target's color count). "For each Town you control" is just a different `DynamicAmount` on the same field — a battlefield count:

```kotlin
genericCostReduction =
    DynamicAmounts.battlefield(Player.You, GameObjectFilter.Land.withSubtype("Town")).count()
```

That's an `AggregateBattlefield` the `DynamicAmountEvaluator` already evaluates over projected state. **No new SDK type, executor, evaluator, or wiring — pure composition of existing primitives.** The FIN gaps backlog itself already lists this card under *"Already supported — no new engine work"*; the original skip note was inaccurate.

## What's in the change

- **Card** — `QiqirnMerchant.kt` (both abilities: the `{1},{T}` looter and the cost-reduced draw-three), auto-discovered into the FIN set.
- **Scenario test** — `QiqirnMerchantTest.kt` pins the exact rule the triage note doubted:
  - full `{7}` with zero Towns; `{4}` with three Towns (`{1}` less each);
  - reduction **floors at `{0}` and never goes negative** with eight Towns (free activation, CR 118.9a);
  - the reduction does **not** leak onto the unreduced `{1},{T}` looter ability.
  - (Towns are placed *tapped* — the engine grants every land an intrinsic mana ability, so untapped Towns would help pay the very cost being metered; tapped Towns still satisfy the "Town you control" count.)
- **Docs** — documents `genericCostReduction` as a general `DynamicAmount` (per-source / per-target / battlefield-count) in the SDK reference, so future triage doesn't misclassify "costs {N} less per «permanents matching a filter»" abilities as needing engine work.
- **Snapshot** — re-blessed FIN card snapshot (Qiqirn-only, additive diff).

## Testing

- `:rules-engine` `QiqirnMerchantTest` — 4/4 pass.
- `:mtg-sets` `CardDefinitionSnapshotTest` (re-blessed) and `CardLintTest` — green.
- `scripts/check-card-printing.py "Qiqirn Merchant"` — canonical in earliest/only printing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)