### PR TITLE
Add DSK spells batch: Duskmourn's Domination, Peer Past the Veil, Say Its Name, Waltz of Rage

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DuskmournsDomination.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DuskmournsDomination.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ControlEnchantedPermanent
+import com.wingedsheep.sdk.scripting.LoseAllAbilities
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Duskmourn's Domination
+ * {4}{U}{U}
+ * Enchantment — Aura
+ * Enchant creature
+ * You control enchanted creature.
+ * Enchanted creature gets -3/-0 and loses all abilities.
+ *
+ * Three independent continuous effects from the Aura on its enchanted creature:
+ *  - control change ([ControlEnchantedPermanent], Annex-style) — you become the creature's controller
+ *    for as long as the Aura is attached;
+ *  - a Layer 6 ability-removal ([LoseAllAbilities]); and
+ *  - a Layer 7c stat modifier ([ModifyStats] -3/0). [ModifyStats] as an Aura staticAbility applies to
+ *    the enchanted creature by default, so no explicit target is needed.
+ */
+val DuskmournsDomination = card("Duskmourn's Domination") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "You control enchanted creature.\n" +
+        "Enchanted creature gets -3/-0 and loses all abilities."
+
+    auraTarget = Targets.Creature
+
+    // You control enchanted creature.
+    staticAbility {
+        ability = ControlEnchantedPermanent
+    }
+
+    // Enchanted creature loses all abilities.
+    staticAbility {
+        ability = LoseAllAbilities()
+    }
+
+    // Enchanted creature gets -3/-0.
+    staticAbility {
+        ability = ModifyStats(-3, 0)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Eli Minaya"
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1d96dbc9-c2fd-42c1-9d55-5c14fa1c1c6f.jpg?1726286043"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PeerPastTheVeil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PeerPastTheVeil.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Peer Past the Veil
+ * {2}{R}{G}
+ * Instant
+ * Discard your hand. Then draw X cards, where X is the number of card types among cards in your graveyard.
+ *
+ * The discard and draw resolve in sequence within the [Effects.Composite]; the discarded cards reach the
+ * graveyard before X is evaluated, so they contribute their card types to the count (CR 608.2: the spell's
+ * instructions are followed in order). X reads [DynamicAmount.AggregateZone] over the controller's graveyard
+ * with [Aggregation.DISTINCT_TYPES] — the number of distinct card types (artifact, creature, enchantment,
+ * instant, land, planeswalker, sorcery, …) among those cards.
+ */
+val PeerPastTheVeil = card("Peer Past the Veil") {
+    manaCost = "{2}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Instant"
+    oracleText = "Discard your hand. Then draw X cards, where X is the number of card types among cards in your graveyard."
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Hand.discardHand(EffectTarget.Controller),
+            Effects.DrawCards(
+                DynamicAmount.AggregateZone(
+                    player = Player.You,
+                    zone = Zone.GRAVEYARD,
+                    aggregation = Aggregation.DISTINCT_TYPES
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "226"
+        artist = "Tuan Duong Chu"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/874eadb6-602e-47dc-8094-82e37ac89c94.jpg?1726286712"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SayItsName.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SayItsName.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Say Its Name
+ * {1}{G}
+ * Sorcery
+ * Mill three cards. Then you may return a creature or land card from your graveyard to your hand.
+ * Exile this card and two other cards named Say Its Name from your graveyard: Search your graveyard,
+ * hand, and/or library for a card named Altanak, the Thrice-Called and put it onto the battlefield.
+ * If you search your library this way, shuffle. Activate only as a sorcery.
+ *
+ * Spell half:
+ *  - "Mill three cards." → [Patterns.Library.mill].
+ *  - "Then you may return a creature or land card from your graveyard to your hand." modeled as a
+ *    resolution-time Gather → Select(ChooseUpTo 1) → Move(hand) pipeline rather than a cast-time
+ *    target, because the milled cards only reach the graveyard during resolution and must be eligible
+ *    to return (CR 608.2). The "you may" falls out of [SelectionMode.ChooseUpTo] of 1 (the player can
+ *    select zero).
+ *
+ * Graveyard-activated ability (CR 113.6: an activated ability that functions from the graveyard):
+ *  - Cost: exile this card plus two other cards named "Say Its Name" from your graveyard — a flat
+ *    [Costs.ExileFromGraveyard] of 3 cards filtered to the card's own name. The source card itself is
+ *    one valid choice, matching "this card and two other cards named Say Its Name" (3 total).
+ *  - Effect: search graveyard, hand, and library ([CardSource.FromMultipleZones]) for a card named
+ *    "Altanak, the Thrice-Called", choose up to one, and put it onto the battlefield. The library is
+ *    always among the searched zones, so we always [ShuffleLibraryEffect] afterward ("If you search
+ *    your library this way, shuffle").
+ *  - [TimingRule.SorcerySpeed] enforces "Activate only as a sorcery."
+ */
+val SayItsName = card("Say Its Name") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Mill three cards. Then you may return a creature or land card from your graveyard to your hand.\n" +
+        "Exile this card and two other cards named Say Its Name from your graveyard: Search your " +
+        "graveyard, hand, and/or library for a card named Altanak, the Thrice-Called and put it onto " +
+        "the battlefield. If you search your library this way, shuffle. Activate only as a sorcery."
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Library.mill(3),
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.You,
+                    filter = GameObjectFilter.CreatureOrLand
+                ),
+                storeAs = "sayItsNameReturn"
+            ),
+            SelectFromCollectionEffect(
+                from = "sayItsNameReturn",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "sayItsNameChosen",
+                prompt = "You may return a creature or land card from your graveyard to your hand"
+            ),
+            MoveCollectionEffect(
+                from = "sayItsNameChosen",
+                destination = CardDestination.ToZone(Zone.HAND)
+            )
+        )
+    }
+
+    // Exile this card and two other cards named Say Its Name from your graveyard: search graveyard,
+    // hand, and/or library for Altanak, the Thrice-Called and put it onto the battlefield.
+    activatedAbility {
+        cost = Costs.ExileFromGraveyard(3, GameObjectFilter.Any.named("Say Its Name"))
+        activateFromZone = Zone.GRAVEYARD
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromMultipleZones(
+                    zones = listOf(Zone.GRAVEYARD, Zone.HAND, Zone.LIBRARY),
+                    player = Player.You,
+                    filter = GameObjectFilter.Any.named("Altanak, the Thrice-Called")
+                ),
+                storeAs = "altanak"
+            ),
+            SelectFromCollectionEffect(
+                from = "altanak",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "altanakChosen",
+                prompt = "Search for Altanak, the Thrice-Called to put onto the battlefield"
+            ),
+            MoveCollectionEffect(
+                from = "altanakChosen",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD)
+            ),
+            // If you search your library this way, shuffle. The library is always searched, so always shuffle.
+            ShuffleLibraryEffect()
+        )
+        description = "Exile this card and two other cards named Say Its Name from your " +
+            "graveyard: Search your graveyard, hand, and/or library for a card named Altanak, the " +
+            "Thrice-Called and put it onto the battlefield. If you search your library this way, " +
+            "shuffle. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Sam Wolfe Connelly"
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94c58683-b5f2-4863-9562-6f6be1ec21fe.jpg?1726286600"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/WaltzOfRage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/WaltzOfRage.kt
@@ -13,7 +13,6 @@ import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
-import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
 import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
