### PR TITLE
Add DSK Room cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DefiledCryptCadaverLab.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DefiledCryptCadaverLab.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Defiled Crypt // Cadaver Lab (DSK 91) — split-layout Room (CR 709.5).
+ *
+ * Defiled Crypt {3}{B} — Enchantment — Room
+ *   Whenever one or more cards leave your graveyard, create a 2/2 black Horror enchantment
+ *   creature token. This ability triggers only once each turn.
+ *
+ * Cadaver Lab {B} — Enchantment — Room
+ *   When you unlock this door, return target creature card from your graveyard to your hand.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ *
+ * Defiled Crypt reuses the batching [Triggers.CardsLeaveYourGraveyard] leave-graveyard trigger
+ * with `oncePerTurn = true` for "This ability triggers only once each turn" (the tracker is
+ * cleared at end of turn). The token is an enchantment creature, modeled via
+ * `enchantmentToken = true`. Cadaver Lab is a "when you unlock this door" trigger (CR 709.5h)
+ * returning a target creature card from the controller's own graveyard.
+ */
+val DefiledCryptCadaverLab = card("Defiled Crypt // Cadaver Lab") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "B"
+
+    face("Defiled Crypt") {
+        manaCost = "{3}{B}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Whenever one or more cards leave your graveyard, create a 2/2 black Horror " +
+            "enchantment creature token. This ability triggers only once each turn."
+
+        triggeredAbility {
+            trigger = Triggers.CardsLeaveYourGraveyard()
+            oncePerTurn = true
+            effect = Effects.CreateToken(
+                power = 2,
+                toughness = 2,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Horror"),
+                enchantmentToken = true,
+                imageUri = "https://cards.scryfall.io/normal/front/3/6/36bb6907-e7d7-4f99-966a-ab09ca130fb8.jpg?1754931076"
+            )
+        }
+    }
+
+    face("Cadaver Lab") {
+        manaCost = "{B}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, return target creature card from your graveyard to your hand."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            val creatureCard = target(
+                "target creature card from your graveyard",
+                Targets.CreatureCardInYourGraveyard
+            )
+            effect = Effects.ReturnToHand(creatureCard)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "91"
+        artist = "Martin de Diego Sádaba"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg?1726780590"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -2998,6 +2998,85 @@
     ]
 }
 
+// Defiled Crypt // Cadaver Lab
+{
+    "name": "Defiled Crypt // Cadaver Lab",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "Whenever one or more cards leave your graveyard, create a 2/2 black Horror enchantment creature token. This ability triggers only once each turn.\n//\nWhen you unlock this door, return target creature card from your graveyard to your hand.",
+    "metadata": {
+        "collectorNumber": "91",
+        "rarity": "UNCOMMON",
+        "artist": "Martin de Diego Sádaba",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d94fb4da-0d3f-4d84-966b-914b84b23289.jpg?1726780590"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Defiled Crypt",
+            "manaCost": "{3}{B}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Whenever one or more cards leave your graveyard, create a 2/2 black Horror enchantment creature token. This ability triggers only once each turn.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "CardsLeftYourGraveyardEvent",
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "CreateToken",
+                            "power": 2,
+                            "toughness": 2,
+                            "colors": [
+                                "BLACK"
+                            ],
+                            "creatureTypes": [
+                                "Horror"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/3/6/36bb6907-e7d7-4f99-966a-ab09ca130fb8.jpg?1754931076",
+                            "enchantmentToken": true
+                        },
+                        "oncePerTurn": true
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Cadaver Lab",
+            "manaCost": "{B}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, return target creature card from your graveyard to your hand.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card from your graveyard"
+                            },
+                            "destination": "Hand"
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            },
+                            "id": "target creature card from your graveyard"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Demonic Counsel
 {
     "name": "Demonic Counsel",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DefiledCryptCadaverLabTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DefiledCryptCadaverLabTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.DefiledCryptCadaverLab
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario for `Defiled Crypt // Cadaver Lab` (DSK 91), a split-layout Room (CR 709.5).
+ *
+ * Defiled Crypt {3}{B} — "Whenever one or more cards leave your graveyard, create a 2/2 black
+ *                         Horror enchantment creature token. This ability triggers only once each turn."
+ * Cadaver Lab {B}      — "When you unlock this door, return target creature card from your
+ *                         graveyard to your hand."
+ */
+class DefiledCryptCadaverLabTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(DefiledCryptCadaverLab)
+        d.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    /** Count Horror creature tokens controlled by [playerId]. */
+    fun GameTestDriver.horrorTokenCount(playerId: com.wingedsheep.sdk.model.EntityId): Int =
+        getCreatures(playerId).count { id ->
+            state.getEntity(id)?.get<CardComponent>()?.typeLine?.subtypes
+                ?.any { it.value.equals("Horror", ignoreCase = true) } == true
+        }
+
+    test("casting Cadaver Lab returns a target creature card from your graveyard to your hand") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = d.putCardInGraveyard(p1, "Grizzly Bears")
+
+        // Cast Cadaver Lab ({B}, face 1). The cast face enters unlocked, firing its trigger.
+        val roomId = d.putCardInHand(p1, DefiledCryptCadaverLab.name)
+        d.giveMana(p1, Color.BLACK, 1)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+        d.bothPass()
+
+        val room = d.state.getEntity(roomId)?.get<RoomComponent>()
+        room shouldNotBe null
+        room!!.unlocked shouldBe setOf(RoomFaceId("Cadaver Lab"))
+
+        // The "When you unlock this door" trigger asks for its target creature card.
+        val handBefore = d.getHand(p1).size
+        d.submitTargetSelection(p1, listOf(bears))
+        d.bothPass()
+
+        d.getGraveyard(p1).contains(bears) shouldBe false
+        d.getHand(p1).contains(bears) shouldBe true
+        d.getHand(p1).size shouldBe handBefore + 1
+    }
+
+    test("Defiled Crypt makes one 2/2 Horror enchantment token when one or more cards leave your graveyard") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two creature cards in the graveyard; both will leave in a single batch (one unlock).
+        val bears1 = d.putCardInGraveyard(p1, "Grizzly Bears")
+        d.putCardInGraveyard(p1, "Grizzly Bears")
+
+        // Cast Defiled Crypt (face 0, {3}{B}) — its leave-graveyard trigger is now live.
+        val roomId = d.putCardInHand(p1, DefiledCryptCadaverLab.name)
+        d.giveMana(p1, Color.BLACK, 4)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe setOf(RoomFaceId("Defiled Crypt"))
+
+        d.horrorTokenCount(p1) shouldBe 0
+
+        // Unlock Cadaver Lab ({B}); the unlock special action pauses for Cadaver Lab's
+        // "When you unlock this door" target. Its return makes a card leave the graveyard,
+        // which fires Defiled Crypt's batching leave-graveyard token trigger.
+        d.giveMana(p1, Color.BLACK, 1)
+        d.submit(UnlockRoomDoor(p1, roomId, RoomFaceId("Cadaver Lab")))
+        // Cadaver Lab's unlock trigger targets a graveyard creature card.
+        d.submitTargetSelection(p1, listOf(bears1))
+        d.bothPass() // resolve Cadaver Lab's return; the card leaving fires Defiled Crypt's trigger
+        d.bothPass() // resolve Defiled Crypt's leave-graveyard token trigger
+
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.isFullyUnlocked shouldBe true
+        d.getHand(p1).contains(bears1) shouldBe true
+
+        // Exactly one 2/2 Horror enchantment token entered (batching trigger fires once per batch).
+        d.horrorTokenCount(p1) shouldBe 1
+        val token = d.getCreatures(p1).first { id ->
+            d.state.getEntity(id)?.get<CardComponent>()?.typeLine?.subtypes
+                ?.any { it.value.equals("Horror", ignoreCase = true) } == true
+        }
+        val tokenCard = d.state.getEntity(token)!!.get<CardComponent>()!!
+        tokenCard.typeLine.isEnchantment shouldBe true
+        tokenCard.typeLine.isCreature shouldBe true
+    }
+})


