### PR TITLE
Add DSK standalone cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AbhorrentOculus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AbhorrentOculus.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Abhorrent Oculus
+ * {2}{U}
+ * Creature — Eye
+ * 5/5
+ * As an additional cost to cast this spell, exile six cards from your graveyard.
+ * Flying
+ * At the beginning of each opponent's upkeep, manifest dread. (Look at the top two cards of your
+ * library. Put one onto the battlefield face down as a 2/2 creature and the other into your
+ * graveyard. Turn it face up any time for its mana cost if it's a creature card.)
+ *
+ * The graveyard exile is an [AdditionalCost.ExileFrom] over six cards from your graveyard
+ * (CR 601.2f — paid as the spell is cast), so the spell can't be cast without six cards to exile.
+ * The upkeep payoff reuses [Patterns.Library.manifestDread] (CR 701.62).
+ */
+val AbhorrentOculus = card("Abhorrent Oculus") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Eye"
+    oracleText = "As an additional cost to cast this spell, exile six cards from your graveyard.\n" +
+        "Flying\n" +
+        "At the beginning of each opponent's upkeep, manifest dread. (Look at the top two cards of " +
+        "your library. Put one onto the battlefield face down as a 2/2 creature and the other into " +
+        "your graveyard. Turn it face up any time for its mana cost if it's a creature card.)"
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.FLYING)
+
+    additionalCost(
+        Costs.additional.ExileCards(count = 6)
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EachOpponentUpkeep
+        effect = Patterns.Library.manifestDread()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "42"
+        artist = "Bryan Sola"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2705b43-a94a-44c0-8740-82e0b296820c.jpg?1726286015"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfMissingOut.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FearOfMissingOut.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fear of Missing Out
+ * {1}{R}
+ * Enchantment Creature — Nightmare
+ * 2/3
+ * When this creature enters, discard a card, then draw a card.
+ * Delirium — Whenever this creature attacks for the first time each turn, if there are four or more
+ * card types among cards in your graveyard, untap target creature. After this phase, there is an
+ * additional combat phase.
+ *
+ * The Delirium attack ability is one triggered ability gated by an intervening "if" (CR 603.4 —
+ * [Conditions.Delirium]). Per its rulings the untap and the extra combat phase resolve together:
+ * if the target creature is illegal as the ability resolves, neither happens. The phase added is a
+ * combat phase only ([Effects.AddCombatPhase]) — no additional main phase (so end-of-combat goes
+ * straight into the next begin-combat).
+ */
+val FearOfMissingOut = card("Fear of Missing Out") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment Creature — Nightmare"
+    oracleText = "When this creature enters, discard a card, then draw a card.\n" +
+        "Delirium — Whenever this creature attacks for the first time each turn, if there are four " +
+        "or more card types among cards in your graveyard, untap target creature. After this phase, " +
+        "there is an additional combat phase."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Discard(1).then(Effects.DrawCards(1))
+        description = "When this creature enters, discard a card, then draw a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.AttacksFirstTimeEachTurn
+        triggerCondition = Conditions.Delirium(4)
+        val t = target("creature", TargetCreature())
+        effect = Effects.Composite(
+            Effects.Untap(t),
+            Effects.AddCombatPhase,
+        )
+        description = "Delirium — Whenever this creature attacks for the first time each turn, if " +
+            "there are four or more card types among cards in your graveyard, untap target " +
+            "creature. After this phase, there is an additional combat phase."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "136"
+        artist = "John Stanko"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d48aaff-46ab-411b-9456-171d4709f951.jpg?1726286354"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GhostlyDancers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GhostlyDancers.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ghostly Dancers
+ * {3}{W}{W}
+ * Creature — Spirit
+ * 2/5
+ * Flying
+ * When this creature enters, return an enchantment card from your graveyard to your hand or unlock
+ * a locked door of a Room you control.
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, create a
+ * 3/1 white Spirit creature token with flying.
+ *
+ * The ETB is a "choose one" modal (CR 700.2): mode 1 returns an enchantment card from your graveyard
+ * to your hand (a resolution-time Gather → Select(1) → Move-to-hand, not a target); mode 2 unlocks a
+ * locked door of a Room you control via the resolution-time [Effects.UnlockDoor] effect (CR 709.5f),
+ * modeled as "up to one target Room you control with a locked door" so a player with no eligible
+ * Room can still pick this mode. The Eerie ability is the two standard Eerie triggers (an enchantment
+ * you control entering, and fully unlocking a Room) each creating the flying Spirit token.
+ */
+val GhostlyDancers = card("Ghostly Dancers") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    power = 2
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When this creature enters, return an enchantment card from your graveyard to your hand or " +
+        "unlock a locked door of a Room you control.\n" +
+        "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, " +
+        "create a 3/1 white Spirit creature token with flying."
+
+    keywords(Keyword.FLYING, Keyword.EERIE)
+
+    // ETB — choose one: return an enchantment from your graveyard, or unlock a Room door.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.Composite(
+                    GatherCardsEffect(
+                        source = CardSource.FromZone(
+                            Zone.GRAVEYARD,
+                            Player.You,
+                            GameObjectFilter.Enchantment,
+                        ),
+                        storeAs = "ghostlyDancersReturnable",
+                    ),
+                    SelectFromCollectionEffect(
+                        from = "ghostlyDancersReturnable",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        storeSelected = "ghostlyDancersToReturn",
+                        showAllCards = true,
+                        prompt = "Return an enchantment card from your graveyard to your hand",
+                        selectedLabel = "Return to hand",
+                    ),
+                    MoveCollectionEffect(
+                        from = "ghostlyDancersToReturn",
+                        destination = CardDestination.ToZone(Zone.HAND),
+                    ),
+                ),
+                "Return an enchantment card from your graveyard to your hand",
+            ),
+            Mode.withTarget(
+                Effects.UnlockDoor(EffectTarget.ContextTarget(0)),
+                TargetObject(
+                    optional = true,
+                    filter = TargetFilter(
+                        GameObjectFilter.Any.withSubtype(Subtype.ROOM).youControl(),
+                    ).hasLockedDoor(),
+                ),
+                "Unlock a locked door of a Room you control",
+            ),
+        )
+        description = "When this creature enters, return an enchantment card from your graveyard to " +
+            "your hand or unlock a locked door of a Room you control."
+    }
+
+    // Eerie — part 1: whenever an enchantment you control enters.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/4/b/4b7697e3-b3fb-481c-a90f-1ae08d8a9880.jpg?1726236503",
+        )
+        description = "Eerie — Whenever an enchantment you control enters, create a 3/1 white Spirit creature token with flying."
+    }
+
+    // Eerie — part 2: whenever you fully unlock a Room.
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/4/b/4b7697e3-b3fb-481c-a90f-1ae08d8a9880.jpg?1726236503",
+        )
+        description = "Eerie — Whenever you fully unlock a Room, create a 3/1 white Spirit creature token with flying."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "13"
+        artist = "Josh Newton"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab38adb5-8f16-4a4a-8dbc-f6ec14ca6c9f.jpg?1726285905"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -49,6 +49,102 @@
     ]
 }
 
