### PR TITLE
Fix CI OutOfMemoryError: raise Kotlin compiler heap to 4g

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,11 @@ org.gradle.caching=true
 # (Note that some plugins may not yet be compatible with the configuration cache.)
 # https://docs.gradle.org/current/userguide/configuration_cache.html
 org.gradle.configuration-cache=true
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+# The Gradle daemon hosts in-process Kotlin compilation for several modules at once
+# (configuration-cache enables parallel task execution), so the corpus-sized mtg-sets
+# compile plus concurrent module compiles need headroom — 2g OOMed in CI as the card
+# corpus grew. ubuntu-latest runners have ~16g, so 4g is safe.
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m
+# Pin the Kotlin compiler daemon's heap independently so it doesn't fall back to a
+# smaller default when Kotlin compiles out-of-process.
+kotlin.daemon.jvmargs=-Xmx4g


### PR DESCRIPTION
## Problem

CI run [28254775213](https://github.com/wingedsheep/argentum-engine/actions/runs/28254775213) failed: the `test (engine)`, `test (content)`, and `coverage` jobs all died with `java.lang.OutOfMemoryError: Java heap space` during **Kotlin compilation** (not a test-logic failure):

- `:mtg-sets:compileKotlin` FAILED (content + coverage)
- `:rules-engine:compileTestKotlin` FAILED (engine)

## Root cause

Resource, not logic. The configuration cache enables parallel task execution, so the Gradle daemon hosts several module compiles concurrently. The card corpus has grown (recent FIN + SPM batches), and the now-large `mtg-sets` compile plus the concurrent module compiles exceeded the 2 GB daemon heap. It's marginal — a clean compile of `mtg-sets` alone still succeeds at 2g locally — which is why it only tipped over now.

## Fix

- Bump `org.gradle.jvmargs` from `-Xmx2g` to `-Xmx4g`
- Pin `kotlin.daemon.jvmargs=-Xmx4g` so out-of-process Kotlin compilation also gets headroom

`ubuntu-latest` runners have ~16 GB, so 4 GB is safe.

## Verification

Both previously-failing modules compile cleanly with the new settings:

```
./gradlew :mtg-sets:compileKotlin :rules-engine:compileTestKotlin --rerun-tasks
BUILD SUCCESSFUL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)