### PR DESCRIPTION
Implements Duskmourn: House of Horror (DSK) "Room" cards (split double-faced enchantments with two unlockable doors).

## Implemented

- **Defiled Crypt // Cadaver Lab** (DSK 91)
  - *Defiled Crypt* `{3}{B}` — "Whenever one or more cards leave your graveyard, create a 2/2 black Horror enchantment creature token. This ability triggers only once each turn." (`Triggers.CardsLeaveYourGraveyard()` + `oncePerTurn = true`, enchantment token).
  - *Cadaver Lab* `{B}` — "When you unlock this door, return target creature card from your graveyard to your hand." (`OnDoorUnlocked` door trigger + `Targets.CreatureCardInYourGraveyard`).
  - Built entirely from existing SDK primitives. Scenario test covers both faces, including the combined flow where Cadaver Lab's return fires Defiled Crypt's batching leave-graveyard token trigger.

## Skipped (need `add-feature`, not pure authoring)

- **Central Elevator // Promising Stairs** (DSK 44) — *Promising Stairs* is supported (`Effects.Surveil` + `DynamicAmount.UnlockedDoors(distinctNames = true)` win condition already exist). But *Central Elevator*'s door — "search your library for a Room card that **doesn't have the same name as a Room you control**" — needs a new search-filter predicate comparing a candidate's name against the names of controlled Rooms. No such predicate exists; approximating with a plain "search for a Room" would wrongly allow fetching duplicates. Since a Room is one card with two faces, the whole card is deferred.

- **Charred Foyer // Warped Space** (DSK 129) — *Charred Foyer*'s impulse draw is supported (`Effects.GrantMayPlayFromExile`). But *Warped Space* — "Once each turn, you may pay `{0}` rather than pay the mana cost for a spell you cast **from exile**" — needs a generalized once-per-turn, from-exile alternative-cost static. The existing `GrantAlternativeCastingCost` (Jodah) applies to all spells with no zone restriction or once-per-turn limit, and `FreeFirstEquipEachTurn` is equip-specific. Whole card deferred.

- **Dazzling Theater // Prop Room** (DSK 3) — *Both* faces are **static abilities** (Dazzling Theater: "Creature spells you cast have convoke"; Prop Room: "Untap each creature you control during each other player's untap step"). The matching SDK statics exist (`GrantKeywordToOwnSpells`, `UntapFilteredDuringOtherUntapSteps`), but the engine does **not** apply a Room face's *static* abilities while that door is unlocked: triggered abilities of unlocked faces are aggregated (`TriggerAbilityResolver.getRoomFaceTriggeredAbilities`), but static-ability collection (`StaticAbilityHandler`, `GrantedKeywordResolver`, `CleanupPhaseManager.hasNoMaximumHandSize`, etc.) only reads the Room's empty top-level script. Confirmed by spotting the same latent gap in the already-merged `RoaringFurnaceSteamingSauna` (its `NoMaximumHandSize` face static is read from the wrong place). This is an `add-feature` fix — making Room face static abilities effective while unlocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)