### PR TITLE
DSK: Betrayer's Bargain, Unwanted Remake, Doomsday Excruciator

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BetrayersBargain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/BetrayersBargain.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Betrayer's Bargain
+ * {1}{R}
+ * Instant
+ * As an additional cost to cast this spell, sacrifice a creature or enchantment or pay {2}.
+ * Betrayer's Bargain deals 5 damage to target creature. If that creature would die this turn,
+ * exile it instead.
+ *
+ * Two pieces, both modeled with existing primitives:
+ *
+ * - The binary additional cost (sacrifice a creature or enchantment, OR pay {2}) is the
+ *   [LashOfTheBalrog] shape: a non-modal [ModalEffect.chooseOne] whose two modes carry the same
+ *   target requirement and effect but different costs — one sacrifices a creature/enchantment, the
+ *   other pays {2}. `countsAsModalSpell = false` because there is no "Choose one —" on the card; the
+ *   fork is purely a cost choice the caster makes at cast time.
+ * - "Deals 5 damage … if that creature would die this turn, exile it instead" is the [AgateAssault]
+ *   shape: [MarkExileOnDeathEffect] sets up the die→exile replacement on the target first, then
+ *   [Effects.DealDamage] deals the 5. Per the Scryfall ruling the replacement applies to *any* death
+ *   this turn (not just death from this damage), which is exactly what `MarkExileOnDeathEffect` does.
+ */
+val BetrayersBargain = card("Betrayer's Bargain") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a creature or enchantment or " +
+        "pay {2}.\nBetrayer's Bargain deals 5 damage to target creature. If that creature would die " +
+        "this turn, exile it instead."
+
+    val creature = EffectTarget.ContextTarget(0)
+    val body = MarkExileOnDeathEffect(creature).then(Effects.DealDamage(5, creature))
+
+    spell {
+        effect = ModalEffect.chooseOne(
+            // Sacrifice a creature or enchantment
+            Mode(
+                effect = body,
+                targetRequirements = listOf(Targets.Creature),
+                description = "Sacrifice a creature or enchantment — deal 5 damage to target creature",
+                additionalCosts = listOf(
+                    Costs.additional.SacrificePermanent(filter = GameObjectFilter.CreatureOrEnchantment)
+                )
+            ),
+            // Pay {2}
+            Mode(
+                effect = body,
+                targetRequirements = listOf(Targets.Creature),
+                description = "Pay {2} — deal 5 damage to target creature",
+                additionalManaCost = "{2}"
+            ),
+            countsAsModalSpell = false
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "126"
+        artist = "Billy Christian"
+        flavorText = "\"This is my way out. You'll have to find your own.\"\n—Winter, to Niko"
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/7956ae00-8f0c-48f0-8110-19ff53863876.jpg?1726286318"
+        ruling(
+            "2024-09-20",
+            "If Betrayer's Bargain resolves, its effect causes the creature to be exiled any time it " +
+                "would die that turn, not just if it would die as a result of damage dealt by Betrayer's Bargain."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DoomsdayExcruciator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DoomsdayExcruciator.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LookAudience
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Doomsday Excruciator
+ * {B}{B}{B}{B}{B}{B}
+ * Creature — Demon
+ * 6/6
+ * Flying
+ * When this creature enters, if it was cast, each player exiles all but the bottom six cards of
+ * their library face down.
+ * At the beginning of your upkeep, draw a card.
+ *
+ * Modeled with existing primitives:
+ * - Flying via the keyword.
+ * - The ETB is a [Triggers.EntersBattlefield] gated by [Conditions.WasCast] (the intervening "if it
+ *   was cast" clause — it does nothing for a token copy or a creature put onto the battlefield
+ *   without being cast). "Each player exiles all but the bottom six cards of their library face down"
+ *   is one [Effects.ForEachPlayer] over [Player.Each]; the iteration rebinds the body's controller to
+ *   each player so [CardSource.TopOfLibrary] (defaulting to `Player.You`) reads that player's own
+ *   library. We gather the top `librarySize - 6` cards — i.e. everything but the bottom six —
+ *   clamped to zero with [DynamicAmount.IfPositive] so a player with six or fewer cards exiles
+ *   nothing (matching the Scryfall ruling). Those cards move to exile face down
+ *   ([FaceDownMode.HIDDEN], hidden in exile) via [MoveCollectionEffect].
+ * - The upkeep payoff is a standard [Triggers.YourUpkeep] drawing a card.
+ */
+val DoomsdayExcruciator = card("Doomsday Excruciator") {
+    manaCost = "{B}{B}{B}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Demon"
+    power = 6
+    toughness = 6
+    oracleText = "Flying\nWhen this creature enters, if it was cast, each player exiles all but the " +
+        "bottom six cards of their library face down.\nAt the beginning of your upkeep, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    // Top (librarySize - 6) cards = everything except the bottom six. Clamp to >= 0 so a library of
+    // six or fewer yields zero cards to exile (CR / ruling: nothing happens).
+    val allButBottomSix = DynamicAmount.IfPositive(
+        DynamicAmount.Subtract(
+            DynamicAmount.Count(Player.You, Zone.LIBRARY),
+            DynamicAmount.Fixed(6)
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(allButBottomSix),
+                    storeAs = "doomsdayExiled",
+                    revealed = false,
+                    lookAudience = LookAudience.None
+                ),
+                MoveCollectionEffect(
+                    from = "doomsdayExiled",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN
+                )
+            )
+        )
+        description = "When this creature enters, if it was cast, each player exiles all but the " +
+            "bottom six cards of their library face down."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.DrawCards(1)
+        description = "At the beginning of your upkeep, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "94"
+        artist = "Denys Tsiperko"
+        flavorText = "\"All stars grow dark. All worlds come to an end.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/542c89b6-48c6-4fcb-8a4c-b5ed2fa1d384.jpg?1726286201"
+        ruling(
+            "2024-09-20",
+            "A player with six or fewer cards remaining in their library when Doomsday Excruciator's " +
+                "second ability resolves won't exile any cards."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnwantedRemake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnwantedRemake.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Unwanted Remake
+ * {W}
+ * Instant
+ * Destroy target creature. Its controller manifests dread. (That player looks at the top two cards
+ * of their library, then puts one onto the battlefield face down as a 2/2 creature and the other
+ * into their graveyard. If it's a creature card, it can be turned face up any time for its mana
+ * cost.)
+ *
+ * Modeled with existing primitives — the [FearOfImpostors] "its controller manifests dread" shape:
+ * - [Effects.Destroy] destroys the targeted creature.
+ * - "Its controller manifests dread" runs the shared [Patterns.Library.manifestDread] recipe under
+ *   the destroyed creature's controller via [Effects.ForEachPlayer] over the single
+ *   [Player.ControllerOf] the target. The iteration rebinds the body's controller to that player, so
+ *   they look at their own library, choose, and the face-down 2/2 enters under their control.
+ *   `Player.ControllerOf` resolves from the chosen target even after the destroy, since target ids
+ *   are captured at resolution.
+ * - Per the Scryfall ruling, an illegal target on resolution fizzles the whole spell (no manifest
+ *   dread) — the standard targeting behavior, no special casing needed.
+ */
+val UnwantedRemake = card("Unwanted Remake") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Destroy target creature. Its controller manifests dread. (That player looks at the " +
+        "top two cards of their library, then puts one onto the battlefield face down as a 2/2 " +
+        "creature and the other into their graveyard. If it's a creature card, it can be turned face " +
+        "up any time for its mana cost.)"
+
+    spell {
+        target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.Destroy(EffectTarget.ContextTarget(0)),
+            // Its controller manifests dread — run the shared recipe under the target's controller.
+            Effects.ForEachPlayer(
+                players = Player.ControllerOf("target creature"),
+                effects = Patterns.Library.manifestDread().effects,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "39"
+        artist = "Eli Minaya"
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7b54447f-1daf-4352-b5c3-3c0ec8b8f4d0.jpg?1726286001"
+        ruling(
+            "2024-09-20",
+            "If the target creature is an illegal target as Unwanted Remake tries to resolve, it " +
+                "won't resolve and none of its effects will happen. The creature's controller won't manifest dread."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -864,6 +864,116 @@
     ]
 }
 
+// Betrayer's Bargain
+{
+    "name": "Betrayer's Bargain",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a creature or enchantment or pay {2}.\nBetrayer's Bargain deals 5 damage to target creature. If that creature would die this turn, exile it instead.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MarkExileOnDeath",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Sacrifice a creature or enchantment — deal 5 damage to target creature",
+                    "additionalCosts": [
+                        {
+                            "type": "AdditionalAtom",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature|enchantment"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MarkExileOnDeath",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "Pay {2} — deal 5 damage to target creature",
+                    "additionalManaCost": "{2}"
+                }
+            ],
+            "countsAsModalSpell": false
+        }
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "rarity": "UNCOMMON",
+        "artist": "Billy Christian",
+        "flavorText": "\"This is my way out. You'll have to find your own.\"\n—Winter, to Niko",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/7956ae00-8f0c-48f0-8110-19ff53863876.jpg?1726286318",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "If Betrayer's Bargain resolves, its effect causes the creature to be exiled any time it would die that turn, not just if it would die as a result of damage dealt by Betrayer's Bargain."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Blazemire Verge
 {
     "name": "Blazemire Verge",
@@ -3238,6 +3348,110 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Doomsday Excruciator
+{
+    "name": "Doomsday Excruciator",
+    "manaCost": "{B}{B}{B}{B}{B}{B}",
+    "typeLine": "Creature — Demon",
+    "oracleText": "Flying\nWhen this creature enters, if it was cast, each player exiles all but the bottom six cards of their library face down.\nAt the beginning of your upkeep, draw a card.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "IfPositive",
+                                        "amount": {
+                                            "type": "Subtract",
+                                            "left": {
+                                                "type": "Count",
+                                                "player": "You",
+                                                "zone": "Library"
+                                            },
+                                            "right": {
+                                                "type": "Fixed",
+                                                "amount": 6
+                                            }
+                                        }
+                                    }
+                                },
+                                "storeAs": "doomsdayExiled",
+                                "lookAudience": "None"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "doomsdayExiled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "faceDown": "HIDDEN"
+                            }
+                        ]
+                    }
+                },
+                "triggerCondition": "WasCast",
+                "descriptionOverride": "When this creature enters, if it was cast, each player exiles all but the bottom six cards of their library face down."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "rarity": "RARE",
+        "artist": "Denys Tsiperko",
+        "flavorText": "\"All stars grow dark. All worlds come to an end.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/542c89b6-48c6-4fcb-8a4c-b5ed2fa1d384.jpg?1726286201",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "A player with six or fewer cards remaining in their library when Doomsday Excruciator's second ability resolves won't exile any cards."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -13626,6 +13840,113 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Unwanted Remake
+{
+    "name": "Unwanted Remake",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target creature. Its controller manifests dread. (That player looks at the top two cards of their library, then puts one onto the battlefield face down as a 2/2 creature and the other into their graveyard. If it's a creature card, it can be turned face up any time for its mana cost.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": {
+                            "type": "ControllerOf",
+                            "targetDescription": "target creature"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeAs": "manifestDreadLooked"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "manifestDreadLooked",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "manifestDreadManifested",
+                                "storeRemainder": "manifestDreadGraveyard",
+                                "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                "remainderLabel": "Put into your graveyard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadManifested",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "faceDown": "MANIFEST"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            },
+                            "EmitManifestedDreadEvent"
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "UNCOMMON",
+        "artist": "Eli Minaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7b54447f-1daf-4352-b5c3-3c0ec8b8f4d0.jpg?1726286001",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "If the target creature is an illegal target as Unwanted Remake tries to resolve, it won't resolve and none of its effects will happen. The creature's controller won't manifest dread."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BetrayersBargainScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BetrayersBargainScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Betrayer's Bargain (DSK #126) — {1}{R} Instant.
+ *
+ *   "As an additional cost to cast this spell, sacrifice a creature or enchantment or pay {2}.
+ *    Betrayer's Bargain deals 5 damage to target creature. If that creature would die this turn,
+ *    exile it instead."
+ *
+ * Pure composition: a non-modal two-mode cost fork (LashOfTheBalrog shape) — sacrifice a
+ * creature/enchantment, or pay {2} — wrapping the same body, which first marks the target so any
+ * death this turn exiles it (AgateAssault shape: MarkExileOnDeath) and then deals 5 damage.
+ */
+class BetrayersBargainScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Betrayer's Bargain — 5 damage, exile on death; sacrifice-or-pay cost") {
+
+            test("pay {2}: deals 5 to the target, which dies and is exiled instead of going to the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withLandsOnBattlefield(1, "Mountain", 4) // {1}{R} + {2}
+                    .withCardInHand(1, "Betrayer's Bargain")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // opponent's 2/2
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)
+                        ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name ==
+                        "Betrayer's Bargain"
+                }
+                // Mode 1 = "Pay {2}" (the second mode, index 1).
+                val targets = listOf<ChosenTarget>(ChosenTarget.Permanent(bears))
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = targets,
+                        chosenModes = listOf(1),
+                        modeTargetsOrdered = listOf(targets)
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the 2/2 took 5 lethal damage and left the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("it was exiled instead of going to the graveyard") {
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("sacrifice a creature: pays the cost by sacrificing, deals 5, exiles the target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withLandsOnBattlefield(1, "Mountain", 2) // only enough for {1}{R}
+                    .withCardInHand(1, "Betrayer's Bargain")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // own creature, fodder to sacrifice
+                    .withCardOnBattlefield(2, "Hill Giant") // opponent's 3/3 target
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val target = game.findPermanent("Hill Giant")!!
+                val fodder = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)
+                        ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name ==
+                        "Betrayer's Bargain"
+                }
+                val targets = listOf<ChosenTarget>(ChosenTarget.Permanent(target))
+                // Mode 0 = "Sacrifice a creature or enchantment".
+                game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = targets,
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(targets),
+                        additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(fodder))
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("the sacrificed creature is gone (in its owner's graveyard)") {
+                    game.state.getBattlefield(game.player1Id).contains(fodder) shouldBe false
+                }
+                withClue("the 3/3 target took 5 lethal damage and was exiled instead of dying") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInExile(2, "Hill Giant") shouldBe true
+                    game.isInGraveyard(2, "Hill Giant") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoomsdayExcruciatorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DoomsdayExcruciatorScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.DoomsdayExcruciator
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+
+/**
+ * Doomsday Excruciator (DSK #94) — {B}{B}{B}{B}{B}{B} Creature — Demon 6/6, Flying.
+ *
+ *   "When this creature enters, if it was cast, each player exiles all but the bottom six cards of
+ *    their library face down."
+ *   "At the beginning of your upkeep, draw a card."
+ *
+ * Composition: the ETB is an EntersBattlefield trigger gated by WasCast; the body is a
+ * ForEachPlayer(Player.Each) that gathers each player's top `librarySize - 6` cards (clamped to
+ * zero) and moves them to exile face down (FaceDownMode.HIDDEN). The upkeep payoff is a standard
+ * YourUpkeep draw.
+ */
+class DoomsdayExcruciatorScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + DoomsdayExcruciator)
+        initMirrorMatch(deck = Deck.of("Swamp" to 60), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("when cast, each player exiles all but the bottom six cards of their library face down") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+
+        val myLibBefore = d.state.getLibrary(me).size
+        val oppLibBefore = d.state.getLibrary(opp).size
+        myLibBefore shouldBeGreaterThan 6
+        oppLibBefore shouldBeGreaterThan 6
+
+        // Cast Doomsday Excruciator for real (so "if it was cast" holds).
+        val demon = d.putCardInHand(me, "Doomsday Excruciator")
+        d.giveMana(me, Color.BLACK, 6)
+        d.castSpell(me, demon).error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Each player's library is reduced to exactly the bottom six cards.
+        d.state.getLibrary(me).size shouldBe 6
+        d.state.getLibrary(opp).size shouldBe 6
+
+        // The exiled cards are face down in exile, and the count matches what was removed.
+        val myExile = d.getExile(me)
+        val oppExile = d.getExile(opp)
+        myExile.size shouldBe (myLibBefore - 6)
+        oppExile.size shouldBe (oppLibBefore - 6)
+        myExile.forEach { d.state.getEntity(it)?.get<FaceDownComponent>() shouldBe FaceDownComponent }
+        oppExile.forEach { d.state.getEntity(it)?.get<FaceDownComponent>() shouldBe FaceDownComponent }
+    }
+
+    test("a player with six or fewer cards in library exiles nothing") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+
+        // Trim the opponent's library down to exactly four cards.
+        val keep = d.state.getLibrary(opp).take(4)
+        d.replaceState(
+            d.state.copy(
+                zones = d.state.zones + (com.wingedsheep.engine.state.ZoneKey(opp, Zone.LIBRARY) to keep)
+            )
+        )
+        d.state.getLibrary(opp).size shouldBe 4
+
+        val demon = d.putCardInHand(me, "Doomsday Excruciator")
+        d.giveMana(me, Color.BLACK, 6)
+        d.castSpell(me, demon).error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Opponent had <= 6, so nothing is exiled from their library (CR / ruling).
+        d.state.getLibrary(opp).size shouldBe 4
+        d.getExile(opp).size shouldBe 0
+    }
+
+    test("draws a card at the beginning of your upkeep") {
+        val d = driver()
+        val me = d.activePlayer!!
+
+        d.putCreatureOnBattlefield(me, "Doomsday Excruciator")
+
+        // Advance past the opponent's turn to my next turn's upkeep (the YourUpkeep trigger only
+        // fires on the controller's own upkeep). Turn 1 = mine (PRECOMBAT_MAIN now); step through
+        // the opponent's upkeep + main, then stop at my next upkeep.
+        d.passPriorityUntil(Step.UPKEEP, maxPasses = 300) // opponent's upkeep (turn 2)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300) // opponent's main
+        // Record the hand size after the opponent's turn so the assertion isolates my upkeep draw.
+        d.passPriorityUntil(Step.UPKEEP, maxPasses = 300) // my upkeep (turn 3)
+        d.activePlayer shouldBe me
+        val handBefore = d.getHandSize(me)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.getHandSize(me) shouldBe (handBefore + 1)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnwantedRemakeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnwantedRemakeScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnwantedRemake
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Unwanted Remake (DSK #39) — {W} Instant.
+ *
+ *   "Destroy target creature. Its controller manifests dread."
+ *
+ * Verifies the destroyed creature's controller — not Unwanted Remake's controller — is the one who
+ * manifests dread (looks at the top two of *their* library, manifests one face-down 2/2 under their
+ * control, bins the other). Modeled by running the shared manifest-dread recipe under
+ * `ForEachPlayer(Player.ControllerOf("target creature"))`.
+ */
+class UnwantedRemakeScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + UnwantedRemake)
+        initMirrorMatch(deck = Deck.of("Plains" to 60), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("destroys the target and makes the target's controller manifest dread") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+
+        // The opponent controls a creature; I'll destroy it.
+        val victim = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        // Stack the opponent's top two cards: a creature on top, a land beneath.
+        val oppLand = d.putCardOnTopOfLibrary(opp, "Plains")
+        val oppCreature = d.putCardOnTopOfLibrary(opp, "Hill Giant") // now the top card
+
+        // I cast Unwanted Remake targeting the opponent's creature.
+        val spell = d.putCardInHand(me, "Unwanted Remake")
+        d.giveMana(me, Color.WHITE, 1)
+        d.castSpell(me, spell, targets = listOf(victim)).error shouldBe null
+
+        // Resolve until the opponent's manifest-dread pick pauses.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The targeted creature was destroyed (in its owner's graveyard).
+        d.getGraveyard(opp) shouldContain victim
+
+        // The OPPONENT (the destroyed creature's controller) chooses which card to manifest.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pick.options.toSet() shouldBe setOf(oppCreature, oppLand)
+        pick.playerId shouldBe opp
+        d.submitDecision(opp, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(oppCreature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The opponent's chosen card is a face-down 2/2 under the opponent's control; the other binned.
+        d.getPermanents(opp) shouldContain oppCreature
+        val entity = d.state.getEntity(oppCreature)
+        entity?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        entity?.get<ManifestedComponent>() shouldBe ManifestedComponent
+        d.state.projectedState.getPower(oppCreature) shouldBe 2
+        d.getGraveyard(opp) shouldContain oppLand
+    }
+})


### PR DESCRIPTION
Implements three Duskmourn: House of Horror (DSK) cards. All three compose existing SDK primitives — no new effects, triggers, conditions, or keywords were needed, so the SDK reference is unchanged.

## Cards

### Betrayer's Bargain — {1}{R} Instant (#126)
> As an additional cost to cast this spell, sacrifice a creature or enchantment or pay {2}. Betrayer's Bargain deals 5 damage to target creature. If that creature would die this turn, exile it instead.

- The binary cost fork is the **Lash of the Balrog** shape: a non-modal `ModalEffect.chooseOne` (`countsAsModalSpell = false`) whose two modes carry the same target/effect but different costs — `SacrificePermanent(CreatureOrEnchantment)` vs `additionalManaCost = {2}`.
- The body is the **Agate Assault** shape: `MarkExileOnDeathEffect(target)` sets up the die→exile replacement first, then `DealDamage(5)`. Per the Scryfall ruling the replacement applies to *any* death this turn.

### Unwanted Remake — {W} Instant (#39)
> Destroy target creature. Its controller manifests dread.

- The **Fear of Impostors** shape: `Effects.Destroy` then `ForEachPlayer(Player.ControllerOf("target creature"), manifestDread().effects)`. The iteration rebinds the body's controller to the destroyed creature's controller, so *that* player looks at their own library and the face-down 2/2 enters under their control.
- Illegal-target-on-resolution fizzle (no manifest dread) is the standard targeting behavior — no special casing.

### Doomsday Excruciator — {B}{B}{B}{B}{B}{B} Creature — Demon 6/6 (#94)
> Flying. When this creature enters, if it was cast, each player exiles all but the bottom six cards of their library face down. At the beginning of your upkeep, draw a card.

- ETB is `EntersBattlefield` gated by `Conditions.WasCast` (the intervening "if it was cast" — inert for token copies / non-cast entries).
- The body is `ForEachPlayer(Player.Each)` gathering each player's top `IfPositive(Count(LIBRARY) - 6)` cards and moving them to exile face down (`FaceDownMode.HIDDEN`). The `IfPositive` clamp means a player with six or fewer cards exiles nothing (matches the ruling).
- Upkeep payoff is a standard `YourUpkeep` draw.

## Tests
3 new scenario tests (6 cases), all passing:
- **Betrayer's Bargain** — pay {2} path and sacrifice path; both deal 5 and exile the dying creature instead of binning it.
- **Unwanted Remake** — destroys the target and the *target's controller* (not the caster) manifests dread; verifies the face-down 2/2 enters under that player's control.
- **Doomsday Excruciator** — each player's library reduced to exactly the bottom six with the rest face down in exile; the ≤6-cards "exiles nothing" ruling; the upkeep draw.

Re-blessed the DSK card-snapshot golden (adds only these three cards; no other card changed). `CardLintTest`, `FacadeBoundaryTest`, and `check-card-printing` all pass for the three.

None skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)