### PR TITLE
Populate sideboards through the deck path (Limited wishes working)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/SideboardDerivation.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/SideboardDerivation.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.gameserver.deck
+
+import com.wingedsheep.sdk.model.CardDefinition
+
+/**
+ * Derives a Limited player's sideboard from their card pool (CR 100.4b):
+ *
+ * > "In limited play involving individual players, all cards in a player's card pool not included
+ * > in their deck are in that player's sideboard."
+ *
+ * So there is no separate sideboard editor in Sealed/Draft — every opened or drafted card the
+ * player didn't run is automatically their sideboard, and wish effects (Burning Wish, …) draw on
+ * exactly that. The complement is computed server-side at deck-submission time (the only point the
+ * full pool is in scope), counted by card name.
+ *
+ * Basic lands are excluded: they're an unlimited resource in Limited deckbuilding, not finite pool
+ * cards, so "leftover" basics aren't meaningful sideboard material.
+ */
+object SideboardDerivation {
+
+    private val BASIC_LAND_NAMES = setOf("Plains", "Island", "Swamp", "Mountain", "Forest")
+
+    /**
+     * @param pool the player's full sealed/drafted card pool (one entry per physical card)
+     * @param maindeck the submitted deck as card-name → count (includes basics they chose to run)
+     * @return sideboard as card-name → count: `poolCount(name) − deckCount(name)`, clamped at 0,
+     *         excluding basic lands. Empty when the deck uses the whole non-basic pool.
+     */
+    fun fromPool(pool: List<CardDefinition>, maindeck: Map<String, Int>): Map<String, Int> {
+        val poolCounts = pool
+            .map { it.name }
+            .filterNot { it in BASIC_LAND_NAMES }
+            .groupingBy { it }
+            .eachCount()
+
+        return poolCounts
+            .mapValues { (name, available) -> available - (maindeck[name] ?: 0) }
+            .filterValues { it > 0 }
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -121,7 +121,10 @@ class FreeForAllHandler(
             val deck = if (commander != null) stripCommanderFromCards(deckWithEgg, commander) else deckWithEgg
 
             val playerSession = identity.toPlayerSession()
-            gameSession.addPlayer(playerSession, deck, commanderCardName = commander)
+            gameSession.addPlayer(
+                playerSession, deck, commanderCardName = commander,
+                sideboard = lobby.getSubmittedSideboard(identity.playerId),
+            )
             gameSession.setPlayerPersistenceInfo(
                 playerSession.playerId, playerSession.playerName, identity.token,
                 isAi = identity.isAi, aiModelOverride = identity.aiModelOverride

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -125,7 +125,9 @@ class GamePlayHandler(
             printingRegistry = printingRegistry,
         )
         gameSession.quickGameSetCode = quickGameSetCode
-        gameSession.addPlayer(playerSession, deckList)
+        // A generated random/quick deck has no sideboard; only a real submitted deck carries one.
+        val sideboard = if (quickGameSetCode != null) emptyMap() else message.sideboard
+        gameSession.addPlayer(playerSession, deckList, sideboard = sideboard)
 
         // Store player info for persistence
         val token = sessionRegistry.getTokenByWsId(session.id)
@@ -261,7 +263,9 @@ class GamePlayHandler(
             message.deckList
         }
 
-        gameSession.addPlayer(playerSession, deckList)
+        // A generated random deck (empty submission) has no sideboard.
+        val sideboard = if (message.deckList.isEmpty()) emptyMap() else message.sideboard
+        gameSession.addPlayer(playerSession, deckList, sideboard = sideboard)
 
         // Store player info for persistence
         val token = sessionRegistry.getTokenByWsId(session.id)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -512,7 +512,7 @@ class LobbyHandler(
                 ?: throw IllegalStateException("Player $playerId has no submitted deck")
             val deckWithVariants = BoosterGenerator.distributeBasicLandVariants(baseDeck, sealedSession.allBasicLandVariants)
             val deck = EasterEggDeckInjector.maybeInjectEasterEggs(playerState.session.playerName, deckWithVariants)
-            gameSession.addPlayer(playerState.session, deck)
+            gameSession.addPlayer(playerState.session, deck, sideboard = playerState.submittedSideboard)
 
             // Store player info for persistence
             val token = sessionRegistry.getTokenByWsId(playerState.session.webSocketSession.id)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -476,8 +476,14 @@ class TournamentMatchHandler(
         val ps1 = player1State.identity.toPlayerSession()
         val ps2 = player2State.identity.toPlayerSession()
 
-        gameSession.addPlayer(ps1, deck1, commanderCardName = commander1)
-        gameSession.addPlayer(ps2, deck2, commanderCardName = commander2)
+        gameSession.addPlayer(
+            ps1, deck1, commanderCardName = commander1,
+            sideboard = lobby.getSubmittedSideboard(match.player1Id),
+        )
+        gameSession.addPlayer(
+            ps2, deck2, commanderCardName = commander2,
+            sideboard = lobby.getSubmittedSideboard(match.player2Id),
+        )
 
         // Carry isAi / aiModelOverride from each identity so a server restart can rehydrate and
         // re-wire an AI seat. Omitting these persisted the AI as isAi=false, so on recovery it was

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.gameserver.lobby
 
+import com.wingedsheep.gameserver.deck.SideboardDerivation
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.gameserver.session.PlayerIdentity
@@ -167,6 +168,13 @@ data class LobbyPlayerState(
      */
     var poolSizeAtRoundStart: Int = 0,
     var submittedDeck: Map<String, Int>? = null,
+    /**
+     * The player's sideboard ("outside the game", CR 100.4), card name → count. In Limited it is
+     * derived as `pool − maindeck` (CR 100.4b) at submission via [SideboardDerivation]; in
+     * PREMADE_DECKS (constructed) it is whatever explicit sideboard the client sent. Seeds the
+     * SIDEBOARD zone at game start so wish effects can fetch from it.
+     */
+    var submittedSideboard: Map<String, Int> = emptyMap(),
     /**
      * Commander card name when the lobby's [TournamentLobby.deckFormat] is commander-shape
      * (Commander / Brawl / Standard Brawl). Null otherwise. The card name is expected to
@@ -1365,6 +1373,7 @@ class TournamentLobby(
         playerId: EntityId,
         deckList: Map<String, Int>,
         commander: String? = null,
+        sideboard: Map<String, Int> = emptyMap(),
     ): DeckSubmissionResult {
         val isPremade = format == TournamentFormat.PREMADE_DECKS
         // PREMADE_DECKS: players pick their deck while WAITING_FOR_PLAYERS, before the host starts.
@@ -1399,8 +1408,18 @@ class TournamentLobby(
             }
         }
 
+        // Sideboard (CR 100.4). In Limited the pool is authoritative, so the sideboard is
+        // *derived* as pool − maindeck (CR 100.4b) and any client-sent value is ignored. In
+        // PREMADE_DECKS (constructed) there is no pool, so the explicit client sideboard is kept.
+        val effectiveSideboard = if (isPremade) {
+            sideboard
+        } else {
+            SideboardDerivation.fromPool(playerState.cardPool, deckList)
+        }
+
         players[playerId] = playerState.copy(
             submittedDeck = deckList,
+            submittedSideboard = effectiveSideboard,
             // Commander is meaningful only for commander-shape deckFormats; keep whatever the
             // caller passed (LobbyHandler is responsible for clearing it for non-commander
             // submissions).
@@ -1430,7 +1449,11 @@ class TournamentLobby(
         }
 
         // Clear deck and ready state
-        players[playerId] = playerState.copy(submittedDeck = null, commander = null)
+        players[playerId] = playerState.copy(
+            submittedDeck = null,
+            submittedSideboard = emptyMap(),
+            commander = null,
+        )
         playersReadyForNextRound.remove(playerId)
         return true
     }
@@ -1495,6 +1518,15 @@ class TournamentLobby(
      */
     fun getSubmittedDeck(playerId: EntityId): Map<String, Int>? {
         return players[playerId]?.submittedDeck
+    }
+
+    /**
+     * Get the player's sideboard ("outside the game", CR 100.4) — card name → count. Derived as
+     * pool − maindeck in Limited, or the explicit constructed sideboard in PREMADE_DECKS. Empty
+     * when the player has no sideboard.
+     */
+    fun getSubmittedSideboard(playerId: EntityId): Map<String, Int> {
+        return players[playerId]?.submittedSideboard ?: emptyMap()
     }
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/GameSessionConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/GameSessionConverter.kt
@@ -22,6 +22,7 @@ fun GameSession.toPersistent(
         sessionId = sessionId,
         gameState = getStateForPersistence(),
         deckLists = getDeckListsForPersistence().mapKeys { it.key.value },
+        sideboards = getSideboardsForPersistence().mapKeys { it.key.value },
         lastProcessedMessageId = getLastMessageIdsForPersistence().mapKeys { it.key.value },
         gameLogs = getLogsForPersistence().mapKeys { it.key.value },
         playerInfos = getPlayerPersistenceInfo().map { (playerId, info) ->
@@ -64,6 +65,7 @@ fun restoreGameSession(
 
     // Convert persisted data back to EntityId-keyed maps
     val deckLists = persistent.deckLists.mapKeys { EntityId(it.key) }
+    val sideboards = persistent.sideboards.mapKeys { EntityId(it.key) }
     val lastMessageIds = persistent.lastProcessedMessageId.mapKeys { EntityId(it.key) }
     val logs = persistent.gameLogs.mapKeys { EntityId(it.key) }
         .mapValues { it.value.toMutableList() }
@@ -73,7 +75,8 @@ fun restoreGameSession(
         state = persistent.gameState,
         decks = deckLists,
         logs = logs,
-        lastIds = lastMessageIds
+        lastIds = lastMessageIds,
+        sideboardLists = sideboards
     )
 
     // Restore player persistence info

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
@@ -49,7 +49,8 @@ fun TournamentLobby.toPersistent(): PersistentTournamentLobby {
                 submittedDeck = playerState.submittedDeck,
                 currentSpectatingGameId = playerState.identity.currentSpectatingGameId,
                 isAi = playerState.identity.isAi,
-                aiModelOverride = playerState.identity.aiModelOverride
+                aiModelOverride = playerState.identity.aiModelOverride,
+                submittedSideboard = playerState.submittedSideboard
             )
         },
         currentPackNumber = currentPackNumber,
@@ -152,7 +153,8 @@ fun restoreTournamentLobby(
             cardPool = cardPool,
             currentPack = currentPack,
             packQueue = packQueue,
-            submittedDeck = persistentPlayer.submittedDeck
+            submittedDeck = persistentPlayer.submittedDeck,
+            submittedSideboard = persistentPlayer.submittedSideboard
         )
         lobby.players[playerId] = playerState
     }
@@ -210,7 +212,8 @@ fun SealedSession.toPersistent(): PersistentSealedSession {
                 playerId = playerState.session.playerId.value,
                 playerName = playerState.session.playerName,
                 cardPoolNames = playerState.cardPool.map { it.name },
-                submittedDeck = playerState.submittedDeck
+                submittedDeck = playerState.submittedDeck,
+                submittedSideboard = playerState.submittedSideboard
             )
         }
     )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentGameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentGameSession.kt
@@ -16,7 +16,8 @@ data class PersistentGameSession(
     val lastProcessedMessageId: Map<String, String>,  // playerId.value -> messageId
     val gameLogs: Map<String, List<ClientEvent>>,  // playerId.value -> events
     val playerInfos: List<PersistentPlayerInfo>,
-    val lobbyId: String?
+    val lobbyId: String?,
+    val sideboards: Map<String, List<String>> = emptyMap(),  // playerId.value -> sideboard card names
 )
 
 /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentLobby.kt
@@ -63,7 +63,8 @@ data class PersistentLobbyPlayer(
     val submittedDeck: Map<String, Int>?,  // cardName -> count
     val currentSpectatingGameId: String? = null,  // Game being spectated (for bye players)
     val isAi: Boolean = false,
-    val aiModelOverride: String? = null
+    val aiModelOverride: String? = null,
+    val submittedSideboard: Map<String, Int> = emptyMap(),  // cardName -> count (outside the game)
 )
 
 /**
@@ -86,5 +87,6 @@ data class PersistentSealedPlayer(
     val playerId: String,
     val playerName: String,
     val cardPoolNames: List<String>,
-    val submittedDeck: Map<String, Int>?
+    val submittedDeck: Map<String, Int>?,
+    val submittedSideboard: Map<String, Int> = emptyMap()
 )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -35,6 +35,11 @@ sealed interface ClientMessage {
          * is used (no per-card printing pinning).
          */
         val cardEntries: List<DeckEntryDTO>? = null,
+        /**
+         * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Reachable
+         * in-game only by wish effects (Burning Wish, …). Empty for almost every deck.
+         */
+        val sideboard: Map<String, Int> = emptyMap(),
     ) : ClientMessage
 
     /**
@@ -47,6 +52,8 @@ sealed interface ClientMessage {
         val deckList: Map<String, Int>,
         /** Rich, optionally-pinned entries. See [CreateGame.cardEntries]. */
         val cardEntries: List<DeckEntryDTO>? = null,
+        /** Constructed sideboard, card name → count. See [CreateGame.sideboard]. */
+        val sideboard: Map<String, Int> = emptyMap(),
     ) : ClientMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/DeckRequestConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/DeckRequestConverter.kt
@@ -25,13 +25,18 @@ object DeckRequestConverter {
         cardEntries: List<DeckEntryDTO>? = null,
         commander: String? = null,
         commanderPrinting: PrintingRef? = null,
+        sideboard: Map<String, Int> = emptyMap(),
     ): Deck {
+        // Sideboard cards ("outside the game", CR 100.4) are name-only here — wish fetches don't
+        // depend on printing, and the engine seeds the SIDEBOARD zone from these names.
+        val sideboardEntries = sideboard.flatMap { (name, count) -> List(count) { CardEntry(name) } }
         val rich = cardEntries.takeUnless { it.isNullOrEmpty() }
         return if (rich != null) {
             Deck.fromEntries(
                 entries = rich.map { CardEntry(it.name, it.printing) },
                 commander = commander,
                 commanderPrinting = commanderPrinting,
+                sideboard = sideboardEntries,
             )
         } else {
             val cards = deckList.flatMap { (name, count) -> List(count) { name } }
@@ -39,6 +44,7 @@ object DeckRequestConverter {
                 cards = cards,
                 commander = commander,
                 commanderPrinting = commanderPrinting,
+                sideboard = sideboardEntries,
             )
         }
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/sealed/SealedSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/sealed/SealedSession.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.sealed
 
 import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.gameserver.deck.SideboardDerivation
 import com.wingedsheep.gameserver.session.PlayerSession
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
@@ -27,7 +28,12 @@ enum class SealedSessionState {
 data class SealedPlayerState(
     val session: PlayerSession,
     val cardPool: List<CardDefinition>,
-    var submittedDeck: Map<String, Int>? = null
+    var submittedDeck: Map<String, Int>? = null,
+    /**
+     * Sideboard ("outside the game", CR 100.4), card name → count. Derived as `pool − maindeck`
+     * (CR 100.4b) when the deck is submitted; seeds the SIDEBOARD zone at game start.
+     */
+    var submittedSideboard: Map<String, Int> = emptyMap()
 ) {
     val hasSubmittedDeck: Boolean get() = submittedDeck != null
 }
@@ -149,8 +155,11 @@ class SealedSession(
             return DeckSubmissionResult.Error(validationResult)
         }
 
-        // Update player state with submitted deck
-        players[playerId] = playerState.copy(submittedDeck = deckList)
+        // Update player state with submitted deck + derived sideboard (pool − maindeck, CR 100.4b)
+        players[playerId] = playerState.copy(
+            submittedDeck = deckList,
+            submittedSideboard = SideboardDerivation.fromPool(playerState.cardPool, deckList),
+        )
 
         // Update session state
         state = if (bothPlayersSubmitted()) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -26,6 +26,7 @@ import com.wingedsheep.engine.state.components.player.MulliganStateComponent
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardEntry
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import org.slf4j.LoggerFactory
@@ -120,6 +121,12 @@ class GameSession(
 
     private val players = mutableMapOf<EntityId, PlayerSession>()
     private val deckLists = mutableMapOf<EntityId, List<String>>()
+    /**
+     * Per-player sideboard card names ("outside the game", CR 100.4). Flat list, one entry per
+     * copy. Empty for almost every game. Seeds [com.wingedsheep.sdk.core.Zone.SIDEBOARD] at game
+     * start so wish effects (Burning Wish, …) can fetch from it.
+     */
+    private val sideboards = mutableMapOf<EntityId, List<String>>()
     /** Per-player commander card name for commander-shape formats. Null = no commander. */
     private val commanderCardNames = mutableMapOf<EntityId, String>()
     private val spectators = mutableSetOf<PlayerSession>()
@@ -255,6 +262,7 @@ class GameSession(
         playerSession: PlayerSession,
         deckList: Map<String, Int>,
         commanderCardName: String? = null,
+        sideboard: Map<String, Int> = emptyMap(),
     ): EntityId {
         require(!isFull) { "Game session is full" }
 
@@ -266,6 +274,7 @@ class GameSession(
             List(count) { cardName }
         }
         deckLists[playerId] = cards
+        sideboards[playerId] = sideboard.flatMap { (cardName, count) -> List(count) { cardName } }
         if (commanderCardName != null) {
             commanderCardNames[playerId] = commanderCardName
         } else {
@@ -283,6 +292,7 @@ class GameSession(
         players[playerId]?.currentGameSessionId = null
         players.remove(playerId)
         deckLists.remove(playerId)
+        sideboards.remove(playerId)
     }
 
     /**
@@ -404,7 +414,10 @@ class GameSession(
         val playerConfigs = players.map { (playerId, session) ->
             PlayerConfig(
                 name = session.playerName,
-                deck = Deck(deckLists[playerId]!!),
+                deck = Deck(
+                    cards = deckLists[playerId]!!,
+                    sideboard = sideboards[playerId].orEmpty().map { CardEntry(it) },
+                ),
                 playerId = playerId,  // Pass existing player ID to the engine
                 commanderCardName = commanderCardNames[playerId],
             )
@@ -1286,6 +1299,11 @@ class GameSession(
     internal fun getDeckListsForPersistence(): Map<EntityId, List<String>> = deckLists.toMap()
 
     /**
+     * Get the per-player sideboards for persistence. Empty for almost every session.
+     */
+    internal fun getSideboardsForPersistence(): Map<EntityId, List<String>> = sideboards.toMap()
+
+    /**
      * Get the game logs for persistence.
      */
     internal fun getLogsForPersistence(): Map<EntityId, List<ClientEvent>> =
@@ -1308,12 +1326,15 @@ class GameSession(
         state: GameState?,
         decks: Map<EntityId, List<String>>,
         logs: Map<EntityId, MutableList<ClientEvent>>,
-        lastIds: Map<EntityId, String>
+        lastIds: Map<EntityId, String>,
+        sideboardLists: Map<EntityId, List<String>> = emptyMap()
     ) {
         synchronized(stateLock) {
             gameState = state
             deckLists.clear()
             deckLists.putAll(decks)
+            sideboards.clear()
+            sideboards.putAll(sideboardLists)
             gameLogs.clear()
             gameLogs.putAll(logs)
             lastProcessedMessageId.clear()

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/SideboardDerivationTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/SideboardDerivationTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.gameserver.deck
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [SideboardDerivation.fromPool] — the Limited sideboard = pool − maindeck rule
+ * (CR 100.4b).
+ */
+class SideboardDerivationTest : FunSpec({
+
+    fun card(name: String): CardDefinition =
+        CardDefinition.sorcery(name, ManaCost.parse("{1}"), "")
+
+    fun pool(vararg entries: Pair<String, Int>): List<CardDefinition> =
+        entries.flatMap { (name, count) -> List(count) { card(name) } }
+
+    test("leftover non-basic pool cards become the sideboard") {
+        val pool = pool("Lightning Bolt" to 3, "Shock" to 2, "Counterspell" to 1)
+        val deck = mapOf("Lightning Bolt" to 1, "Counterspell" to 1)
+
+        SideboardDerivation.fromPool(pool, deck) shouldBe mapOf(
+            "Lightning Bolt" to 2,  // 3 in pool − 1 played
+            "Shock" to 2,           // 2 in pool − 0 played
+        )
+    }
+
+    test("a card fully used in the deck does not appear in the sideboard") {
+        val pool = pool("Shock" to 2)
+        SideboardDerivation.fromPool(pool, mapOf("Shock" to 2)) shouldBe emptyMap()
+    }
+
+    test("basic lands are never sideboard material even if 'unused' in the pool") {
+        val pool = pool("Mountain" to 10, "Shock" to 1)
+        val deck = mapOf("Mountain" to 7, "Shock" to 1)
+
+        // Mountains are excluded entirely; Shock is fully used → empty sideboard.
+        SideboardDerivation.fromPool(pool, deck) shouldBe emptyMap()
+    }
+
+    test("playing more copies than the pool holds never yields a negative count") {
+        val pool = pool("Shock" to 1)
+        SideboardDerivation.fromPool(pool, mapOf("Shock" to 4)) shouldBe emptyMap()
+    }
+
+    test("an empty deck makes the whole non-basic pool the sideboard") {
+        val pool = pool("Shock" to 2, "Forest" to 5)
+        SideboardDerivation.fromPool(pool, emptyMap()) shouldBe mapOf("Shock" to 2)
+    }
+})


### PR DESCRIPTION
Stacked on #968 (the wish engine mechanic). Threads `Deck.sideboard` end-to-end on the **server** so wish effects (Burning Wish, …) actually have cards to fetch in real games.

## What works after this PR

**Limited (sealed / draft / tournament) — fully functional, no UI needed.** Per CR 100.4b, a Limited player's sideboard *is* every card in their pool they didn't run. That complement is derived server-side at deck submission (the only point the full pool is in scope), stored, and seeded into the `SIDEBOARD` zone at game start. Open a sealed/draft game with Burning Wish in your deck and you can wish for any sorcery you opened but didn't play.

**Constructed — server-ready.** The wire DTOs carry an explicit sideboard; the deckbuilder UI to *curate* one is the next PR (see below).

## Changes

**Game-start seam**
- `GameSession.addPlayer` gains `sideboard: Map<String,Int>`; `startGame()` seeds `Deck.sideboard` from it (per-player, name-only, not shuffled, never drawn). Persisted across Redis restart (`PersistentGameSession.sideboards`).

**Limited derivation (CR 100.4b)**
- `SideboardDerivation.fromPool(pool, maindeck)` — leftover non-basic pool cards counted by name, basics excluded. **Unit-tested** (`SideboardDerivationTest`, 5 cases).
- Derived at submission and stored: `TournamentLobby` + `SealedSession` gain `submittedSideboard` (+ `getSubmittedSideboard`), persisted in their lobby DTOs.
- Forwarded at game start: `TournamentMatchHandler`, `FreeForAllHandler`, `LobbyHandler` (sealed) pass `getSubmittedSideboard` → `addPlayer`.

**Constructed wire (explicit)**
- `ClientMessage.CreateGame`/`JoinGame` carry an optional `sideboard` map; `GamePlayHandler` forwards it (a generated random deck has none).
- `DeckRequestConverter.toDeck` threads a sideboard into `Deck.sideboard`.

Everything added is optional/defaulted, so every existing caller and persisted blob is unchanged.

## Verified

- `SideboardDerivationTest` (5/5)
- full `:game-server:test` suite green (session/lobby/persistence converters included)
- `:game-server` compiles

## Next PR — constructed deckbuilder editing UI

The one remaining piece is purely visual and best done with the running app + screenshots (per `web-client/CLAUDE.md`): a sideboard panel in `DeckbuilderPage` (curate ≤15 cards, move between deck/sideboard), persist it on the saved deck, wire the Arena-import sideboard (currently parsed but dropped), and thread the sideboard through the deck-select → `createGame` chain (`DeckPicker` / `GameUI` / `QuickGameLobby` / `gameplaySlice` / `messages`). The server contract above plugs straight into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)