### PR TITLE
Constructed deckbuilder: sideboard editing UI

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -439,6 +439,7 @@ class LobbyHandler(
                 message.commander,
                 message.cardEntries,
                 message.commanderPrinting,
+                message.sideboard,
             )
             return
         }
@@ -2161,6 +2162,7 @@ class LobbyHandler(
         commander: String? = null,
         cardEntries: List<com.wingedsheep.gameserver.protocol.DeckEntryDTO>? = null,
         commanderPrinting: com.wingedsheep.sdk.model.PrintingRef? = null,
+        sideboard: Map<String, Int> = emptyMap(),
     ) {
         val lobby = lobbyRepository.findLobbyById(lobbyId)
         if (lobby == null) {
@@ -2261,7 +2263,9 @@ class LobbyHandler(
             }
         }
 
-        val result = lobby.submitDeck(identity.playerId, deckList, effectiveCommander)
+        // For a PREMADE_DECKS (constructed) lobby this explicit sideboard is honored; for Limited
+        // lobbies TournamentLobby.submitDeck ignores it and derives pool − maindeck (CR 100.4b).
+        val result = lobby.submitDeck(identity.playerId, deckList, effectiveCommander, sideboard)
         when (result) {
             is TournamentLobby.DeckSubmissionResult.Success -> {
                 val deckSize = deckList.values.sum()

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -133,6 +133,12 @@ sealed interface ClientMessage {
         val cardEntries: List<DeckEntryDTO>? = null,
         /** Optional pinned printing for [commander]. Ignored when [commander] is null. */
         val commanderPrinting: PrintingRef? = null,
+        /**
+         * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Used for
+         * constructed/premade lobbies; ignored for Limited lobbies, which derive the sideboard as
+         * pool − maindeck server-side (CR 100.4b).
+         */
+        val sideboard: Map<String, Int> = emptyMap(),
     ) : ClientMessage
 
     // =========================================================================

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
@@ -1701,7 +1701,8 @@
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-/* Sideboard ("outside the game") panel — the wish target. Sits below the deck list. */
+/* Sideboard panel — cards kept alongside the deck. Sits below the deck list and is a drop
+   target: drag cards from the catalog grid or the deck list onto it. */
 .sideboardPanel {
   display: flex;
   flex-direction: column;
@@ -1709,6 +1710,13 @@
   padding: var(--space-3);
   border-top: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(106, 163, 255, 0.04);
+  transition: background 0.12s ease, box-shadow 0.12s ease;
+}
+
+/* Active drop state while a card is dragged over the panel. */
+.sideboardPanelDrop {
+  background: rgba(106, 163, 255, 0.14);
+  box-shadow: inset 0 0 0 2px var(--accent-primary, #6aa3ff);
 }
 
 .sideboardHeader {

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
@@ -1701,6 +1701,45 @@
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+/* Sideboard ("outside the game") panel — the wish target. Sits below the deck list. */
+.sideboardPanel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(106, 163, 255, 0.04);
+}
+
+.sideboardHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sideboardTitle {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary, #c7d2e0);
+}
+
+.sideboardHint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  line-height: 1.3;
+}
+
+.sideboardEmpty {
+  margin: 0;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  text-align: center;
+  padding: var(--space-2) 0;
+}
+
 .actionRow {
   display: flex;
   gap: var(--space-2);

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -293,6 +293,11 @@ export function DeckbuilderPage() {
   // Working deck state.
   const [deckName, setDeckName] = useState('Untitled deck')
   const [deckCards, setDeckCards] = useState<Record<string, number>>({})
+  // Constructed sideboard ("outside the game", CR 100.4a) — cards reachable in-game only by wish
+  // effects (Burning Wish, …). Persisted on the saved deck and sent as `sideboard` when playing.
+  // Limited (sealed/draft) decks don't use this: their sideboard is the pool − maindeck complement,
+  // derived server-side (CR 100.4b).
+  const [sideboardCards, setSideboardCards] = useState<Record<string, number>>({})
   const [activeDeckId, setActiveDeckId] = useState<string | null>(null)
   // Pinned printings, keyed by card name. Empty unless the user opens the printing picker
   // and chooses a non-default printing for some row. Persisted via [SavedDeck.entries] (v2)
@@ -788,6 +793,29 @@ export function DeckbuilderPage() {
     })
   }, [])
 
+  // Sideboard add/remove. The 4-of cap (CR 100.2a) applies to deck + sideboard *combined*, so a
+  // card already maxed in the main deck can't also be added to the sideboard.
+  const addToSideboard = useCallback((card: CardSummary) => {
+    setSideboardCards((prev) => {
+      const inSide = prev[card.name] ?? 0
+      const inDeck = deckCards[card.name] ?? 0
+      const cap = effectiveCopyCap(card, isCommanderFormat)
+      if (inDeck + inSide >= cap) return prev
+      return { ...prev, [card.name]: inSide + 1 }
+    })
+  }, [deckCards, isCommanderFormat])
+
+  const removeFromSideboard = useCallback((name: string) => {
+    setSideboardCards((prev) => {
+      const current = prev[name] ?? 0
+      if (current <= 0) return prev
+      const next = { ...prev }
+      if (current === 1) delete next[name]
+      else next[name] = current - 1
+      return next
+    })
+  }, [])
+
   const setPinnedPrinting = useCallback((name: string, printing: PrintingDTO) => {
     setPinnedPrintings((prev) => ({
       ...prev,
@@ -817,6 +845,7 @@ export function DeckbuilderPage() {
   const handleNew = () => {
     setDeckName('Untitled deck')
     setDeckCards({})
+    setSideboardCards({})
     setCommander(null)
     setActiveDeckId(null)
     setPinnedPrintings({})
@@ -839,6 +868,7 @@ export function DeckbuilderPage() {
       ...(designated ? { commander: designated } : {}),
       ...(commanderPrintingForSave ? { commanderPrinting: commanderPrintingForSave } : {}),
       ...(entries ? { entries } : {}),
+      ...(Object.keys(sideboardCards).length > 0 ? { sideboard: sideboardCards } : {}),
     })
     setActiveDeckId(saved.id)
     if (saved.id !== deckId) navigate(`/deckbuilder/${saved.id}${searchSuffix()}`, { replace: true })
@@ -858,6 +888,7 @@ export function DeckbuilderPage() {
       ...(designated ? { commander: designated } : {}),
       ...(commanderPrintingForSave ? { commanderPrinting: commanderPrintingForSave } : {}),
       ...(entries ? { entries } : {}),
+      ...(Object.keys(sideboardCards).length > 0 ? { sideboard: sideboardCards } : {}),
     })
     setDeckName(saved.name)
     setActiveDeckId(saved.id)
@@ -910,6 +941,7 @@ export function DeckbuilderPage() {
   const handleLoadSaved = (deck: SavedDeck) => {
     setDeckName(deck.name)
     setDeckCards(mergeCommanderIntoCards(deck.cards, deck.commander ?? null))
+    setSideboardCards(deck.sideboard ? { ...deck.sideboard } : {})
     setCommander(deck.commander ?? null)
     setActiveDeckId(deck.id)
     setPinnedPrintings(pinnedPrintingsFromEntries(deck.entries, deck.commander, deck.commanderPrinting))
@@ -943,8 +975,11 @@ export function DeckbuilderPage() {
     cards: Record<string, number>,
     suggestedName: string | null,
     importedCommander: string | null,
+    importedSideboard: Record<string, number> = {},
   ) => {
     setDeckCards(cards)
+    // The Arena/MTGO list's "Sideboard"/"SB:" section becomes the wish sideboard (CR 100.4a).
+    setSideboardCards(importedSideboard)
     // The commander designation rides along when the source list had a Commander
     // section; otherwise reset so a stale value from the previous deck doesn't leak.
     setCommander(importedCommander)
@@ -1276,6 +1311,16 @@ export function DeckbuilderPage() {
               onOpenPicker={handleOpenPicker}
             />
 
+            <SideboardPanel
+              sideboardCards={sideboardCards}
+              catalog={catalog}
+              catalogIndex={catalogIndex}
+              activeFormat={activeFormat}
+              isCommanderFormat={isCommanderFormat}
+              onAdd={addToSideboard}
+              onRemove={removeFromSideboard}
+            />
+
             <div className={styles.deckSummaryWrap}>
               <DeckSummary
                 validation={validation}
@@ -1335,6 +1380,16 @@ export function DeckbuilderPage() {
             onHoverLeave={handleDeckHoverLeave}
             pinnedPrintings={pinnedPrintings}
             onOpenPicker={handleOpenPicker}
+          />
+
+          <SideboardPanel
+            sideboardCards={sideboardCards}
+            catalog={catalog}
+            catalogIndex={catalogIndex}
+            activeFormat={activeFormat}
+            isCommanderFormat={isCommanderFormat}
+            onAdd={addToSideboard}
+            onRemove={removeFromSideboard}
           />
 
           <DeckCentricFooter
@@ -1565,6 +1620,7 @@ function ImportDeckModal({
     cards: Record<string, number>,
     suggestedName: string | null,
     commander: string | null,
+    sideboard: Record<string, number>,
   ) => void
 }) {
   const [text, setText] = useState('')
@@ -1606,7 +1662,11 @@ function ImportDeckModal({
       ? catalog.find((c) => c.name.toLowerCase() === commanderEntry.name.toLowerCase())?.name
         ?? commanderEntry.name
       : null
-    onImport(merged, preview.parsed.deckName ?? null, commanderName)
+    // Resolve the "Sideboard"/"SB:" section against the catalog the same way as the main deck,
+    // so the imported sideboard becomes the wish sideboard (unknown cards survive as placeholders).
+    const sideResolved = resolveAgainstCatalog(preview.parsed.sideboard, catalog)
+    const sideboard = { ...sideResolved.deckCards, ...sideResolved.unmatchedCards }
+    onImport(merged, preview.parsed.deckName ?? null, commanderName, sideboard)
   }
 
   return (
@@ -3750,6 +3810,7 @@ function DeckListPanel({
   pinnedPrintings,
   pinnedPrintingArt,
   onOpenPicker,
+  hideBasicLandHelpers = false,
 }: {
   deckCards: Record<string, number>
   catalog: Record<string, CardSummary>
@@ -3765,10 +3826,12 @@ function DeckListPanel({
   pinnedPrintings: Record<string, PrintingRef>
   pinnedPrintingArt: Record<string, { imageUri: string | null; backFaceImageUri: string | null }>
   onOpenPicker: (name: string) => void
+  // Sideboard use: suppress the "Suggest basic lands" button and the 0-count basic placeholders.
+  hideBasicLandHelpers?: boolean
 }) {
   const grouped = useMemo(
-    () => groupForDeckList(deckCards, catalog, commander),
-    [deckCards, catalog, commander],
+    () => groupForDeckList(deckCards, catalog, commander, hideBasicLandHelpers),
+    [deckCards, catalog, commander, hideBasicLandHelpers],
   )
   const [hoverCard, setHoverCard] = useState<CardSummary | null>(null)
   const [hoverName, setHoverName] = useState<string | null>(null)
@@ -3833,7 +3896,7 @@ function DeckListPanel({
             <h3 className={styles.deckGroupLabel}>
               {group.label} ({group.entries.reduce((a, e) => a + e.count, 0)})
             </h3>
-            {group.label === 'Lands' && (
+            {group.label === 'Lands' && !hideBasicLandHelpers && (
               <button
                 type="button"
                 className={styles.basicLandsSuggest}
@@ -3877,6 +3940,83 @@ function DeckListPanel({
         imageRotateDeg={splitImageRotateDeg(effectiveHoverCard)}
       />
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sideboard panel — the constructed "outside the game" list (CR 100.4a) that
+// wish effects (Burning Wish, …) fetch from. Reuses AddCardSearch for input and
+// DeckListPanel for the rows, with commander/printing/validation chrome turned
+// off (a sideboard has no commander, and the 4-of cap is enforced combined with
+// the main deck at add-time). Limited decks never use this — their sideboard is
+// the pool − maindeck complement, derived server-side (CR 100.4b).
+// ---------------------------------------------------------------------------
+
+const SB_NOOP = () => {}
+const SB_NOOP_NAME = (_name: string) => {}
+const SB_NO_VIOLATIONS: Map<string, Set<string>> = new Map()
+const SB_NO_PRINTINGS: Record<string, PrintingRef> = {}
+const SB_NO_PRINTING_ART: Record<string, { imageUri: string | null; backFaceImageUri: string | null }> = {}
+
+function SideboardPanel({
+  sideboardCards,
+  catalog,
+  catalogIndex,
+  activeFormat,
+  isCommanderFormat,
+  onAdd,
+  onRemove,
+}: {
+  sideboardCards: Record<string, number>
+  catalog: CardSummary[]
+  catalogIndex: Record<string, CardSummary>
+  activeFormat: string | null
+  isCommanderFormat: boolean
+  onAdd: (card: CardSummary) => void
+  onRemove: (name: string) => void
+}) {
+  const total = Object.values(sideboardCards).reduce((a, b) => a + b, 0)
+  return (
+    <section className={styles.sideboardPanel} aria-label="Sideboard">
+      <div className={styles.sideboardHeader}>
+        <h3 className={styles.sideboardTitle}>Sideboard{total > 0 ? ` (${total})` : ''}</h3>
+        <span className={styles.sideboardHint}>
+          Cards “outside the game” — wishes (Burning Wish…) fetch from here.
+        </span>
+      </div>
+      <AddCardSearch
+        catalog={catalog}
+        deckCards={sideboardCards}
+        isCommanderFormat={isCommanderFormat}
+        onAdd={onAdd}
+        onSuggestBasics={SB_NOOP}
+        hideSuggestBasics
+        placeholder="Find and add cards to your sideboard…"
+      />
+      {total > 0 ? (
+        <DeckListPanel
+          deckCards={sideboardCards}
+          catalog={catalogIndex}
+          activeFormat={activeFormat}
+          onAdd={onAdd}
+          onRemove={onRemove}
+          commander={null}
+          showCommanderControls={false}
+          onToggleCommander={SB_NOOP_NAME}
+          rowViolations={SB_NO_VIOLATIONS}
+          isCommanderFormat={isCommanderFormat}
+          onSuggestBasics={SB_NOOP}
+          pinnedPrintings={SB_NO_PRINTINGS}
+          pinnedPrintingArt={SB_NO_PRINTING_ART}
+          onOpenPicker={SB_NOOP_NAME}
+          hideBasicLandHelpers
+        />
+      ) : (
+        <p className={styles.sideboardEmpty}>
+          Search above to add cards your wishes can fetch. Optional — most decks leave this empty.
+        </p>
+      )}
+    </section>
   )
 }
 
@@ -4104,12 +4244,16 @@ function AddCardSearch({
   isCommanderFormat,
   onAdd,
   onSuggestBasics,
+  hideSuggestBasics = false,
+  placeholder = 'Find and add cards to your deck…',
 }: {
   catalog: CardSummary[]
   deckCards: Record<string, number>
   isCommanderFormat: boolean
   onAdd: (card: CardSummary) => void
   onSuggestBasics: () => void
+  hideSuggestBasics?: boolean
+  placeholder?: string
 }) {
   const [text, setText] = useState('')
   const [open, setOpen] = useState(false)
@@ -4192,18 +4336,20 @@ function AddCardSearch({
             handleAdd(matches[0]!)
           }
         }}
-        placeholder="Find and add cards to your deck…"
-        aria-label="Find and add cards to your deck"
+        placeholder={placeholder}
+        aria-label={placeholder}
       />
-      <button
-        type="button"
-        className={styles.addCardBasicsButton}
-        onClick={onSuggestBasics}
-        disabled={Object.keys(deckCards).length === 0}
-        title="Auto-fill basic lands (Plains, Island, Swamp, Mountain, Forest) from your deck's mana curve and color requirements"
-      >
-        Suggest basic lands
-      </button>
+      {!hideSuggestBasics && (
+        <button
+          type="button"
+          className={styles.addCardBasicsButton}
+          onClick={onSuggestBasics}
+          disabled={Object.keys(deckCards).length === 0}
+          title="Auto-fill basic lands (Plains, Island, Swamp, Mountain, Forest) from your deck's mana curve and color requirements"
+        >
+          Suggest basic lands
+        </button>
+      )}
       {open && matches.length > 0 && (
         <div className={styles.addCardDropdown} role="listbox">
           {matches.map((card) => {
@@ -4460,6 +4606,9 @@ function groupForDeckList(
   deck: Record<string, number>,
   catalog: Record<string, CardSummary>,
   commander: string | null,
+  // When true (sideboard use), don't inject the 0-count basic-land sticky rows — a sideboard
+  // shouldn't show an empty mana base. Basics actually present in the sideboard still appear.
+  hideEmptyBasics = false,
 ): DeckGroup[] {
   const spells: DeckGroup['entries'] = []
   const lands: DeckGroup['entries'] = []
@@ -4487,7 +4636,9 @@ function groupForDeckList(
   for (const basicName of BASIC_LAND_ORDER) {
     const card = catalog[basicName]
     if (!card) continue
-    basicEntries.push({ name: basicName, count: deck[basicName] ?? 0, card })
+    const count = deck[basicName] ?? 0
+    if (hideEmptyBasics && count <= 0) continue
+    basicEntries.push({ name: basicName, count, card })
   }
   const allLands = [...lands, ...basicEntries]
   const groups: DeckGroup[] = []

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -1309,16 +1309,17 @@ export function DeckbuilderPage() {
               pinnedPrintings={pinnedPrintings}
               pinnedPrintingArt={pinnedPrintingArt}
               onOpenPicker={handleOpenPicker}
+              rowDragSource="deck"
             />
 
             <SideboardPanel
               sideboardCards={sideboardCards}
-              catalog={catalog}
               catalogIndex={catalogIndex}
               activeFormat={activeFormat}
               isCommanderFormat={isCommanderFormat}
               onAdd={addToSideboard}
               onRemove={removeFromSideboard}
+              onMoveFromDeck={removeCard}
             />
 
             <div className={styles.deckSummaryWrap}>
@@ -1384,12 +1385,12 @@ export function DeckbuilderPage() {
 
           <SideboardPanel
             sideboardCards={sideboardCards}
-            catalog={catalog}
             catalogIndex={catalogIndex}
             activeFormat={activeFormat}
             isCommanderFormat={isCommanderFormat}
             onAdd={addToSideboard}
             onRemove={removeFromSideboard}
+            onMoveFromDeck={removeCard}
           />
 
           <DeckCentricFooter
@@ -3630,6 +3631,8 @@ const CardTile = memo(function CardTile({
     <div
       ref={ref}
       className={styles.cardTile}
+      draggable
+      onDragStart={(e) => setCardDragData(e, card.name, 'catalog')}
       onClick={handleClick}
       onContextMenu={handleContextMenu}
       onMouseEnter={() => onHover(card)}
@@ -3811,6 +3814,7 @@ function DeckListPanel({
   pinnedPrintingArt,
   onOpenPicker,
   hideBasicLandHelpers = false,
+  rowDragSource,
 }: {
   deckCards: Record<string, number>
   catalog: Record<string, CardSummary>
@@ -3828,6 +3832,9 @@ function DeckListPanel({
   onOpenPicker: (name: string) => void
   // Sideboard use: suppress the "Suggest basic lands" button and the 0-count basic placeholders.
   hideBasicLandHelpers?: boolean
+  // When set, rows are draggable with this source tag (the main deck uses 'deck' so rows can be
+  // dragged into the sideboard). Omitted for the sideboard's own list.
+  rowDragSource?: CardDragSource
 }) {
   const grouped = useMemo(
     () => groupForDeckList(deckCards, catalog, commander, hideBasicLandHelpers),
@@ -3924,6 +3931,7 @@ function DeckListPanel({
               onLeave={handleLeave}
               pinnedPrinting={pinnedPrintings[entry.name]}
               onOpenPicker={onOpenPicker}
+              {...(rowDragSource ? { dragSource: rowDragSource } : {})}
             />
           ))}
         </div>
@@ -3958,41 +3966,88 @@ const SB_NO_VIOLATIONS: Map<string, Set<string>> = new Map()
 const SB_NO_PRINTINGS: Record<string, PrintingRef> = {}
 const SB_NO_PRINTING_ART: Record<string, { imageUri: string | null; backFaceImageUri: string | null }> = {}
 
+// Drag payload shared by the card grid, deck rows, and the sideboard drop zone. We carry both a
+// custom MIME (so we can tag where the drag started) and `text/plain` (so the drag still has a
+// sane fallback). `source` lets the sideboard treat a card dragged out of the main deck as a
+// *move* (remove one there, add one here) versus a catalog drag as a plain add.
+const CARD_DRAG_MIME = 'application/x-argentum-card'
+type CardDragSource = 'catalog' | 'deck'
+
+function setCardDragData(e: React.DragEvent, name: string, source: CardDragSource) {
+  e.dataTransfer.setData(CARD_DRAG_MIME, JSON.stringify({ name, source }))
+  e.dataTransfer.setData('text/plain', name)
+  e.dataTransfer.effectAllowed = 'copyMove'
+}
+
+function readCardDragData(e: React.DragEvent): { name: string; source: CardDragSource } | null {
+  const raw = e.dataTransfer.getData(CARD_DRAG_MIME)
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as { name: string; source: CardDragSource }
+      if (parsed.name) return parsed
+    } catch {
+      // fall through to the text/plain fallback
+    }
+  }
+  const name = e.dataTransfer.getData('text/plain')
+  return name ? { name, source: 'catalog' } : null
+}
+
 function SideboardPanel({
   sideboardCards,
-  catalog,
   catalogIndex,
   activeFormat,
   isCommanderFormat,
   onAdd,
   onRemove,
+  onMoveFromDeck,
 }: {
   sideboardCards: Record<string, number>
-  catalog: CardSummary[]
   catalogIndex: Record<string, CardSummary>
   activeFormat: string | null
   isCommanderFormat: boolean
   onAdd: (card: CardSummary) => void
   onRemove: (name: string) => void
+  // Move one copy out of the main deck (used when a deck row is dragged into the sideboard).
+  onMoveFromDeck: (name: string) => void
 }) {
   const total = Object.values(sideboardCards).reduce((a, b) => a + b, 0)
+  const [dragActive, setDragActive] = useState(false)
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setDragActive(false)
+    const payload = readCardDragData(e)
+    if (!payload) return
+    const card = catalogIndex[payload.name]
+    if (!card) return
+    // Dragged out of the main deck → move it (the combined 4-of cap means a plain add could
+    // otherwise be a silent no-op when the deck already holds the max).
+    if (payload.source === 'deck') onMoveFromDeck(payload.name)
+    onAdd(card)
+  }
+
   return (
-    <section className={styles.sideboardPanel} aria-label="Sideboard">
+    <section
+      className={`${styles.sideboardPanel} ${dragActive ? styles.sideboardPanelDrop : ''}`}
+      aria-label="Sideboard"
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'copy'
+        if (!dragActive) setDragActive(true)
+      }}
+      onDragLeave={(e) => {
+        // Only clear when the pointer actually leaves the panel, not when crossing child elements.
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragActive(false)
+      }}
+      onDrop={handleDrop}
+    >
       <div className={styles.sideboardHeader}>
         <h3 className={styles.sideboardTitle}>Sideboard{total > 0 ? ` (${total})` : ''}</h3>
         <span className={styles.sideboardHint}>
-          Cards “outside the game” — wishes (Burning Wish…) fetch from here.
+          Cards kept alongside your deck. Drag cards here from the grid or your deck list.
         </span>
       </div>
-      <AddCardSearch
-        catalog={catalog}
-        deckCards={sideboardCards}
-        isCommanderFormat={isCommanderFormat}
-        onAdd={onAdd}
-        onSuggestBasics={SB_NOOP}
-        hideSuggestBasics
-        placeholder="Find and add cards to your sideboard…"
-      />
       {total > 0 ? (
         <DeckListPanel
           deckCards={sideboardCards}
@@ -4013,7 +4068,7 @@ function SideboardPanel({
         />
       ) : (
         <p className={styles.sideboardEmpty}>
-          Search above to add cards your wishes can fetch. Optional — most decks leave this empty.
+          Drag cards here to set them aside. Optional — most decks leave this empty.
         </p>
       )}
     </section>
@@ -4045,6 +4100,7 @@ const DeckRow = memo(function DeckRow({
   onLeave,
   pinnedPrinting,
   onOpenPicker,
+  dragSource,
 }: {
   entry: { name: string; count: number; card: CardSummary | undefined }
   activeFormat: string | null
@@ -4059,6 +4115,8 @@ const DeckRow = memo(function DeckRow({
   onLeave: () => void
   pinnedPrinting: PrintingRef | undefined
   onOpenPicker: (name: string) => void
+  // When set, the row can be dragged (e.g. into the sideboard) carrying this source tag.
+  dragSource?: CardDragSource
 }) {
   const illegal =
     activeFormat !== null &&
@@ -4134,6 +4192,12 @@ const DeckRow = memo(function DeckRow({
     <div
       className={rowClasses}
       title={rowTitle}
+      {...(dragSource
+        ? {
+            draggable: true,
+            onDragStart: (e: React.DragEvent) => setCardDragData(e, entry.name, dragSource),
+          }
+        : {})}
       onMouseEnter={() => onEnter(entry)}
       onMouseLeave={onLeave}
     >
@@ -4244,16 +4308,12 @@ function AddCardSearch({
   isCommanderFormat,
   onAdd,
   onSuggestBasics,
-  hideSuggestBasics = false,
-  placeholder = 'Find and add cards to your deck…',
 }: {
   catalog: CardSummary[]
   deckCards: Record<string, number>
   isCommanderFormat: boolean
   onAdd: (card: CardSummary) => void
   onSuggestBasics: () => void
-  hideSuggestBasics?: boolean
-  placeholder?: string
 }) {
   const [text, setText] = useState('')
   const [open, setOpen] = useState(false)
@@ -4336,20 +4396,18 @@ function AddCardSearch({
             handleAdd(matches[0]!)
           }
         }}
-        placeholder={placeholder}
-        aria-label={placeholder}
+        placeholder="Find and add cards to your deck…"
+        aria-label="Find and add cards to your deck"
       />
-      {!hideSuggestBasics && (
-        <button
-          type="button"
-          className={styles.addCardBasicsButton}
-          onClick={onSuggestBasics}
-          disabled={Object.keys(deckCards).length === 0}
-          title="Auto-fill basic lands (Plains, Island, Swamp, Mountain, Forest) from your deck's mana curve and color requirements"
-        >
-          Suggest basic lands
-        </button>
-      )}
+      <button
+        type="button"
+        className={styles.addCardBasicsButton}
+        onClick={onSuggestBasics}
+        disabled={Object.keys(deckCards).length === 0}
+        title="Auto-fill basic lands (Plains, Island, Swamp, Mountain, Forest) from your deck's mana curve and color requirements"
+      >
+        Suggest basic lands
+      </button>
       {open && matches.length > 0 && (
         <div className={styles.addCardDropdown} role="listbox">
           {matches.map((card) => {
@@ -4474,6 +4532,7 @@ function DeckCentricView({
                 onLeave={onHoverLeave}
                 pinnedPrinting={pinnedPrintings[entry.name]}
                 onOpenPicker={onOpenPicker}
+                dragSource="deck"
               />
             ))}
           </div>

--- a/web-client/src/components/ui/DeckPicker.tsx
+++ b/web-client/src/components/ui/DeckPicker.tsx
@@ -53,7 +53,11 @@ export interface DeckPickerProps {
    * Game / Premade-Decks tournament flows pass it through to the server so commander-shape
    * formats can wire the engine into Format.Commander.
    */
-  onDeckChange: (deckList: Record<string, number>, commander?: string | null) => void
+  onDeckChange: (
+    deckList: Record<string, number>,
+    commander?: string | null,
+    sideboard?: Record<string, number>,
+  ) => void
   onValidityChange?: (isValid: boolean) => void
   /**
    * Optional set selection callback for the "Random" tab. When the picker is on Random and
@@ -283,6 +287,18 @@ export function DeckPicker({
     return null
   }, [tab, decks, selectedSavedId, pasteCommander])
 
+  // The constructed sideboard ("outside the game", CR 100.4a) the wish effects fetch from. Only
+  // saved decks carry one (the deckbuilder persists it); paste/random/examples have none. The
+  // server ignores it for Limited lobbies (those derive pool − maindeck) and uses it for
+  // constructed/premade ones.
+  const currentSideboard: Record<string, number> = useMemo(() => {
+    if (tab === 'saved') {
+      const saved = decks.find((d) => d.id === selectedSavedId)
+      return saved?.sideboard ?? {}
+    }
+    return {}
+  }, [tab, decks, selectedSavedId])
+
   // Strip the commander out of `currentDeck` before crossing the network boundary. `currentDeck`
   // keeps the commander baked in so the totalCards display reads "100 cards" for a Commander
   // deck, but the server's `Deck.cards` is documented as the library only (CR 903.6a) — the
@@ -300,8 +316,8 @@ export function DeckPicker({
   // On the Random tab `{}` *is* the chosen deck (server generates a random pool), so emit it.
   useEffect(() => {
     if (tab !== 'random' && Object.keys(currentDeck).length === 0) return
-    onDeckChange(deckListForServer, currentCommander)
-  }, [tab, currentDeck, deckListForServer, currentCommander, onDeckChange])
+    onDeckChange(deckListForServer, currentCommander, currentSideboard)
+  }, [tab, currentDeck, deckListForServer, currentCommander, currentSideboard, onDeckChange])
 
   // Server-side validation when the deck is non-empty.
   useEffect(() => {

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -1676,12 +1676,14 @@ function PremadeDeckPickerPanel({ lobbyState }: { lobbyState: LobbyState }) {
 
   const [pendingDeck, setPendingDeck] = useState<Record<string, number>>({})
   const [pendingCommander, setPendingCommander] = useState<string | null>(null)
+  const [pendingSideboard, setPendingSideboard] = useState<Record<string, number>>({})
   const [isValid, setIsValid] = useState(false)
 
   const handleDeckChange = useCallback(
-    (deck: Record<string, number>, commander?: string | null) => {
+    (deck: Record<string, number>, commander?: string | null, sideboard?: Record<string, number>) => {
       setPendingDeck(deck)
       setPendingCommander(commander ?? null)
+      setPendingSideboard(sideboard ?? {})
     },
     [],
   )
@@ -1733,7 +1735,7 @@ function PremadeDeckPickerPanel({ lobbyState }: { lobbyState: LobbyState }) {
           format={deckFormat ?? null}
         />
         <button
-          onClick={() => submitLobbyDeck(pendingDeck, isCommanderShape ? pendingCommander : null)}
+          onClick={() => submitLobbyDeck(pendingDeck, isCommanderShape ? pendingCommander : null, pendingSideboard)}
           disabled={!canSubmit}
           title={submitTitle}
           className={styles.startButton}

--- a/web-client/src/store/deckLibrary.ts
+++ b/web-client/src/store/deckLibrary.ts
@@ -56,6 +56,14 @@ export interface SavedDeck {
    * in sync so legacy code paths (counts, summaries) keep working unchanged.
    */
   entries?: readonly SavedDeckEntry[]
+  /**
+   * Optional — the constructed sideboard ("outside the game", CR 100.4a), card name → count.
+   * Reachable in-game only by wish effects (Burning Wish, …). Sent over the wire as `sideboard`
+   * and seeded into the engine's SIDEBOARD zone. Absent/empty for almost every deck. (Limited
+   * decks don't store this — their sideboard is the pool − maindeck complement, derived
+   * server-side, CR 100.4b.)
+   */
+  sideboard?: Record<string, number>
   updatedAt: number
 }
 
@@ -247,6 +255,9 @@ export const useDeckLibrary = create<DeckLibraryState>((set, get) => ({
       ...(input.commander !== undefined ? { commander: input.commander } : {}),
       ...(input.commanderPrinting !== undefined ? { commanderPrinting: input.commanderPrinting } : {}),
       ...(input.entries !== undefined ? { entries: input.entries } : {}),
+      ...(input.sideboard !== undefined && Object.keys(input.sideboard).length > 0
+        ? { sideboard: input.sideboard }
+        : {}),
       updatedAt: now,
     }
     const decks = existing

--- a/web-client/src/store/slices/lobbySlice.ts
+++ b/web-client/src/store/slices/lobbySlice.ts
@@ -53,7 +53,11 @@ export interface LobbySliceActions {
    * Submit a deck directly from the lobby (Premade Decks tournament format).
    * For Sealed/Draft, players use the dedicated deckbuilder instead via `submitSealedDeck`.
    */
-  submitLobbyDeck: (deckList: Record<string, number>, commander?: string | null) => void
+  submitLobbyDeck: (
+    deckList: Record<string, number>,
+    commander?: string | null,
+    sideboard?: Record<string, number>,
+  ) => void
   /** Unsubmit (and re-edit) a previously submitted lobby deck. */
   unsubmitLobbyDeck: () => void
 }
@@ -146,12 +150,12 @@ export const createLobbySlice: SliceCreator<LobbySlice> = (set, get) => ({
     set({ spectatingState: state })
   },
 
-  submitLobbyDeck: (deckList, commander) => {
+  submitLobbyDeck: (deckList, commander, sideboard) => {
     trackEvent('premade_deck_submitted', {
       deck_size: Object.values(deckList).reduce((a, b) => a + b, 0),
       has_commander: !!commander,
     })
-    getWebSocket()?.send(createSubmitSealedDeckMessage(deckList, commander))
+    getWebSocket()?.send(createSubmitSealedDeckMessage(deckList, commander, undefined, undefined, sideboard))
   },
 
   unsubmitLobbyDeck: () => {

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -886,7 +886,11 @@ export type GameStore = {
   kickPlayer: (playerId: string) => void
   leaveTournament: () => void
   /** Submit a deck directly from the lobby (Premade Decks tournament format). */
-  submitLobbyDeck: (deckList: Record<string, number>, commander?: string | null) => void
+  submitLobbyDeck: (
+    deckList: Record<string, number>,
+    commander?: string | null,
+    sideboard?: Record<string, number>,
+  ) => void
   unsubmitLobbyDeck: () => void
 
   // Quick Game Lobby slice

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1824,6 +1824,8 @@ export interface CreateGameMessage {
   readonly setCode?: string
   /** Rich entries with optional pinned printings. See [DeckEntry]. */
   readonly cardEntries?: readonly DeckEntry[]
+  /** Constructed sideboard ("outside the game", CR 100.4a), card name → count. Wish target. */
+  readonly sideboard?: Record<string, number>
 }
 
 /**
@@ -1834,6 +1836,8 @@ export interface JoinGameMessage {
   readonly sessionId: string
   readonly deckList: Record<string, number>
   readonly cardEntries?: readonly DeckEntry[]
+  /** Constructed sideboard, card name → count. See [CreateGameMessage.sideboard]. */
+  readonly sideboard?: Record<string, number>
 }
 
 /**
@@ -1914,6 +1918,12 @@ export interface SubmitSealedDeckMessage {
   readonly cardEntries?: readonly DeckEntry[]
   /** Optional pinned printing for the commander. Ignored when `commander` is null. */
   readonly commanderPrinting?: PrintingRef
+  /**
+   * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Used for
+   * constructed/premade lobbies; ignored for Limited lobbies, which derive the sideboard as
+   * pool − maindeck server-side (CR 100.4b).
+   */
+  readonly sideboard?: Record<string, number>
 }
 
 // ============================================================================
@@ -2002,6 +2012,7 @@ export function createCreateGameMessage(
   vsAi?: boolean,
   setCode?: string,
   cardEntries?: readonly DeckEntry[],
+  sideboard?: Record<string, number>,
 ): CreateGameMessage {
   const msg: CreateGameMessage = {
     type: 'createGame',
@@ -2009,6 +2020,7 @@ export function createCreateGameMessage(
     ...(vsAi ? { vsAi } : {}),
     ...(setCode ? { setCode } : {}),
     ...(cardEntries && cardEntries.length > 0 ? { cardEntries } : {}),
+    ...(sideboard && Object.keys(sideboard).length > 0 ? { sideboard } : {}),
   }
   return msg
 }
@@ -2017,12 +2029,14 @@ export function createJoinGameMessage(
   sessionId: string,
   deckList: Record<string, number>,
   cardEntries?: readonly DeckEntry[],
+  sideboard?: Record<string, number>,
 ): JoinGameMessage {
   return {
     type: 'joinGame',
     sessionId,
     deckList,
     ...(cardEntries && cardEntries.length > 0 ? { cardEntries } : {}),
+    ...(sideboard && Object.keys(sideboard).length > 0 ? { sideboard } : {}),
   }
 }
 
@@ -2064,6 +2078,7 @@ export function createSubmitSealedDeckMessage(
   commander?: string | null,
   cardEntries?: readonly DeckEntry[],
   commanderPrinting?: PrintingRef,
+  sideboard?: Record<string, number>,
 ): SubmitSealedDeckMessage {
   return {
     type: 'submitSealedDeck',
@@ -2071,6 +2086,7 @@ export function createSubmitSealedDeckMessage(
     ...(commander ? { commander } : {}),
     ...(cardEntries && cardEntries.length > 0 ? { cardEntries } : {}),
     ...(commanderPrinting ? { commanderPrinting } : {}),
+    ...(sideboard && Object.keys(sideboard).length > 0 ? { sideboard } : {}),
   }
 }
 


### PR DESCRIPTION
Stacked on #972 (server deck-population). Adds the **constructed sideboard** surface so players can curate the cards they keep alongside their deck — and sends it into games. This is the last piece of the wish feature.

Limited (sealed/draft) still needs **no** UI: that sideboard is the `pool − maindeck` complement, derived server-side (CR 100.4b, in #972).

## Screenshots

**Sideboard panel — empty, and after dragging cards in:**

![empty sideboard](https://raw.githubusercontent.com/wingedsheep/argentum-engine/wish-deckbuilder-screenshots/sb2-empty.png)
![populated sideboard](https://raw.githubusercontent.com/wingedsheep/argentum-engine/wish-deckbuilder-screenshots/sb2-populated.png)

**Full deckbuilder** (cards dragged from the catalog grid into the sideboard at the bottom of the deck rail):

![deckbuilder with sideboard](https://raw.githubusercontent.com/wingedsheep/argentum-engine/wish-deckbuilder-screenshots/sb2-full.png)

_(Screenshots hosted on the throwaway `wish-deckbuilder-screenshots` branch, not committed to the feature branch.)_

## Deckbuilder UI

- A **`SideboardPanel`** below the deck list in both the cards and deck-centric layouts.
- **Drag-and-drop** to populate it — no separate search box (that duplicated the catalog grid already on screen). Catalog tiles and main-deck rows are draggable; the panel is a drop target with a drag-over highlight. Dropping a catalog card **adds** it; dropping a card dragged out of the main deck **moves** it (the combined 4-of cap, CR 100.2a, is enforced so a plain add wouldn't silently no-op at the max).
- **Persisted** on the saved deck (`SavedDeck.sideboard`) and restored on load.
- **Arena/MTGO import**: the `Sideboard` / `SB:` section (previously parsed then dropped) now populates the sideboard.

## Play-path wiring

The sideboard reaches a game through the standard lobby/tournament flow:

`SavedDeck.sideboard` → `DeckPicker` (`onDeckChange`) → `GameUI` → `submitLobbyDeck` → `createSubmitSealedDeckMessage(sideboard)` → `ClientMessage.SubmitSealedDeck.sideboard` → `handleLobbyDeckSubmit` → `lobby.submitDeck(sideboard)`.

For a PREMADE/constructed lobby the explicit sideboard is honored; Limited lobbies ignore it and derive from the pool. `createGame`/`joinGame` builders also carry an optional sideboard.

## Verified

- `web-client` `tsc --noEmit` + production build green
- `:game-server` compiles
- Driven in the running app via Playwright — dragging catalog cards into the sideboard populates it (screenshots above)

## Known gaps (noted, not blocking)

- The **Quick-Game-vs-AI** overlay's debounced auto-submit doesn't forward the sideboard yet (it uses a deck-only ref); the standard lobby/tournament path does.
- **Share-link** export doesn't encode the sideboard yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)