### PR TITLE
DSK: Cursed Windbreaker, Hedge Shredder, Found Footage

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2412,6 +2412,13 @@ in the repo today):
 - `CardsPutIntoYourGraveyard(filter?)` — when matching cards enter your yard.
 - `PermanentCardsPutIntoYourGraveyard` — only permanent cards.
 - `CreaturesPutIntoGraveyardFromLibrary` — mill-trigger shape.
+- `LandsPutIntoGraveyardFromLibrary` — batching mill-trigger filtered to land cards. The matching
+  land cards are captured into the resolving ability's pipeline under
+  `IterationSpace.TRIGGER_CAPTURED_COLLECTION`, so a `MoveCollectionEffect(from = …, destination =
+  ToZone(BATTLEFIELD, placement = Tapped))` payoff can put exactly those lands onto the battlefield
+  (Hedge Shredder). Like `CreaturesPutIntoGraveyardFromLibrary`, both wrap
+  `CardsPutIntoGraveyardFromLibraryEvent(filter)`; the batch detector matches `IsCreature` /
+  `IsLand` / `IsNonland` / `HasSubtype` predicates and captures the matching cards.
 - `CardsLeaveYourGraveyard(filter?)` — batching trigger; fires once per event batch when one
   or more matching cards **leave** your graveyard (cast/exiled/reanimated/returned to hand,
   etc.), regardless of how many or where they went. For the common "leave your graveyard

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -668,6 +668,20 @@ object Triggers {
     )
 
     /**
+     * Whenever one or more land cards are put into your graveyard from your library.
+     * Batching trigger — fires at most once per event batch regardless of how many lands were
+     * milled. The matching land cards are captured into the resolving ability's pipeline under
+     * `TRIGGER_CAPTURED_COLLECTION`, so a payoff can act on exactly the lands that caused it (e.g.
+     * Hedge Shredder's "put them onto the battlefield tapped").
+     */
+    val LandsPutIntoGraveyardFromLibrary: TriggerSpec = TriggerSpec(
+        event = CardsPutIntoGraveyardFromLibraryEvent(
+            filter = GameObjectFilter.Land
+        ),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * Whenever one or more cards matching [filter] are put into your graveyard from anywhere.
      * Batching trigger — fires at most once per event batch regardless of how many cards entered,
      * and regardless of which source zone they came from.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CursedWindbreaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CursedWindbreaker.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cursed Windbreaker
+ * {2}{U}
+ * Artifact — Equipment
+ * When this Equipment enters, manifest dread, then attach this Equipment to that creature. (Look
+ * at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature
+ * and the other into your graveyard. Turn it face up any time for its mana cost if it's a
+ * creature card.)
+ * Equipped creature has flying.
+ * Equip {3}
+ *
+ * Manifest dread (CR 701.62) stores the manifested creature under the pipeline collection
+ * "manifestDreadManifested" (see [Patterns.Library.manifestDread]); the follow-up attach targets
+ * that creature via [EffectTarget.PipelineTarget]. If the library is empty (no creature is
+ * manifested), there is nothing to attach and the attach step is a no-op.
+ */
+val CursedWindbreaker = card("Cursed Windbreaker") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, manifest dread, then attach this Equipment to that " +
+        "creature. (Look at the top two cards of your library. Put one onto the battlefield face " +
+        "down as a 2/2 creature and the other into your graveyard. Turn it face up any time for " +
+        "its mana cost if it's a creature card.)\n" +
+        "Equipped creature has flying.\n" +
+        "Equip {3}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.manifestDread(),
+            Effects.AttachEquipment(EffectTarget.PipelineTarget("manifestDreadManifested"))
+        )
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "47"
+        artist = "Nino Vecia"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f651e216-f9da-4696-8a1d-6d674e9044c0.jpg?1726286030"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FoundFootage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FoundFootage.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.LookAtFaceDownCreatures
+
+/**
+ * Found Footage
+ * {1}
+ * Artifact — Clue
+ * You may look at face-down creatures your opponents control any time.
+ * {2}, Sacrifice this artifact: Surveil 2, then draw a card. (To surveil 2, look at the top two
+ * cards of your library, then put any number of them into your graveyard and the rest on top of
+ * your library in any order.)
+ *
+ * "Look at face-down creatures your opponents control" maps to the
+ * [LookAtFaceDownCreatures] static ability (CR 707.10 — it grants visibility of face-down
+ * creatures you don't control). The Clue subtype carries no built-in ability; the printed
+ * sacrifice ability here is surveil-2-then-draw, modeled directly as an activated ability.
+ */
+val FoundFootage = card("Found Footage") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Clue"
+    oracleText = "You may look at face-down creatures your opponents control any time.\n" +
+        "{2}, Sacrifice this artifact: Surveil 2, then draw a card. (To surveil 2, look at the " +
+        "top two cards of your library, then put any number of them into your graveyard and the " +
+        "rest on top of your library in any order.)"
+
+    staticAbility {
+        ability = LookAtFaceDownCreatures
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.SacrificeSelf
+        )
+        effect = Patterns.Library.surveil(2) then Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "246"
+        artist = "Jarel Threat"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b12eb087-762e-4e7d-a6e0-f48df603b7c7.jpg?1726286790"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/HedgeShredder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/HedgeShredder.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.IterationSpace
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * Hedge Shredder
+ * {2}{G}{G}
+ * Artifact — Vehicle
+ * 5/5
+ * Whenever this Vehicle attacks, you may mill two cards.
+ * Whenever one or more land cards are put into your graveyard from your library, put them onto
+ * the battlefield tapped.
+ * Crew 1
+ *
+ * The second ability is a library-to-graveyard batching trigger ("one or more ... are put into
+ * your graveyard" fires once per event regardless of how many cards moved, per CR 603.2c on a
+ * single trigger event): the milled land cards that caused it are captured into the resolving
+ * ability's pipeline under
+ * [IterationSpace.TRIGGER_CAPTURED_COLLECTION], and a [MoveCollectionEffect] moves
+ * exactly those cards from the graveyard onto the battlefield tapped under the controller's
+ * control. Because the trigger feeds off the same mill the first ability performs, milling lands
+ * (e.g. from "may mill two cards") puts them straight into play.
+ */
+val HedgeShredder = card("Hedge Shredder") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Vehicle"
+    power = 5
+    toughness = 5
+    oracleText = "Whenever this Vehicle attacks, you may mill two cards.\n" +
+        "Whenever one or more land cards are put into your graveyard from your library, put them " +
+        "onto the battlefield tapped.\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        optional = true
+        effect = Patterns.Library.mill(2)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.LandsPutIntoGraveyardFromLibrary
+        effect = MoveCollectionEffect(
+            from = IterationSpace.TRIGGER_CAPTURED_COLLECTION,
+            destination = CardDestination.ToZone(
+                zone = Zone.BATTLEFIELD,
+                placement = ZonePlacement.Tapped
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 1))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "183"
+        artist = "Cristi Balanescu"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39e83502-2ffd-4169-94e3-116701323ed5.jpg?1726286545"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -2454,6 +2454,132 @@
     ]
 }
 
