### PR TITLE
Add face-down turn trackers + Oblivious Bookworm (DSK)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4254,6 +4254,18 @@ default to "you" so card authors don't need to pass it explicitly.
   `DynamicAmounts.permanentsSacrificedThisTurn()` amount for "that much" damage (Sawblade Skinripper:
   "At the beginning of your end step, if you sacrificed one or more permanents this turn, this creature
   deals that much damage to any target").
+- `PermanentEnteredFaceDownThisTurn` — a permanent entered the battlefield face down under your
+  control this turn (morph / disguise / manifest / cloak). Composes through
+  `Compare(DynamicAmount.TurnTracking(Player.You, TurnTracker.PERMANENTS_ENTERED_FACE_DOWN), GTE,
+  Fixed(1))`. Backed by the per-player `FaceDownPermanentsEnteredThisTurnComponent`, bumped once per
+  face-down ETB in `PermanentEntryTracker.record` and cleared by `CleanupPhaseManager`.
+- `YouTurnedPermanentFaceUpThisTurn` — you turned a permanent face up this turn, via the turn-face-up
+  special action (CR 116.2b) or an effect (`TurnFaceUpEffect`). Composes through
+  `Compare(DynamicAmount.TurnTracking(Player.You, TurnTracker.PERMANENTS_TURNED_FACE_UP), GTE,
+  Fixed(1))`. Backed by the per-player `PermanentsTurnedFaceUpThisTurnComponent`, bumped at every
+  `TurnFaceUpEvent` emission point (`FaceUpTracker.record`); merely revealing a face-down permanent as
+  it changes zones (CR 708.9) does not count. Pair the two with `Conditions.Any(...)` for the
+  "entered face down … or … turned a permanent face up this turn" gate (Oblivious Bookworm).
 - `GraveyardContains(filter)` — "there is at least one card matching `filter` in your graveyard"
   (`Exists(Player.You, Zone.GRAVEYARD, filter)`). Compose with `Conditions.All`/`Any` for multi-type
   checks, e.g. `All(GraveyardContains(Filters.Instant), GraveyardContains(Filters.Sorcery))` =
@@ -4872,6 +4884,16 @@ of `AddMana`. The engine empties pools at end of turn, so:
   counter (which sums every player's sacrifices). Backs `Conditions.YouSacrificedPermanentsThisTurn(atLeast)`
   and `DynamicAmounts.permanentsSacrificedThisTurn(player)` — e.g. Sawblade Skinripper's "if you sacrificed
   one or more permanents this turn, ... deals that much damage".
+- `PERMANENTS_ENTERED_FACE_DOWN` — number of permanents that entered the battlefield face down under the
+  player's control this turn (morph / disguise / manifest / cloak). Backed by the per-player
+  `FaceDownPermanentsEnteredThisTurnComponent`, bumped once per face-down ETB in
+  `PermanentEntryTracker.record` and reset at turn start. Backs `Conditions.PermanentEnteredFaceDownThisTurn`
+  (Oblivious Bookworm).
+- `PERMANENTS_TURNED_FACE_UP` — number of permanents the player turned face up this turn, via the
+  turn-face-up special action (CR 116.2b) or `TurnFaceUpEffect`. Backed by the per-player
+  `PermanentsTurnedFaceUpThisTurnComponent`, bumped at every `TurnFaceUpEvent` emission point
+  (`FaceUpTracker.record`); revealing a face-down permanent as it leaves the battlefield (CR 708.9) does
+  not count. Backs `Conditions.YouTurnedPermanentFaceUpThisTurn` (Oblivious Bookworm).
 
 `SubtypeEnteredUnderControlThisTurn(player, subtype, excludeTriggeringEntity?)` /
 `DynamicAmounts.subtypeEnteredUnderControlThisTurn(subtype, player?, excludeTriggeringEntity?)` —

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1171,6 +1171,22 @@ object Conditions {
         )
 
     /**
+     * If a permanent entered the battlefield face down under your control this turn (morph,
+     * disguise, manifest, cloak). Backed by the per-player `FaceDownPermanentsEnteredThisTurnComponent`.
+     * Used by Oblivious Bookworm.
+     */
+    val PermanentEnteredFaceDownThisTurn: ConditionInterface =
+        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.PERMANENTS_ENTERED_FACE_DOWN)
+
+    /**
+     * If you turned a permanent face up this turn — via the turn-face-up special action (paying a
+     * morph/disguise cost) or an effect. Backed by the per-player
+     * `PermanentsTurnedFaceUpThisTurnComponent`. Used by Oblivious Bookworm.
+     */
+    val YouTurnedPermanentFaceUpThisTurn: ConditionInterface =
+        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.PERMANENTS_TURNED_FACE_UP)
+
+    /**
      * If a permanent of the given card type entered the battlefield under the given player's
      * control this turn. The permanent need not still be on the battlefield, still be of that
      * type, or still be under that player's control — only the entry event matters.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -88,7 +88,24 @@ enum class TurnTracker {
      * `GameState.permanentsSacrificedThisTurn` cost-reduction counter. Powers "if you sacrificed
      * one or more permanents this turn, ... deals that much damage" (Sawblade Skinripper).
      */
