### PR TITLE
FIN: Suplex, Tellah, You're Not Alone

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Suplex.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Suplex.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+
+/**
+ * Suplex
+ * {1}{R}
+ * Sorcery
+ * Choose one —
+ * • Suplex deals 3 damage to target creature. If that creature would die this turn, exile it instead.
+ * • Exile target artifact.
+ */
+val Suplex = card("Suplex") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n• Suplex deals 3 damage to target creature. If that creature would die this turn, exile it instead.\n• Exile target artifact."
+    spell {
+        modal(chooseCount = 1) {
+            mode("Suplex deals 3 damage to target creature. If that creature would die this turn, exile it instead") {
+                val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+                effect = Effects.Composite(
+                    DealDamageEffect(3, t),
+                    MarkExileOnDeathEffect(t)
+                )
+            }
+            mode("Exile target artifact") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.Artifact))
+                effect = Effects.Exile(t)
+            }
+        }
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Fang Xinyu"
+        flavorText = "\"The time has come to put my training to use!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f61693a2-7042-44e0-85ba-9bf12ab94e7e.jpg?1748706376"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TellahGreatSage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TellahGreatSage.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+
+/**
+ * Tellah, Great Sage
+ * {3}{U}{R}
+ * Legendary Creature — Human Wizard
+ * 3/3
+ * Whenever you cast a noncreature spell, create a 1/1 colorless Hero creature token. If four or
+ * more mana was spent to cast that spell, draw two cards. If eight or more mana was spent to cast
+ * that spell, sacrifice Tellah and it deals that much damage to each opponent.
+ */
+val TellahGreatSage = card("Tellah, Great Sage") {
+    manaCost = "{3}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Human Wizard"
+    oracleText = "Whenever you cast a noncreature spell, create a 1/1 colorless Hero creature token. If four or more mana was spent to cast that spell, draw two cards. If eight or more mana was spent to cast that spell, sacrifice Tellah and it deals that much damage to each opponent."
+    power = 3
+    toughness = 3
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                creatureTypes = setOf("Hero"),
+                imageUri = "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030",
+            ),
+            ConditionalEffect(
+                condition = Compare(
+                    DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(4)
+                ),
+                effect = DrawCardsEffect(2)
+            ),
+            ConditionalEffect(
+                condition = Compare(
+                    DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(8)
+                ),
+                effect = Effects.Composite(
+                    SacrificeSelfEffect,
+                    DealDamageEffect(
+                        DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+                        EffectTarget.PlayerRef(Player.EachOpponent)
+                    )
+                )
+            )
+        )
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "244"
+        artist = "Yumi Yaoshida"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a67793ef-ef80-4434-9c54-e3fd8a270bbe.jpg?1748706698"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/YoureNotAlone.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/YoureNotAlone.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * You're Not Alone
+ * {W}
+ * Instant
+ * Target creature gets +2/+2 until end of turn. If you control three or more creatures, it gets
+ * +4/+4 until end of turn instead.
+ *
+ * The "instead" swaps the buff amount based on how many creatures you control at resolution; both
+ * branches buff the same target until end of turn.
+ */
+val YoureNotAlone = card("You're Not Alone") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 until end of turn. If you control three or more creatures, it gets +4/+4 until end of turn instead."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = ConditionalEffect(
+            condition = Conditions.ControlCreaturesAtLeast(3),
+            effect = Effects.ModifyStats(4, 4, t),
+            elseEffect = Effects.ModifyStats(2, 2, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "44"
+        artist = "Ignatius Budi"
+        flavorText = "\"You've always protected us. But you still don't understand that we looked out for you, too!\"\n—Dagger"
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/1867b5cb-2bb0-4f49-b302-036fdffa2344.jpg?1748705918"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -7849,6 +7849,198 @@
     ]
 }
 
+// Suplex
+{
+    "name": "Suplex",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Suplex deals 3 damage to target creature. If that creature would die this turn, exile it instead.\n• Exile target artifact.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            {
+                                "type": "MarkExileOnDeath",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Suplex deals 3 damage to target creature. If that creature would die this turn, exile it instead"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Exile"
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Exile target artifact"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Fang Xinyu",
+        "flavorText": "\"The time has come to put my training to use!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f61693a2-7042-44e0-85ba-9bf12ab94e7e.jpg?1748706376"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Tellah, Great Sage
+{
+    "name": "Tellah, Great Sage",
+    "manaCost": "{3}{U}{R}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Whenever you cast a noncreature spell, create a 1/1 colorless Hero creature token. If four or more mana was spent to cast that spell, draw two cards. If eight or more mana was spent to cast that spell, sacrifice Tellah and it deals that much damage to each opponent.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "ContextProperty",
+                                        "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "ContextProperty",
+                                        "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 8
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    "SacrificeSelf",
+                                    {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "ContextProperty",
+                                            "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "EachOpponent"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "244",
+        "rarity": "RARE",
+        "artist": "Yumi Yaoshida",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a67793ef-ef80-4434-9c54-e3fd8a270bbe.jpg?1748706698"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // The Crystal's Chosen
 {
     "name": "The Crystal's Chosen",
@@ -9453,6 +9645,83 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// You're Not Alone
+{
+    "name": "You're Not Alone",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 until end of turn. If you control three or more creatures, it gets +4/+4 until end of turn instead.",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            },
+            "then": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 4
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 4
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target"
+                }
+            },
+            "otherwise": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target"
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "artist": "Ignatius Budi",
+        "flavorText": "\"You've always protected us. But you still don't understand that we looked out for you, too!\"\n—Dagger",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/1867b5cb-2bb0-4f49-b302-036fdffa2344.jpg?1748705918"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 


### PR DESCRIPTION
Implements three Final Fantasy (FIN) cards. All three compose from existing SDK primitives — no new effects, triggers, or conditions were needed.

## Cards
- **Suplex** ({1}{R} Sorcery) — Choose one: deal 3 damage to target creature and exile it if it would die this turn (`MarkExileOnDeathEffect`), or exile target artifact.
- **Tellah, Great Sage** ({3}{U}{R} Legendary 3/3) — Whenever you cast a noncreature spell, create a 1/1 colorless Hero token; if 4+ mana was spent, draw two; if 8+ mana was spent, sacrifice Tellah and deal that much damage to each opponent (`MANA_SPENT_ON_TRIGGERING_SPELL` gates).
- **You're Not Alone** ({W} Instant) — Target creature gets +2/+2, or +4/+4 instead if you control three or more creatures (`ConditionalEffect` with `elseEffect`).

## Tests
- `:mtg-sets:test` passes in full (including `CardLintTest`).
- `CardDefinitionSnapshotTest` re-blessed — FIN.json diff adds only the three new card trees, nothing else changed.
- `check-card-printing` confirms all three are canonical in their earliest real printing (FIN).
- rules-engine compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)