+// Cursed Windbreaker
+{
+    "name": "Cursed Windbreaker",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, manifest dread, then attach this Equipment to that creature. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)\nEquipped creature has flying.\nEquip {3}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeAs": "manifestDreadLooked"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "manifestDreadLooked",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "manifestDreadManifested",
+                                    "storeRemainder": "manifestDreadGraveyard",
+                                    "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                    "remainderLabel": "Put into your graveyard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadManifested",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    },
+                                    "faceDown": "MANIFEST"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadGraveyard",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                },
+                                "EmitManifestedDreadEvent"
+                            ]
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "manifestDreadManifested"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "FLYING"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "47",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Vecia",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f651e216-f9da-4696-8a1d-6d674e9044c0.jpg?1726286030"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Cynical Loner
 {
     "name": "Cynical Loner",
@@ -4917,6 +5043,59 @@
     ]
 }
 
+// Found Footage
+{
+    "name": "Found Footage",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Clue",
+    "oracleText": "You may look at face-down creatures your opponents control any time.\n{2}, Sacrifice this artifact: Surveil 2, then draw a card. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Surveil",
+                            "count": 2
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            "LookAtFaceDownCreatures"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "artist": "Jarel Threat",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b12eb087-762e-4e7d-a6e0-f48df603b7c7.jpg?1726286790"
+    },
+    "colorIdentityOverride": []
+}
+
 // Frantic Strength
 {
     "name": "Frantic Strength",
@@ -6322,6 +6501,87 @@
         "rarity": "MYTHIC",
         "artist": "John Tedrick",
         "imageUri": "https://cards.scryfall.io/normal/front/7/4/744ef0bc-9973-450e-a0c4-056d8244f357.jpg?1726286542"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Hedge Shredder
+{
+    "name": "Hedge Shredder",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Whenever this Vehicle attacks, you may mill two cards.\nWhenever one or more land cards are put into your graveyard from your library, put them onto the battlefield tapped.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "optional": true
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CardsPutIntoGraveyardFromLibraryEvent",
+                    "filter": "land"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveCollection",
+                    "from": "trigger.captured",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "RARE",
+        "artist": "Cristi Balanescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/39e83502-2ffd-4169-94e3-116701323ed5.jpg?1726286545"
     },
     "colorIdentityOverride": [
         "GREEN"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1491,32 +1491,37 @@ class TriggerDetector(
                 val controllerId = entry.controllerId
                 val ownerEvents = libToGravByOwner[controllerId] ?: continue
 
-                // Check if any of the milled cards match the filter
-                val hasMatch = ownerEvents.any { event ->
-                    if (trigger.filter == GameObjectFilter.Any) return@any true
-                    val entity = state.getEntity(event.entityId)
-                    val cardComponent = entity?.get<CardComponent>()
-                    if (cardComponent != null) {
-                        trigger.filter.cardPredicates.all { predicate ->
-                            when (predicate) {
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
-                                    cardComponent.typeLine.isCreature
-                                is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
-                                    cardComponent.typeLine.hasSubtype(predicate.subtype)
-                                else -> true
-                            }
+                // The milled cards matching the filter. These "caused" the trigger and are exposed
+                // to the payoff via TRIGGER_CAPTURED_COLLECTION (a single trigger event fires once
+                // for the whole batch, CR 603.2c) so an effect can act on exactly them — e.g. Hedge
+                // Shredder's "put them onto the battlefield tapped".
+                val matchingIds = ownerEvents.filter { event ->
+                    if (trigger.filter == GameObjectFilter.Any) return@filter true
+                    val cardComponent = state.getEntity(event.entityId)?.get<CardComponent>()
+                        ?: return@filter false
+                    trigger.filter.cardPredicates.all { predicate ->
+                        when (predicate) {
+                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature ->
+                                cardComponent.typeLine.isCreature
+                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLand ->
+                                cardComponent.typeLine.isLand
+                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonland ->
+                                !cardComponent.typeLine.isLand
+                            is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype ->
+                                cardComponent.typeLine.hasSubtype(predicate.subtype)
+                            else -> true
                         }
-                    } else false
-                }
+                    }
+                }.map { it.entityId }
 
-                if (hasMatch) {
+                if (matchingIds.isNotEmpty()) {
                     triggers.add(
                         PendingTrigger(
                             ability = ability,
                             sourceId = entry.entityId,
                             sourceName = entry.cardComponent.name,
                             controllerId = controllerId,
-                            triggerContext = TriggerContext()
+                            triggerContext = TriggerContext(capturedEntityIds = matchingIds)
                         )
                     )
                 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CursedWindbreakerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CursedWindbreakerScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.CursedWindbreaker
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Cursed Windbreaker (DSK #47) — {2}{U} Artifact — Equipment.
+ *
+ * "When this Equipment enters, manifest dread, then attach this Equipment to that creature."
+ * Equipped creature has flying. Equip {3}.
+ *
+ * The ETB composes [com.wingedsheep.sdk.dsl.Patterns.Library.manifestDread] (storing the manifested
+ * creature under the pipeline collection "manifestDreadManifested") with
+ * [com.wingedsheep.sdk.dsl.Effects.AttachEquipment] targeting that pipeline collection. We verify the
+ * Windbreaker attaches to the freshly-manifested 2/2 and grants it flying.
+ */
+class CursedWindbreakerScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + CursedWindbreaker)
+        initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+    }
+
+    test("ETB manifests dread and attaches to the manifested creature, granting flying") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Stack the top two cards: a creature on top, a land beneath it.
+        d.putCardOnTopOfLibrary(you, "Island")
+        val creature = d.putCardOnTopOfLibrary(you, "Centaur Courser") // {2}{G} 3/3, now top
+
+        val windbreaker = d.putCardInHand(you, "Cursed Windbreaker")
+        d.giveMana(you, Color.BLUE, 3)
+        d.castSpell(you, windbreaker)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Manifest dread pauses to choose which looked-at card to manifest.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(you, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The creature is a manifested 2/2 on the battlefield.
+        val manifested = d.state.getEntity(creature)
+        manifested?.get<ManifestedComponent>() shouldBe ManifestedComponent
+
+        // The Windbreaker (find it on the battlefield) is attached to that creature.
+        val windbreakerEntity = d.getPermanents(you).first { d.getCardName(it) == "Cursed Windbreaker" }
+        val attachedTo = d.state.getEntity(windbreakerEntity)?.get<AttachedToComponent>()
+        attachedTo.shouldNotBeNull()
+        attachedTo.targetId shouldBe creature
+
+        // The equipped, manifested creature has flying.
+        d.state.projectedState.hasKeyword(creature, Keyword.FLYING) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FoundFootageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FoundFootageScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.FoundFootage
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Found Footage (DSK #246) — {1} Artifact — Clue.
+ *
+ * "{2}, Sacrifice this artifact: Surveil 2, then draw a card."
+ *
+ * Exercises the activated ability: surveil 2 (keeping both cards on top), then draw. We verify the
+ * Clue is sacrificed (moves to the graveyard) and the controller's hand grows by exactly one card
+ * (the draw — surveil itself does not change hand size when nothing is binned).
+ */
+class FoundFootageScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + FoundFootage)
+        initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20, skipMulligans = true)
+    }
+
+    test("activated ability sacrifices the Clue, surveils 2, then draws a card") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val footage = d.putPermanentOnBattlefield(you, "Found Footage")
+        d.giveColorlessMana(you, 2)
+
+        val handBefore = d.getHand(you).size
+
+        d.submit(ActivateAbility(you, footage, FoundFootage.activatedAbilities[0].id)).isSuccess shouldBe true
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Surveil 2 pauses to choose which looked-at cards to bin — keep both on top.
+        while (d.isPaused) {
+            when (val decision = d.pendingDecision) {
+                is SelectCardsDecision -> d.submitDecision(you, CardsSelectedResponse(decision.id, emptyList()))
+                is ReorderLibraryDecision -> d.submitDecision(you, OrderedResponse(decision.id, decision.cards))
+                else -> break
+            }
+        }
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The Clue was sacrificed to the graveyard.
+        d.getGraveyard(you) shouldContain footage
+
+        // Hand grew by exactly one (the draw); surveil kept both cards on top so binned nothing.
+        d.getHand(you).size shouldBe handBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HedgeShredderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HedgeShredderScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.HedgeShredder
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hedge Shredder (DSK #183) — {2}{G}{G} Artifact — Vehicle 5/5.
+ *
+ * Second ability: "Whenever one or more land cards are put into your graveyard from your library,
+ * put them onto the battlefield tapped." This exercises the new
+ * [com.wingedsheep.sdk.dsl.Triggers.LandsPutIntoGraveyardFromLibrary] batching trigger plus its
+ * `IterationSpace.TRIGGER_CAPTURED_COLLECTION` → `MoveCollectionEffect(... Tapped)` payoff.
+ *
+ * We drive a real library→graveyard mill with Hedge Shredder on the battlefield and assert that
+ * milled lands land on the battlefield tapped under the controller, while milled nonlands stay in
+ * the graveyard.
+ */
+class HedgeShredderScenarioTest : FunSpec({
+
+    // A {0} sorcery that mills the caster's top two cards — produces real library→graveyard
+    // ZoneChangeEvents that drive the batching trigger.
+    val MillTwo = card("Mill Two Iso") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "Mill two cards."
+        spell { effect = Patterns.Library.mill(2) }
+    }
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + HedgeShredder + MillTwo)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20, skipMulligans = true)
+    }
+
+    test("milled land cards enter the battlefield tapped; nonlands stay in the graveyard") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(you, "Hedge Shredder")
+
+        // Stack the top two of the library: a nonland on top, a land beneath it (both milled).
+        val land = d.putCardOnTopOfLibrary(you, "Forest")
+        val nonland = d.putCardOnTopOfLibrary(you, "Grizzly Bears") // now top
+
+        val mill = d.putCardInHand(you, "Mill Two Iso")
+        d.castSpell(you, mill)
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 12) d.bothPass()
+
+        // The land was put onto the battlefield (under your control) tapped.
+        d.getPermanents(you).contains(land) shouldBe true
+        d.state.getEntity(land)?.has<TappedComponent>() shouldBe true
+
+        // The nonland stayed milled in the graveyard.
+        d.getGraveyard(you).contains(nonland) shouldBe true
+    }
+
+    test("milling only nonlands puts nothing onto the battlefield") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(you, "Hedge Shredder")
+
+        val a = d.putCardOnTopOfLibrary(you, "Grizzly Bears")
+        val b = d.putCardOnTopOfLibrary(you, "Grizzly Bears")
+
+        val mill = d.putCardInHand(you, "Mill Two Iso")
+        d.castSpell(you, mill)
+        var guard = 0
+        while (d.stackSize > 0 && guard++ < 12) d.bothPass()
+
+        // Both nonlands stay in the graveyard — nothing enters the battlefield.
+        d.getGraveyard(you).contains(a) shouldBe true
+        d.getGraveyard(you).contains(b) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements three Duskmourn: House of Horror artifacts. All canonical in DSK (first printing).

## Cards

### Cursed Windbreaker — {2}{U} Artifact — Equipment (uncommon, #47)
"When this Equipment enters, manifest dread, then attach this Equipment to that creature. Equipped creature has flying. Equip {3}."

Pure composition: `Patterns.Library.manifestDread()` + `Effects.AttachEquipment(EffectTarget.PipelineTarget("manifestDreadManifested"))`, plus a `GrantKeyword(FLYING)` equip static — the exact shape of the existing Conductive Machete. No engine changes.

### Found Footage — {1} Artifact — Clue (common, #246)
"You may look at face-down creatures your opponents control any time. {2}, Sacrifice this artifact: Surveil 2, then draw a card."

`LookAtFaceDownCreatures` static ability + an activated ability (`Costs.Mana("{2}") + Costs.SacrificeSelf`) running `Patterns.Library.surveil(2) then Effects.DrawCards(1)`. Existing primitives only.

### Hedge Shredder — {2}{G}{G} Artifact — Vehicle 5/5 (rare, #183)
"Whenever this Vehicle attacks, you may mill two cards. Whenever one or more land cards are put into your graveyard from your library, put them onto the battlefield tapped. Crew 1."

The second ability needed a small, general engine addition:
- **`Triggers.LandsPutIntoGraveyardFromLibrary`** — a land-filtered sibling of the existing `CreaturesPutIntoGraveyardFromLibrary`, wrapping `CardsPutIntoGraveyardFromLibraryEvent(GameObjectFilter.Land)`.
- The **library-to-graveyard batch detector** now captures the matching milled cards into `TriggerContext.capturedEntityIds` (seeded to the resolving ability's pipeline under `IterationSpace.TRIGGER_CAPTURED_COLLECTION`, the same slot Kambal / Paranormal Analyst use) and handles the `IsLand` / `IsNonland` card predicates in its filter match (previously only `IsCreature` / `HasSubtype`).
- The payoff is a plain `MoveCollectionEffect` from that captured collection to the battlefield with `ZonePlacement.Tapped` — **no new effect type**. The captured cards are not pruned (the no-prune path only applies to enters-the-battlefield batch triggers), so the milled lands survive in the graveyard to resolution.

## Tests
- New scenario tests in `rules-engine` for all three cards (Cursed Windbreaker attach + flying; Found Footage sacrifice/surveil/draw; Hedge Shredder lands-enter-tapped + nonlands-stay-in-graveyard).
- Full `:rules-engine:test` and `:mtg-sets:test` suites green (incl. `TriggerDetectorBatchTriggerTest`, `ConductiveMacheteScenarioTest`, `ManifestDreadScenarioTest`, `CardLintTest`).
- DSK card snapshot re-blessed — diff is exactly the three new cards, no unrelated card moved.

## Docs / tooling
- `docs/card-sdk-language-reference.md` updated with the new trigger.
- mtgish generator: left as `SCAFFOLD` for Hedge Shredder's land-mill→battlefield payoff (a card-specific batch-trigger shape the emitter declines; the broader mill-trigger family is not emitter-rendered either) — "decline→SCAFFOLD, don't widen".

🤖 Generated with [Claude Code](https://claude.com/claude-code)