### PR TITLE
Add Malboro, Tonberry, Sahagin to Final Fantasy (FIN)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1323,6 +1323,10 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
     pipeline internals change. Any effect-tree walker that needs the inner nodes expands through the
     single `LibraryPatterns.expandMacro(effect)` helper.
 - `mill(count)` — top N cards into graveyard.
+- `exileTop(count, target = Controller)` — top N cards of a player's library into exile (Malboro's
+  "exiles the top three cards of their library"). Same Gather → Move pipeline as `mill`, destination
+  exile. `count` is an `Int` or `DynamicAmount`. Pass a `target` (e.g. a `Player.You` rebind under
+  `Effects.ForEachPlayer(Player.EachOpponent, …)`) to exile another player's library top.
 - `lookAtTopAndKeep(count, keepCount)` — Ancestral Memories — keep exactly K to hand.
 - `lookAtTopRevealMatchingToHand(count, filter, prompt, restDestination?, restOrder?)` — Radagast the
   Brown / Star Charter shape: look at top `count`, **optionally** reveal one card matching `filter` to
@@ -4083,6 +4087,11 @@ answer it and would silently return `false`.
   mana was spent to cast it" about the *triggering* spell (reads its `CastRecordComponent`). Used as a
   triggered-ability intervening-if (Boromir, Warden of the Tower: "Whenever an opponent casts a spell,
   if no mana was spent to cast it, counter that spell" → pair with `Effects.CounterTriggeringSpell()`).
+- `TriggeringSpellManaSpentAtLeast(amount)` — threshold counterpart of
+  `TriggeringSpellCastWithoutPayingMana`: "if at least `amount` mana was spent to cast it" about the
+  *triggering* spell (sums the mana paid recorded on its `SpellOnStackComponent`). Triggered-ability
+  intervening-if (Sahagin: "Whenever you cast a noncreature spell, if at least four mana was spent to
+  cast it, …"). Counts actual mana paid, so an {X} spell that paid four or more qualifies.
 - `BlightWasPaid(amount)` — the Blight X additional cost was paid.
 
 ### Source state

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1323,6 +1323,13 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TriggeringSpellCastWithoutPayingMana
 
     /**
+     * Intervening-if: "if at least [amount] mana was spent to cast it" about the triggering spell
+     * (Sahagin). Threshold counterpart of [TriggeringSpellCastWithoutPayingMana].
+     */
+    fun TriggeringSpellManaSpentAtLeast(amount: Int): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TriggeringSpellManaSpentAtLeast(amount)
+
+    /**
      * If the triggering entity entered or was cast from a graveyard.
      * Used by Twilight Diviner: "if they entered or were cast from a graveyard".
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -595,6 +595,38 @@ object LibraryPatterns {
         )
     }
 
+    /**
+     * Exile the top [count] cards of a player's library — "exiles the top N cards of their
+     * library" (Malboro). Same Gather → Move pipeline as [mill], but the destination is exile
+     * rather than the graveyard. Defaults to the controller; pass a [target] (e.g. a
+     * `Player.You` rebind under `Effects.ForEachPlayer(Player.EachOpponent, …)`) to exile another
+     * player's library top.
+     */
+    fun exileTop(count: Int, target: EffectTarget = EffectTarget.Controller): CompositeEffect =
+        exileTop(DynamicAmount.Fixed(count), target)
+
+    fun exileTop(count: DynamicAmount, target: EffectTarget = EffectTarget.Controller): CompositeEffect {
+        val player = when (target) {
+            EffectTarget.Controller -> Player.You
+            is EffectTarget.ContextTarget -> Player.ContextPlayer(target.index)
+            is EffectTarget.BoundVariable -> Player.ContextPlayer(0)
+            is EffectTarget.PlayerRef -> target.player
+            else -> Player.You
+        }
+        return CompositeEffect(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(count, player),
+                    storeAs = "exiled_top"
+                ),
+                MoveCollectionEffect(
+                    from = "exiled_top",
+                    destination = CardDestination.ToZone(Zone.EXILE, player)
+                )
+            )
+        )
+    }
+
     fun shuffleGraveyardIntoLibrary(target: EffectTarget = EffectTarget.ContextTarget(0)): CompositeEffect {
         val player = effectTargetToPlayer(target)
         return CompositeEffect(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/BattlefieldConditions.kt
@@ -104,6 +104,21 @@ data object TriggeringSpellCastWithoutPayingMana : Condition {
 }
 
 /**
+ * Condition: "if at least [amount] mana was spent to cast it" — about the TRIGGERING spell.
+ * Reads the total mana paid recorded on the triggering spell's `SpellOnStackComponent`
+ * (the same source [TriggeringSpellCastWithoutPayingMana] reads) and is true when that total
+ * is `>= amount`. The threshold counterpart of [TriggeringSpellCastWithoutPayingMana]; the
+ * intervening-"if" clause for cast-payoffs like Sahagin ("Whenever you cast a noncreature
+ * spell, if at least four mana was spent to cast it, …"). False when the triggering entity
+ * isn't a spell on the stack.
+ */
+@SerialName("TriggeringSpellManaSpentAtLeast")
+@Serializable
+data class TriggeringSpellManaSpentAtLeast(val amount: Int) : Condition {
+    override val description: String = "if at least $amount mana was spent to cast it"
+}
+
+/**
  * Condition: "if it entered or was cast from a graveyard".
  * True when the triggering entity has either EnteredFromGraveyardComponent (reanimated
  * directly from graveyard → battlefield) or CastFromGraveyardComponent (spell was cast

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Malboro.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Malboro.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Malboro
+ * {4}{B}{B}
+ * Creature — Plant Horror
+ * 4/4
+ * Bad Breath — When this creature enters, each opponent discards a card, loses 2 life, and
+ * exiles the top three cards of their library.
+ * Swampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it,
+ * put it into your hand, then shuffle.)
+ *
+ * The ETB acts on *each* opponent individually, so it is modeled with
+ * [Effects.ForEachPlayer] over [Player.EachOpponent]: within each iteration `Player.You`
+ * rebinds to that opponent, so the discard / life loss / exile-top all target the player
+ * being processed. Swampcycling is Typecycling for the Swamp land type.
+ */
+val Malboro = card("Malboro") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Plant Horror"
+    power = 4
+    toughness = 4
+    oracleText = "Bad Breath — When this creature enters, each opponent discards a card, loses 2 life, " +
+        "and exiles the top three cards of their library.\n" +
+        "Swampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, " +
+        "put it into your hand, then shuffle.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachPlayer(
+            Player.EachOpponent,
+            listOf(
+                Patterns.Hand.discardCards(1, EffectTarget.Controller),
+                Effects.LoseLife(2, EffectTarget.Controller),
+                Patterns.Library.exileTop(3, EffectTarget.Controller),
+            ),
+        )
+    }
+
+    keywordAbility(KeywordAbility.typecycling("Swamp", ManaCost.parse("{2}")))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "106"
+        artist = "Dan Watson"
+        imageUri = "https://cards.scryfall.io/normal/front/e/4/e46d8048-03ce-4e07-ba24-f41ba6140a4e.jpg?1748706158"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Sahagin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Sahagin.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sahagin
+ * {1}{U}
+ * Creature — Merfolk Warrior
+ * 1/3
+ * Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a
+ * +1/+1 counter on this creature and it can't be blocked this turn.
+ *
+ * "If at least four mana was spent to cast it" is an intervening-if on the cast trigger,
+ * modeled by the new [Conditions.TriggeringSpellManaSpentAtLeast] reading the triggering
+ * spell's recorded total mana paid (so {X} spells that paid four or more qualify, while a
+ * four-mana-value spell cast for less does not). The payoff adds a +1/+1 counter to this
+ * creature and grants it CANT_BE_BLOCKED for the turn.
+ */
+val Sahagin = card("Sahagin") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Warrior"
+    power = 1
+    toughness = 3
+    oracleText = "Whenever you cast a noncreature spell, if at least four mana was spent to cast it, " +
+        "put a +1/+1 counter on this creature and it can't be blocked this turn."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        triggerCondition = Conditions.TriggeringSpellManaSpentAtLeast(4)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            .then(Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "71"
+        artist = "Nino Is"
+        flavorText = "\"Pshhh... Shhhilence, shhhorewalker! Try to eshhhcape, and I'll shhhlice gills into your neck!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/516940c7-c271-4f64-af75-c7ba98548382.jpg?1748706022"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Tonberry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Tonberry.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Tonberry
+ * {B}
+ * Creature — Salamander Horror
+ * 2/1
+ * This creature enters tapped with a stun counter on it. (If it would become untapped,
+ * remove a stun counter from it instead.)
+ * Chef's Knife — During your turn, this creature has first strike and deathtouch.
+ *
+ * "Enters tapped with a stun counter" is two self-only enters replacements: [EntersTapped]
+ * (unconditional) + [EntersWithCounters] of one stun counter. Stun-counter untap consumption
+ * is handled engine-side by the tap/untap atom. "During your turn …" is a pair of
+ * [ConditionalStaticAbility] keyword grants on [Filters.Self], gated by [Conditions.IsYourTurn].
+ */
+val Tonberry = card("Tonberry") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Salamander Horror"
+    power = 2
+    toughness = 1
+    oracleText = "This creature enters tapped with a stun counter on it. (If it would become untapped, " +
+        "remove a stun counter from it instead.)\n" +
+        "Chef's Knife — During your turn, this creature has first strike and deathtouch."
+
+    // Enters tapped with a stun counter on it (self only).
+    replacementEffect(EntersTapped())
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named("stun"),
+            count = 1,
+            selfOnly = true,
+        )
+    )
+
+    // Chef's Knife — during your turn, this creature has first strike and deathtouch.
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.Self),
+            condition = Conditions.IsYourTurn,
+        )
+    }
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.DEATHTOUCH, Filters.Self),
+            condition = Conditions.IsYourTurn,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "122"
+        artist = "Leonardo Santanna"
+        flavorText = "Fearful monsters that creep ever forward, knives poised with deadly intent."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a9b8723-4383-4c14-b24d-52863af8703d.jpg?1748706219"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -5475,6 +5475,131 @@
     ]
 }
 
