### PR TITLE
Add 4 FIN spells: Airship Crash, Haste Magic, Phoenix Down, Slash of Light

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AirshipCrash.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AirshipCrash.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Airship Crash
+ * {2}{G}
+ * Instant
+ * Destroy target artifact, enchantment, or creature with flying.
+ * Cycling {2} ({2}, Discard this card: Draw a card.)
+ *
+ * The target filter is a heterogeneous OR — any artifact, any enchantment, OR a
+ * creature that has flying. The flying restriction binds only to the creature branch.
+ */
+val AirshipCrash = card("Airship Crash") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact, enchantment, or creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)"
+
+    spell {
+        val t = target(
+            "target",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact or
+                        GameObjectFilter.Enchantment or
+                        GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+                )
+            )
+        )
+        effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
+    }
+
+    keywordAbility(KeywordAbility.cycling("{2}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "171"
+        artist = "Enora Mercier"
+        flavorText = "\"Just our luck to crash in this forest... it's gonna get interesting...\"\n—Baku, Tantalus leader"
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ec91c4e4-711f-464d-bc83-e6813f4fdcdb.jpg?1750188044"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/HasteMagic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/HasteMagic.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Haste Magic
+ * {1}{R}
+ * Instant
+ * Target creature gets +3/+1 and gains haste until end of turn. Exile the top card of
+ * your library. You may play it until your next end step.
+ *
+ * The exile-and-may-play clause is "impulse draw" with an extended permission window
+ * ([MayPlayExpiry.UntilNextEndStep] — this turn's end step counts on your own turn).
+ */
+val HasteMagic = card("Haste Magic") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+1 and gains haste until end of turn. Exile the top card of your library. You may play it until your next end step."
+
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 1, t),
+            Effects.GrantKeyword(Keyword.HASTE, t),
+            Patterns.Exile.impulse(count = 1, expiry = MayPlayExpiry.UntilNextEndStep)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "David Astruga"
+        flavorText = "\"Double time.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3af9d100-70ee-4c6c-a762-11a0c4f3ef6f.jpg?1748706286"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PhoenixDown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PhoenixDown.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Phoenix Down
+ * {W}
+ * Artifact
+ * {1}{W}, {T}, Exile this artifact: Choose one —
+ * • Return target creature card with mana value 4 or less from your graveyard to the battlefield tapped.
+ * • Exile target Skeleton, Spirit, or Zombie.
+ *
+ * A modal activated ability whose cost includes exiling the artifact itself
+ * ([Costs.ExileSelf]). Mode 1 reanimates a small creature from your graveyard (entering
+ * tapped via [ZonePlacement.Tapped]); Mode 2 exiles a creature of one of the three named
+ * undead/spirit types.
+ */
+val PhoenixDown = card("Phoenix Down") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "{1}{W}, {T}, Exile this artifact: Choose one —\n" +
+        "• Return target creature card with mana value 4 or less from your graveyard to the battlefield tapped.\n" +
+        "• Exile target Skeleton, Spirit, or Zombie."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{W}"), Costs.Tap, Costs.ExileSelf)
+        effect = ModalEffect.chooseOne(
+            Mode.withTarget(
+                Effects.Move(
+                    EffectTarget.ContextTarget(0),
+                    Zone.BATTLEFIELD,
+                    placement = ZonePlacement.Tapped,
+                    fromZone = Zone.GRAVEYARD
+                ),
+                TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMost(4)),
+                "Return target creature card with mana value 4 or less from your graveyard to the battlefield tapped"
+            ),
+            Mode.withTarget(
+                Effects.Exile(EffectTarget.ContextTarget(0)),
+                TargetCreature(
+                    filter = TargetFilter(GameObjectFilter.Creature.withAnySubtype("Skeleton", "Spirit", "Zombie"))
+                ),
+                "Exile target Skeleton, Spirit, or Zombie"
+            ),
+            countsAsModalSpell = false
+        )
+        description = "{1}{W}, {T}, Exile this artifact: Choose one — Return target creature card with mana value 4 or less from your graveyard to the battlefield tapped; or Exile target Skeleton, Spirit, or Zombie."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "John Severin Brassell"
+        flavorText = "A feather with the power to revive those who have exhausted their strength."
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62e299b0-9ef6-49d3-aa79-384325fed89e.jpg?1748705861"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SlashOfLight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SlashOfLight.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Slash of Light
+ * {1}{W}
+ * Instant
+ * Slash of Light deals damage equal to the number of creatures you control plus the
+ * number of Equipment you control to target creature.
+ *
+ * The damage amount sums two battlefield counts (creatures + Equipment, each scoped to
+ * the controller) via [DynamicAmount.Add]. The spell itself is the damage source.
+ */
+val SlashOfLight = card("Slash of Light") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Slash of Light deals damage equal to the number of creatures you control plus the number of Equipment you control to target creature."
+
+    spell {
+        val t = target("target", Targets.Creature)
+        effect = Effects.DealDamage(
+            DynamicAmount.Add(
+                DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature),
+                DynamicAmount.Count(
+                    Player.You,
+                    Zone.BATTLEFIELD,
+                    GameObjectFilter.Artifact.withSubtype(Subtype("Equipment"))
+                )
+            ),
+            t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "32"
+        artist = "Nathaniel Himawan"
+        flavorText = "The endless struggle that raged over two thousand years had ended, and peace prevailed once more."
+        imageUri = "https://cards.scryfall.io/normal/front/d/a/da6d9529-3cb0-4adc-8209-b9b02db3bf54.jpg?1748705874"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -273,6 +273,74 @@
     ]
 }
 
