### PR TITLE
Add Enduring Curiosity, Tenacity, and Vitality to Duskmourn (DSK)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EnduringCuriosity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EnduringCuriosity.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.enduring
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Enduring Curiosity
+ * {2}{U}{U}
+ * Enchantment Creature — Cat Glimmer
+ * 4/3
+ * Flash
+ * Whenever a creature you control deals combat damage to a player, draw a card.
+ * When Enduring Curiosity dies, if it was a creature, return it to the battlefield under its
+ *   owner's control. It's an enchantment. (It's not a creature.)
+ *
+ * The combat-damage trigger is the generic "a creature you control deals combat damage to a
+ * player" shape (binding ANY — any creature you control can be the source). The death clause is
+ * the Duskmourn "Enduring" mechanic — see [enduring].
+ */
+val EnduringCuriosity = card("Enduring Curiosity") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Cat Glimmer"
+    oracleText = "Flash\n" +
+        "Whenever a creature you control deals combat damage to a player, draw a card.\n" +
+        "When Enduring Curiosity dies, if it was a creature, return it to the battlefield under " +
+        "its owner's control. It's an enchantment. (It's not a creature.)"
+    power = 4
+    toughness = 3
+
+    keywords(Keyword.FLASH)
+    enduring()
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.Combat,
+            recipient = RecipientFilter.AnyPlayer,
+            sourceFilter = GameObjectFilter.Creature.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "51"
+        artist = "Julie Dillon"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/8616629e-08f9-41ad-bfec-f86c8096f1cb.jpg?1726286044"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EnduringTenacity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EnduringTenacity.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.enduring
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Enduring Tenacity
+ * {2}{B}{B}
+ * Enchantment Creature — Snake Glimmer
+ * 4/3
+ * Whenever you gain life, target opponent loses that much life.
+ * When Enduring Tenacity dies, if it was a creature, return it to the battlefield under its
+ *   owner's control. It's an enchantment. (It's not a creature.)
+ *
+ * "That much" is the amount of life gained by the triggering life-gain event, read from the
+ * trigger context as [ContextPropertyKey.TRIGGER_LIFE_GAINED]. The drain targets a single
+ * opponent (CR: "target opponent"). The death clause is the Duskmourn "Enduring" mechanic —
+ * see [enduring].
+ */
+val EnduringTenacity = card("Enduring Tenacity") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment Creature — Snake Glimmer"
+    oracleText = "Whenever you gain life, target opponent loses that much life.\n" +
+        "When Enduring Tenacity dies, if it was a creature, return it to the battlefield under " +
+        "its owner's control. It's an enchantment. (It's not a creature.)"
+    power = 4
+    toughness = 3
+
+    enduring()
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        target = Targets.Opponent
+        effect = Effects.LoseLife(
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_LIFE_GAINED),
+            EffectTarget.ContextTarget(0)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "95"
+        artist = "Isis"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5756d4b-3068-412c-8643-880d3459151e.jpg?1726286203"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EnduringVitality.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/EnduringVitality.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.enduring
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Enduring Vitality
+ * {1}{G}{G}
+ * Enchantment Creature — Elk Glimmer
+ * 3/3
+ * Vigilance
+ * Creatures you control have "{T}: Add one mana of any color."
+ * When Enduring Vitality dies, if it was a creature, return it to the battlefield under its
+ *   owner's control. It's an enchantment. (It's not a creature.)
+ *
+ * The mana ability is granted to every creature you control via [GrantActivatedAbility] (the
+ * Citanul Hierophants / Cryptolith Rite lord shape); each grantee taps for one mana of any
+ * color. The death clause is the Duskmourn "Enduring" mechanic — see [enduring].
+ */
+val EnduringVitality = card("Enduring Vitality") {
+    manaCost = "{1}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment Creature — Elk Glimmer"
+    oracleText = "Vigilance\n" +
+        "Creatures you control have \"{T}: Add one mana of any color.\"\n" +
+        "When Enduring Vitality dies, if it was a creature, return it to the battlefield under " +
+        "its owner's control. It's an enchantment. (It's not a creature.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.VIGILANCE)
+    enduring()
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Tap,
+                effect = Effects.AddAnyColorMana(1)
+            ),
+            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "176"
+        artist = "Valera Lutfullina"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d76a30c-0431-4334-892a-9822dda9671a.jpg?1726286517"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -3948,6 +3948,69 @@
     ]
 }
 
+// Enduring Curiosity
+{
+    "name": "Enduring Curiosity",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Enchantment Creature — Cat Glimmer",
+    "oracleText": "Flash\nWhenever a creature you control deals combat damage to a player, draw a card.\nWhen Enduring Curiosity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "ENDURING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer",
+                    "sourceFilter": "creature ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "TransformPermanent",
+                    "setCardTypes": [
+                        "ENCHANTMENT"
+                    ],
+                    "clearSubtypes": true,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "SourceReturnedAsEnchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "RARE",
+        "artist": "Julie Dillon",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/8616629e-08f9-41ad-bfec-f86c8096f1cb.jpg?1726286044"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Enduring Innocence
 {
     "name": "Enduring Innocence",
@@ -4008,6 +4071,123 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Enduring Tenacity
+{
+    "name": "Enduring Tenacity",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Enchantment Creature — Snake Glimmer",
+    "oracleText": "Whenever you gain life, target opponent loses that much life.\nWhen Enduring Tenacity dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "ENDURING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_LIFE_GAINED"
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": "TargetOpponent"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "TransformPermanent",
+                    "setCardTypes": [
+                        "ENCHANTMENT"
+                    ],
+                    "clearSubtypes": true,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "SourceReturnedAsEnchantment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "RARE",
+        "artist": "Isis",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5756d4b-3068-412c-8643-880d3459151e.jpg?1726286203"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Enduring Vitality
+{
+    "name": "Enduring Vitality",
+    "manaCost": "{1}{G}{G}",
+    "typeLine": "Enchantment Creature — Elk Glimmer",
+    "oracleText": "Vigilance\nCreatures you control have \"{T}: Add one mana of any color.\"\nWhen Enduring Vitality dies, if it was a creature, return it to the battlefield under its owner's control. It's an enchantment. (It's not a creature.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE",
+        "ENDURING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "TransformPermanent",
+                    "setCardTypes": [
+                        "ENCHANTMENT"
+                    ],
+                    "clearSubtypes": true,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "SourceReturnedAsEnchantment"
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": "CostTap",
+                    "effect": "AddManaOfChoice"
+                },
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "176",
+        "rarity": "RARE",
+        "artist": "Valera Lutfullina",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d76a30c-0431-4334-892a-9822dda9671a.jpg?1726286517"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EnduringCuriosityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EnduringCuriosityScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Enduring Curiosity.
+ *
+ * Enduring Curiosity ({2}{U}{U}): Enchantment Creature — Cat Glimmer, 4/3
+ * - Flash
+ * - Whenever a creature you control deals combat damage to a player, draw a card.
+ * - Enduring: when it dies (as a creature) it returns as a (non-creature) enchantment.
+ *
+ * The Enduring death clause is covered by EnduringMechanicTest; here we prove the
+ * unique combat-damage draw trigger, including that it counts *any* creature you control
+ * (not just Curiosity itself) and that an opponent's creature does not trigger it.
+ */
+class EnduringCuriosityScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Enduring Curiosity's combat-damage draw trigger") {
+
+            test("a creature you control dealing combat damage to a player draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Enduring Curiosity", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                // Attack with the (other) Grizzly Bears — an unblocked creature you control.
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.state.pendingDecision != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("Combat damage to the player should have triggered a draw") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("Enduring Curiosity itself dealing combat damage to a player draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Enduring Curiosity", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.declareAttackers(mapOf("Enduring Curiosity" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.state.pendingDecision != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("Curiosity is also a creature you control, so its own combat damage draws") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("an opponent's creature dealing combat damage does NOT draw you a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Enduring Curiosity", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                // Player 2 attacks Player 1 with their own creature.
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.state.pendingDecision != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("The trigger only fires for a creature YOU control; no draw here") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EnduringTenacityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EnduringTenacityScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Enduring Tenacity.
+ *
+ * Enduring Tenacity ({2}{B}{B}): Enchantment Creature — Snake Glimmer, 4/3
+ * - Whenever you gain life, target opponent loses that much life.
+ * - Enduring: when it dies (as a creature) it returns as a (non-creature) enchantment.
+ *
+ * The Enduring death clause is covered by EnduringMechanicTest; here we prove the
+ * unique life-drain trigger, that the amount drained equals the life actually gained
+ * ("that much"), and that an opponent gaining life does not trigger it.
+ */
+class EnduringTenacityScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Enduring Tenacity drains an opponent when you gain life") {
+
+            test("gaining 6 life drains the opponent for 6") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Enduring Tenacity")
+                    .withCardInHand(1, "Rejuvenate")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Rejuvenate: "You gain 6 life." (untargeted, sorcery-speed)
+                game.castSpell(1, "Rejuvenate").error shouldBe null
+                game.resolveStack()
+
+                withClue("Controller gained 6 life: 20 -> 26") {
+                    game.getLifeTotal(1) shouldBe 26
+                }
+                withClue("Target opponent lost that much (6): 20 -> 14") {
+                    game.getLifeTotal(2) shouldBe 14
+                }
+            }
+
+            test("an opponent gaining life does not trigger Tenacity") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Enduring Tenacity")
+                    .withCardInHand(2, "Rejuvenate")
+                    .withLandsOnBattlefield(2, "Forest", 4)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 2 (the opponent) gains the life; Tenacity reads "Whenever YOU gain life".
+                game.castSpell(2, "Rejuvenate").error shouldBe null
+                game.resolveStack()
+
+                withClue("Opponent gained 6 life: 20 -> 26") {
+                    game.getLifeTotal(2) shouldBe 26
+                }
+                withClue("Tenacity's controller is unaffected — the trigger is yours, not theirs") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EnduringVitalityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EnduringVitalityScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Enduring Vitality.
+ *
+ * Enduring Vitality ({1}{G}{G}): Enchantment Creature — Elk Glimmer, 3/3
+ * - Vigilance
+ * - Creatures you control have "{T}: Add one mana of any color."
+ * - Enduring: when it dies (as a creature) it returns as a (non-creature) enchantment.
+ *
+ * The Enduring death clause is covered by EnduringMechanicTest; here we prove the
+ * granted mana ability: another creature you control gains it, it actually produces a
+ * mana of the chosen color, and an opponent's creature is not granted it.
+ */
+class EnduringVitalityScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Enduring Vitality grants a tap-for-any-color mana ability to your creatures") {
+
+            test("another creature you control gains the granted mana ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Enduring Vitality")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val manaAction = game.getLegalActions(1).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == bears
+                }
+                withClue("Grizzly Bears should gain '{T}: Add one mana of any color' from Vitality") {
+                    manaAction shouldNotBe null
+                }
+            }
+
+            test("activating the granted ability taps the creature and adds a mana of the chosen color") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Enduring Vitality", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val def = cardRegistry.getCard("Enduring Vitality")!!
+                val abilityId = def.staticAbilities
+                    .filterIsInstance<GrantActivatedAbility>().first().ability.id
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                // "{T}: Add one mana of any color" — a mana ability. The color is chosen at
+                // activation time (manaColorChoice); if the engine instead pauses for a color
+                // decision, answer it with green.
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = bears,
+                        abilityId = abilityId,
+                        manaColorChoice = Color.GREEN
+                    )
+                )
+                withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+                (game.getPendingDecision() as? ChooseColorDecision)?.let { decision ->
+                    game.submitDecision(ColorChosenResponse(decision.id, Color.GREEN))
+                    game.resolveStack()
+                }
+
+                withClue("Grizzly Bears should be tapped after paying the {T} cost") {
+                    game.state.getEntity(bears)?.get<TappedComponent>() shouldNotBe null
+                }
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("Exactly one mana of any color should have been produced") {
+                    pool?.total shouldBe 1
+                }
+            }
+
+            test("an opponent's creature is NOT granted the mana ability") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Enduring Vitality")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val manaAction = game.getLegalActions(2).find {
+                    it.actionType == "ActivateAbility" &&
+                        (it.action as? ActivateAbility)?.sourceId == bears
+                }
+                withClue("The grant is 'creatures YOU control'; opponent's creature gets nothing") {
+                    manaAction shouldBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three cards from the Duskmourn: House of Horror "Enduring" Glimmer cycle, plus skips one card that needs an engine feature.

## Cards implemented

- **Enduring Curiosity** ({2}{U}{U}, Enchantment Creature — Cat Glimmer, 4/3) — Flash; "Whenever a creature you control deals combat damage to a player, draw a card." Modeled with `Triggers.dealsDamage(Combat, AnyPlayer, Creature.youControl(), ANY)` + `Effects.DrawCards(1)`, plus the shared `enduring()` death clause.
- **Enduring Tenacity** ({2}{B}{B}, Enchantment Creature — Snake Glimmer, 4/3) — "Whenever you gain life, target opponent loses that much life." Uses `Triggers.YouGainLife` with `target = Targets.Opponent` and `Effects.LoseLife(ContextProperty(TRIGGER_LIFE_GAINED), ContextTarget(0))`, plus `enduring()`.
- **Enduring Vitality** ({1}{G}{G}, Enchantment Creature — Elk Glimmer, 3/3) — Vigilance; "Creatures you control have '{T}: Add one mana of any color.'" Uses `GrantActivatedAbility(ActivatedAbility(Costs.Tap, Effects.AddAnyColorMana(1)), Creatures.youControl())` (Citanul Hierophants shape), plus `enduring()`.

All three reuse the existing Duskmourn `enduring()` mechanic (return-as-enchantment dies trigger), already covered by `EnduringMechanicTest`. No new SDK types were needed, so the SDK reference required no change.

## Card skipped

- **Keys to the House** ({1}, Artifact) — **skipped**. Its first ability (sacrifice to tutor a basic land) is fully supported, but its second ability, "Lock or unlock a door of target Room you control," requires **locking** a Room door. The engine only has `UnlockDoorEffect` (CR 709.5f) — there is no effect/executor to re-lock an unlocked door. Faithfully implementing that half is `add-feature` work (a new effect type + executor + the door-locking state transition + targeting "Room you control"), out of scope for single-card authoring. Rather than ship a card missing half its printed function, it is left for a follow-up.

## Tests

New scenario tests in `rules-engine` proving each card's unique ability:
- `EnduringCuriosityScenarioTest` — combat damage from any creature you control draws; opponent's creature does not.
- `EnduringTenacityScenarioTest` — gaining N life drains a target opponent for N; opponent's life gain does not trigger it.
- `EnduringVitalityScenarioTest` — another creature you control gains the mana ability and taps for one mana; opponent's creature does not gain it.

Card-definition snapshot golden for DSK re-blessed for the three new cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)