### PR TITLE
Wish: land server deck-population + deckbuilder sideboard UI on main

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/SideboardDerivation.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/deck/SideboardDerivation.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.gameserver.deck
+
+import com.wingedsheep.sdk.model.CardDefinition
+
+/**
+ * Derives a Limited player's sideboard from their card pool (CR 100.4b):
+ *
+ * > "In limited play involving individual players, all cards in a player's card pool not included
+ * > in their deck are in that player's sideboard."
+ *
+ * So there is no separate sideboard editor in Sealed/Draft — every opened or drafted card the
+ * player didn't run is automatically their sideboard, and wish effects (Burning Wish, …) draw on
+ * exactly that. The complement is computed server-side at deck-submission time (the only point the
+ * full pool is in scope), counted by card name.
+ *
+ * Basic lands are excluded: they're an unlimited resource in Limited deckbuilding, not finite pool
+ * cards, so "leftover" basics aren't meaningful sideboard material.
+ */
+object SideboardDerivation {
+
+    private val BASIC_LAND_NAMES = setOf("Plains", "Island", "Swamp", "Mountain", "Forest")
+
+    /**
+     * @param pool the player's full sealed/drafted card pool (one entry per physical card)
+     * @param maindeck the submitted deck as card-name → count (includes basics they chose to run)
+     * @return sideboard as card-name → count: `poolCount(name) − deckCount(name)`, clamped at 0,
+     *         excluding basic lands. Empty when the deck uses the whole non-basic pool.
+     */
+    fun fromPool(pool: List<CardDefinition>, maindeck: Map<String, Int>): Map<String, Int> {
+        val poolCounts = pool
+            .map { it.name }
+            .filterNot { it in BASIC_LAND_NAMES }
+            .groupingBy { it }
+            .eachCount()
+
+        return poolCounts
+            .mapValues { (name, available) -> available - (maindeck[name] ?: 0) }
+            .filterValues { it > 0 }
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/FreeForAllHandler.kt
@@ -121,7 +121,10 @@ class FreeForAllHandler(
             val deck = if (commander != null) stripCommanderFromCards(deckWithEgg, commander) else deckWithEgg
 
             val playerSession = identity.toPlayerSession()
-            gameSession.addPlayer(playerSession, deck, commanderCardName = commander)
+            gameSession.addPlayer(
+                playerSession, deck, commanderCardName = commander,
+                sideboard = lobby.getSubmittedSideboard(identity.playerId),
+            )
             gameSession.setPlayerPersistenceInfo(
                 playerSession.playerId, playerSession.playerName, identity.token,
                 isAi = identity.isAi, aiModelOverride = identity.aiModelOverride

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -125,7 +125,9 @@ class GamePlayHandler(
             printingRegistry = printingRegistry,
         )
         gameSession.quickGameSetCode = quickGameSetCode
-        gameSession.addPlayer(playerSession, deckList)
+        // A generated random/quick deck has no sideboard; only a real submitted deck carries one.
+        val sideboard = if (quickGameSetCode != null) emptyMap() else message.sideboard
+        gameSession.addPlayer(playerSession, deckList, sideboard = sideboard)
 
         // Store player info for persistence
         val token = sessionRegistry.getTokenByWsId(session.id)
@@ -261,7 +263,9 @@ class GamePlayHandler(
             message.deckList
         }
 
-        gameSession.addPlayer(playerSession, deckList)
+        // A generated random deck (empty submission) has no sideboard.
+        val sideboard = if (message.deckList.isEmpty()) emptyMap() else message.sideboard
+        gameSession.addPlayer(playerSession, deckList, sideboard = sideboard)
 
         // Store player info for persistence
         val token = sessionRegistry.getTokenByWsId(session.id)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -439,6 +439,7 @@ class LobbyHandler(
                 message.commander,
                 message.cardEntries,
                 message.commanderPrinting,
+                message.sideboard,
             )
             return
         }
@@ -2161,6 +2162,7 @@ class LobbyHandler(
         commander: String? = null,
         cardEntries: List<com.wingedsheep.gameserver.protocol.DeckEntryDTO>? = null,
         commanderPrinting: com.wingedsheep.sdk.model.PrintingRef? = null,
+        sideboard: Map<String, Int> = emptyMap(),
     ) {
         val lobby = lobbyRepository.findLobbyById(lobbyId)
         if (lobby == null) {
@@ -2261,7 +2263,9 @@ class LobbyHandler(
             }
         }
 
-        val result = lobby.submitDeck(identity.playerId, deckList, effectiveCommander)
+        // For a PREMADE_DECKS (constructed) lobby this explicit sideboard is honored; for Limited
+        // lobbies TournamentLobby.submitDeck ignores it and derives pool − maindeck (CR 100.4b).
+        val result = lobby.submitDeck(identity.playerId, deckList, effectiveCommander, sideboard)
         when (result) {
             is TournamentLobby.DeckSubmissionResult.Success -> {
                 val deckSize = deckList.values.sum()

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -512,7 +512,7 @@ class LobbyHandler(
                 ?: throw IllegalStateException("Player $playerId has no submitted deck")
             val deckWithVariants = BoosterGenerator.distributeBasicLandVariants(baseDeck, sealedSession.allBasicLandVariants)
             val deck = EasterEggDeckInjector.maybeInjectEasterEggs(playerState.session.playerName, deckWithVariants)
-            gameSession.addPlayer(playerState.session, deck)
+            gameSession.addPlayer(playerState.session, deck, sideboard = playerState.submittedSideboard)
 
             // Store player info for persistence
             val token = sessionRegistry.getTokenByWsId(playerState.session.webSocketSession.id)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -476,8 +476,14 @@ class TournamentMatchHandler(
         val ps1 = player1State.identity.toPlayerSession()
         val ps2 = player2State.identity.toPlayerSession()
 
-        gameSession.addPlayer(ps1, deck1, commanderCardName = commander1)
-        gameSession.addPlayer(ps2, deck2, commanderCardName = commander2)
+        gameSession.addPlayer(
+            ps1, deck1, commanderCardName = commander1,
+            sideboard = lobby.getSubmittedSideboard(match.player1Id),
+        )
+        gameSession.addPlayer(
+            ps2, deck2, commanderCardName = commander2,
+            sideboard = lobby.getSubmittedSideboard(match.player2Id),
+        )
 
         // Carry isAi / aiModelOverride from each identity so a server restart can rehydrate and
         // re-wire an AI seat. Omitting these persisted the AI as isAi=false, so on recovery it was

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.gameserver.lobby
 
+import com.wingedsheep.gameserver.deck.SideboardDerivation
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.engine.limited.BoosterGenerator
 import com.wingedsheep.gameserver.session.PlayerIdentity
@@ -167,6 +168,13 @@ data class LobbyPlayerState(
      */
     var poolSizeAtRoundStart: Int = 0,
     var submittedDeck: Map<String, Int>? = null,
+    /**
+     * The player's sideboard ("outside the game", CR 100.4), card name → count. In Limited it is
+     * derived as `pool − maindeck` (CR 100.4b) at submission via [SideboardDerivation]; in
+     * PREMADE_DECKS (constructed) it is whatever explicit sideboard the client sent. Seeds the
+     * SIDEBOARD zone at game start so wish effects can fetch from it.
+     */
+    var submittedSideboard: Map<String, Int> = emptyMap(),
     /**
      * Commander card name when the lobby's [TournamentLobby.deckFormat] is commander-shape
      * (Commander / Brawl / Standard Brawl). Null otherwise. The card name is expected to
@@ -1365,6 +1373,7 @@ class TournamentLobby(
         playerId: EntityId,
         deckList: Map<String, Int>,
         commander: String? = null,
+        sideboard: Map<String, Int> = emptyMap(),
     ): DeckSubmissionResult {
         val isPremade = format == TournamentFormat.PREMADE_DECKS
         // PREMADE_DECKS: players pick their deck while WAITING_FOR_PLAYERS, before the host starts.
@@ -1399,8 +1408,18 @@ class TournamentLobby(
             }
         }
 
+        // Sideboard (CR 100.4). In Limited the pool is authoritative, so the sideboard is
+        // *derived* as pool − maindeck (CR 100.4b) and any client-sent value is ignored. In
+        // PREMADE_DECKS (constructed) there is no pool, so the explicit client sideboard is kept.
+        val effectiveSideboard = if (isPremade) {
+            sideboard
+        } else {
+            SideboardDerivation.fromPool(playerState.cardPool, deckList)
+        }
+
         players[playerId] = playerState.copy(
             submittedDeck = deckList,
+            submittedSideboard = effectiveSideboard,
             // Commander is meaningful only for commander-shape deckFormats; keep whatever the
             // caller passed (LobbyHandler is responsible for clearing it for non-commander
             // submissions).
@@ -1430,7 +1449,11 @@ class TournamentLobby(
         }
 
         // Clear deck and ready state
-        players[playerId] = playerState.copy(submittedDeck = null, commander = null)
+        players[playerId] = playerState.copy(
+            submittedDeck = null,
+            submittedSideboard = emptyMap(),
+            commander = null,
+        )
         playersReadyForNextRound.remove(playerId)
         return true
     }
@@ -1495,6 +1518,15 @@ class TournamentLobby(
      */
     fun getSubmittedDeck(playerId: EntityId): Map<String, Int>? {
         return players[playerId]?.submittedDeck
+    }
+
+    /**
+     * Get the player's sideboard ("outside the game", CR 100.4) — card name → count. Derived as
+     * pool − maindeck in Limited, or the explicit constructed sideboard in PREMADE_DECKS. Empty
+     * when the player has no sideboard.
+     */
+    fun getSubmittedSideboard(playerId: EntityId): Map<String, Int> {
+        return players[playerId]?.submittedSideboard ?: emptyMap()
     }
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/GameSessionConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/GameSessionConverter.kt
@@ -22,6 +22,7 @@ fun GameSession.toPersistent(
         sessionId = sessionId,
         gameState = getStateForPersistence(),
         deckLists = getDeckListsForPersistence().mapKeys { it.key.value },
+        sideboards = getSideboardsForPersistence().mapKeys { it.key.value },
         lastProcessedMessageId = getLastMessageIdsForPersistence().mapKeys { it.key.value },
         gameLogs = getLogsForPersistence().mapKeys { it.key.value },
         playerInfos = getPlayerPersistenceInfo().map { (playerId, info) ->
@@ -64,6 +65,7 @@ fun restoreGameSession(
 
     // Convert persisted data back to EntityId-keyed maps
     val deckLists = persistent.deckLists.mapKeys { EntityId(it.key) }
+    val sideboards = persistent.sideboards.mapKeys { EntityId(it.key) }
     val lastMessageIds = persistent.lastProcessedMessageId.mapKeys { EntityId(it.key) }
     val logs = persistent.gameLogs.mapKeys { EntityId(it.key) }
         .mapValues { it.value.toMutableList() }
@@ -73,7 +75,8 @@ fun restoreGameSession(
         state = persistent.gameState,
         decks = deckLists,
         logs = logs,
-        lastIds = lastMessageIds
+        lastIds = lastMessageIds,
+        sideboardLists = sideboards
     )
 
     // Restore player persistence info

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/LobbyConverter.kt
@@ -49,7 +49,8 @@ fun TournamentLobby.toPersistent(): PersistentTournamentLobby {
                 submittedDeck = playerState.submittedDeck,
                 currentSpectatingGameId = playerState.identity.currentSpectatingGameId,
                 isAi = playerState.identity.isAi,
-                aiModelOverride = playerState.identity.aiModelOverride
+                aiModelOverride = playerState.identity.aiModelOverride,
+                submittedSideboard = playerState.submittedSideboard
             )
         },
         currentPackNumber = currentPackNumber,
@@ -152,7 +153,8 @@ fun restoreTournamentLobby(
             cardPool = cardPool,
             currentPack = currentPack,
             packQueue = packQueue,
-            submittedDeck = persistentPlayer.submittedDeck
+            submittedDeck = persistentPlayer.submittedDeck,
+            submittedSideboard = persistentPlayer.submittedSideboard
         )
         lobby.players[playerId] = playerState
     }
@@ -210,7 +212,8 @@ fun SealedSession.toPersistent(): PersistentSealedSession {
                 playerId = playerState.session.playerId.value,
                 playerName = playerState.session.playerName,
                 cardPoolNames = playerState.cardPool.map { it.name },
-                submittedDeck = playerState.submittedDeck
+                submittedDeck = playerState.submittedDeck,
+                submittedSideboard = playerState.submittedSideboard
             )
         }
     )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentGameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentGameSession.kt
@@ -16,7 +16,8 @@ data class PersistentGameSession(
     val lastProcessedMessageId: Map<String, String>,  // playerId.value -> messageId
     val gameLogs: Map<String, List<ClientEvent>>,  // playerId.value -> events
     val playerInfos: List<PersistentPlayerInfo>,
-    val lobbyId: String?
+    val lobbyId: String?,
+    val sideboards: Map<String, List<String>> = emptyMap(),  // playerId.value -> sideboard card names
 )
 
 /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentLobby.kt
@@ -63,7 +63,8 @@ data class PersistentLobbyPlayer(
     val submittedDeck: Map<String, Int>?,  // cardName -> count
     val currentSpectatingGameId: String? = null,  // Game being spectated (for bye players)
     val isAi: Boolean = false,
-    val aiModelOverride: String? = null
+    val aiModelOverride: String? = null,
+    val submittedSideboard: Map<String, Int> = emptyMap(),  // cardName -> count (outside the game)
 )
 
 /**
@@ -86,5 +87,6 @@ data class PersistentSealedPlayer(
     val playerId: String,
     val playerName: String,
     val cardPoolNames: List<String>,
-    val submittedDeck: Map<String, Int>?
+    val submittedDeck: Map<String, Int>?,
+    val submittedSideboard: Map<String, Int> = emptyMap()
 )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -133,6 +133,12 @@ sealed interface ClientMessage {
         val cardEntries: List<DeckEntryDTO>? = null,
         /** Optional pinned printing for [commander]. Ignored when [commander] is null. */
         val commanderPrinting: PrintingRef? = null,
+        /**
+         * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Used for
+         * constructed/premade lobbies; ignored for Limited lobbies, which derive the sideboard as
+         * pool − maindeck server-side (CR 100.4b).
+         */
+        val sideboard: Map<String, Int> = emptyMap(),
     ) : ClientMessage
 
     // =========================================================================

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -35,6 +35,11 @@ sealed interface ClientMessage {
          * is used (no per-card printing pinning).
          */
         val cardEntries: List<DeckEntryDTO>? = null,
+        /**
+         * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Reachable
+         * in-game only by wish effects (Burning Wish, …). Empty for almost every deck.
+         */
+        val sideboard: Map<String, Int> = emptyMap(),
     ) : ClientMessage
 
     /**
@@ -47,6 +52,8 @@ sealed interface ClientMessage {
         val deckList: Map<String, Int>,
         /** Rich, optionally-pinned entries. See [CreateGame.cardEntries]. */
         val cardEntries: List<DeckEntryDTO>? = null,
+        /** Constructed sideboard, card name → count. See [CreateGame.sideboard]. */
+        val sideboard: Map<String, Int> = emptyMap(),
     ) : ClientMessage
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/DeckRequestConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/DeckRequestConverter.kt
@@ -25,13 +25,18 @@ object DeckRequestConverter {
         cardEntries: List<DeckEntryDTO>? = null,
         commander: String? = null,
         commanderPrinting: PrintingRef? = null,
+        sideboard: Map<String, Int> = emptyMap(),
     ): Deck {
+        // Sideboard cards ("outside the game", CR 100.4) are name-only here — wish fetches don't
+        // depend on printing, and the engine seeds the SIDEBOARD zone from these names.
+        val sideboardEntries = sideboard.flatMap { (name, count) -> List(count) { CardEntry(name) } }
         val rich = cardEntries.takeUnless { it.isNullOrEmpty() }
         return if (rich != null) {
             Deck.fromEntries(
                 entries = rich.map { CardEntry(it.name, it.printing) },
                 commander = commander,
                 commanderPrinting = commanderPrinting,
+                sideboard = sideboardEntries,
             )
         } else {
             val cards = deckList.flatMap { (name, count) -> List(count) { name } }
@@ -39,6 +44,7 @@ object DeckRequestConverter {
                 cards = cards,
                 commander = commander,
                 commanderPrinting = commanderPrinting,
+                sideboard = sideboardEntries,
             )
         }
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/sealed/SealedSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/sealed/SealedSession.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.sealed
 
 import com.wingedsheep.engine.limited.BoosterGenerator
+import com.wingedsheep.gameserver.deck.SideboardDerivation
 import com.wingedsheep.gameserver.session.PlayerSession
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
@@ -27,7 +28,12 @@ enum class SealedSessionState {
 data class SealedPlayerState(
     val session: PlayerSession,
     val cardPool: List<CardDefinition>,
-    var submittedDeck: Map<String, Int>? = null
+    var submittedDeck: Map<String, Int>? = null,
+    /**
+     * Sideboard ("outside the game", CR 100.4), card name → count. Derived as `pool − maindeck`
+     * (CR 100.4b) when the deck is submitted; seeds the SIDEBOARD zone at game start.
+     */
+    var submittedSideboard: Map<String, Int> = emptyMap()
 ) {
     val hasSubmittedDeck: Boolean get() = submittedDeck != null
 }
@@ -149,8 +155,11 @@ class SealedSession(
             return DeckSubmissionResult.Error(validationResult)
         }
 
-        // Update player state with submitted deck
-        players[playerId] = playerState.copy(submittedDeck = deckList)
+        // Update player state with submitted deck + derived sideboard (pool − maindeck, CR 100.4b)
+        players[playerId] = playerState.copy(
+            submittedDeck = deckList,
+            submittedSideboard = SideboardDerivation.fromPool(playerState.cardPool, deckList),
+        )
 
         // Update session state
         state = if (bothPlayersSubmitted()) {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -26,6 +26,7 @@ import com.wingedsheep.engine.state.components.player.MulliganStateComponent
 import com.wingedsheep.engine.state.components.player.PlayerLostComponent
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardEntry
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
 import org.slf4j.LoggerFactory
@@ -120,6 +121,12 @@ class GameSession(
 
     private val players = mutableMapOf<EntityId, PlayerSession>()
     private val deckLists = mutableMapOf<EntityId, List<String>>()
+    /**
+     * Per-player sideboard card names ("outside the game", CR 100.4). Flat list, one entry per
+     * copy. Empty for almost every game. Seeds [com.wingedsheep.sdk.core.Zone.SIDEBOARD] at game
+     * start so wish effects (Burning Wish, …) can fetch from it.
+     */
+    private val sideboards = mutableMapOf<EntityId, List<String>>()
     /** Per-player commander card name for commander-shape formats. Null = no commander. */
     private val commanderCardNames = mutableMapOf<EntityId, String>()
     private val spectators = mutableSetOf<PlayerSession>()
@@ -255,6 +262,7 @@ class GameSession(
         playerSession: PlayerSession,
         deckList: Map<String, Int>,
         commanderCardName: String? = null,
+        sideboard: Map<String, Int> = emptyMap(),
     ): EntityId {
         require(!isFull) { "Game session is full" }
 
@@ -266,6 +274,7 @@ class GameSession(
             List(count) { cardName }
         }
         deckLists[playerId] = cards
+        sideboards[playerId] = sideboard.flatMap { (cardName, count) -> List(count) { cardName } }
         if (commanderCardName != null) {
             commanderCardNames[playerId] = commanderCardName
         } else {
@@ -283,6 +292,7 @@ class GameSession(
         players[playerId]?.currentGameSessionId = null
         players.remove(playerId)
         deckLists.remove(playerId)
+        sideboards.remove(playerId)
     }
 
     /**
@@ -404,7 +414,10 @@ class GameSession(
         val playerConfigs = players.map { (playerId, session) ->
             PlayerConfig(
                 name = session.playerName,
-                deck = Deck(deckLists[playerId]!!),
+                deck = Deck(
+                    cards = deckLists[playerId]!!,
+                    sideboard = sideboards[playerId].orEmpty().map { CardEntry(it) },
+                ),
                 playerId = playerId,  // Pass existing player ID to the engine
                 commanderCardName = commanderCardNames[playerId],
             )
@@ -1286,6 +1299,11 @@ class GameSession(
     internal fun getDeckListsForPersistence(): Map<EntityId, List<String>> = deckLists.toMap()
 
     /**
+     * Get the per-player sideboards for persistence. Empty for almost every session.
+     */
+    internal fun getSideboardsForPersistence(): Map<EntityId, List<String>> = sideboards.toMap()
+
+    /**
      * Get the game logs for persistence.
      */
     internal fun getLogsForPersistence(): Map<EntityId, List<ClientEvent>> =
@@ -1308,12 +1326,15 @@ class GameSession(
         state: GameState?,
         decks: Map<EntityId, List<String>>,
         logs: Map<EntityId, MutableList<ClientEvent>>,
-        lastIds: Map<EntityId, String>
+        lastIds: Map<EntityId, String>,
+        sideboardLists: Map<EntityId, List<String>> = emptyMap()
     ) {
         synchronized(stateLock) {
             gameState = state
             deckLists.clear()
             deckLists.putAll(decks)
+            sideboards.clear()
+            sideboards.putAll(sideboardLists)
             gameLogs.clear()
             gameLogs.putAll(logs)
             lastProcessedMessageId.clear()

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/SideboardDerivationTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/deck/SideboardDerivationTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.gameserver.deck
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [SideboardDerivation.fromPool] — the Limited sideboard = pool − maindeck rule
+ * (CR 100.4b).
+ */
+class SideboardDerivationTest : FunSpec({
+
+    fun card(name: String): CardDefinition =
+        CardDefinition.sorcery(name, ManaCost.parse("{1}"), "")
+
+    fun pool(vararg entries: Pair<String, Int>): List<CardDefinition> =
+        entries.flatMap { (name, count) -> List(count) { card(name) } }
+
+    test("leftover non-basic pool cards become the sideboard") {
+        val pool = pool("Lightning Bolt" to 3, "Shock" to 2, "Counterspell" to 1)
+        val deck = mapOf("Lightning Bolt" to 1, "Counterspell" to 1)
+
+        SideboardDerivation.fromPool(pool, deck) shouldBe mapOf(
+            "Lightning Bolt" to 2,  // 3 in pool − 1 played
+            "Shock" to 2,           // 2 in pool − 0 played
+        )
+    }
+
+    test("a card fully used in the deck does not appear in the sideboard") {
+        val pool = pool("Shock" to 2)
+        SideboardDerivation.fromPool(pool, mapOf("Shock" to 2)) shouldBe emptyMap()
+    }
+
+    test("basic lands are never sideboard material even if 'unused' in the pool") {
+        val pool = pool("Mountain" to 10, "Shock" to 1)
+        val deck = mapOf("Mountain" to 7, "Shock" to 1)
+
+        // Mountains are excluded entirely; Shock is fully used → empty sideboard.
+        SideboardDerivation.fromPool(pool, deck) shouldBe emptyMap()
+    }
+
+    test("playing more copies than the pool holds never yields a negative count") {
+        val pool = pool("Shock" to 1)
+        SideboardDerivation.fromPool(pool, mapOf("Shock" to 4)) shouldBe emptyMap()
+    }
+
+    test("an empty deck makes the whole non-basic pool the sideboard") {
+        val pool = pool("Shock" to 2, "Forest" to 5)
+        SideboardDerivation.fromPool(pool, emptyMap()) shouldBe mapOf("Shock" to 2)
+    }
+})

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
@@ -1701,7 +1701,8 @@
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-/* Sideboard ("outside the game") panel — the wish target. Sits below the deck list. */
+/* Sideboard panel — cards kept alongside the deck. Sits below the deck list and is a drop
+   target: drag cards from the catalog grid or the deck list onto it. */
 .sideboardPanel {
   display: flex;
   flex-direction: column;
@@ -1709,6 +1710,13 @@
   padding: var(--space-3);
   border-top: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(106, 163, 255, 0.04);
+  transition: background 0.12s ease, box-shadow 0.12s ease;
+}
+
+/* Active drop state while a card is dragged over the panel. */
+.sideboardPanelDrop {
+  background: rgba(106, 163, 255, 0.14);
+  box-shadow: inset 0 0 0 2px var(--accent-primary, #6aa3ff);
 }
 
 .sideboardHeader {

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
@@ -1701,6 +1701,45 @@
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+/* Sideboard ("outside the game") panel — the wish target. Sits below the deck list. */
+.sideboardPanel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(106, 163, 255, 0.04);
+}
+
+.sideboardHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sideboardTitle {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary, #c7d2e0);
+}
+
+.sideboardHint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  line-height: 1.3;
+}
+
+.sideboardEmpty {
+  margin: 0;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  text-align: center;
+  padding: var(--space-2) 0;
+}
+
 .actionRow {
   display: flex;
   gap: var(--space-2);

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -293,6 +293,11 @@ export function DeckbuilderPage() {
   // Working deck state.
   const [deckName, setDeckName] = useState('Untitled deck')
   const [deckCards, setDeckCards] = useState<Record<string, number>>({})
+  // Constructed sideboard ("outside the game", CR 100.4a) — cards reachable in-game only by wish
+  // effects (Burning Wish, …). Persisted on the saved deck and sent as `sideboard` when playing.
+  // Limited (sealed/draft) decks don't use this: their sideboard is the pool − maindeck complement,
+  // derived server-side (CR 100.4b).
+  const [sideboardCards, setSideboardCards] = useState<Record<string, number>>({})
   const [activeDeckId, setActiveDeckId] = useState<string | null>(null)
   // Pinned printings, keyed by card name. Empty unless the user opens the printing picker
   // and chooses a non-default printing for some row. Persisted via [SavedDeck.entries] (v2)
@@ -788,6 +793,29 @@ export function DeckbuilderPage() {
     })
   }, [])
 
+  // Sideboard add/remove. The 4-of cap (CR 100.2a) applies to deck + sideboard *combined*, so a
+  // card already maxed in the main deck can't also be added to the sideboard.
+  const addToSideboard = useCallback((card: CardSummary) => {
+    setSideboardCards((prev) => {
+      const inSide = prev[card.name] ?? 0
+      const inDeck = deckCards[card.name] ?? 0
+      const cap = effectiveCopyCap(card, isCommanderFormat)
+      if (inDeck + inSide >= cap) return prev
+      return { ...prev, [card.name]: inSide + 1 }
+    })
+  }, [deckCards, isCommanderFormat])
+
+  const removeFromSideboard = useCallback((name: string) => {
+    setSideboardCards((prev) => {
+      const current = prev[name] ?? 0
+      if (current <= 0) return prev
+      const next = { ...prev }
+      if (current === 1) delete next[name]
+      else next[name] = current - 1
+      return next
+    })
+  }, [])
+
   const setPinnedPrinting = useCallback((name: string, printing: PrintingDTO) => {
     setPinnedPrintings((prev) => ({
       ...prev,
@@ -817,6 +845,7 @@ export function DeckbuilderPage() {
   const handleNew = () => {
     setDeckName('Untitled deck')
     setDeckCards({})
+    setSideboardCards({})
     setCommander(null)
     setActiveDeckId(null)
     setPinnedPrintings({})
@@ -839,6 +868,7 @@ export function DeckbuilderPage() {
       ...(designated ? { commander: designated } : {}),
       ...(commanderPrintingForSave ? { commanderPrinting: commanderPrintingForSave } : {}),
       ...(entries ? { entries } : {}),
+      ...(Object.keys(sideboardCards).length > 0 ? { sideboard: sideboardCards } : {}),
     })
     setActiveDeckId(saved.id)
     if (saved.id !== deckId) navigate(`/deckbuilder/${saved.id}${searchSuffix()}`, { replace: true })
@@ -858,6 +888,7 @@ export function DeckbuilderPage() {
       ...(designated ? { commander: designated } : {}),
       ...(commanderPrintingForSave ? { commanderPrinting: commanderPrintingForSave } : {}),
       ...(entries ? { entries } : {}),
+      ...(Object.keys(sideboardCards).length > 0 ? { sideboard: sideboardCards } : {}),
     })
     setDeckName(saved.name)
     setActiveDeckId(saved.id)
@@ -910,6 +941,7 @@ export function DeckbuilderPage() {
   const handleLoadSaved = (deck: SavedDeck) => {
     setDeckName(deck.name)
     setDeckCards(mergeCommanderIntoCards(deck.cards, deck.commander ?? null))
+    setSideboardCards(deck.sideboard ? { ...deck.sideboard } : {})
     setCommander(deck.commander ?? null)
     setActiveDeckId(deck.id)
     setPinnedPrintings(pinnedPrintingsFromEntries(deck.entries, deck.commander, deck.commanderPrinting))
@@ -943,8 +975,11 @@ export function DeckbuilderPage() {
     cards: Record<string, number>,
     suggestedName: string | null,
     importedCommander: string | null,
+    importedSideboard: Record<string, number> = {},
   ) => {
     setDeckCards(cards)
+    // The Arena/MTGO list's "Sideboard"/"SB:" section becomes the wish sideboard (CR 100.4a).
+    setSideboardCards(importedSideboard)
     // The commander designation rides along when the source list had a Commander
     // section; otherwise reset so a stale value from the previous deck doesn't leak.
     setCommander(importedCommander)
@@ -1276,6 +1311,16 @@ export function DeckbuilderPage() {
               onOpenPicker={handleOpenPicker}
             />
 
+            <SideboardPanel
+              sideboardCards={sideboardCards}
+              catalog={catalog}
+              catalogIndex={catalogIndex}
+              activeFormat={activeFormat}
+              isCommanderFormat={isCommanderFormat}
+              onAdd={addToSideboard}
+              onRemove={removeFromSideboard}
+            />
+
             <div className={styles.deckSummaryWrap}>
               <DeckSummary
                 validation={validation}
@@ -1335,6 +1380,16 @@ export function DeckbuilderPage() {
             onHoverLeave={handleDeckHoverLeave}
             pinnedPrintings={pinnedPrintings}
             onOpenPicker={handleOpenPicker}
+          />
+
+          <SideboardPanel
+            sideboardCards={sideboardCards}
+            catalog={catalog}
+            catalogIndex={catalogIndex}
+            activeFormat={activeFormat}
+            isCommanderFormat={isCommanderFormat}
+            onAdd={addToSideboard}
+            onRemove={removeFromSideboard}
           />
 
           <DeckCentricFooter
@@ -1565,6 +1620,7 @@ function ImportDeckModal({
     cards: Record<string, number>,
     suggestedName: string | null,
     commander: string | null,
+    sideboard: Record<string, number>,
   ) => void
 }) {
   const [text, setText] = useState('')
@@ -1606,7 +1662,11 @@ function ImportDeckModal({
       ? catalog.find((c) => c.name.toLowerCase() === commanderEntry.name.toLowerCase())?.name
         ?? commanderEntry.name
       : null
-    onImport(merged, preview.parsed.deckName ?? null, commanderName)
+    // Resolve the "Sideboard"/"SB:" section against the catalog the same way as the main deck,
+    // so the imported sideboard becomes the wish sideboard (unknown cards survive as placeholders).
+    const sideResolved = resolveAgainstCatalog(preview.parsed.sideboard, catalog)
+    const sideboard = { ...sideResolved.deckCards, ...sideResolved.unmatchedCards }
+    onImport(merged, preview.parsed.deckName ?? null, commanderName, sideboard)
   }
 
   return (
@@ -3750,6 +3810,7 @@ function DeckListPanel({
   pinnedPrintings,
   pinnedPrintingArt,
   onOpenPicker,
+  hideBasicLandHelpers = false,
 }: {
   deckCards: Record<string, number>
   catalog: Record<string, CardSummary>
@@ -3765,10 +3826,12 @@ function DeckListPanel({
   pinnedPrintings: Record<string, PrintingRef>
   pinnedPrintingArt: Record<string, { imageUri: string | null; backFaceImageUri: string | null }>
   onOpenPicker: (name: string) => void
+  // Sideboard use: suppress the "Suggest basic lands" button and the 0-count basic placeholders.
+  hideBasicLandHelpers?: boolean
 }) {
   const grouped = useMemo(
-    () => groupForDeckList(deckCards, catalog, commander),
-    [deckCards, catalog, commander],
+    () => groupForDeckList(deckCards, catalog, commander, hideBasicLandHelpers),
+    [deckCards, catalog, commander, hideBasicLandHelpers],
   )
   const [hoverCard, setHoverCard] = useState<CardSummary | null>(null)
   const [hoverName, setHoverName] = useState<string | null>(null)
@@ -3833,7 +3896,7 @@ function DeckListPanel({
             <h3 className={styles.deckGroupLabel}>
               {group.label} ({group.entries.reduce((a, e) => a + e.count, 0)})
             </h3>
-            {group.label === 'Lands' && (
+            {group.label === 'Lands' && !hideBasicLandHelpers && (
               <button
                 type="button"
                 className={styles.basicLandsSuggest}
@@ -3877,6 +3940,83 @@ function DeckListPanel({
         imageRotateDeg={splitImageRotateDeg(effectiveHoverCard)}
       />
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sideboard panel — the constructed "outside the game" list (CR 100.4a) that
+// wish effects (Burning Wish, …) fetch from. Reuses AddCardSearch for input and
+// DeckListPanel for the rows, with commander/printing/validation chrome turned
+// off (a sideboard has no commander, and the 4-of cap is enforced combined with
+// the main deck at add-time). Limited decks never use this — their sideboard is
+// the pool − maindeck complement, derived server-side (CR 100.4b).
+// ---------------------------------------------------------------------------
+
+const SB_NOOP = () => {}
+const SB_NOOP_NAME = (_name: string) => {}
+const SB_NO_VIOLATIONS: Map<string, Set<string>> = new Map()
+const SB_NO_PRINTINGS: Record<string, PrintingRef> = {}
+const SB_NO_PRINTING_ART: Record<string, { imageUri: string | null; backFaceImageUri: string | null }> = {}
+
+function SideboardPanel({
+  sideboardCards,
+  catalog,
+  catalogIndex,
+  activeFormat,
+  isCommanderFormat,
+  onAdd,
+  onRemove,
+}: {
+  sideboardCards: Record<string, number>
+  catalog: CardSummary[]
+  catalogIndex: Record<string, CardSummary>
+  activeFormat: string | null
+  isCommanderFormat: boolean
+  onAdd: (card: CardSummary) => void
+  onRemove: (name: string) => void
+}) {
+  const total = Object.values(sideboardCards).reduce((a, b) => a + b, 0)
+  return (
+    <section className={styles.sideboardPanel} aria-label="Sideboard">
+      <div className={styles.sideboardHeader}>
+        <h3 className={styles.sideboardTitle}>Sideboard{total > 0 ? ` (${total})` : ''}</h3>
+        <span className={styles.sideboardHint}>
+          Cards “outside the game” — wishes (Burning Wish…) fetch from here.
+        </span>
+      </div>
+      <AddCardSearch
+        catalog={catalog}
+        deckCards={sideboardCards}
+        isCommanderFormat={isCommanderFormat}
+        onAdd={onAdd}
+        onSuggestBasics={SB_NOOP}
+        hideSuggestBasics
+        placeholder="Find and add cards to your sideboard…"
+      />
+      {total > 0 ? (
+        <DeckListPanel
+          deckCards={sideboardCards}
+          catalog={catalogIndex}
+          activeFormat={activeFormat}
+          onAdd={onAdd}
+          onRemove={onRemove}
+          commander={null}
+          showCommanderControls={false}
+          onToggleCommander={SB_NOOP_NAME}
+          rowViolations={SB_NO_VIOLATIONS}
+          isCommanderFormat={isCommanderFormat}
+          onSuggestBasics={SB_NOOP}
+          pinnedPrintings={SB_NO_PRINTINGS}
+          pinnedPrintingArt={SB_NO_PRINTING_ART}
+          onOpenPicker={SB_NOOP_NAME}
+          hideBasicLandHelpers
+        />
+      ) : (
+        <p className={styles.sideboardEmpty}>
+          Search above to add cards your wishes can fetch. Optional — most decks leave this empty.
+        </p>
+      )}
+    </section>
   )
 }
 
@@ -4104,12 +4244,16 @@ function AddCardSearch({
   isCommanderFormat,
   onAdd,
   onSuggestBasics,
+  hideSuggestBasics = false,
+  placeholder = 'Find and add cards to your deck…',
 }: {
   catalog: CardSummary[]
   deckCards: Record<string, number>
   isCommanderFormat: boolean
   onAdd: (card: CardSummary) => void
   onSuggestBasics: () => void
+  hideSuggestBasics?: boolean
+  placeholder?: string
 }) {
   const [text, setText] = useState('')
   const [open, setOpen] = useState(false)
@@ -4192,18 +4336,20 @@ function AddCardSearch({
             handleAdd(matches[0]!)
           }
         }}
-        placeholder="Find and add cards to your deck…"
-        aria-label="Find and add cards to your deck"
+        placeholder={placeholder}
+        aria-label={placeholder}
       />
-      <button
-        type="button"
-        className={styles.addCardBasicsButton}
-        onClick={onSuggestBasics}
-        disabled={Object.keys(deckCards).length === 0}
-        title="Auto-fill basic lands (Plains, Island, Swamp, Mountain, Forest) from your deck's mana curve and color requirements"
-      >
-        Suggest basic lands
-      </button>
+      {!hideSuggestBasics && (
+        <button
+          type="button"
+          className={styles.addCardBasicsButton}
+          onClick={onSuggestBasics}
+          disabled={Object.keys(deckCards).length === 0}
+          title="Auto-fill basic lands (Plains, Island, Swamp, Mountain, Forest) from your deck's mana curve and color requirements"
+        >
+          Suggest basic lands
+        </button>
+      )}
       {open && matches.length > 0 && (
         <div className={styles.addCardDropdown} role="listbox">
           {matches.map((card) => {
@@ -4460,6 +4606,9 @@ function groupForDeckList(
   deck: Record<string, number>,
   catalog: Record<string, CardSummary>,
   commander: string | null,
+  // When true (sideboard use), don't inject the 0-count basic-land sticky rows — a sideboard
+  // shouldn't show an empty mana base. Basics actually present in the sideboard still appear.
+  hideEmptyBasics = false,
 ): DeckGroup[] {
   const spells: DeckGroup['entries'] = []
   const lands: DeckGroup['entries'] = []
@@ -4487,7 +4636,9 @@ function groupForDeckList(
   for (const basicName of BASIC_LAND_ORDER) {
     const card = catalog[basicName]
     if (!card) continue
-    basicEntries.push({ name: basicName, count: deck[basicName] ?? 0, card })
+    const count = deck[basicName] ?? 0
+    if (hideEmptyBasics && count <= 0) continue
+    basicEntries.push({ name: basicName, count, card })
   }
   const allLands = [...lands, ...basicEntries]
   const groups: DeckGroup[] = []

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -1309,16 +1309,17 @@ export function DeckbuilderPage() {
               pinnedPrintings={pinnedPrintings}
               pinnedPrintingArt={pinnedPrintingArt}
               onOpenPicker={handleOpenPicker}
+              rowDragSource="deck"
             />
 
             <SideboardPanel
               sideboardCards={sideboardCards}
-              catalog={catalog}
               catalogIndex={catalogIndex}
               activeFormat={activeFormat}
               isCommanderFormat={isCommanderFormat}
               onAdd={addToSideboard}
               onRemove={removeFromSideboard}
+              onMoveFromDeck={removeCard}
             />
 
             <div className={styles.deckSummaryWrap}>
@@ -1384,12 +1385,12 @@ export function DeckbuilderPage() {
 
           <SideboardPanel
             sideboardCards={sideboardCards}
-            catalog={catalog}
             catalogIndex={catalogIndex}
             activeFormat={activeFormat}
             isCommanderFormat={isCommanderFormat}
             onAdd={addToSideboard}
             onRemove={removeFromSideboard}
+            onMoveFromDeck={removeCard}
           />
 
           <DeckCentricFooter
@@ -3630,6 +3631,8 @@ const CardTile = memo(function CardTile({
     <div
       ref={ref}
       className={styles.cardTile}
+      draggable
+      onDragStart={(e) => setCardDragData(e, card.name, 'catalog')}
       onClick={handleClick}
       onContextMenu={handleContextMenu}
       onMouseEnter={() => onHover(card)}
@@ -3811,6 +3814,7 @@ function DeckListPanel({
   pinnedPrintingArt,
   onOpenPicker,
   hideBasicLandHelpers = false,
+  rowDragSource,
 }: {
   deckCards: Record<string, number>
   catalog: Record<string, CardSummary>
@@ -3828,6 +3832,9 @@ function DeckListPanel({
   onOpenPicker: (name: string) => void
   // Sideboard use: suppress the "Suggest basic lands" button and the 0-count basic placeholders.
   hideBasicLandHelpers?: boolean
+  // When set, rows are draggable with this source tag (the main deck uses 'deck' so rows can be
+  // dragged into the sideboard). Omitted for the sideboard's own list.
+  rowDragSource?: CardDragSource
 }) {
   const grouped = useMemo(
     () => groupForDeckList(deckCards, catalog, commander, hideBasicLandHelpers),
@@ -3924,6 +3931,7 @@ function DeckListPanel({
               onLeave={handleLeave}
               pinnedPrinting={pinnedPrintings[entry.name]}
               onOpenPicker={onOpenPicker}
+              {...(rowDragSource ? { dragSource: rowDragSource } : {})}
             />
           ))}
         </div>
@@ -3958,41 +3966,88 @@ const SB_NO_VIOLATIONS: Map<string, Set<string>> = new Map()
 const SB_NO_PRINTINGS: Record<string, PrintingRef> = {}
 const SB_NO_PRINTING_ART: Record<string, { imageUri: string | null; backFaceImageUri: string | null }> = {}
 
+// Drag payload shared by the card grid, deck rows, and the sideboard drop zone. We carry both a
+// custom MIME (so we can tag where the drag started) and `text/plain` (so the drag still has a
+// sane fallback). `source` lets the sideboard treat a card dragged out of the main deck as a
+// *move* (remove one there, add one here) versus a catalog drag as a plain add.
+const CARD_DRAG_MIME = 'application/x-argentum-card'
+type CardDragSource = 'catalog' | 'deck'
+
+function setCardDragData(e: React.DragEvent, name: string, source: CardDragSource) {
+  e.dataTransfer.setData(CARD_DRAG_MIME, JSON.stringify({ name, source }))
+  e.dataTransfer.setData('text/plain', name)
+  e.dataTransfer.effectAllowed = 'copyMove'
+}
+
+function readCardDragData(e: React.DragEvent): { name: string; source: CardDragSource } | null {
+  const raw = e.dataTransfer.getData(CARD_DRAG_MIME)
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as { name: string; source: CardDragSource }
+      if (parsed.name) return parsed
+    } catch {
+      // fall through to the text/plain fallback
+    }
+  }
+  const name = e.dataTransfer.getData('text/plain')
+  return name ? { name, source: 'catalog' } : null
+}
+
 function SideboardPanel({
   sideboardCards,
-  catalog,
   catalogIndex,
   activeFormat,
   isCommanderFormat,
   onAdd,
   onRemove,
+  onMoveFromDeck,
 }: {
   sideboardCards: Record<string, number>
-  catalog: CardSummary[]
   catalogIndex: Record<string, CardSummary>
   activeFormat: string | null
   isCommanderFormat: boolean
   onAdd: (card: CardSummary) => void
   onRemove: (name: string) => void
+  // Move one copy out of the main deck (used when a deck row is dragged into the sideboard).
+  onMoveFromDeck: (name: string) => void
 }) {
   const total = Object.values(sideboardCards).reduce((a, b) => a + b, 0)
+  const [dragActive, setDragActive] = useState(false)
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setDragActive(false)
+    const payload = readCardDragData(e)
+    if (!payload) return
+    const card = catalogIndex[payload.name]
+    if (!card) return
+    // Dragged out of the main deck → move it (the combined 4-of cap means a plain add could
+    // otherwise be a silent no-op when the deck already holds the max).
+    if (payload.source === 'deck') onMoveFromDeck(payload.name)
+    onAdd(card)
+  }
+
   return (
-    <section className={styles.sideboardPanel} aria-label="Sideboard">
+    <section
+      className={`${styles.sideboardPanel} ${dragActive ? styles.sideboardPanelDrop : ''}`}
+      aria-label="Sideboard"
+      onDragOver={(e) => {
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'copy'
+        if (!dragActive) setDragActive(true)
+      }}
+      onDragLeave={(e) => {
+        // Only clear when the pointer actually leaves the panel, not when crossing child elements.
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragActive(false)
+      }}
+      onDrop={handleDrop}
+    >
       <div className={styles.sideboardHeader}>
         <h3 className={styles.sideboardTitle}>Sideboard{total > 0 ? ` (${total})` : ''}</h3>
         <span className={styles.sideboardHint}>
-          Cards “outside the game” — wishes (Burning Wish…) fetch from here.
+          Cards kept alongside your deck. Drag cards here from the grid or your deck list.
         </span>
       </div>
-      <AddCardSearch
-        catalog={catalog}
-        deckCards={sideboardCards}
-        isCommanderFormat={isCommanderFormat}
-        onAdd={onAdd}
-        onSuggestBasics={SB_NOOP}
-        hideSuggestBasics
-        placeholder="Find and add cards to your sideboard…"
-      />
       {total > 0 ? (
         <DeckListPanel
           deckCards={sideboardCards}
@@ -4013,7 +4068,7 @@ function SideboardPanel({
         />
       ) : (
         <p className={styles.sideboardEmpty}>
-          Search above to add cards your wishes can fetch. Optional — most decks leave this empty.
+          Drag cards here to set them aside. Optional — most decks leave this empty.
         </p>
       )}
     </section>
@@ -4045,6 +4100,7 @@ const DeckRow = memo(function DeckRow({
   onLeave,
   pinnedPrinting,
   onOpenPicker,
+  dragSource,
 }: {
   entry: { name: string; count: number; card: CardSummary | undefined }
   activeFormat: string | null
@@ -4059,6 +4115,8 @@ const DeckRow = memo(function DeckRow({
   onLeave: () => void
   pinnedPrinting: PrintingRef | undefined
   onOpenPicker: (name: string) => void
+  // When set, the row can be dragged (e.g. into the sideboard) carrying this source tag.
+  dragSource?: CardDragSource
 }) {
   const illegal =
     activeFormat !== null &&
@@ -4134,6 +4192,12 @@ const DeckRow = memo(function DeckRow({
     <div
       className={rowClasses}
       title={rowTitle}
+      {...(dragSource
+        ? {
+            draggable: true,
+            onDragStart: (e: React.DragEvent) => setCardDragData(e, entry.name, dragSource),
+          }
+        : {})}
       onMouseEnter={() => onEnter(entry)}
       onMouseLeave={onLeave}
     >
@@ -4244,16 +4308,12 @@ function AddCardSearch({
   isCommanderFormat,
   onAdd,
   onSuggestBasics,
-  hideSuggestBasics = false,
-  placeholder = 'Find and add cards to your deck…',
 }: {
   catalog: CardSummary[]
   deckCards: Record<string, number>
   isCommanderFormat: boolean
   onAdd: (card: CardSummary) => void
   onSuggestBasics: () => void
-  hideSuggestBasics?: boolean
-  placeholder?: string
 }) {
   const [text, setText] = useState('')
   const [open, setOpen] = useState(false)
@@ -4336,20 +4396,18 @@ function AddCardSearch({
             handleAdd(matches[0]!)
           }
         }}
-        placeholder={placeholder}
-        aria-label={placeholder}
+        placeholder="Find and add cards to your deck…"
+        aria-label="Find and add cards to your deck"
       />
-      {!hideSuggestBasics && (
-        <button
-          type="button"
-          className={styles.addCardBasicsButton}
-          onClick={onSuggestBasics}
-          disabled={Object.keys(deckCards).length === 0}
-          title="Auto-fill basic lands (Plains, Island, Swamp, Mountain, Forest) from your deck's mana curve and color requirements"
-        >
-          Suggest basic lands
-        </button>
-      )}
+      <button
+        type="button"
+        className={styles.addCardBasicsButton}
+        onClick={onSuggestBasics}
+        disabled={Object.keys(deckCards).length === 0}
+        title="Auto-fill basic lands (Plains, Island, Swamp, Mountain, Forest) from your deck's mana curve and color requirements"
+      >
+        Suggest basic lands
+      </button>
       {open && matches.length > 0 && (
         <div className={styles.addCardDropdown} role="listbox">
           {matches.map((card) => {
@@ -4474,6 +4532,7 @@ function DeckCentricView({
                 onLeave={onHoverLeave}
                 pinnedPrinting={pinnedPrintings[entry.name]}
                 onOpenPicker={onOpenPicker}
+                dragSource="deck"
               />
             ))}
           </div>

--- a/web-client/src/components/ui/DeckPicker.tsx
+++ b/web-client/src/components/ui/DeckPicker.tsx
@@ -53,7 +53,11 @@ export interface DeckPickerProps {
    * Game / Premade-Decks tournament flows pass it through to the server so commander-shape
    * formats can wire the engine into Format.Commander.
    */
-  onDeckChange: (deckList: Record<string, number>, commander?: string | null) => void
+  onDeckChange: (
+    deckList: Record<string, number>,
+    commander?: string | null,
+    sideboard?: Record<string, number>,
+  ) => void
   onValidityChange?: (isValid: boolean) => void
   /**
    * Optional set selection callback for the "Random" tab. When the picker is on Random and
@@ -283,6 +287,18 @@ export function DeckPicker({
     return null
   }, [tab, decks, selectedSavedId, pasteCommander])
 
+  // The constructed sideboard ("outside the game", CR 100.4a) the wish effects fetch from. Only
+  // saved decks carry one (the deckbuilder persists it); paste/random/examples have none. The
+  // server ignores it for Limited lobbies (those derive pool − maindeck) and uses it for
+  // constructed/premade ones.
+  const currentSideboard: Record<string, number> = useMemo(() => {
+    if (tab === 'saved') {
+      const saved = decks.find((d) => d.id === selectedSavedId)
+      return saved?.sideboard ?? {}
+    }
+    return {}
+  }, [tab, decks, selectedSavedId])
+
   // Strip the commander out of `currentDeck` before crossing the network boundary. `currentDeck`
   // keeps the commander baked in so the totalCards display reads "100 cards" for a Commander
   // deck, but the server's `Deck.cards` is documented as the library only (CR 903.6a) — the
@@ -300,8 +316,8 @@ export function DeckPicker({
   // On the Random tab `{}` *is* the chosen deck (server generates a random pool), so emit it.
   useEffect(() => {
     if (tab !== 'random' && Object.keys(currentDeck).length === 0) return
-    onDeckChange(deckListForServer, currentCommander)
-  }, [tab, currentDeck, deckListForServer, currentCommander, onDeckChange])
+    onDeckChange(deckListForServer, currentCommander, currentSideboard)
+  }, [tab, currentDeck, deckListForServer, currentCommander, currentSideboard, onDeckChange])
 
   // Server-side validation when the deck is non-empty.
   useEffect(() => {

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -1676,12 +1676,14 @@ function PremadeDeckPickerPanel({ lobbyState }: { lobbyState: LobbyState }) {
 
   const [pendingDeck, setPendingDeck] = useState<Record<string, number>>({})
   const [pendingCommander, setPendingCommander] = useState<string | null>(null)
+  const [pendingSideboard, setPendingSideboard] = useState<Record<string, number>>({})
   const [isValid, setIsValid] = useState(false)
 
   const handleDeckChange = useCallback(
-    (deck: Record<string, number>, commander?: string | null) => {
+    (deck: Record<string, number>, commander?: string | null, sideboard?: Record<string, number>) => {
       setPendingDeck(deck)
       setPendingCommander(commander ?? null)
+      setPendingSideboard(sideboard ?? {})
     },
     [],
   )
@@ -1733,7 +1735,7 @@ function PremadeDeckPickerPanel({ lobbyState }: { lobbyState: LobbyState }) {
           format={deckFormat ?? null}
         />
         <button
-          onClick={() => submitLobbyDeck(pendingDeck, isCommanderShape ? pendingCommander : null)}
+          onClick={() => submitLobbyDeck(pendingDeck, isCommanderShape ? pendingCommander : null, pendingSideboard)}
           disabled={!canSubmit}
           title={submitTitle}
           className={styles.startButton}

--- a/web-client/src/store/deckLibrary.ts
+++ b/web-client/src/store/deckLibrary.ts
@@ -56,6 +56,14 @@ export interface SavedDeck {
    * in sync so legacy code paths (counts, summaries) keep working unchanged.
    */
   entries?: readonly SavedDeckEntry[]
+  /**
+   * Optional — the constructed sideboard ("outside the game", CR 100.4a), card name → count.
+   * Reachable in-game only by wish effects (Burning Wish, …). Sent over the wire as `sideboard`
+   * and seeded into the engine's SIDEBOARD zone. Absent/empty for almost every deck. (Limited
+   * decks don't store this — their sideboard is the pool − maindeck complement, derived
+   * server-side, CR 100.4b.)
+   */
+  sideboard?: Record<string, number>
   updatedAt: number
 }
 
@@ -247,6 +255,9 @@ export const useDeckLibrary = create<DeckLibraryState>((set, get) => ({
       ...(input.commander !== undefined ? { commander: input.commander } : {}),
       ...(input.commanderPrinting !== undefined ? { commanderPrinting: input.commanderPrinting } : {}),
       ...(input.entries !== undefined ? { entries: input.entries } : {}),
+      ...(input.sideboard !== undefined && Object.keys(input.sideboard).length > 0
+        ? { sideboard: input.sideboard }
+        : {}),
       updatedAt: now,
     }
     const decks = existing

--- a/web-client/src/store/slices/lobbySlice.ts
+++ b/web-client/src/store/slices/lobbySlice.ts
@@ -53,7 +53,11 @@ export interface LobbySliceActions {
    * Submit a deck directly from the lobby (Premade Decks tournament format).
    * For Sealed/Draft, players use the dedicated deckbuilder instead via `submitSealedDeck`.
    */
-  submitLobbyDeck: (deckList: Record<string, number>, commander?: string | null) => void
+  submitLobbyDeck: (
+    deckList: Record<string, number>,
+    commander?: string | null,
+    sideboard?: Record<string, number>,
+  ) => void
   /** Unsubmit (and re-edit) a previously submitted lobby deck. */
   unsubmitLobbyDeck: () => void
 }
@@ -146,12 +150,12 @@ export const createLobbySlice: SliceCreator<LobbySlice> = (set, get) => ({
     set({ spectatingState: state })
   },
 
-  submitLobbyDeck: (deckList, commander) => {
+  submitLobbyDeck: (deckList, commander, sideboard) => {
     trackEvent('premade_deck_submitted', {
       deck_size: Object.values(deckList).reduce((a, b) => a + b, 0),
       has_commander: !!commander,
     })
-    getWebSocket()?.send(createSubmitSealedDeckMessage(deckList, commander))
+    getWebSocket()?.send(createSubmitSealedDeckMessage(deckList, commander, undefined, undefined, sideboard))
   },
 
   unsubmitLobbyDeck: () => {

--- a/web-client/src/store/slices/types.ts
+++ b/web-client/src/store/slices/types.ts
@@ -886,7 +886,11 @@ export type GameStore = {
   kickPlayer: (playerId: string) => void
   leaveTournament: () => void
   /** Submit a deck directly from the lobby (Premade Decks tournament format). */
-  submitLobbyDeck: (deckList: Record<string, number>, commander?: string | null) => void
+  submitLobbyDeck: (
+    deckList: Record<string, number>,
+    commander?: string | null,
+    sideboard?: Record<string, number>,
+  ) => void
   unsubmitLobbyDeck: () => void
 
   // Quick Game Lobby slice

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1824,6 +1824,8 @@ export interface CreateGameMessage {
   readonly setCode?: string
   /** Rich entries with optional pinned printings. See [DeckEntry]. */
   readonly cardEntries?: readonly DeckEntry[]
+  /** Constructed sideboard ("outside the game", CR 100.4a), card name → count. Wish target. */
+  readonly sideboard?: Record<string, number>
 }
 
 /**
@@ -1834,6 +1836,8 @@ export interface JoinGameMessage {
   readonly sessionId: string
   readonly deckList: Record<string, number>
   readonly cardEntries?: readonly DeckEntry[]
+  /** Constructed sideboard, card name → count. See [CreateGameMessage.sideboard]. */
+  readonly sideboard?: Record<string, number>
 }
 
 /**
@@ -1914,6 +1918,12 @@ export interface SubmitSealedDeckMessage {
   readonly cardEntries?: readonly DeckEntry[]
   /** Optional pinned printing for the commander. Ignored when `commander` is null. */
   readonly commanderPrinting?: PrintingRef
+  /**
+   * Constructed sideboard ("outside the game", CR 100.4a), card name → count. Used for
+   * constructed/premade lobbies; ignored for Limited lobbies, which derive the sideboard as
+   * pool − maindeck server-side (CR 100.4b).
+   */
+  readonly sideboard?: Record<string, number>
 }
 
 // ============================================================================
@@ -2002,6 +2012,7 @@ export function createCreateGameMessage(
   vsAi?: boolean,
   setCode?: string,
   cardEntries?: readonly DeckEntry[],
+  sideboard?: Record<string, number>,
 ): CreateGameMessage {
   const msg: CreateGameMessage = {
     type: 'createGame',
@@ -2009,6 +2020,7 @@ export function createCreateGameMessage(
     ...(vsAi ? { vsAi } : {}),
     ...(setCode ? { setCode } : {}),
     ...(cardEntries && cardEntries.length > 0 ? { cardEntries } : {}),
+    ...(sideboard && Object.keys(sideboard).length > 0 ? { sideboard } : {}),
   }
   return msg
 }
@@ -2017,12 +2029,14 @@ export function createJoinGameMessage(
   sessionId: string,
   deckList: Record<string, number>,
   cardEntries?: readonly DeckEntry[],
+  sideboard?: Record<string, number>,
 ): JoinGameMessage {
   return {
     type: 'joinGame',
     sessionId,
     deckList,
     ...(cardEntries && cardEntries.length > 0 ? { cardEntries } : {}),
+    ...(sideboard && Object.keys(sideboard).length > 0 ? { sideboard } : {}),
   }
 }
 
@@ -2064,6 +2078,7 @@ export function createSubmitSealedDeckMessage(
   commander?: string | null,
   cardEntries?: readonly DeckEntry[],
   commanderPrinting?: PrintingRef,
+  sideboard?: Record<string, number>,
 ): SubmitSealedDeckMessage {
   return {
     type: 'submitSealedDeck',
@@ -2071,6 +2086,7 @@ export function createSubmitSealedDeckMessage(
     ...(commander ? { commander } : {}),
     ...(cardEntries && cardEntries.length > 0 ? { cardEntries } : {}),
     ...(commanderPrinting ? { commanderPrinting } : {}),
+    ...(sideboard && Object.keys(sideboard).length > 0 ? { sideboard } : {}),
   }
 }
 


### PR DESCRIPTION
The three wish PRs were merged **stacked**, so only #968 (engine mechanic) reached `main` — it merged before #972/#973 landed in their intermediate base branches. This brings the remaining two onto `main`:

- **#972** — server deck-population + Limited (sealed/draft) sideboards (pool − maindeck, CR 100.4b)
- **#973** — constructed deckbuilder sideboard UI (drag-to-add) + play-path wiring

No new code — these are the already-reviewed-and-merged commits, now retargeted to `main`. Merge is **conflict-free** against current `main` (verified with `git merge-tree`); `main`'s 19 newer commits (PRs #969–#971, SDK audit) are untouched.

Net diff vs `main` is just the sideboard work: `SideboardDerivation` + game-server deck threading, and the deckbuilder `SideboardPanel` + client deck-submission plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)