+// Malboro
+{
+    "name": "Malboro",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Plant Horror",
+    "oracleText": "Bad Breath — When this creature enters, each opponent discards a card, loses 2 life, and exiles the top three cards of their library.\nSwampcycling {2} ({2}, Discard this card: Search your library for a Swamp card, reveal it, put it into your hand, then shuffle.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{2}",
+            "searchFilter": {
+                "cardPredicates": [
+                    {
+                        "type": "HasSubtype",
+                        "subtype": "Swamp"
+                    }
+                ]
+            },
+            "displayPrefix": "Swampcycling"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": "Controller"
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "TopOfLibrary",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 3
+                                            }
+                                        },
+                                        "storeAs": "exiled_top"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "exiled_top",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "106",
+        "artist": "Dan Watson",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/4/e46d8048-03ce-4e07-ba24-f41ba6140a4e.jpg?1748706158"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Midgar, City of Mako
 {
     "name": "Midgar, City of Mako",
@@ -6723,6 +6848,63 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Sahagin
+{
+    "name": "Sahagin",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Warrior",
+    "oracleText": "Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a +1/+1 counter on this creature and it can't be blocked this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "CANT_BE_BLOCKED",
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "TriggeringSpellManaSpentAtLeast",
+                    "amount": 4
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "artist": "Nino Is",
+        "flavorText": "\"Pshhh... Shhhilence, shhhorewalker! Try to eshhhcape, and I'll shhhlice gills into your neck!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/516940c7-c271-4f64-af75-c7ba98548382.jpg?1748706022"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -8857,6 +9039,68 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Tonberry
+{
+    "name": "Tonberry",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Salamander Horror",
+    "oracleText": "This creature enters tapped with a stun counter on it. (If it would become untapped, remove a stun counter from it instead.)\nChef's Knife — During your turn, this creature has first strike and deathtouch.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped",
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "stun"
+                },
+                "count": 1,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "UNCOMMON",
+        "artist": "Leonardo Santanna",
+        "flavorText": "Fearful monsters that creep ever forward, knives poised with deadly intent.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a9b8723-4383-4c14-b24d-52863af8703d.jpg?1748706219"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -404,6 +404,8 @@ class ConditionEvaluator(
             is TriggeringEntityWasCast -> ifResolution { evaluateTriggeringEntityWasCast(state, it) }
             is com.wingedsheep.sdk.scripting.conditions.TriggeringSpellCastWithoutPayingMana ->
                 ifResolution { evaluateTriggeringSpellCastWithoutPayingMana(state, it) }
+            is com.wingedsheep.sdk.scripting.conditions.TriggeringSpellManaSpentAtLeast ->
+                ifResolution { evaluateTriggeringSpellManaSpentAtLeast(state, condition.amount, it) }
             is TriggeringEntityEnteredOrWasCastFromGraveyard ->
                 ifResolution { evaluateTriggeringEntityEnteredOrWasCastFromGraveyard(state, it) }
             is TriggeringEntityHadMinusOneMinusOneCounter ->
@@ -960,6 +962,25 @@ class ConditionEvaluator(
             ?.get<com.wingedsheep.engine.state.components.stack.SpellOnStackComponent>() ?: return false
         return spell.manaSpentWhite + spell.manaSpentBlue + spell.manaSpentBlack +
             spell.manaSpentRed + spell.manaSpentGreen + spell.manaSpentColorless == 0
+    }
+
+    /**
+     * Threshold counterpart of [evaluateTriggeringSpellCastWithoutPayingMana]: true when the
+     * total mana spent on the triggering spell (summed across colors + colorless on the
+     * [SpellOnStackComponent]) is at least [amount]. False when the triggering entity isn't a
+     * spell on the stack.
+     */
+    private fun evaluateTriggeringSpellManaSpentAtLeast(
+        state: GameState,
+        amount: Int,
+        context: EffectContext
+    ): Boolean {
+        val entityId = context.triggeringEntityId ?: return false
+        val spell = state.getEntity(entityId)
+            ?.get<com.wingedsheep.engine.state.components.stack.SpellOnStackComponent>() ?: return false
+        val total = spell.manaSpentWhite + spell.manaSpentBlue + spell.manaSpentBlack +
+            spell.manaSpentRed + spell.manaSpentGreen + spell.manaSpentColorless
+        return total >= amount
     }
 
     private fun evaluateWasKicked(state: GameState, context: EffectContext): Boolean {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MalboroScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MalboroScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Malboro (FIN #106).
+ *
+ * Malboro {4}{B}{B} Creature — Plant Horror 4/4
+ * Bad Breath — When this creature enters, each opponent discards a card, loses 2 life, and
+ * exiles the top three cards of their library.
+ * Swampcycling {2}
+ *
+ * Exercises the new [com.wingedsheep.sdk.dsl.LibraryPatterns.exileTop] facade and the
+ * per-opponent ForEachPlayer composition (discard + lose life + exile-top all rebind onto
+ * the iterated opponent).
+ */
+class MalboroScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("Bad Breath ETB: opponent discards 1, loses 2 life, exiles top 3") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Give the opponent a card in hand to discard (on top of their opening hand).
+        driver.putCardInHand(opponent, "Grizzly Bears")
+        val handBefore = driver.getHandSize(opponent)
+        val lifeBefore = driver.getLifeTotal(opponent)
+        val exileBefore = driver.getExile(opponent).size
+
+        val malboro = driver.putCardInHand(active, "Malboro")
+        driver.giveMana(active, Color.BLACK, 2)
+        driver.giveColorlessMana(active, 4)
+
+        driver.castSpell(active, malboro).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature; Bad Breath trigger goes on the stack
+        driver.bothPass() // resolve the trigger; it pauses for the opponent's discard choice
+
+        // The opponent must choose a card to discard.
+        val decision = driver.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        val toDiscard = (decision as SelectCardsDecision).options.take(1)
+        driver.submitCardSelection(opponent, toDiscard)
+        driver.bothPass() // resolve the rest of the trigger
+
+        driver.getHandSize(opponent) shouldBe handBefore - 1
+        driver.getLifeTotal(opponent) shouldBe lifeBefore - 2
+        driver.getExile(opponent).size shouldBe exileBefore + 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SahaginScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SahaginScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Sahagin (FIN #71).
+ *
+ * Sahagin {1}{U} Creature — Merfolk Warrior 1/3
+ * Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a
+ * +1/+1 counter on this creature and it can't be blocked this turn.
+ *
+ * Exercises the new [com.wingedsheep.sdk.dsl.Conditions.TriggeringSpellManaSpentAtLeast]
+ * intervening-if: a 4-mana noncreature spell triggers the payoff; a 1-mana one does not.
+ */
+class SahaginScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("casting a 4-mana noncreature spell adds a +1/+1 counter and makes Sahagin unblockable") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sahagin = driver.putCreatureOnBattlefield(active, "Sahagin")
+
+        // Cast Stoke the Flames ({2}{R}{R}, a 4-mana instant) targeting the opponent, paying full mana.
+        val stoke = driver.putCardInHand(active, "Stoke the Flames")
+        driver.giveMana(active, Color.RED, 2)
+        driver.giveColorlessMana(active, 2)
+        driver.castSpellWithTargets(
+            active,
+            stoke,
+            listOf(entityIdToChosenTarget(driver.state, opponent)),
+        ).isSuccess shouldBe true
+        // Resolve Sahagin's trigger (on top of the stack), then the spell.
+        driver.bothPass()
+        driver.bothPass()
+
+        plusCounters(driver, sahagin) shouldBe 1
+        projector.project(driver.state).hasKeyword(sahagin, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+    }
+
+    test("casting a sub-4-mana noncreature spell does nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sahagin = driver.putCreatureOnBattlefield(active, "Sahagin")
+
+        // Lightning Bolt ({R}) is a 1-mana noncreature spell — below the four-mana threshold.
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.giveMana(active, Color.RED, 1)
+        driver.castSpellWithTargets(
+            active,
+            bolt,
+            listOf(entityIdToChosenTarget(driver.state, opponent)),
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        plusCounters(driver, sahagin) shouldBe 0
+        projector.project(driver.state).hasKeyword(sahagin, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TonberryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TonberryScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Tonberry (FIN #122).
+ *
+ * Tonberry {B} Creature — Salamander Horror 2/1
+ * This creature enters tapped with a stun counter on it.
+ * Chef's Knife — During your turn, this creature has first strike and deathtouch.
+ */
+class TonberryScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun stunCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    test("enters tapped with a stun counter; has first strike + deathtouch only on its controller's turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tonberry = driver.putCardInHand(active, "Tonberry")
+        driver.giveMana(active, Color.BLACK, 1)
+        driver.castSpell(active, tonberry).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature; enters-replacements apply
+
+        // Enters tapped with one stun counter.
+        driver.isTapped(tonberry) shouldBe true
+        stunCounters(driver, tonberry) shouldBe 1
+
+        // On its controller's turn it has first strike and deathtouch.
+        val onMyTurn = projector.project(driver.state)
+        onMyTurn.hasKeyword(tonberry, Keyword.FIRST_STRIKE) shouldBe true
+        onMyTurn.hasKeyword(tonberry, Keyword.DEATHTOUCH) shouldBe true
+
+        // Advance into the opponent's turn — the conditional grants drop off.
+        driver.passPriorityUntil(Step.END)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe driver.getOpponent(active)
+        val onOpponentTurn = projector.project(driver.state)
+        onOpponentTurn.hasKeyword(tonberry, Keyword.FIRST_STRIKE) shouldBe false
+        onOpponentTurn.hasKeyword(tonberry, Keyword.DEATHTOUCH) shouldBe false
+    }
+})


### PR DESCRIPTION
Implements three Final Fantasy (FIN) creatures via the `add-card` skill.

## Cards

- **Malboro** `{4}{B}{B}` 4/4 Plant Horror — *Bad Breath* ETB: each opponent discards a card, loses 2 life, and exiles the top three cards of their library; Swampcycling {2}. Modeled per-opponent with `Effects.ForEachPlayer(Player.EachOpponent, …)`.
- **Tonberry** `{B}` 2/1 Salamander Horror — enters tapped with a stun counter; *Chef's Knife*: during your turn it has first strike and deathtouch.
- **Sahagin** `{1}{U}` 1/3 Merfolk Warrior — whenever you cast a noncreature spell, if at least four mana was spent, put a +1/+1 counter on it and it can't be blocked this turn.

## Skipped

- **Ancient Adamantoise** — requires a new engine feature (`add-feature` territory): "Damage isn't removed from this creature during cleanup steps", a cleanup-step damage-persistence mechanic the engine doesn't support. That clause is load-bearing for how the card plays (20 toughness + all-damage-redirected-to-it), so a lossy approximation was declined per the skill's no-shortcuts rule.

## SDK additions (small, reusable)

- `Patterns.Library.exileTop(count, target = Controller)` — top N of a player's library to exile (the `mill` sibling). Used by Malboro.
- `Conditions.TriggeringSpellManaSpentAtLeast(amount)` — intervening-if reading the triggering spell's recorded total mana paid; the threshold counterpart of `TriggeringSpellCastWithoutPayingMana`. Used by Sahagin.

Tonberry composes existing primitives only (`EntersTapped`, `EntersWithCounters`, `ConditionalStaticAbility` + `GrantKeyword(Self)` gated on `IsYourTurn`).

## Tests

- New scenario tests: `MalboroScenarioTest`, `TonberryScenarioTest`, `SahaginScenarioTest` (all passing).
- FIN card snapshot re-blessed (only the three new card trees added).
- `docs/card-sdk-language-reference.md` updated for both new building blocks.
- Full `:mtg-sdk`/`:mtg-sets`/`:rules-engine` suites pass; mtgish POR emitter golden unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)