+// Abhorrent Oculus
+{
+    "name": "Abhorrent Oculus",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Eye",
+    "oracleText": "As an additional cost to cast this spell, exile six cards from your graveyard.\nFlying\nAt the beginning of each opponent's upkeep, manifest dread. (Look at the top two cards of your library. Put one onto the battlefield face down as a 2/2 creature and the other into your graveyard. Turn it face up any time for its mana cost if it's a creature card.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "manifestDreadLooked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "manifestDreadLooked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "manifestDreadManifested",
+                            "storeRemainder": "manifestDreadGraveyard",
+                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadManifested",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "faceDown": "MANIFEST"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "manifestDreadGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        },
+                        "EmitManifestedDreadEvent"
+                    ]
+                }
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomExileFrom",
+                    "zone": "Graveyard",
+                    "count": 6
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "42",
+        "rarity": "MYTHIC",
+        "artist": "Bryan Sola",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2705b43-a94a-44c0-8740-82e0b296820c.jpg?1726286015"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Acrobatic Cheerleader
 {
     "name": "Acrobatic Cheerleader",
@@ -4884,6 +4980,126 @@
     ]
 }
 
+// Fear of Missing Out
+{
+    "name": "Fear of Missing Out",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment Creature — Nightmare",
+    "oracleText": "When this creature enters, discard a card, then draw a card.\nDelirium — Whenever this creature attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, discard a card, then draw a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        "AttacksFirstTimeEachTurn"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "creature"
+                            },
+                            "tap": false
+                        },
+                        "AddCombatPhase"
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "creature"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "Delirium — Whenever this creature attacks for the first time each turn, if there are four or more card types among cards in your graveyard, untap target creature. After this phase, there is an additional combat phase."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "RARE",
+        "artist": "John Stanko",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d48aaff-46ab-411b-9456-171d4709f951.jpg?1726286354"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Fear of Surveillance
 {
     "name": "Fear of Surveillance",
@@ -5617,6 +5833,158 @@
         "imageUri": "https://cards.scryfall.io/normal/front/8/a/8ac39c01-127f-4471-bc74-11a90c48e306.jpg?1726286797"
     },
     "colorIdentityOverride": []
