### PR TITLE
Add 4 FIN Equipment: Aettir and Priwen, Bard's Bow, Genji Glove, Thief's Knife

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -203,10 +203,13 @@ so a land // spell Adventure offers *both* "play the land" (PlayLandEnumerator) 
    `DynamicAmounts.devotionTo(vararg colors)`; the evaluator counts colored mana symbols (incl. hybrid / monocolored
    hybrid / Phyrexian) on controlled permanents, read via projected controller. → Clive, Ifrit's Dominant (ETB).
 
-8. **"First combat phase of the turn" condition + additional-combat rider** — ❌ GAP. `AddCombatPhaseEffect` exists,
-   but nothing tests *"if it's the first combat phase of the turn"* to gate the extra phase (and untap-the-attacker
-   rider). → Genji Glove, Balthier and Fran, Sidequest: Play Blitzball. Add an `is-first-combat-phase` condition +
-   the untap-and-add-phase composition.
+8. **"First combat phase of the turn" condition + additional-combat rider** — ⚠️ PARTIAL. `AddCombatPhaseEffect`
+   exists, but nothing tests *"if it's the first combat phase of the turn"* to gate the extra phase. Genji Glove ships
+   using the accepted `oncePerTurn = true` anti-infinite-loop approximation (same precedent as Raph & Leo / Éomer —
+   composes `Triggers.attacks(binding = ATTACHED)` + untap the equipped creature + `Effects.AddCombatPhase`); the two
+   diverge only when another source of additional combat exists *and* the equipped creature first attacks in combat #2.
+   Still desirable: a faithful `Conditions.IsFirstCombatPhase` primitive to swap in for `oncePerTurn`. → Genji Glove
+   (DONE via approximation), Balthier and Fran, Sidequest: Play Blitzball.
 
 9. **Additional end step** — ❌ GAP. No `AddEndStepEffect` analogous to `AddCombatPhaseEffect` /
    `AddAdditionalUpkeepStepsEffect`. → Y'shtola Rhul ("there is an additional end step after this step"). One new

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AettirAndPriwen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AettirAndPriwen.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessDynamicStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aettir and Priwen
+ * {6}
+ * Legendary Artifact — Equipment
+ * Equipped creature has base power and toughness X/X, where X is your life total.
+ * Equip {5}
+ *
+ * "Your life total" = the Equipment's controller's life total. Modeled as a
+ * characteristic-defining base-P/T set (Layer 7b) on the attached creature, with the
+ * value recomputed continuously from the controller's current life total via
+ * [DynamicAmount.YourLifeTotal] (reads the controller from projection context).
+ */
+val AettirAndPriwen = card("Aettir and Priwen") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Equipped creature has base power and toughness X/X, where X is your life total.\nEquip {5}"
+
+    staticAbility {
+        ability = SetBasePowerToughnessDynamicStatic(
+            power = DynamicAmount.YourLifeTotal,
+            toughness = DynamicAmount.YourLifeTotal,
+            filter = GroupFilter.attachedCreature(),
+        )
+    }
+
+    equipAbility("{5}")
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "253"
+        artist = "Vilhelmas Banys"
+        flavorText = "\"The pinnacle o' perfection, forged from blood, sweat, an' tears!\"\n—Gerolt Blackthorne"
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/038710ca-c756-4e66-a9de-278e676c9f5b.jpg?1748706739"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BardsBow.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BardsBow.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Bard's Bow
+ * {2}{G}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +2/+2, has reach, and is a Bard in addition to its other types.
+ * Perseus's Bow — Equip {6}
+ */
+val BardsBow = card("Bard's Bow") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +2/+2, has reach, and is a Bard in addition to its other types.\n" +
+        "Perseus's Bow — Equip {6} ({6}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = ModifyStats(2, 2, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.REACH, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantSubtype("Bard", Filters.EquippedCreature)
+    }
+
+    equipAbility("{6}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Josephine Chang"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2ac03e90-1e16-453f-88e4-a0448db73403.jpg?1748706414"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GenjiGlove.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GenjiGlove.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Genji Glove
+ * {5}
+ * Artifact — Equipment
+ * Equipped creature has double strike.
+ * Whenever equipped creature attacks, if it's the first combat phase of the turn, untap it.
+ *   After this phase, there is an additional combat phase.
+ * Equip {3}
+ *
+ * Mirrors the Raph & Leo / Éomer shape: attack trigger with an anti-infinite-loop limiter,
+ * untap the attacker, then [Effects.AddCombatPhase] to add a second combat phase (combat only,
+ * no trailing main phase). The trigger binds to the attached creature via [TriggerBinding.ATTACHED],
+ * and "untap it" untaps that same equipped creature via [EffectTarget.EquippedCreature].
+ *
+ * **Approximation note:** the printed rider is *"if it's the first combat phase of the turn"*
+ * (intervening-if), but the engine has no "first combat phase" condition today. The same
+ * anti-infinite-loop function is served by `oncePerTurn = true`; the two diverge only in a narrow
+ * edge case (another source of additional combat exists *and* the equipped creature first attacks
+ * in combat #2 — the intervening-if would fail, `oncePerTurn = true` would still let it fire once).
+ * When a `Conditions.IsFirstCombatPhase` primitive lands, swap `oncePerTurn = true` for a faithful
+ * `triggerCondition`.
+ */
+val GenjiGlove = card("Genji Glove") {
+    manaCost = "{5}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has double strike.\n" +
+        "Whenever equipped creature attacks, if it's the first combat phase of the turn, untap it. After this phase, there is an additional combat phase.\n" +
+        "Equip {3}"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.DOUBLE_STRIKE, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.attacks(binding = TriggerBinding.ATTACHED)
+        oncePerTurn = true
+        effect = Effects.Composite(
+            listOf(
+                // "untap it" — the attacking equipped creature.
+                Effects.Untap(EffectTarget.EquippedCreature),
+                // "After this phase, there is an additional combat phase." (combat only — no main)
+                Effects.AddCombatPhase,
+            )
+        )
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "258"
+        artist = "Elizabeth Peiró"
+        flavorText = "\"I must say, I quite enjoy these tussles.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f724dde1-84b0-4e3b-a9b8-44cd22bb9f79.jpg?1748706757"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ThiefsKnife.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ThiefsKnife.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Thief's Knife
+ * {2}{U}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +1/+1, has "Whenever this creature deals combat damage to a
+ *   player, draw a card," and is a Rogue in addition to its other types.
+ * Equip {4}
+ *
+ * The granted "deals combat damage to a player → draw a card" ability lives on the equipped
+ * creature (GrantTriggeredAbility over the attached-creature filter, SELF binding), so it fires
+ * on the equipped creature's own combat damage and draws for the creature's controller.
+ */
+val ThiefsKnife = card("Thief's Knife") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +1/+1, has \"Whenever this creature deals combat damage to a player, draw a card,\" and is a Rogue in addition to its other types.\n" +
+        "Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToPlayer.event,
+                binding = Triggers.DealsCombatDamageToPlayer.binding,
+                effect = Effects.DrawCards(1)
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+    staticAbility {
+        ability = GrantSubtype("Rogue", Filters.EquippedCreature)
+    }
+
+    equipAbility("{4}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "81"
+        artist = "Domenico Cava"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2dcfd0a-3f52-4616-a09a-fd2db8b6b93e.jpg?1748706064"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -214,6 +214,66 @@
     "colorIdentityOverride": []
 }
 
+// Aettir and Priwen
+{
+    "name": "Aettir and Priwen",
+    "manaCost": "{6}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Equipped creature has base power and toughness X/X, where X is your life total.\nEquip {5}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "SetBasePowerToughnessDynamicStatic",
+                "power": "YourLifeTotal",
+                "toughness": "YourLifeTotal",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{5}",
+    "metadata": {
+        "collectorNumber": "253",
+        "rarity": "MYTHIC",
+        "artist": "Vilhelmas Banys",
+        "flavorText": "\"The pinnacle o' perfection, forged from blood, sweat, an' tears!\"\n—Gerolt Blackthorne",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/038710ca-c756-4e66-a9de-278e676c9f5b.jpg?1748706739"
+    },
+    "colorIdentityOverride": []
+}
+
 // Ahriman
 {
     "name": "Ahriman",
@@ -630,6 +690,109 @@
         "artist": "Fang Xinyu",
         "flavorText": "\"Sometimes it's better to run!\"\n—Quistis Trepe",
         "imageUri": "https://cards.scryfall.io/normal/front/e/5/e5857b1b-73bc-458e-b26b-7ed8bef785f3.jpg?1748706407"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Bard's Bow
+{
+    "name": "Bard's Bow",
+    "manaCost": "{2}{G}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +2/+2, has reach, and is a Bard in addition to its other types.\nPerseus's Bow — Equip {6} ({6}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{6}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 2
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "REACH"
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Bard",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{6}",
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Josephine Chang",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2ac03e90-1e16-453f-88e4-a0448db73403.jpg?1748706414"
     },
     "colorIdentityOverride": [
         "GREEN"
@@ -3346,6 +3509,80 @@
     "colorIdentityOverride": [
         "WHITE"
     ]
+}
+
+// Genji Glove
+{
+    "name": "Genji Glove",
+    "manaCost": "{5}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has double strike.\nWhenever equipped creature attacks, if it's the first combat phase of the turn, untap it. After this phase, there is an additional combat phase.\nEquip {3}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": "EquippedCreature",
+                            "tap": false
+                        },
+                        "AddCombatPhase"
+                    ]
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOUBLE_STRIKE"
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "258",
+        "rarity": "RARE",
+        "artist": "Elizabeth Peiró",
+        "flavorText": "\"I must say, I quite enjoy these tussles.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f724dde1-84b0-4e3b-a9b8-44cd22bb9f79.jpg?1748706757"
+    },
+    "colorIdentityOverride": []
 }
 
 // Gigantoad
@@ -8536,6 +8773,124 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Thief's Knife
+{
+    "name": "Thief's Knife",
+    "manaCost": "{2}{U}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +1/+1, has \"Whenever this creature deals combat damage to a player, draw a card,\" and is a Rogue in addition to its other types.\nEquip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "damageType": "DamageCombat",
+                        "recipient": "AnyPlayer"
+                    },
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Rogue",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{4}",
+    "metadata": {
+        "collectorNumber": "81",
+        "rarity": "UNCOMMON",
+        "artist": "Domenico Cava",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2dcfd0a-3f52-4616-a09a-fd2db8b6b93e.jpg?1748706064"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinEquipmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinEquipmentScenarioTest.kt
@@ -3,6 +3,9 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.SelectCardsDecision
 import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.AdditionalPhasesComponent
+import com.wingedsheep.engine.state.components.player.ExtraPhaseKind
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Keyword
@@ -225,6 +228,165 @@ class FinEquipmentScenarioTest : ScenarioTestBase() {
 
             withClue("Opponent took 3 (Bolt) + 1 (granted ability) = 4 damage") {
                 game.getLifeTotal(2) shouldBe oppLifeBefore - 4
+            }
+        }
+
+        val aettirEquipId by lazy {
+            cardRegistry.requireCard("Aettir and Priwen").activatedAbilities[0].id
+        }
+
+        val genjiEquipId by lazy {
+            cardRegistry.requireCard("Genji Glove").activatedAbilities[0].id
+        }
+
+        test("Genji Glove: equipped creature has double strike; attacking untaps it and adds a combat phase") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Genji Glove")
+                .withLandsOnBattlefield(1, "Plains", 3) // pay Equip {3}
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val glove = game.findPermanent("Genji Glove")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = glove,
+                    abilityId = genjiEquipId,
+                    targets = listOf(ChosenTarget.Permanent(bears))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("Equipped creature has double strike") {
+                stateProjector.project(game.state).hasKeyword(bears, Keyword.DOUBLE_STRIKE) shouldBe true
+            }
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Grizzly Bears" to 2))
+            // Attacking taps it...
+            withClue("Bears is tapped right after declaring it as an attacker") {
+                game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+            }
+            // ...the Genji Glove attack trigger resolves: untap it + queue an additional combat phase.
+            game.passPriority()
+            game.resolveStack()
+
+            withClue("Genji Glove's trigger untapped the attacking equipped creature") {
+                game.state.getEntity(bears)?.has<TappedComponent>() shouldBe false
+            }
+            withClue("An additional combat phase was queued for the active player") {
+                val extra = game.state.getEntity(game.player1Id)?.get<AdditionalPhasesComponent>()
+                (extra?.phases?.contains(ExtraPhaseKind.COMBAT)) shouldBe true
+            }
+        }
+
+        test("Aettir and Priwen: equipped creature has base power/toughness = controller's life total") {
+            // Life set to 13 — distinct from both the printed 2/2 and the default 20, so the
+            // assertion proves the CDA *sets* base P/T to the controller's life total.
+            val game = scenario()
+                .withPlayers()
+                .withLifeTotal(1, 13)
+                .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 base — overwritten by the CDA
+                .withCardOnBattlefield(1, "Aettir and Priwen")
+                .withLandsOnBattlefield(1, "Plains", 5)    // pay Equip {5}
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val equip = game.findPermanent("Aettir and Priwen")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = equip,
+                    abilityId = aettirEquipId,
+                    targets = listOf(ChosenTarget.Permanent(bears))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            val projected = stateProjector.project(game.state)
+            withClue("Base P/T is *set* to controller's life total (13), overwriting the printed 2/2") {
+                projected.getPower(bears) shouldBe 13
+                projected.getToughness(bears) shouldBe 13
+            }
+        }
+
+        test("Bard's Bow: +2/+2, reach, and Bard (job select)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Bard's Bow")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Bard's Bow").error shouldBe null
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            val hero = game.findPermanent("Hero Token")!!
+            val projected = stateProjector.project(game.state)
+            withClue("Equipped Hero token should be 3/3 (1/1 base + 2/+2)") {
+                projected.getPower(hero) shouldBe 3
+                projected.getToughness(hero) shouldBe 3
+            }
+            withClue("Equipped Hero token should have reach") {
+                projected.hasKeyword(hero, Keyword.REACH) shouldBe true
+            }
+            withClue("Equipped Hero token should be a Bard in addition to its other types") {
+                projected.hasSubtype(hero, "Bard") shouldBe true
+            }
+        }
+
+        test("Thief's Knife: +1/+1, granted 'combat damage to a player -> draw', and Rogue (job select)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Thief's Knife")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withCardInLibrary(1, "Plains") // drawn by the granted trigger
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Thief's Knife").error shouldBe null
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            val hero = game.findPermanent("Hero Token")!!
+            run {
+                val projected = stateProjector.project(game.state)
+                withClue("Equipped Hero token should be 2/2 (1/1 base + 1/+1)") {
+                    projected.getPower(hero) shouldBe 2
+                    projected.getToughness(hero) shouldBe 2
+                }
+                withClue("Equipped Hero token should be a Rogue in addition to its other types") {
+                    projected.hasSubtype(hero, "Rogue") shouldBe true
+                }
+            }
+
+            val handBefore = game.handSize(1)
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Hero Token" to 2))
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareNoBlockers()
+            game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+            game.passPriority()
+            game.resolveStack()
+
+            withClue("Opponent took 2 combat damage from the equipped Hero token") {
+                game.getLifeTotal(2) shouldBe 18
+            }
+            withClue("Dealing combat damage to a player drew a card") {
+                game.handSize(1) shouldBe handBefore + 1
             }
         }
 