@@ -55,7 +54,7 @@ val WaltzOfRage = card("Waltz of Rage") {
         val chosen = target("target creature you control", Targets.CreatureYouControl)
         effect = Effects.Composite(
             // Target creature you control deals damage equal to its power to each other creature.
-            ForEachInGroupEffect(
+            Effects.ForEachInGroup(
                 filter = GroupFilter(GameObjectFilter.Creature).otherThanTarget(),
                 effect = DealDamageEffect(
                     amount = DynamicAmounts.targetPower(0),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/WaltzOfRage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/WaltzOfRage.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.ForEachInGroupEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Waltz of Rage
+ * {3}{R}{R}
+ * Sorcery
+ * Target creature you control deals damage equal to its power to each other creature.
+ * Until end of turn, whenever a creature you control dies, exile the top card of your library.
+ * You may play it until the end of your next turn.
+ *
+ * Two clauses:
+ *  - The chosen creature deals damage equal to its power to each OTHER creature: a
+ *    [ForEachInGroupEffect] over [GroupFilter.AllCreatures] with `.otherThanTarget()` (excludes the
+ *    chosen creature), each iterated creature ([EffectTarget.Self]) taking [DynamicAmounts.targetPower]
+ *    damage *from the chosen creature itself* (`damageSource = ContextTarget(0)` — so combat keywords
+ *    like deathtouch / lifelink on the chosen creature apply, and "dealt damage by" triggers see the
+ *    correct source).
+ *  - A turn-duration event-based delayed trigger ([CreateDelayedTriggerEffect] with
+ *    [Triggers.YourCreatureDies], `expiry = EndOfTurn`, `fireOnce = false`) that fires once per
+ *    creature-you-control death this turn, impulse-drawing the top card with
+ *    [MayPlayExpiry.UntilEndOfNextTurn]. The per-creature [Triggers.YourCreatureDies] (ZoneChangeEvent,
+ *    ANY binding) matches the singular "a creature" wording — a board wipe fires it once per creature.
+ */
+val WaltzOfRage = card("Waltz of Rage") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Target creature you control deals damage equal to its power to each other creature. " +
+        "Until end of turn, whenever a creature you control dies, exile the top card of your library. " +
+        "You may play it until the end of your next turn."
+
+    spell {
+        val chosen = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            // Target creature you control deals damage equal to its power to each other creature.
+            ForEachInGroupEffect(
+                filter = GroupFilter(GameObjectFilter.Creature).otherThanTarget(),
+                effect = DealDamageEffect(
+                    amount = DynamicAmounts.targetPower(0),
+                    target = EffectTarget.Self,
+                    damageSource = chosen
+                )
+            ),
+            // Until end of turn, whenever a creature you control dies, exile the top card of your
+            // library. You may play it until the end of your next turn.
+            CreateDelayedTriggerEffect(
+                trigger = Triggers.YourCreatureDies,
+                expiry = DelayedTriggerExpiry.EndOfTurn,
+                fireOnce = false,
+                effect = Effects.Composite(
+                    GatherCardsEffect(
+                        source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                        storeAs = "waltzExiled"
+                    ),
+                    MoveCollectionEffect(
+                        from = "waltzExiled",
+                        destination = CardDestination.ToZone(Zone.EXILE)
+                    ),
+                    GrantMayPlayFromExileEffect("waltzExiled", MayPlayExpiry.UntilEndOfNextTurn)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "165"
+        artist = "Mathias Kollros"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abf17d8b-12bc-4122-865d-50cf91f04f67.jpg?1726286472"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -3822,6 +3822,40 @@
     ]
 }
 
+// Duskmourn's Domination
+{
+    "name": "Duskmourn's Domination",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nYou control enchanted creature.\nEnchanted creature gets -3/-0 and loses all abilities.",
+    "script": {
+        "staticAbilities": [
+            "ControlEnchantedPermanent",
+            "LoseAllAbilities",
+            {
+                "type": "ModifyStats",
+                "powerBonus": -3,
+                "toughnessBonus": 0
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "UNCOMMON",
+        "artist": "Eli Minaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1d96dbc9-c2fd-42c1-9d55-5c14fa1c1c6f.jpg?1726286043"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Emerge from the Cocoon
 {
     "name": "Emerge from the Cocoon",
@@ -10787,6 +10821,62 @@
     ]
 }
 
+// Peer Past the Veil
+{
+    "name": "Peer Past the Veil",
+    "manaCost": "{2}{R}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Discard your hand. Then draw X cards, where X is the number of card types among cards in your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand"
+                            },
+                            "storeAs": "discardedHand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discardedHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "RARE",
+        "artist": "Tuan Duong Chu",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/874eadb6-602e-47dc-8094-82e37ac89c94.jpg?1726286712"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Piggy Bank
 {
     "name": "Piggy Bank",
@@ -11914,6 +12004,147 @@
     "colorIdentityOverride": [
         "BLACK",
         "RED"
+    ]
+}
+
+// Say Its Name
+{
+    "name": "Say Its Name",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Mill three cards. Then you may return a creature or land card from your graveyard to your hand.\nExile this card and two other cards named Say Its Name from your graveyard: Search your graveyard, hand, and/or library for a card named Altanak, the Thrice-Called and put it onto the battlefield. If you search your library this way, shuffle. Activate only as a sorcery.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "filter": "creature|land"
+                    },
+                    "storeAs": "sayItsNameReturn"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "sayItsNameReturn",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "sayItsNameChosen",
+                    "prompt": "You may return a creature or land card from your graveyard to your hand"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "sayItsNameChosen",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                }
+            ]
+        },
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomExileFrom",
+                        "zone": "Graveyard",
+                        "filter": "name:Say Its Name",
+                        "count": 3
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromMultipleZones",
+                                "zones": [
+                                    "Graveyard",
+                                    "Hand",
+                                    "Library"
+                                ],
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "NameEquals",
+                                            "name": "Altanak, the Thrice-Called"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "altanak"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "altanak",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "altanakChosen",
+                            "prompt": "Search for Altanak, the Thrice-Called to put onto the battlefield"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "altanakChosen",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        },
+                        "ShuffleLibrary"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "Exile this card and two other cards named Say Its Name from your graveyard: Search your graveyard, hand, and/or library for a card named Altanak, the Thrice-Called and put it onto the battlefield. If you search your library this way, shuffle. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "artist": "Sam Wolfe Connelly",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94c58683-b5f2-4863-9562-6f6be1ec21fe.jpg?1726286600"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -15580,6 +15811,107 @@
         "artist": "Mirko Failoni",
         "flavorText": "Rage can be a potent antidote to fear.",
         "imageUri": "https://cards.scryfall.io/normal/front/a/4/a47c968b-1edd-45ac-a67c-311647e7e2fc.jpg?1726286465"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Waltz of Rage
+{
+    "name": "Waltz of Rage",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target creature you control deals damage equal to its power to each other creature. Until end of turn, whenever a creature you control dies, exile the top card of your library. You may play it until the end of your next turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature",
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Power"
+                        },
+                        "target": "Self",
+                        "damageSource": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    }
+                },
+                {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeAs": "waltzExiled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "waltzExiled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            },
+                            {
+                                "type": "GrantMayPlayFromExile",
+                                "from": "waltzExiled",
+                                "expiry": {
+                                    "type": "UntilControllerStep",
+                                    "step": "CLEANUP",
+                                    "includeCurrentTurn": false
+                                }
+                            }
+                        ]
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "ZoneChangeEvent",
+                            "filter": "creature ctrl:you",
+                            "from": "Battlefield",
+                            "to": "Graveyard"
+                        },
+                        "binding": "ANY"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "RARE",
+        "artist": "Mathias Kollros",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abf17d8b-12bc-4122-865d-50cf91f04f67.jpg?1726286472"
     },
     "colorIdentityOverride": [
         "RED"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskSpellsBatchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DskSpellsBatchScenarioTest.kt
@@ -1,0 +1,212 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.SayItsName
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for the DSK spells batch, all composed from existing SDK primitives:
+ *
+ *  - Duskmourn's Domination ({4}{U}{U} Aura) — control the enchanted creature, it gets -3/-0 and
+ *    loses all abilities. (ControlEnchantedPermanent + LoseAllAbilities + ModifyStats.)
+ *  - Peer Past the Veil ({2}{R}{G} Instant) — discard your hand, then draw X = card types among
+ *    cards in your graveyard. (Patterns.Hand.discardHand + DrawCards over AggregateZone DISTINCT_TYPES.)
+ *  - Say Its Name ({1}{G} Sorcery) — mill three, then may return a creature/land card from your
+ *    graveyard; plus a graveyard-activated "exile three Say Its Names → search for Altanak" ability.
+ *  - Waltz of Rage ({3}{R}{R} Sorcery) — target creature you control deals damage equal to its
+ *    power to each other creature, plus a turn-long delayed impulse-draw on each of your creatures' deaths.
+ */
+class DskSpellsBatchScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Duskmourn's Domination — control + -3/-0 + loses all abilities") {
+
+            test("attaching the Aura steals control, applies -3/-0, and removes flying/vigilance") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(2, "Serra Angel", summoningSickness = false)
+                    .withCardAttachedTo(1, "Duskmourn's Domination", "Serra Angel")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val angel = game.findPermanent("Serra Angel")!!
+
+                withClue("Player 1 now controls the enchanted Serra Angel") {
+                    game.state.projectedState.getController(angel) shouldBe game.player1Id
+                }
+                withClue("Serra Angel (4/4) gets -3/-0 → 1/4") {
+                    game.state.projectedState.getPower(angel) shouldBe 1
+                    game.state.projectedState.getToughness(angel) shouldBe 4
+                }
+                withClue("Serra Angel loses all abilities, including flying and vigilance") {
+                    game.state.projectedState.hasKeyword(angel, Keyword.FLYING) shouldBe false
+                    game.state.projectedState.hasKeyword(angel, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+        }
+
+        context("Peer Past the Veil — discard hand, draw X = card types in graveyard") {
+
+            test("discards the whole hand then draws one card per distinct card type in the graveyard") {
+                // Graveyard seeded with three distinct card types: creature, instant, land.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Peer Past the Veil")
+                    .withCardsInHand(1, "Grizzly Bears", 2)
+                    .withCardInGraveyard(1, "Grizzly Bears") // creature
+                    .withCardInGraveyard(1, "Lightning Bolt") // instant
+                    .withCardInGraveyard(1, "Forest") // land
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Island")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("Graveyard starts with 3 cards (creature, instant, land)") {
+                    game.state.getGraveyard(game.player1Id!!).size shouldBe 3
+                }
+
+                game.castSpell(1, "Peer Past the Veil").error shouldBe null
+                game.resolveStack()
+
+                // After resolution the 2 Grizzly Bears are discarded (creature already present) and
+                // Peer Past the Veil itself reaches the graveyard as an instant (already present). So the
+                // card types among graveyard cards = {creature, instant, land} = 3, and 3 cards are drawn.
+                withClue("Hand was discarded then refilled with 3 drawn cards (X = 3 card types)") {
+                    game.state.getHand(game.player1Id!!).size shouldBe 3
+                }
+                withClue("Discarded Grizzly Bears are now in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+
+        context("Say Its Name — mill three, then may return a creature/land card") {
+
+            test("mills three and returns a chosen creature card from the graveyard to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Say Its Name")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Say Its Name").error shouldBe null
+                game.resolveStack()
+
+                // Mill 3 puts the top three library cards (Grizzly Bears, Lightning Bolt, Forest) into
+                // the graveyard, then a Gather/Select(up to 1) over creature/land cards prompts.
+                withClue("Say Its Name pauses for the optional creature/land return") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val bearsInGy = game.findCardsInGraveyard(1, "Grizzly Bears")
+                withClue("Milled Grizzly Bears is a legal return candidate") {
+                    bearsInGy.isNotEmpty() shouldBe true
+                }
+                game.selectCards(listOf(bearsInGy.first())).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears returned to hand") {
+                    game.findCardsInHand(1, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("Lightning Bolt (instant) stays milled in the graveyard") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                }
+            }
+
+            test("graveyard ability exiles three Say Its Names as its cost and searches for Altanak") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Say Its Name")
+                    .withCardInGraveyard(1, "Say Its Name")
+                    .withCardInGraveyard(1, "Say Its Name")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val copies = game.findCardsInGraveyard(1, "Say Its Name")
+                withClue("Three Say Its Name copies seeded in the graveyard") {
+                    copies.size shouldBe 3
+                }
+                val sourceId = copies.first()
+                val abilityId = SayItsName.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id!!,
+                        sourceId = sourceId,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(exiledCards = copies)
+                    )
+                )
+                withClue("Activating the graveyard ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                // The multi-zone search may surface a (possibly empty) optional selection; skip it.
+                if (game.hasPendingDecision()) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+
+                // Altanak, the Thrice-Called isn't implemented, so the search finds nothing — but the
+                // cost is still paid: all three Say Its Name copies are exiled from the graveyard.
+                withClue("All three Say Its Name copies were exiled to pay the cost") {
+                    game.findCardsInGraveyard(1, "Say Its Name").size shouldBe 0
+                    game.state.getExile(game.player1Id!!).size shouldBeGreaterThanOrEqual 3
+                }
+            }
+        }
+
+        context("Waltz of Rage — chosen creature pings each other creature; deaths impulse-draw") {
+
+            test("chosen creature deals power damage to each other creature and survives itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Waltz of Rage")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false) // 3/3
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanents("Hill Giant").first()
+                game.castSpell(1, "Waltz of Rage", giant).error shouldBe null
+                game.resolveStack()
+
+                // Hill Giant (power 3) deals 3 to each OTHER creature, so both 2/2 Grizzly Bears die,
+                // while Hill Giant itself survives (it's excluded from "each other creature").
+                withClue("Hill Giant survives (excluded from 'each other creature')") {
+                    game.findPermanents("Hill Giant").size shouldBe 1
+                }
+                withClue("Both 2/2 Grizzly Bears took 3 damage and died") {
+                    game.findAllPermanents("Grizzly Bears").size shouldBe 0
+                }
+                withClue("Player 1's creature death triggered the delayed impulse-draw to exile") {
+                    game.state.getExile(game.player1Id!!).size shouldBeGreaterThanOrEqual 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Duskmourn: House of Horror (DSK) spells. All four compose existing SDK primitives — **no new engine/SDK features were needed**, so the `card-sdk-language-reference.md` requires no update.

## Cards implemented

- **Duskmourn's Domination** ({4}{U}{U} Enchantment — Aura) — "You control enchanted creature. Enchanted creature gets -3/-0 and loses all abilities." Three static abilities on the Aura: `ControlEnchantedPermanent` (Annex-style control change) + `LoseAllAbilities` (Layer 6) + `ModifyStats(-3, 0)` (Layer 7c, applies to the enchanted creature by default).
- **Peer Past the Veil** ({2}{R}{G} Instant) — "Discard your hand. Then draw X cards, where X is the number of card types among cards in your graveyard." `Patterns.Hand.discardHand` then `Effects.DrawCards(AggregateZone(GRAVEYARD, DISTINCT_TYPES))`. The discard resolves first, so discarded cards count toward the graveyard card-type total.
- **Say Its Name** ({1}{G} Sorcery) — "Mill three cards. Then you may return a creature or land card from your graveyard to your hand." Plus the graveyard-activated ability "Exile this card and two other cards named Say Its Name from your graveyard: Search your graveyard, hand, and/or library for Altanak, the Thrice-Called and put it onto the battlefield. … Activate only as a sorcery." Modeled with `activateFromZone = GRAVEYARD`, `TimingRule.SorcerySpeed`, `Costs.ExileFromGraveyard(3, named "Say Its Name")`, and a `FromMultipleZones(GRAVEYARD, HAND, LIBRARY)` search → battlefield → shuffle. The optional return uses a resolution-time Gather/Select(ChooseUpTo 1)/Move pipeline (the milled cards must be eligible). Note: *Altanak, the Thrice-Called* is not yet implemented, so the fetch finds nothing in practice, but the ability, its zone/timing restriction, and its exile cost are all wired and tested.
- **Waltz of Rage** ({3}{R}{R} Sorcery) — "Target creature you control deals damage equal to its power to each other creature. Until end of turn, whenever a creature you control dies, exile the top card of your library. You may play it until the end of your next turn." `ForEachInGroup(AllCreatures.otherThanTarget(), DealDamage(targetPower, damageSource = chosen creature))` + an event-based `CreateDelayedTriggerEffect(Triggers.YourCreatureDies, expiry = EndOfTurn, fireOnce = false)` that impulse-draws with `UntilEndOfNextTurn`.

## Skipped

None — all four were implementable with existing primitives.

## Testing

- `DskSpellsBatchScenarioTest` (rules-engine) — 5 tests, all passing, covering control-steal + stat/ability loss, the discard-then-draw card-type count, the mill + optional graveyard return, the graveyard-activated exile cost, and the each-other-creature ping + death impulse-draw.
- `CardDefinitionSnapshotTest` reblessed — DSK golden gains only the four new card trees; no other set or existing card changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)