+// Airship Crash
+{
+    "name": "Airship Crash",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact, enchantment, or creature with flying.\nCycling {2} ({2}, Discard this card: Draw a card.)",
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            "IsArtifact",
+                                            "IsEnchantment"
+                                        ]
+                                    },
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasKeyword",
+                                                "keyword": "FLYING"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "artist": "Enora Mercier",
+        "flavorText": "\"Just our luck to crash in this forest... it's gonna get interesting...\"\n—Baku, Tantalus leader",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ec91c4e4-711f-464d-bc83-e6813f4fdcdb.jpg?1750188044"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Al Bhed Salvagers
 {
     "name": "Al Bhed Salvagers",
@@ -3798,6 +3866,94 @@
     ]
 }
 
+// Haste Magic
+{
+    "name": "Haste Magic",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+1 and gains haste until end of turn. Exile the top card of your library. You may play it until your next end step.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "impulseExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "impulseExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "impulseExiled",
+                            "expiry": {
+                                "type": "UntilControllerStep",
+                                "step": "END"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "David Astruga",
+        "flavorText": "\"Double time.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3af9d100-70ee-4c6c-a762-11a0c4f3ef6f.jpg?1748706286"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hecteyes
 {
     "name": "Hecteyes",
@@ -5909,6 +6065,93 @@
     ]
 }
 
+// Phoenix Down
+{
+    "name": "Phoenix Down",
+    "manaCost": "{W}",
+    "typeLine": "Artifact",
+    "oracleText": "{1}{W}, {T}, Exile this artifact: Choose one —\n• Return target creature card with mana value 4 or less from your graveyard to the battlefield tapped.\n• Exile target Skeleton, Spirit, or Zombie.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Battlefield",
+                                "placement": "Tapped",
+                                "fromZone": "Graveyard"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature mv<=4 own:you",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ],
+                            "description": "Return target creature card with mana value 4 or less from your graveyard to the battlefield tapped"
+                        },
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Exile"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature Skeleton|Spirit|Zombie"
+                                    }
+                                }
+                            ],
+                            "description": "Exile target Skeleton, Spirit, or Zombie"
+                        }
+                    ],
+                    "countsAsModalSpell": false
+                },
+                "descriptionOverride": "{1}{W}, {T}, Exile this artifact: Choose one — Return target creature card with mana value 4 or less from your graveyard to the battlefield tapped; or Exile target Skeleton, Spirit, or Zombie."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "John Severin Brassell",
+        "flavorText": "A feather with the power to revive those who have exhausted their strength.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62e299b0-9ef6-49d3-aa79-384325fed89e.jpg?1748705861"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Qiqirn Merchant
 {
     "name": "Qiqirn Merchant",
@@ -7294,6 +7537,56 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Slash of Light
+{
+    "name": "Slash of Light",
+    "manaCost": "{1}{W}",
+    "typeLine": "Instant",
+    "oracleText": "Slash of Light deals damage equal to the number of creatures you control plus the number of Equipment you control to target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Add",
+                "left": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature"
+                },
+                "right": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact Equipment"
+                }
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "artist": "Nathaniel Himawan",
+        "flavorText": "The endless struggle that raged over two thousand years had ended, and peace prevailed once more.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/a/da6d9529-3cb0-4adc-8209-b9b02db3bf54.jpg?1748705874"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AirshipCrashScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AirshipCrashScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CycleCard
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.AirshipCrash
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Airship Crash.
+ *
+ * Airship Crash: {2}{G}
+ * Instant
+ * Destroy target artifact, enchantment, or creature with flying.
+ * Cycling {2}
+ */
+class AirshipCrashScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + AirshipCrash)
+        return driver
+    }
+
+    test("Airship Crash destroys a creature with flying") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Birds of Paradise has flying.
+        val flyer = driver.putCreatureOnBattlefield(opponent, "Birds of Paradise")
+
+        val crash = driver.putCardInHand(activePlayer, "Airship Crash")
+        driver.giveMana(activePlayer, Color.GREEN, 3)
+
+        val castResult = driver.castSpell(activePlayer, crash, listOf(flyer))
+        castResult.isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Birds of Paradise") shouldBe null
+        driver.getGraveyardCardNames(opponent) shouldContain "Birds of Paradise"
+    }
+
+    test("Airship Crash cannot target a creature without flying") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val grounded = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val crash = driver.putCardInHand(activePlayer, "Airship Crash")
+        driver.giveMana(activePlayer, Color.GREEN, 3)
+
+        val castResult = driver.castSpell(activePlayer, crash, listOf(grounded))
+        castResult.isSuccess shouldBe false
+
+        driver.findPermanent(opponent, "Centaur Courser") shouldNotBe null
+    }
+
+    test("Airship Crash can be cycled") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val crash = driver.putCardInHand(activePlayer, "Airship Crash")
+        driver.giveMana(activePlayer, Color.GREEN, 2)
+
+        val handBefore = driver.getHandSize(activePlayer)
+        val result = driver.submit(CycleCard(playerId = activePlayer, cardId = crash))
+        result.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Cycling discards Airship Crash and draws a card; net hand size unchanged.
+        driver.getGraveyardCardNames(activePlayer) shouldContain "Airship Crash"
+        driver.getHandSize(activePlayer) shouldBe handBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HasteMagicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HasteMagicScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.HasteMagic
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Haste Magic (FIN #140) — {1}{R} Instant.
+ *
+ *   "Target creature gets +3/+1 and gains haste until end of turn. Exile the top card of
+ *    your library. You may play it until your next end step."
+ *
+ * Exercises the pump + haste grant plus an impulse-draw with the extended
+ * [com.wingedsheep.sdk.scripting.effects.MayPlayExpiry.UntilNextEndStep] permission window.
+ */
+class HasteMagicScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + HasteMagic)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        return driver
+    }
+
+    test("pumps the target +3/+1, grants haste, and impulse-exiles the top card") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Grizzly Bears is a vanilla 2/2 with no haste.
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.state.projectedState.getPower(bears) shouldBe 2
+        driver.state.projectedState.getToughness(bears) shouldBe 2
+        driver.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe false
+
+        driver.putCardOnTopOfLibrary(me, "Mountain")
+        val spell = driver.putCardInHand(me, "Haste Magic")
+        driver.giveMana(me, Color.RED, 2)
+
+        driver.castSpell(me, spell, listOf(bears)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Pump + haste applied (2/2 Grizzly Bears -> 5/3).
+        driver.state.projectedState.getPower(bears) shouldBe 5
+        driver.state.projectedState.getToughness(bears) shouldBe 3
+        driver.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+
+        // Top card exiled and flagged playable.
+        driver.getExileCardNames(me) shouldBe listOf("Mountain")
+        val exiled = driver.getExile(me).single()
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds } shouldBe true
+
+        // It can actually be played from exile this turn.
+        driver.playLand(me, exiled).isSuccess shouldBe true
+        driver.getExile(me).contains(exiled) shouldBe false
+    }
+
+    test("the play permission expires at the controller's own next end step") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(me, "Mountain")
+        val spell = driver.putCardInHand(me, "Haste Magic")
+        driver.giveMana(me, Color.RED, 2)
+
+        driver.castSpell(me, spell, listOf(bears)).isSuccess shouldBe true
+        driver.bothPass()
+
+        val exiled = driver.getExile(me).single()
+        // Live on the turn it was cast — "your next end step" is this turn's end step.
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds } shouldBe true
+
+        // Once we pass this turn's end step into the opponent's turn, the window has closed.
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+        driver.state.activePlayerId shouldBe opp
+        driver.state.mayPlayPermissions.any { exiled in it.cardIds } shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PhoenixDownScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PhoenixDownScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.PhoenixDown
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Phoenix Down (FIN #29) — {W} Artifact.
+ *
+ *   "{1}{W}, {T}, Exile this artifact: Choose one —
+ *    • Return target creature card with mana value 4 or less from your graveyard to the battlefield tapped.
+ *    • Exile target Skeleton, Spirit, or Zombie."
+ *
+ * Modal activated ability with an Exile-self cost. Mode 0 reanimates a small creature
+ * (entering tapped); Mode 1 exiles a Skeleton/Spirit/Zombie.
+ */
+class PhoenixDownScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + PhoenixDown)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        return driver
+    }
+
+    test("mode 0: reanimate a small creature from your graveyard, entering tapped") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Centaur Courser is a 3/3 for {2}{G} — mana value 3, within the "4 or less" gate.
+        driver.putCardInGraveyard(me, "Centaur Courser")
+        val down = driver.putPermanentOnBattlefield(me, "Phoenix Down")
+        driver.giveMana(me, Color.WHITE, 2) // {1}{W}
+
+        val abilityId = PhoenixDown.activatedAbilities[0].id
+        driver.submit(ActivateAbility(playerId = me, sourceId = down, abilityId = abilityId)).isSuccess shouldBe true
+        driver.bothPass() // resolve → mode choice
+
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(me, OptionChosenResponse(modeDecision.id, 0))
+        // Per-mode target: the creature in the graveyard.
+        val courser = driver.getGraveyard(me).first { driver.getCardName(it) == "Centaur Courser" }
+        driver.submitTargetSelection(me, listOf(courser))
+        driver.bothPass()
+
+        // Reanimated onto the battlefield, tapped; the artifact exiled itself.
+        val reanimated = driver.getCreatures(me).first { driver.getCardName(it) == "Centaur Courser" }
+        driver.isTapped(reanimated) shouldBe true
+        driver.getExile(me).contains(down) shouldBe true
+    }
+
+    test("mode 1: exile a target Zombie") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Black Creature is a 2/2 Zombie.
+        val zombie = driver.putCreatureOnBattlefield(opp, "Black Creature")
+        val down = driver.putPermanentOnBattlefield(me, "Phoenix Down")
+        driver.giveMana(me, Color.WHITE, 2)
+
+        val abilityId = PhoenixDown.activatedAbilities[0].id
+        driver.submit(ActivateAbility(playerId = me, sourceId = down, abilityId = abilityId)).isSuccess shouldBe true
+        driver.bothPass()
+
+        val modeDecision = driver.pendingDecision as ChooseOptionDecision
+        driver.submitDecision(me, OptionChosenResponse(modeDecision.id, 1))
+        driver.submitTargetSelection(me, listOf(zombie))
+        driver.bothPass()
+
+        driver.findPermanent(opp, "Black Creature") shouldBe null
+        driver.getExileCardNames(opp) shouldContain "Black Creature"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlashOfLightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlashOfLightScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SlashOfLight
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Slash of Light (FIN #32) — {1}{W} Instant.
+ *
+ *   "Slash of Light deals damage equal to the number of creatures you control plus the
+ *    number of Equipment you control to target creature."
+ *
+ * Verifies the summed dynamic damage (creatures + Equipment you control).
+ */
+class SlashOfLightScenarioTest : FunSpec({
+
+    // A simple Equipment artifact to count toward the damage.
+    val testEquipment = card("Test Sword") {
+        manaCost = "{1}"
+        typeLine = "Artifact — Equipment"
+        oracleText = "Equip {1}"
+        equipAbility("{1}")
+    }
+
+    // A plain (non-Equipment) artifact that must NOT count toward the damage.
+    val plainArtifact = card("Test Trinket") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+
+    // A high-toughness target so it survives and we can read the marked damage exactly.
+    val bigWall = card("Big Wall") {
+        manaCost = "{4}"
+        typeLine = "Creature — Wall"
+        power = 0
+        toughness = 10
+        oracleText = ""
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SlashOfLight, testEquipment, plainArtifact, bigWall))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        return driver
+    }
+
+    fun GameTestDriver.markedDamage(id: EntityId): Int =
+        state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    test("deals damage equal to creatures + Equipment you control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // 2 creatures and 1 Equipment under my control -> expected 3 damage.
+        driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        driver.putPermanentOnBattlefield(me, "Test Sword")
+
+        val target = driver.putCreatureOnBattlefield(opp, "Big Wall")
+
+        val slash = driver.putCardInHand(me, "Slash of Light")
+        driver.giveMana(me, Color.WHITE, 2)
+
+        driver.castSpell(me, slash, listOf(target)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.markedDamage(target) shouldBe 3
+    }
+
+    test("counts only Equipment, not other artifacts; only creatures you control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // 1 of my creatures + 1 Equipment = 2. Opponent's creature and a non-Equipment
+        // artifact must not count.
+        driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        driver.putPermanentOnBattlefield(me, "Test Sword")
+        driver.putCreatureOnBattlefield(opp, "Centaur Courser") // not mine
+        driver.putPermanentOnBattlefield(me, "Test Trinket")    // artifact, not Equipment
+
+        val target = driver.putCreatureOnBattlefield(opp, "Big Wall")
+
+        val slash = driver.putCardInHand(me, "Slash of Light")
+        driver.giveMana(me, Color.WHITE, 2)
+
+        driver.castSpell(me, slash, listOf(target)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.markedDamage(target) shouldBe 2
+    }
+})


### PR DESCRIPTION
Implements four Final Fantasy (FIN) cards, each composed from existing SDK primitives — no new engine types, executors, keywords, or conditions.

## Cards

| Card | Cost / Type | Mechanic |
|------|-------------|----------|
| **Airship Crash** | {2}{G} Instant, Cycling {2} | Destroy target artifact, enchantment, or creature with flying. Heterogeneous `or` target filter (`Artifact or Enchantment or Creature.withKeyword(FLYING)`) collapsing to a flat `CardPredicate.Or`. |
| **Haste Magic** | {1}{R} Instant | Target creature gets +3/+1 and gains haste until EOT; impulse-draw via `Patterns.Exile.impulse` with the extended `MayPlayExpiry.UntilNextEndStep` window. |
| **Phoenix Down** | {W} Artifact | Modal activated ability with an Exile-self cost (`Costs.Composite(Mana, Tap, ExileSelf)`): reanimate a MV≤4 creature from your graveyard entering tapped (`ZonePlacement.Tapped`), or exile a target Skeleton/Spirit/Zombie. |
| **Slash of Light** | {1}{W} Instant | Deals damage to target creature equal to `DynamicAmount.Add(Count creatures you control, Count Equipment you control)`. |

## Tests

Nine rules-engine scenario test cases (all passing) covering happy paths and edge cases: illegal targets, cycling, both Phoenix Down modes (reanimate + exile), dynamic-count scoping (only your creatures, only Equipment), and the impulse permission expiring at the controller's own next end step. FIN card-definition snapshot golden re-blessed (diff adds only the four new cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)