### PR DESCRIPTION
Implements four Final Fantasy (FIN) Equipment cards, each via the `add-card` skill and composed entirely from existing SDK primitives (no new effect types).

## Cards

| Card | Cost | Equip | Behavior |
|------|------|-------|----------|
| **Aettir and Priwen** | {6} | {5} | Equipped creature has base P/T X/X where X is your life total |
| **Bard's Bow** | {2}{G} | {6} | Job select; +2/+2, reach, is a Bard |
| **Genji Glove** | {5} | {3} | Double strike; attack trigger untaps it + adds a combat phase |
| **Thief's Knife** | {2}{U} | {4} | Job select; +1/+1, granted "combat damage to a player → draw", is a Rogue |

## Implementation notes

- **Aettir and Priwen** — `SetBasePowerToughnessDynamicStatic` (Layer 7b CDA) over `attachedCreature()`, with power/toughness = `DynamicAmount.YourLifeTotal`. `YourLifeTotal` reads `context.controllerId` — the Equipment's controller — so it correctly means "your life total" and recomputes continuously at projection (proven by a test asserting 13/13 at 13 life, overwriting the printed 2/2).
- **Bard's Bow** / **Thief's Knife** — `jobSelect()` + `Filters.EquippedCreature` static abilities, matching the existing Samurai's Katana / White Mage's Staff pattern. Thief's Knife grants its draw-on-combat-damage ability via `GrantTriggeredAbility` (SELF binding on the equipped creature).
- **Genji Glove** — double-strike static + `Triggers.attacks(binding = ATTACHED)` trigger that untaps the equipped creature (`EffectTarget.EquippedCreature`) and composes `Effects.AddCombatPhase`. The printed "if it's the first combat phase of the turn" rider uses the accepted `oncePerTurn = true` anti-infinite-loop approximation — the same precedent already shipped on Raph & Leo / Éomer, since the engine has no `IsFirstCombatPhase` condition yet. Backlog updated accordingly.

## Tests

- Added scenario coverage for all four to `FinEquipmentScenarioTest` (P/T from life total, job-select stats/subtypes/granted triggers, double strike + untap + extra combat phase, combat-damage draw). All 9 tests in the class pass.
- Reblessed the FIN card snapshot (`CardDefinitionSnapshotTest`) — diff adds only the four new card trees.
- `CardLintTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)