-    PERMANENTS_SACRIFICED;
+    PERMANENTS_SACRIFICED,
+    /**
+     * Number of permanents that entered the battlefield face down under the player's control this
+     * turn (morph, disguise, manifest, cloak, …). Backed by
+     * `FaceDownPermanentsEnteredThisTurnComponent`, populated once per face-down ETB by
+     * `PermanentEntryTracker.record` and reset to 0 for every player at the start of each turn.
+     * Powers "a permanent entered the battlefield face down under your control this turn"
+     * (Oblivious Bookworm).
+     */
+    PERMANENTS_ENTERED_FACE_DOWN,
+    /**
+     * Number of permanents the player turned face up this turn — via the turn-face-up special
+     * action (paying a morph/disguise cost, CR 116.2b) or an effect that turns a permanent face up.
+     * Merely revealing a face-down permanent as it changes zones (CR 708.9) does **not** count.
+     * Backed by `PermanentsTurnedFaceUpThisTurnComponent`, reset to 0 for every player at the start
+     * of each turn. Powers "you turned a permanent face up this turn" (Oblivious Bookworm).
+     */
+    PERMANENTS_TURNED_FACE_UP;
 
     fun descriptionFor(player: Player): String = when (this) {
         CREATURES_DIED -> "the number of creatures that died under ${player.possessive} control this turn"
@@ -110,6 +127,8 @@ enum class TurnTracker {
         CARDS_DRAWN -> "the number of cards ${player.description} have drawn this turn"
         CARDS_PUT_INTO_EXILE -> "the number of cards put into exile this turn"
         PERMANENTS_SACRIFICED -> "the number of permanents ${player.description} sacrificed this turn"
+        PERMANENTS_ENTERED_FACE_DOWN -> "the number of permanents that entered the battlefield face down under ${player.possessive} control this turn"
+        PERMANENTS_TURNED_FACE_UP -> "the number of permanents ${player.description} turned face up this turn"
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ObliviousBookworm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ObliviousBookworm.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Oblivious Bookworm (DSK 225)
+ * {G}{U}
+ * Creature — Human Wizard
+ * 2/3
+ * At the beginning of your end step, you may draw a card. If you do, discard a card unless a
+ * permanent entered the battlefield face down under your control this turn or you turned a
+ * permanent face up this turn.
+ *
+ * The "unless ~" rider is modelled as a [ConditionalEffect] gating the discard on the *negation*
+ * of the two turn-tracking facts — so the discard only happens when neither face-down event
+ * occurred this turn. Both facts are backed by per-player turn trackers
+ * ([Conditions.PermanentEnteredFaceDownThisTurn] / [Conditions.YouTurnedPermanentFaceUpThisTurn]).
+ */
+val ObliviousBookworm = card("Oblivious Bookworm") {
+    manaCost = "{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "At the beginning of your end step, you may draw a card. If you do, discard a card unless a permanent entered the battlefield face down under your control this turn or you turned a permanent face up this turn."
+    power = 2
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = MayEffect(
+            effect = IfYouDoEffect(
+                action = Effects.DrawCards(1),
+                ifYouDo = ConditionalEffect(
+                    condition = Conditions.Not(
+                        Conditions.Any(
+                            Conditions.PermanentEnteredFaceDownThisTurn,
+                            Conditions.YouTurnedPermanentFaceUpThisTurn,
+                        )
+                    ),
+                    effect = Patterns.Hand.discardCards(1),
+                ),
+            ),
+            descriptionOverride = "You may draw a card. If you do, discard a card unless a permanent entered the battlefield face down under your control this turn or you turned a permanent face up this turn.",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "225"
+        artist = "Josh Newton"
+        flavorText = "\"Huh, the detector won't stop beeping. Must be on the fritz again.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7b4c50b-fe76-430d-8f96-208f15ca4cd7.jpg?1726286707"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -8689,6 +8689,134 @@
     ]
 }
 
+// Oblivious Bookworm
+{
+    "name": "Oblivious Bookworm",
+    "manaCost": "{G}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "At the beginning of your end step, you may draw a card. If you do, discard a card unless a permanent entered the battlefield face down under your control this turn or you turned a permanent face up this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        },
+                        "then": {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Not",
+                                    "condition": {
+                                        "type": "Any",
+                                        "conditions": [
+                                            {
+                                                "type": "Compare",
+                                                "left": {
+                                                    "type": "TurnTracking",
+                                                    "player": "You",
+                                                    "tracker": "PERMANENTS_ENTERED_FACE_DOWN"
+                                                },
+                                                "operator": "GTE",
+                                                "right": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            {
+                                                "type": "Compare",
+                                                "left": {
+                                                    "type": "TurnTracking",
+                                                    "player": "You",
+                                                    "tracker": "PERMANENTS_TURNED_FACE_UP"
+                                                },
+                                                "operator": "GTE",
+                                                "right": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "descriptionOverride": "You may draw a card. If you do, discard a card unless a permanent entered the battlefield face down under your control this turn or you turned a permanent face up this turn."
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "UNCOMMON",
+        "artist": "Josh Newton",
+        "flavorText": "\"Huh, the detector won't stop beeping. Must be on the fritz again.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7b4c50b-fe76-430d-8f96-208f15ca4cd7.jpg?1726286707"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Omnivorous Flytrap
 {
     "name": "Omnivorous Flytrap",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -48,6 +48,8 @@ import com.wingedsheep.engine.state.components.player.CardsLeftGraveyardThisTurn
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
+import com.wingedsheep.engine.state.components.player.FaceDownPermanentsEnteredThisTurnComponent
+import com.wingedsheep.engine.state.components.player.PermanentsTurnedFaceUpThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeGainedAmountThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeGainedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LifeLostThisTurnComponent
@@ -690,6 +692,12 @@ class CleanupPhaseManager(
                 }
                 if (result.has<PermanentsEnteredUnderControlThisTurnComponent>()) {
                     result = result.without<PermanentsEnteredUnderControlThisTurnComponent>()
+                }
+                if (result.has<FaceDownPermanentsEnteredThisTurnComponent>()) {
+                    result = result.without<FaceDownPermanentsEnteredThisTurnComponent>()
+                }
+                if (result.has<PermanentsTurnedFaceUpThisTurnComponent>()) {
+                    result = result.without<PermanentsTurnedFaceUpThisTurnComponent>()
                 }
                 if (result.has<PutCounterOnCreatureThisTurnComponent>()) {
                     result = result.without<PutCounterOnCreatureThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -494,6 +494,8 @@ val engineSerializersModule = SerializersModule {
         subclass(PermanentTypesEnteredBattlefieldThisTurnComponent::class)
         subclass(LandsEnteredUnderControlThisTurnComponent::class)
         subclass(PermanentsEnteredUnderControlThisTurnComponent::class)
+        subclass(FaceDownPermanentsEnteredThisTurnComponent::class)
+        subclass(PermanentsTurnedFaceUpThisTurnComponent::class)
         subclass(SpellsCantBeCounteredComponent::class)
         subclass(FlashGrantsThisTurnComponent::class)
         subclass(PutCounterOnCreatureThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -505,6 +505,16 @@ class DynamicAmountEvaluator(
                             ?.get<com.wingedsheep.engine.state.components.player.PermanentsSacrificedThisTurnComponent>()
                             ?.count ?: 0
                     }
+                    TurnTracker.PERMANENTS_ENTERED_FACE_DOWN -> playerIds.sumOf { playerId ->
+                        state.getEntity(playerId)
+                            ?.get<com.wingedsheep.engine.state.components.player.FaceDownPermanentsEnteredThisTurnComponent>()
+                            ?.count ?: 0
+                    }
+                    TurnTracker.PERMANENTS_TURNED_FACE_UP -> playerIds.sumOf { playerId ->
+                        state.getEntity(playerId)
+                            ?.get<com.wingedsheep.engine.state.components.player.PermanentsTurnedFaceUpThisTurnComponent>()
+                            ?.count ?: 0
+                    }
                 }
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/morph/TurnFaceUpHandler.kt
@@ -384,6 +384,10 @@ class TurnFaceUpHandler(
             updated = staticAbilityHandler.addReplacementEffectComponent(updated)
             updated
         }
+        // Track "you turned a permanent face up this turn" (Oblivious Bookworm). The non-mana
+        // morph-cost path flips via TurnFaceUpExecutor (which tracks there); this mana path
+        // flips inline, so record it here. Exactly one bump per turn-face-up.
+        currentState = com.wingedsheep.engine.handlers.effects.FaceUpTracker.record(currentState, action.playerId)
 
         // Execute face-up replacement effect (e.g., "put five +1/+1 counters on it")
         if (morphData.faceUpEffect != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceUpTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/FaceUpTracker.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.engine.handlers.effects
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.PermanentsTurnedFaceUpThisTurnComponent
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Records that a player turned a permanent face up for per-player, per-turn "you turned a
+ * permanent face up this turn" tracking (Oblivious Bookworm).
+ *
+ * Called at every point that emits a [com.wingedsheep.engine.core.TurnFaceUpEvent] — the
+ * turn-face-up special action (CR 116.2b) in `TurnFaceUpHandler`, and the `TurnFaceUpEffect`
+ * executor (`TurnFaceUpExecutor`), which also backs the non-mana morph/disguise cost path via
+ * the cost-payment `onPaid` flip. Merely revealing a face-down permanent as it leaves the
+ * battlefield (CR 708.9) does not emit that event and so does not count.
+ *
+ * Cleared at end of turn by [com.wingedsheep.engine.core.CleanupPhaseManager].
+ */
+object FaceUpTracker {
+
+    /** Record that [controllerId] just turned one of their permanents face up. */
+    fun record(state: GameState, controllerId: EntityId): GameState =
+        state.updateEntity(controllerId) { container ->
+            val existing = container.get<PermanentsTurnedFaceUpThisTurnComponent>()
+                ?: PermanentsTurnedFaceUpThisTurnComponent()
+            container.with(PermanentsTurnedFaceUpThisTurnComponent(existing.count + 1))
+        }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
@@ -1,7 +1,9 @@
 package com.wingedsheep.engine.handlers.effects
 
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.player.EnteredPermanentRecord
+import com.wingedsheep.engine.state.components.player.FaceDownPermanentsEnteredThisTurnComponent
 import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentsEnteredUnderControlThisTurnComponent
@@ -43,16 +45,30 @@ object PermanentEntryTracker {
      * battlefield with its identity components in place).
      */
     fun record(state: GameState, controllerId: EntityId, entityId: EntityId): GameState {
+        // Face-down entry is tracked independently of visible card types: it's the *manner* of
+        // entry that matters ("a permanent entered the battlefield face down under your control
+        // this turn"), so it must hold even for a hypothetical entry with no projected types.
+        val enteredFaceDown = state.getEntity(entityId)?.has<FaceDownComponent>() == true
         val cardTypes = projectedCardTypes(state, entityId)
-        if (cardTypes.isEmpty()) return state
+        if (cardTypes.isEmpty() && !enteredFaceDown) return state
         val subtypes = state.projectedState.getSubtypes(entityId)
         return state.updateEntity(controllerId) { container ->
+            // Bump the per-player face-down entry count once for this ETB. Counts (not a marker)
+            // so future "for each permanent that entered face down this turn" cards compose.
+            val faceDownTracked = if (enteredFaceDown) {
+                val existing = container.get<FaceDownPermanentsEnteredThisTurnComponent>()
+                    ?: FaceDownPermanentsEnteredThisTurnComponent()
+                container.with(FaceDownPermanentsEnteredThisTurnComponent(existing.count + 1))
+            } else {
+                container
+            }
+            if (cardTypes.isEmpty()) return@updateEntity faceDownTracked
             val typeMerged = run {
-                val existing = container.get<PermanentTypesEnteredBattlefieldThisTurnComponent>()
+                val existing = faceDownTracked.get<PermanentTypesEnteredBattlefieldThisTurnComponent>()
                     ?: PermanentTypesEnteredBattlefieldThisTurnComponent()
                 val merged = existing.cardTypes + cardTypes
-                if (merged == existing.cardTypes) container
-                else container.with(PermanentTypesEnteredBattlefieldThisTurnComponent(merged))
+                if (merged == existing.cardTypes) faceDownTracked
+                else faceDownTracked.with(PermanentTypesEnteredBattlefieldThisTurnComponent(merged))
             }
             // Per-permanent entry list, keyed by entityId so a (theoretical) double-record is
             // idempotent. Backs subtype-keyed "for each [type] that entered this turn" counts.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TurnFaceUpExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/TurnFaceUpExecutor.kt
@@ -48,12 +48,14 @@ class TurnFaceUpExecutor(
         val controllerId = container.get<ControllerComponent>()?.playerId ?: context.controllerId
         val cardName = container.get<CardComponent>()?.name ?: "Unknown"
 
-        val newState = state.updateEntity(targetId) { c ->
+        var newState = state.updateEntity(targetId) { c ->
             var updated = c.without<FaceDownComponent>()
             updated = staticAbilityHandler.addContinuousEffectComponent(updated)
             updated = staticAbilityHandler.addReplacementEffectComponent(updated)
             updated
         }
+        // Track "you turned a permanent face up this turn" (Oblivious Bookworm).
+        newState = com.wingedsheep.engine.handlers.effects.FaceUpTracker.record(newState, controllerId)
 
         return EffectResult.success(
             newState,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -981,6 +981,31 @@ data class PermanentsEnteredUnderControlThisTurnComponent(
 ) : Component
 
 /**
+ * Number of permanents that entered the battlefield face down under this player's control this
+ * turn (morph / disguise / manifest / cloak). Bumped once per face-down ETB by
+ * `PermanentEntryTracker.record` (the single sanctioned battlefield-entry point); cleared at end of
+ * turn by [com.wingedsheep.engine.core.CleanupPhaseManager].
+ *
+ * Backs `DynamicAmount.TurnTracking(player, TurnTracker.PERMANENTS_ENTERED_FACE_DOWN)` — e.g.
+ * Oblivious Bookworm's "a permanent entered the battlefield face down under your control this turn".
+ */
+@Serializable
+data class FaceDownPermanentsEnteredThisTurnComponent(val count: Int = 0) : Component
+
+/**
+ * Number of permanents this player turned face up this turn — via the turn-face-up special action
+ * (CR 116.2b) or an effect that turns a permanent face up. Bumped at every `TurnFaceUpEvent`
+ * emission point (`FaceUpTracker.record`); merely revealing a face-down permanent as it changes
+ * zones (CR 708.9) does not count. Cleared at end of turn by
+ * [com.wingedsheep.engine.core.CleanupPhaseManager].
+ *
+ * Backs `DynamicAmount.TurnTracking(player, TurnTracker.PERMANENTS_TURNED_FACE_UP)` — e.g.
+ * Oblivious Bookworm's "you turned a permanent face up this turn".
+ */
+@Serializable
+data class PermanentsTurnedFaceUpThisTurnComponent(val count: Int = 0) : Component
+
+/**
  * Marker component indicating that this player has put a counter on a creature this turn.
  * Cleared at end of turn by CleanupPhaseManager.
  *

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ObliviousBookwormScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ObliviousBookwormScenarioTest.kt
@@ -1,0 +1,189 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TurnFaceUp
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.MorphDataComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Oblivious Bookworm {G}{U} 2/3 Human Wizard.
+ *
+ * "At the beginning of your end step, you may draw a card. If you do, discard a card unless a
+ * permanent entered the battlefield face down under your control this turn or you turned a
+ * permanent face up this turn."
+ *
+ * Exercises the two new per-player turn trackers
+ * ([com.wingedsheep.sdk.scripting.values.TurnTracker.PERMANENTS_ENTERED_FACE_DOWN] /
+ * [com.wingedsheep.sdk.scripting.values.TurnTracker.PERMANENTS_TURNED_FACE_UP]) end to end — both
+ * the write paths (real `TurnFaceUp` action; real manifest ETB) and the read path (the gated
+ * discard) — plus their end-of-turn reset.
+ */
+class ObliviousBookwormScenarioTest : FunSpec({
+
+    // A bare {G} sorcery that manifests the top card face down — a real face-down ETB through the
+    // sanctioned battlefield-entry pipeline (so PermanentEntryTracker.record runs).
+    val manifestTester = card("Bookworm Manifest Tester") {
+        manaCost = "{G}"
+        typeLine = "Sorcery"
+        spell { effect = Patterns.Library.manifest() }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + manifestTester)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30, "Island" to 30), startingLife = 20)
+        return driver
+    }
+
+    // Put a face-down morph creature directly onto the battlefield (mirrors MorphCostPaymentTest).
+    fun GameTestDriver.putFaceDownCreature(playerId: EntityId, cardName: String): EntityId {
+        val creatureId = putCreatureOnBattlefield(playerId, cardName)
+        val cardDef = TestCards.all.first { it.name == cardName }
+        val morph = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Morph>().firstOrNull()
+        replaceState(state.updateEntity(creatureId) { container ->
+            var c = container.with(FaceDownComponent)
+            if (morph != null) c = c.with(MorphDataComponent(morph.morphCost, cardDef.name))
+            c
+        })
+        removeSummoningSickness(creatureId)
+        return creatureId
+    }
+
+    /** Advance to [player]'s end step and resolve the Bookworm trigger up to the may-draw yes/no. */
+    fun GameTestDriver.reachBookwormMayDraw(player: EntityId) {
+        passPriorityUntil(Step.END)
+        var guard = 0
+        while (pendingDecision == null && guard++ < 6) bothPass()
+    }
+
+    test("no face-down activity this turn: draw then discard (net hand size unchanged)") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.putCreatureOnBattlefield(player, "Oblivious Bookworm")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val handBefore = driver.getHandSize(player)
+
+        driver.reachBookwormMayDraw(player)
+        driver.submitYesNo(player, true) // may draw — yes
+
+        // Neither face-down fact holds, so the unless-gate is open: a discard is forced.
+        driver.getHandSize(player) shouldBe handBefore + 1 // drew, discard not yet chosen
+        val toDiscard = driver.getHand(player).first()
+        driver.submitCardSelection(player, listOf(toDiscard))
+
+        driver.getHandSize(player) shouldBe handBefore // drew 1, discarded 1
+    }
+
+    test("declining the may draws nothing and discards nothing") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.putCreatureOnBattlefield(player, "Oblivious Bookworm")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val handBefore = driver.getHandSize(player)
+
+        driver.reachBookwormMayDraw(player)
+        driver.submitYesNo(player, false) // decline
+
+        driver.getHandSize(player) shouldBe handBefore
+        driver.pendingDecision.shouldBeNull() // no discard selection
+    }
+
+    test("turned a permanent face up this turn: draw, no discard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.putCreatureOnBattlefield(player, "Oblivious Bookworm")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Real turn-face-up: Zombie Cutthroat's morph is "pay 5 life" (a non-mana cost that flips
+        // via TurnFaceUpExecutor, so FaceUpTracker.record runs).
+        val cutthroat = driver.putFaceDownCreature(player, "Zombie Cutthroat")
+        driver.submit(TurnFaceUp(playerId = player, sourceId = cutthroat)).error shouldBe null
+        driver.submitYesNo(player, true) // pay the 5 life
+        driver.state.getEntity(cutthroat)?.get<FaceDownComponent>().shouldBeNull()
+
+        val handBefore = driver.getHandSize(player)
+        driver.reachBookwormMayDraw(player)
+        driver.submitYesNo(player, true) // may draw — yes
+
+        // Gate closed by "you turned a permanent face up this turn": draw, no discard.
+        driver.getHandSize(player) shouldBe handBefore + 1
+        driver.pendingDecision.shouldBeNull()
+    }
+
+    test("a permanent entered the battlefield face down this turn: draw, no discard") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(player, "Oblivious Bookworm")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Real face-down ETB: manifest the top card via the {G} tester sorcery.
+        driver.putCardOnTopOfLibrary(player, "Centaur Courser")
+        val spell = driver.putCardInHand(player, "Bookworm Manifest Tester")
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.castSpell(player, spell)
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        val handBefore = driver.getHandSize(player)
+        driver.reachBookwormMayDraw(player)
+        driver.submitYesNo(player, true) // may draw — yes
+
+        // Gate closed by "a permanent entered face down under your control this turn".
+        driver.getHandSize(player) shouldBe handBefore + 1
+        driver.pendingDecision.shouldBeNull()
+    }
+
+    test("the trackers reset at end of turn: gate is open again on the next end step") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.putCreatureOnBattlefield(player, "Oblivious Bookworm")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Turn 1: turn a permanent face up, so the turn-1 end step skips the discard.
+        val cutthroat = driver.putFaceDownCreature(player, "Zombie Cutthroat")
+        driver.submit(TurnFaceUp(playerId = player, sourceId = cutthroat)).error shouldBe null
+        driver.submitYesNo(player, true)
+
+        var handBefore = driver.getHandSize(player)
+        driver.reachBookwormMayDraw(player)
+        driver.submitYesNo(player, true)
+        driver.getHandSize(player) shouldBe handBefore + 1 // no discard turn 1
+        driver.pendingDecision.shouldBeNull()
+
+        // Advance to player1's NEXT turn's end step (no face-down activity this time).
+        // passPriorityUntil auto-resolves the incidental cleanup discard-to-hand-size and stops at
+        // the step boundary before the Bookworm trigger resolves, so the may-draw isn't auto-answered.
+        driver.passPriorityUntil(Step.UPKEEP) // -> opponent's turn (UNTAP is auto-skipped)
+        driver.passPriorityUntil(Step.END)    // -> opponent's end step
+        driver.passPriorityUntil(Step.UPKEEP) // -> player1's next turn
+        driver.passPriorityUntil(Step.END)    // -> player1's next end step
+        driver.activePlayer shouldBe player
+
+        // Resolve the next end-step trigger up to the may-draw.
+        var guard = 0
+        while (driver.pendingDecision == null && guard++ < 6) driver.bothPass()
+        handBefore = driver.getHandSize(player)
+        driver.submitYesNo(player, true) // draw
+
+        // Tracker was reset by cleanup: the gate is open again, so a discard is forced.
+        driver.getHandSize(player) shouldBe handBefore + 1
+        val toDiscard = driver.getHand(player).first()
+        driver.submitCardSelection(player, listOf(toDiscard))
+        driver.getHandSize(player) shouldBe handBefore
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Oblivious Bookworm** (DSK #225) and the engine feature it needed: two per-player, per-turn trackers for *"a permanent entered the battlefield face down under your control this turn"* and *"you turned a permanent face up this turn"*. These had no representation in the engine, so the card was previously deferred.

## Engine feature

Two new `TurnTracker` enum values, modelled exactly like the existing trackers (`LIFE_GAINED`, `PERMANENTS_SACRIFICED`, …) — data + per-player component + evaluator branch + `Conditions` facade + cleanup, no new condition subtype:

- **`PERMANENTS_ENTERED_FACE_DOWN`** — bumped once per face-down ETB inside the single sanctioned entry point `PermanentEntryTracker.record`, independent of the permanent's visible types (a face-down 2/2 is tracked even though it has no printed identity).
- **`PERMANENTS_TURNED_FACE_UP`** — bumped at every `TurnFaceUpEvent` emission point via a shared `FaceUpTracker.record`: the turn-face-up special action (CR 116.2b) and the `TurnFaceUpEffect` executor (which also backs the non-mana morph/disguise cost flip). Merely *revealing* a face-down permanent as it leaves the battlefield (CR 708.9) deliberately does **not** count.

Both are **counts, not markers**, so a future *"for each permanent that entered face down this turn"* card composes for free. Surfaced as `Conditions.PermanentEnteredFaceDownThisTurn` / `Conditions.YouTurnedPermanentFaceUpThisTurn`, read in `DynamicAmountEvaluator`, registered for serialization, and cleared at end of turn by `CleanupPhaseManager`. SDK reference updated.

## Card

`Oblivious Bookworm {G}{U}` 2/3 Human Wizard. The *"discard a card unless …"* rider is a `ConditionalEffect` gating the forced discard on the **negation** of `Any(the two trackers)`, wrapped in the standard `MayEffect(IfYouDoEffect(draw, …))` loot shape.

## Tests

`ObliviousBookwormScenarioTest` (rules-engine) exercises the full path end to end:
- no face-down activity → draw **then** discard (net hand size unchanged);
- declining the "may" → nothing happens;
- **turned a permanent face up** (real `TurnFaceUp` on a Zombie Cutthroat) → draw, no discard;
- **a permanent entered face down** (real manifest ETB) → draw, no discard;
- the trackers **reset** at end of turn → the gate is open again on the next end step.

Full `:rules-engine` and `:mtg-sdk` suites pass; `:mtg-sets` snapshot (re-blessed — only Oblivious Bookworm added) and lint nets pass; `check-card-printing` is clean.

## mtgish tooling

No bridge/emitter change: the two new building blocks are intervening-if turn-tracking *conditions* with no corresponding mtgish IR effect tag, used inside a "draw, discard unless A or B" composite that is SCAFFOLD-tier (the emitter declines such gated composites). DSK is also not in the corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)