### PR TITLE
FIN: Rydia's Return, Sandworm, Shantotto

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RydiasReturn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RydiasReturn.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Rydia's Return
+ * {3}{G}{G}
+ * Sorcery
+ * Choose one —
+ * • Creatures you control get +3/+3 until end of turn.
+ * • Return up to two target permanent cards from your graveyard to your hand.
+ */
+val RydiasReturn = card("Rydia's Return") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Creatures you control get +3/+3 until end of turn.\n" +
+        "• Return up to two target permanent cards from your graveyard to your hand."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Creatures you control get +3/+3 until end of turn") {
+                effect = Effects.ForEachInGroup(
+                    filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+                    effect = ModifyStatsEffect(3, 3, EffectTarget.Self)
+                )
+            }
+            mode("Return up to two target permanent cards from your graveyard to your hand") {
+                target = TargetObject(
+                    optional = true,
+                    count = 2,
+                    filter = TargetFilter(GameObjectFilter.Permanent.ownedByYou(), zone = Zone.GRAVEYARD)
+                )
+                effect = ForEachTargetEffect(
+                    effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND))
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Kohei Hayama"
+        flavorText = "\"Are you okay? You should be able to move now.\"\n—Rydia, Summoner of Mist"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/40a06165-2835-4610-86a1-7f684992fcf2.jpg?1748706502"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Sandworm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Sandworm.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sandworm
+ * {4}{R}
+ * Creature — Worm
+ * 5/4
+ * Haste
+ * When this creature enters, destroy target land. Its controller may search their library for a
+ * basic land card, put it onto the battlefield tapped, then shuffle.
+ *
+ * A Stone-Rain-shaped land destruction stapled to an ETB, with the same Path-to-Exile-style
+ * compensation as [com.wingedsheep.mtg.sets.definitions.sos.cards.Erode]: the destroy resolves
+ * first, then the destroyed land's controller — not Sandworm's controller — gets the optional
+ * search, so the [MayEffect] gate is delegated to [EffectTarget.TargetController] and the search
+ * pipeline is scoped to [Player.ControllerOf] (library to gather from, battlefield to put the basic
+ * onto tapped, and the library to shuffle). "Its controller" resolves from the targeted land at
+ * resolution; since the land has just left the battlefield, it falls back to its owner (the standard
+ * last-known controller for a permanent that left play).
+ */
+val Sandworm = card("Sandworm") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Worm"
+    power = 5
+    toughness = 4
+    oracleText = "Haste\n" +
+        "When this creature enters, destroy target land. Its controller may search their library " +
+        "for a basic land card, put it onto the battlefield tapped, then shuffle."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val land = target("target land", Targets.Land)
+        effect = Effects.Destroy(land) then MayEffect(
+            effect = Effects.Composite(
+                listOf(
+                    GatherCardsEffect(
+                        source = CardSource.FromZone(
+                            zone = Zone.LIBRARY,
+                            player = Player.ControllerOf("target"),
+                            filter = GameObjectFilter.BasicLand,
+                        ),
+                        storeAs = "searchable",
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "searchable",
+                        selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                        storeSelected = "found",
+                    ),
+                    MoveCollectionEffect(
+                        from = "found",
+                        destination = CardDestination.ToZone(
+                            zone = Zone.BATTLEFIELD,
+                            player = Player.ControllerOf("target"),
+                            placement = ZonePlacement.Tapped,
+                        ),
+                    ),
+                    ShuffleLibraryEffect(target = EffectTarget.TargetController),
+                ),
+            ),
+            decisionMaker = EffectTarget.TargetController,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "155"
+        artist = "Awanqi (Angela Wang)"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6e021da-2397-4ad3-a07b-65c701df531a.jpg?1748706340"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ShantottoTacticianMagician.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ShantottoTacticianMagician.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Shantotto, Tactician Magician
+ * {1}{U}{R}
+ * Legendary Creature — Dwarf Wizard
+ * 0/4
+ * Whenever you cast a noncreature spell, Shantotto gets +X/+0 until end of turn, where X is the
+ * amount of mana spent to cast that spell. If X is 4 or more, draw a card.
+ *
+ * X reads `DynamicAmount.ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL)` — the mana actually spent
+ * on the *triggering* spell (the same primitive [com.wingedsheep.mtg.sets.definitions.sos.cards.AberrantManawurm]
+ * uses), distinct from `TRIGGERING_SPELL_MANA_VALUE` (printed mana value). The +X/+0 lasts until end
+ * of turn (the `ModifyStats` default duration). The conditional draw compares that same mana-spent
+ * amount against 4, so cost reductions / extra payments are honored consistently across both halves.
+ */
+val ShantottoTacticianMagician = card("Shantotto, Tactician Magician") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Dwarf Wizard"
+    power = 0
+    toughness = 4
+    oracleText = "Whenever you cast a noncreature spell, Shantotto gets +X/+0 until end of turn, " +
+        "where X is the amount of mana spent to cast that spell. If X is 4 or more, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.ModifyStats(
+            power = DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+            toughness = DynamicAmount.Fixed(0),
+            target = EffectTarget.Self,
+        ) then ConditionalEffect(
+            condition = Conditions.CompareAmounts(
+                left = DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+                operator = ComparisonOperator.GTE,
+                right = DynamicAmount.Fixed(4),
+            ),
+            effect = Effects.DrawCards(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "241"
+        artist = "Joshua Raphael"
+        flavorText = "\"Ohohoho! I might be the harshest mistress in all of Vana'diel. But I may yet " +
+            "forgive you, if at my feet you kneel.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/eff984b2-6ea9-4471-91c5-99c47f87f10b.jpg?1748706682"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ShantottoTacticianMagicianBorderless.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ShantottoTacticianMagicianBorderless.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Shantotto, Tactician Magician — borderless variant (FIN #507).
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] is [ShantottoTacticianMagician] (FIN #241,
+ * same set); this row contributes only the alternate-art presentation data for the borderless printing.
+ */
+val ShantottoTacticianMagicianBorderless = Printing(
+    oracleId = "381df197-5fb7-44ab-a31f-96c4993a0e53",
+    name = "Shantotto, Tactician Magician",
+    setCode = "FIN",
+    collectorNumber = "507",
+    scryfallId = "d1e01457-1696-4313-b21e-36e088735b1f",
+    artist = "Joshua Raphael",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d1e01457-1696-4313-b21e-36e088735b1f.jpg?1748707561",
+    releaseDate = "2025-06-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -6423,6 +6423,81 @@
     ]
 }
 
+// Rydia's Return
+{
+    "name": "Rydia's Return",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Creatures you control get +3/+3 until end of turn.\n• Return up to two target permanent cards from your graveyard to your hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control get +3/+3 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Hand"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "count": 2,
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "permanent own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ],
+                    "description": "Return up to two target permanent cards from your graveyard to your hand"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "Kohei Hayama",
+        "flavorText": "\"Are you okay? You should be able to move now.\"\n—Rydia, Summoner of Mist",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/40a06165-2835-4610-86a1-7f684992fcf2.jpg?1748706502"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Sabotender
 {
     "name": "Sabotender",
@@ -6573,6 +6648,114 @@
         "rarity": "UNCOMMON",
         "artist": "Smirtouille",
         "imageUri": "https://cards.scryfall.io/normal/front/1/1/11f1d378-c78c-402a-ac46-2d32598c23e7.jpg?1748706334"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Sandworm
+{
+    "name": "Sandworm",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Worm",
+    "oracleText": "Haste\nWhen this creature enters, destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield tapped, then shuffle.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land"
+                            },
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Library",
+                                            "player": {
+                                                "type": "ControllerOf",
+                                                "targetDescription": "target"
+                                            },
+                                            "filter": "basicland"
+                                        },
+                                        "storeAs": "searchable"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "searchable",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "found"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "found",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Battlefield",
+                                            "player": {
+                                                "type": "ControllerOf",
+                                                "targetDescription": "target"
+                                            },
+                                            "placement": "Tapped"
+                                        }
+                                    },
+                                    {
+                                        "type": "ShuffleLibrary",
+                                        "target": "TargetController"
+                                    }
+                                ]
+                            },
+                            "decisionMaker": "TargetController"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land"
+                    },
+                    "id": "target land"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "UNCOMMON",
+        "artist": "Awanqi (Angela Wang)",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6e021da-2397-4ad3-a07b-65c701df531a.jpg?1748706340"
     },
     "colorIdentityOverride": [
         "RED"
@@ -6737,6 +6920,87 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Shantotto, Tactician Magician
+{
+    "name": "Shantotto, Tactician Magician",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Legendary Creature — Dwarf Wizard",
+    "oracleText": "Whenever you cast a noncreature spell, Shantotto gets +X/+0 until end of turn, where X is the amount of mana spent to cast that spell. If X is 4 or more, draw a card.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "ContextProperty",
+                                "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "ContextProperty",
+                                        "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "UNCOMMON",
+        "artist": "Joshua Raphael",
+        "flavorText": "\"Ohohoho! I might be the harshest mistress in all of Vana'diel. But I may yet forgive you, if at my feet you kneel.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/eff984b2-6ea9-4471-91c5-99c47f87f10b.jpg?1748706682"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SandwormScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SandwormScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sandworm (FIN #155).
+ *
+ * "{4}{R} Creature — Worm 5/4. Haste. When this creature enters, destroy target land. Its controller
+ *  may search their library for a basic land card, put it onto the battlefield tapped, then shuffle."
+ *
+ * Verifies the ETB destroys the targeted land, and that the optional basic-land search is performed
+ * by the *destroyed land's controller* (the opponent here), who may accept or decline.
+ */
+class SandwormScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sandworm") {
+
+            test("ETB destroys target land; its controller may fetch a tapped basic land") {
+                val game = scenario()
+                    .withPlayers("Caster", "Victim")
+                    .withCardInHand(1, "Sandworm")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withLandsOnBattlefield(2, "Plains", 1)
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victimPlains = game.state.getBattlefield().first { id ->
+                    val e = game.state.getEntity(id)
+                    e?.get<CardComponent>()?.name == "Plains" &&
+                        e.get<ControllerComponent>()?.playerId == game.player2Id
+                }
+
+                game.castSpell(1, "Sandworm")
+                game.resolveStack()
+
+                // ETB trigger needs a land target — choose the opponent's Plains.
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(victimPlains))
+                    game.resolveStack()
+                }
+
+                // Its controller (player 2) may search — accept.
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                // Select the Forest from player 2's library.
+                if (game.hasPendingDecision()) {
+                    val forest = game.state.getLibrary(game.player2Id).first { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    }
+                    game.selectCards(listOf(forest))
+                    game.resolveStack()
+                }
+
+                withClue("The targeted Plains should be destroyed") {
+                    game.state.getBattlefield().none { id ->
+                        val e = game.state.getEntity(id)
+                        e?.get<CardComponent>()?.name == "Plains" &&
+                            e.get<ControllerComponent>()?.playerId == game.player2Id
+                    } shouldBe true
+                }
+                val forestOnBf = game.state.getBattlefield().firstOrNull { id ->
+                    val e = game.state.getEntity(id)
+                    e?.get<CardComponent>()?.name == "Forest" &&
+                        e.get<ControllerComponent>()?.playerId == game.player2Id
+                }
+                withClue("Player 2 should have fetched a Forest onto the battlefield") {
+                    (forestOnBf != null) shouldBe true
+                }
+                withClue("The fetched Forest should be tapped") {
+                    game.state.getEntity(forestOnBf!!)?.get<TappedComponent>() shouldBe TappedComponent
+                }
+            }
+
+            test("the land's controller may decline the search") {
+                val game = scenario()
+                    .withPlayers("Caster", "Victim")
+                    .withCardInHand(1, "Sandworm")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withLandsOnBattlefield(2, "Plains", 1)
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val victimPlains = game.state.getBattlefield().first { id ->
+                    val e = game.state.getEntity(id)
+                    e?.get<CardComponent>()?.name == "Plains" &&
+                        e.get<ControllerComponent>()?.playerId == game.player2Id
+                }
+
+                game.castSpell(1, "Sandworm")
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    game.selectTargets(listOf(victimPlains))
+                    game.resolveStack()
+                }
+
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("The targeted Plains should still be destroyed") {
+                    game.state.getBattlefield().none { id ->
+                        val e = game.state.getEntity(id)
+                        e?.get<CardComponent>()?.name == "Plains" &&
+                            e.get<ControllerComponent>()?.playerId == game.player2Id
+                    } shouldBe true
+                }
+                withClue("No Forest should have entered the battlefield") {
+                    game.state.getBattlefield().none { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShantottoTacticianMagicianScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShantottoTacticianMagicianScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.ShantottoTacticianMagician
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Shantotto, Tactician Magician (FIN #241).
+ *
+ * "{1}{U}{R} Legendary Creature — Dwarf Wizard 0/4. Whenever you cast a noncreature spell, Shantotto
+ *  gets +X/+0 until end of turn, where X is the amount of mana spent to cast that spell. If X is 4 or
+ *  more, draw a card."
+ *
+ * Verifies the +X/+0 scales by the mana actually spent on the *triggering* noncreature spell, and
+ * that the conditional card draw fires only when 4+ mana was spent. Creature spells don't trigger it.
+ */
+class ShantottoTacticianMagicianScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(ShantottoTacticianMagician))
+        return driver
+    }
+
+    fun startTurn(driver: GameTestDriver): EntityId {
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver.activePlayer!!
+    }
+
+    fun projectedPower(driver: GameTestDriver, id: EntityId): Int =
+        StateProjector().getProjectedPower(driver.state, id)
+
+    test("a 1-mana noncreature spell pumps Shantotto +1/+0 and does not draw") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val shantotto = driver.putCreatureOnBattlefield(p, "Shantotto, Tactician Magician") // 0/4
+        val opp = driver.getOpponent(p)
+        val victim = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        val handBefore = driver.getHandSize(p)
+        val bolt = driver.putCardInHand(p, "Lightning Bolt") // {R} → 1 mana
+        driver.giveMana(p, Color.RED, 1)
+
+        driver.castSpell(p, bolt, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // Bolt resolves
+        driver.bothPass() // Shantotto cast-trigger resolves
+
+        // 1 mana spent → +1/+0. Shantotto 0/4 → 1/4.
+        projectedPower(driver, shantotto) shouldBe 1
+        // X < 4 → no draw (hand is back to its pre-Bolt size, Bolt having left the hand).
+        driver.getHandSize(p) shouldBe handBefore
+    }
+
+    test("a 4-mana noncreature spell pumps Shantotto +4/+0 and draws a card") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val shantotto = driver.putCreatureOnBattlefield(p, "Shantotto, Tactician Magician") // 0/4
+        val opp = driver.getOpponent(p)
+        val victim = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        // Stoke the Flames {2}{R}{R}; pay entirely with mana so exactly 4 mana is spent.
+        val stoke = driver.putCardInHand(p, "Stoke the Flames")
+        val handBefore = driver.getHandSize(p) // counts Stoke still in hand
+        driver.giveMana(p, Color.RED, 4)
+
+        driver.castSpell(p, stoke, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // Stoke resolves
+        driver.bothPass() // Shantotto cast-trigger resolves
+
+        // 4 mana spent → +4/+0. Shantotto 0/4 → 4/4.
+        projectedPower(driver, shantotto) shouldBe 4
+        // X >= 4 → draw a card. Stoke left the hand (−1) and the draw added one (+1) → net unchanged.
+        driver.getHandSize(p) shouldBe handBefore
+    }
+
+    test("casting a creature spell does not trigger Shantotto") {
+        val driver = createDriver()
+        val p = startTurn(driver)
+        val shantotto = driver.putCreatureOnBattlefield(p, "Shantotto, Tactician Magician") // 0/4
+
+        val courser = driver.putCardInHand(p, "Centaur Courser") // a creature spell, {2}{G}
+        driver.giveMana(p, Color.GREEN, 3)
+
+        driver.castSpell(p, courser).isSuccess shouldBe true
+        driver.bothPass() // Courser resolves
+        driver.bothPass()
+
+        // No noncreature spell cast → Shantotto stays 0 power.
+        projectedPower(driver, shantotto) shouldBe 0
+    }
+})