+}
+
+// Ghostly Dancers
+{
+    "name": "Ghostly Dancers",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhen this creature enters, return an enchantment card from your graveyard to your hand or unlock a locked door of a Room you control.\nEerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, create a 3/1 white Spirit creature token with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Graveyard",
+                                            "filter": "enchantment"
+                                        },
+                                        "storeAs": "ghostlyDancersReturnable"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "ghostlyDancersReturnable",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "ghostlyDancersToReturn",
+                                        "prompt": "Return an enchantment card from your graveyard to your hand",
+                                        "selectedLabel": "Return to hand",
+                                        "showAllCards": true
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "ghostlyDancersToReturn",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        }
+                                    }
+                                ]
+                            },
+                            "description": "Return an enchantment card from your graveyard to your hand"
+                        },
+                        {
+                            "effect": "UnlockDoor",
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "optional": true,
+                                    "filter": {
+                                        "baseFilter": {
+                                            "cardPredicates": [
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Room"
+                                                }
+                                            ],
+                                            "statePredicates": [
+                                                "HasLockedDoor"
+                                            ],
+                                            "controllerPredicate": "ControlledByYou"
+                                        }
+                                    }
+                                }
+                            ],
+                            "description": "Unlock a locked door of a Room you control"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this creature enters, return an enchantment card from your graveyard to your hand or unlock a locked door of a Room you control."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b7697e3-b3fb-481c-a90f-1ae08d8a9880.jpg?1726236503"
+                },
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, create a 3/1 white Spirit creature token with flying."
+            },
+            {
+                "id": "ability_3",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b7697e3-b3fb-481c-a90f-1ae08d8a9880.jpg?1726236503"
+                },
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, create a 3/1 white Spirit creature token with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "RARE",
+        "artist": "Josh Newton",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab38adb5-8f16-4a4a-8dbc-f6ec14ca6c9f.jpg?1726285905"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Ghostly Keybearer

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbhorrentOculusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbhorrentOculusScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Abhorrent Oculus (DSK #42) — {2}{U} Creature — Eye, 5/5, flying.
+ *
+ * "As an additional cost to cast this spell, exile six cards from your graveyard.
+ *  Flying
+ *  At the beginning of each opponent's upkeep, manifest dread."
+ *
+ * Exercises:
+ *  - the `ExileCards(count = 6, fromZone = GRAVEYARD)` additional cost (paid as the spell is cast —
+ *    so the spell is uncastable without six cards to exile), and
+ *  - the `EachOpponentUpkeep` triggered ability reusing the shared manifest-dread recipe.
+ */
+class AbhorrentOculusScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.fillGraveyard(player: EntityId, count: Int): List<EntityId> =
+        (0 until count).map { putCardInGraveyard(player, "Grizzly Bears") }
+
+    test("casting exiles six cards from the graveyard and resolves onto the battlefield") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        val graveyardCards = driver.fillGraveyard(me, 6)
+        val spell = driver.putCardInHand(me, "Abhorrent Oculus")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 2)
+
+        val cast = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = emptyList(),
+                additionalCostPayment = AdditionalCostPayment(exiledCards = graveyardCards),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        cast.error shouldBe null
+
+        // The six cards are exiled as the spell is cast.
+        driver.getExile(me).shouldContainAll(graveyardCards)
+        driver.getGraveyard(me).size shouldBe 0
+
+        while (driver.state.stack.isNotEmpty()) driver.bothPass()
+        driver.getCreatures(me).map { driver.getCardName(it) } shouldContainAll listOf("Abhorrent Oculus")
+    }
+
+    test("the spell cannot be cast without six cards in the graveyard") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        val tooFew = driver.fillGraveyard(me, 5) // one short
+        val spell = driver.putCardInHand(me, "Abhorrent Oculus")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.giveColorlessMana(me, 2)
+
+        val cast = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = emptyList(),
+                additionalCostPayment = AdditionalCostPayment(exiledCards = tooFew),
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        // Casting must fail — the additional cost requires exiling six cards.
+        (cast.error != null).shouldBe(true)
+        driver.getExile(me).size shouldBe 0
+    }
+
+    test("manifests dread at the beginning of each opponent's upkeep") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        driver.putCreatureOnBattlefield(me, "Abhorrent Oculus")
+
+        // Seed the controller's library so manifest dread has cards to look at.
+        driver.putCardOnTopOfLibrary(me, "Island")
+        val creature = driver.putCardOnTopOfLibrary(me, "Grizzly Bears")
+
+        // Advance to the opponent's upkeep — the trigger fires there.
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        driver.activePlayer shouldBe opponent
+
+        // The trigger goes on the stack at upkeep; resolve until the manifest-dread pick pauses.
+        var guard = 0
+        while (driver.pendingDecision !is SelectCardsDecision && guard++ < 30) {
+            if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+        }
+
+        // Resolve the manifest-dread trigger by choosing the creature to manifest.
+        val pick = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitDecision(me, CardsSelectedResponse(pick.id, listOf(creature)))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // The chosen card is now a face-down 2/2 the controller controls.
+        driver.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfMissingOutScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfMissingOutScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.player.AdditionalPhasesComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fear of Missing Out (DSK #136) — {1}{R} Enchantment Creature — Nightmare 2/3.
+ *
+ * "When this creature enters, discard a card, then draw a card.
+ *  Delirium — Whenever this creature attacks for the first time each turn, if there are four or more
+ *  card types among cards in your graveyard, untap target creature. After this phase, there is an
+ *  additional combat phase."
+ *
+ * Exercises the ETB rummage (discard then draw), and the Delirium-gated first-attack trigger: it
+ * untaps a target creature and queues a single additional combat phase only when Delirium is on,
+ * and does nothing when Delirium is off.
+ */
+class FearOfMissingOutScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    /** Fill the player's graveyard with four distinct card types to switch Delirium on. */
+    fun GameTestDriver.enableDelirium(player: EntityId) {
+        putCardInGraveyard(player, "Grizzly Bears")    // creature
+        putCardInGraveyard(player, "Lightning Bolt")   // instant
+        putCardInGraveyard(player, "Doom Blade")       // sorcery (per Spineseeker test corpus)
+        putCardInGraveyard(player, "Test Enchantment") // enchantment
+    }
+
+    test("enters: discard a card, then draw a card") {
+        val d = newDriver()
+        val me = d.player1
+
+        val toDiscard = d.putCardInHand(me, "Grizzly Bears")
+        d.putCardOnTopOfLibrary(me, "Lightning Bolt") // the card we will draw
+        val fomo = d.putCardInHand(me, "Fear of Missing Out")
+        d.giveMana(me, Color.RED, 1)
+        d.giveColorlessMana(me, 1)
+
+        d.castSpell(me, fomo)
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // ETB pauses to choose the card to discard.
+        val discardPick = d.pendingDecision as? SelectCardsDecision
+            ?: error("expected a discard SelectCardsDecision; got ${d.pendingDecision}")
+        d.submitDecision(me, CardsSelectedResponse(discardPick.id, listOf(toDiscard)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The discarded card is in the graveyard and the drawn card is in hand.
+        d.getGraveyard(me).map { d.getCardName(it) }.contains("Grizzly Bears") shouldBe true
+        d.getHand(me).map { d.getCardName(it) }.contains("Lightning Bolt") shouldBe true
+    }
+
+    test("Delirium on: first attack untaps target creature and queues an additional combat phase") {
+        val d = newDriver()
+        val me = d.player1
+        val opp = d.player2
+
+        val fomo = d.putCreatureOnBattlefield(me, "Fear of Missing Out")
+        d.removeSummoningSickness(fomo)
+        d.enableDelirium(me)
+
+        // A separate tapped creature we control to be the untap target.
+        val tapped = d.putCreatureOnBattlefield(me, "Grizzly Bears")
+        d.tapPermanent(tapped)
+        d.isTapped(tapped) shouldBe true
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(me, listOf(fomo), opp)
+
+        // The Delirium trigger pauses to choose the untap target.
+        var guard = 0
+        while (d.pendingDecision !is ChooseTargetsDecision && guard++ < 20) {
+            if (d.state.stack.isNotEmpty()) d.bothPass() else break
+        }
+        d.pendingDecision as? ChooseTargetsDecision
+            ?: error("expected ChooseTargetsDecision for the untap target; got ${d.pendingDecision}")
+        d.submitTargetSelection(me, listOf(tapped))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Target creature is untapped and an additional combat phase is queued.
+        d.isTapped(tapped) shouldBe false
+        val phases = d.state.getEntity(me)?.get<AdditionalPhasesComponent>()
+        (phases != null && phases.phases.isNotEmpty()) shouldBe true
+    }
+
+    test("Delirium off: first attack does nothing (no target, no extra combat)") {
+        val d = newDriver()
+        val me = d.player1
+        val opp = d.player2
+
+        val fomo = d.putCreatureOnBattlefield(me, "Fear of Missing Out")
+        d.removeSummoningSickness(fomo)
+        // Only three card types in the graveyard — Delirium is OFF.
+        d.putCardInGraveyard(me, "Grizzly Bears")
+        d.putCardInGraveyard(me, "Lightning Bolt")
+        d.putCardInGraveyard(me, "Doom Blade")
+
+        val tapped = d.putCreatureOnBattlefield(me, "Grizzly Bears")
+        d.tapPermanent(tapped)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(me, listOf(fomo), opp)
+        repeat(6) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // No untap, no additional combat phase — the intervening-if failed.
+        d.isTapped(tapped) shouldBe true
+        val phases = d.state.getEntity(me)?.get<AdditionalPhasesComponent>()
+        (phases == null || phases.phases.isEmpty()) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostlyDancersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhostlyDancersScenarioTest.kt
@@ -1,0 +1,186 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ghostly Dancers (DSK #13) — {3}{W}{W} Creature — Spirit 2/5, flying.
+ *
+ * "When this creature enters, return an enchantment card from your graveyard to your hand or unlock
+ *  a locked door of a Room you control.
+ *  Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, create a
+ *  3/1 white Spirit creature token with flying."
+ *
+ * Exercises the choose-one ETB modal (return-from-graveyard vs unlock-a-Room-door) and both Eerie
+ * triggers (the second one firing off the unlock-mode fully unlocking the Room).
+ */
+class GhostlyDancersScenarioTest : FunSpec({
+
+    // A Room whose locked face does nothing special — we only care about fully unlocking it.
+    val testRoom = card("Dancer Hall // Dancer Vault") {
+        layout = CardLayout.SPLIT
+        face("Dancer Hall") {
+            manaCost = "{2}{W}"
+            typeLine = "Enchantment — Room"
+            oracleText = "At the beginning of your end step, draw a card."
+            triggeredAbility {
+                trigger = Triggers.YourEndStep
+                effect = Effects.DrawCards(1)
+            }
+        }
+        face("Dancer Vault") {
+            manaCost = "{3}{W}{W}"
+            typeLine = "Enchantment — Room"
+            oracleText = "Vault."
+        }
+    }
+
+    fun newDriver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(testRoom)
+        d.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun GameTestDriver.tokenCount(player: EntityId): Int =
+        getCreatures(player).count { state.getEntity(it)?.has<TokenComponent>() == true }
+
+    test("ETB mode 1: returns an enchantment card from your graveyard to your hand") {
+        val d = newDriver()
+        val me = d.player1
+
+        val enchantment = d.putCardInGraveyard(me, "Test Enchantment")
+        // A non-enchantment in the graveyard must NOT be eligible.
+        d.putCardInGraveyard(me, "Grizzly Bears")
+        val dancers = d.putCardInHand(me, "Ghostly Dancers")
+        d.giveMana(me, Color.WHITE, 5)
+
+        d.submitSuccess(CastSpell(me, dancers, paymentStrategy = com.wingedsheep.engine.core.PaymentStrategy.FromPool))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The ETB trigger surfaces a mode choice.
+        val mode = d.pendingDecision as? ChooseOptionDecision
+            ?: error("expected a ChooseOptionDecision; got ${d.pendingDecision}")
+        d.submitDecision(me, OptionChosenResponse(mode.id, optionIndex = 0)) // return-from-graveyard
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // With exactly one eligible enchantment card, the mandatory return resolves it without a
+        // prompt; if multiple are eligible the engine pauses on a SelectCardsDecision.
+        (d.pendingDecision as? SelectCardsDecision)?.let { pick ->
+            pick.options shouldContain enchantment
+            d.submitDecision(me, CardsSelectedResponse(pick.id, listOf(enchantment)))
+            while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        }
+
+        // The enchantment came back; the non-enchantment Grizzly Bears stayed in the graveyard.
+        d.getHand(me) shouldContain enchantment
+        d.getGraveyard(me) shouldNotContain enchantment
+    }
+
+    test("ETB mode 2: unlocks a locked door of a target Room you control") {
+        val d = newDriver()
+        val me = d.player1
+
+        // Put the Room on the battlefield with the right door locked (cast its left face).
+        val roomId = d.putCardInHand(me, testRoom.name)
+        d.giveMana(me, Color.WHITE, 3)
+        d.submitSuccess(CastSpell(me, roomId, faceIndex = 0))
+        d.bothPass()
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.isFullyUnlocked shouldBe false
+
+        val dancers = d.putCardInHand(me, "Ghostly Dancers")
+        d.giveMana(me, Color.WHITE, 5)
+        d.submitSuccess(CastSpell(me, dancers, paymentStrategy = com.wingedsheep.engine.core.PaymentStrategy.FromPool))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        val mode = d.pendingDecision as? ChooseOptionDecision
+            ?: error("expected a ChooseOptionDecision; got ${d.pendingDecision}")
+        d.submitDecision(me, OptionChosenResponse(mode.id, optionIndex = 1)) // unlock-a-door
+        while (d.pendingDecision !is ChooseTargetsDecision && d.state.stack.isNotEmpty()) d.bothPass()
+
+        val targetDecision = d.pendingDecision as? ChooseTargetsDecision
+            ?: error("expected a ChooseTargetsDecision for the Room; got ${d.pendingDecision}")
+        targetDecision.legalTargets[0]!! shouldContain roomId
+        d.submitTargetSelection(me, listOf(roomId))
+        repeat(10) { if (!d.isPaused) d.bothPass() }
+
+        // The chosen mode unlocked the locked door, fully unlocking the Room.
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.isFullyUnlocked shouldBe true
+    }
+
+    // NOTE: Ghostly Dancers also has the second Eerie trigger "whenever you fully unlock a Room,
+    // create a 3/1 white flying Spirit token" (Triggers.RoomFullyUnlocked, ANY binding — identical
+    // to the shipped Erratic Apparition / Gremlin Tamer). A probe showed this trigger does NOT fire
+    // off a real unlock for ANY of those cards: the unlock action emits a RoomFullyUnlockedEvent,
+    // but TriggerDetector.detectTriggers does not match the RoomFullyUnlocked trigger, so no Eerie
+    // payoff happens. That is a pre-existing engine gap (no existing test exercises the fully-unlock
+    // Eerie payoff end-to-end), out of scope for this card. The trigger is authored correctly here;
+    // when the engine gap is fixed it will fire. This test pins the part that works today: the
+    // unlock fully unlocks the Room and the event is emitted.
+    test("fully unlocking a Room emits RoomFullyUnlockedEvent (Eerie payoff blocked by a pre-existing engine gap)") {
+        val d = newDriver()
+        val me = d.player1
+
+        d.putCreatureOnBattlefield(me, "Ghostly Dancers")
+
+        // A separate Room on the battlefield with its second door still locked.
+        val roomId = d.putCardInHand(me, testRoom.name)
+        d.giveMana(me, Color.WHITE, 3)
+        d.submitSuccess(CastSpell(me, roomId, faceIndex = 0))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.isFullyUnlocked shouldBe false
+
+        // Fully unlock the Room via the unlock-door special action.
+        d.giveMana(me, Color.WHITE, 5)
+        val ur = d.submitSuccess(UnlockRoomDoor(me, roomId, RoomFaceId("Dancer Vault")))
+
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.isFullyUnlocked shouldBe true
+        ur.events.any { it::class.simpleName == "RoomFullyUnlockedEvent" } shouldBe true
+    }
+
+    test("Eerie: an enchantment entering creates a 3/1 white flying Spirit token") {
+        val d = newDriver()
+        val me = d.player1
+
+        d.putCreatureOnBattlefield(me, "Ghostly Dancers")
+        val tokensBefore = d.tokenCount(me)
+
+        // Play an enchantment — its ETB fires the Eerie trigger.
+        val enchantment = d.putCardInHand(me, "Test Enchantment")
+        d.giveMana(me, Color.WHITE, 5)
+        d.submitSuccess(CastSpell(me, enchantment, paymentStrategy = com.wingedsheep.engine.core.PaymentStrategy.FromPool))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        val token = d.getCreatures(me).firstOrNull {
+            d.state.getEntity(it)?.has<TokenComponent>() == true
+        }
+        (token != null) shouldBe true
+        d.tokenCount(me) shouldBe tokensBefore + 1
+        d.state.projectedState.getPower(token!!) shouldBe 3
+        d.state.projectedState.getToughness(token) shouldBe 1
+    }
+})


### PR DESCRIPTION
Implements three Duskmourn: House of Horror (DSK) cards using only existing SDK primitives — no new engine features.

## Implemented

- **Abhorrent Oculus** ({2}{U} 5/5 flying Eye) — additional cost exiles six cards from your graveyard (`Costs.additional.ExileCards`); at the beginning of each opponent's upkeep it manifests dread (`Patterns.Library.manifestDread` on `Triggers.EachOpponentUpkeep`).
- **Fear of Missing Out** ({1}{R} 2/3 Nightmare) — ETB rummage (discard then draw); Delirium-gated first-attack trigger (`triggerCondition = Conditions.Delirium(4)`) untaps a target creature and adds a single combat phase (`Effects.AddCombatPhase`, no extra main, per the rulings).
- **Ghostly Dancers** ({3}{W}{W} 2/5 flying Spirit) — choose-one ETB modal: return an enchantment card from your graveyard, or unlock a locked door of a Room you control (`Effects.UnlockDoor`); Eerie creates a 3/1 white flying Spirit token on both trigger halves (enchantment enters / fully unlock a Room).

Each card has a `rules-engine` scenario test (additional cost + uncastable-without-six, manifest-dread upkeep trigger, ETB rummage, Delirium on/off, additional combat phase, both ETB modes, enchantment-enters Eerie token). The DSK card snapshot golden was re-blessed (diff adds only the three new cards). Card-lint and snapshot suites pass; all images verified HTTP 200; canonical placement confirmed via `check-card-printing`.

## Skipped

- **Oblivious Bookworm** — its end-step "discard a card **unless** a permanent entered the battlefield face down under your control this turn **or** you turned a permanent face up this turn" needs turn-tracking conditions the engine doesn't have (no `TurnTracker` / `Conditions.*` for entered-face-down or turned-face-up this turn). Implementing it faithfully is `add-feature` work (new SDK conditions + cross-layer event wiring), so it was deferred rather than faked.

## Known pre-existing engine gap (not introduced here)

Ghostly Dancers' "whenever you fully unlock a Room" Eerie token half is authored identically to the shipped **Erratic Apparition** / **Gremlin Tamer**. A probe shows that trigger does not fire off a real unlock for any of those cards: the unlock action emits `RoomFullyUnlockedEvent`, but `TriggerDetector.detectTriggers` does not match the `RoomFullyUnlocked` trigger, so no Eerie payoff happens. No existing test exercises that path end-to-end. The trigger is authored correctly and will fire once the engine gap is closed; the scenario test documents this and pins the behavior that works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)