### PR DESCRIPTION
Implements three Final Fantasy (FIN) cards. All three compose existing SDK primitives — no new effects, triggers, conditions, keywords, or frontend changes.

## Cards

- **Rydia's Return** ({3}{G}{G} Sorcery) — choose one: creatures you control get +3/+3 until end of turn; or return up to two target permanent cards from your graveyard to your hand. Modeled on Bushwhack (modal) + Restock (graveyard-to-hand `ForEachTargetEffect`).
- **Sandworm** ({4}{R}, 5/4 Worm, Haste) — ETB: destroy target land; its controller may search their library for a basic land, put it onto the battlefield tapped, then shuffle. Reuses the Erode compensation pipeline (`MayEffect` gated to `TargetController`, search scoped to `Player.ControllerOf`).
- **Shantotto, Tactician Magician** ({1}{U}{R}, 0/4 Legendary) — whenever you cast a noncreature spell, +X/+0 until end of turn where X = mana spent on that spell (`MANA_SPENT_ON_TRIGGERING_SPELL`, as Aberrant Manawurm); if X is 4+, draw a card. Includes the #507 borderless `Printing` row.

## Tests

- New rules-engine scenario tests for Sandworm (accept + decline) and Shantotto (+X/+0 scaling, 4-mana draw threshold, creature-spell no-op) — all pass. Rydia's Return is pure composition (no new effects), covered by the snapshot net.
- `mtg-sets` snapshot + lint nets pass; FIN card snapshot re-blessed (only the three new cards added).
- `check-card-printing` clean for all three (FIN is the earliest/canonical printing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)