### PR TITLE
Add Altanak, Kona, and Marvin to Duskmourn (DSK)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1882,6 +1882,9 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   a creature type with a creature you control") with `filter = GameObjectFilter.Creature`. A candidate
   with no creature types of its own shares none, so it matches.
 - `.named(name)` — `CardPredicate.NameEquals`: matches a fixed card name.
+- `.notNamed(name)` — `CardPredicate.Not(NameEquals)`: matches cards whose name is **not** `name`. Use for
+  "… that don't have the same name as this creature" wording (Marvin, Murderous Mimic — creatures you control
+  not named "Marvin, Murderous Mimic").
 - `.namedFromVariable(variableName)` — `CardPredicate.NameEqualsChosen`: matches the card name stored in
   `chosenValues[variableName]` (case-insensitive). Set the name with `Effects.ChooseCardName` (player names it)
   or `Effects.StoreCardName` (captured from a chosen card). Fails closed in static/projection contexts. Used by

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -263,6 +263,11 @@ data class GameObjectFilter(
         cardPredicates = cardPredicates + CardPredicate.NameEquals(name)
     )
 
+    /** Match cards whose name is **not** [name] — e.g. "creatures … that don't have the same name". */
+    fun notNamed(name: String) = copy(
+        cardPredicates = cardPredicates + CardPredicate.Not(CardPredicate.NameEquals(name))
+    )
+
     /** Match cards whose name equals the card name stored in chosenValues[variableName] */
     fun namedFromVariable(variableName: String) = copy(
         cardPredicates = cardPredicates + CardPredicate.NameEqualsChosen(variableName)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AltanakTheThriceCalled.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/AltanakTheThriceCalled.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Altanak, the Thrice-Called
+ * {5}{G}{G}
+ * Legendary Creature — Insect Beast
+ * 9/9
+ *
+ * Trample
+ * Whenever Altanak becomes the target of a spell or ability an opponent controls, draw a card.
+ * {1}{G}, Discard this card: Return target land card from your graveyard to the battlefield tapped.
+ *
+ * The last ability functions from hand: its cost discards this card ([Costs.DiscardSelf]) and it's
+ * activated from the hand zone ([activateFromZone] = [Zone.HAND]), so you can ramp by pitching the
+ * fatty when it's stranded in hand.
+ */
+val AltanakTheThriceCalled = card("Altanak, the Thrice-Called") {
+    manaCost = "{5}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Insect Beast"
+    power = 9
+    toughness = 9
+    oracleText = "Trample\nWhenever Altanak becomes the target of a spell or ability an opponent " +
+        "controls, draw a card.\n{1}{G}, Discard this card: Return target land card from your " +
+        "graveyard to the battlefield tapped."
+
+    keywords(Keyword.TRAMPLE)
+
+    // Whenever Altanak becomes the target of a spell or ability an opponent controls, draw a card.
+    triggeredAbility {
+        trigger = Triggers.BecomesTargetByOpponent
+        effect = Effects.DrawCards(1)
+    }
+
+    // {1}{G}, Discard this card: Return target land card from your graveyard to the battlefield tapped.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}"), Costs.DiscardSelf)
+        activateFromZone = Zone.HAND
+        val t = target(
+            "land",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Land.ownedByYou(), zone = Zone.GRAVEYARD))
+        )
+        effect = Effects.PutOntoBattlefield(t, tapped = true)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "166"
+        artist = "Sam Wolfe Connelly"
+        imageUri = "https://cards.scryfall.io/normal/front/8/0/807b0674-8eba-4204-b6b6-fa2b785a79e9.jpg?1726286473"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/KonaRescueBeastie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/KonaRescueBeastie.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Kona, Rescue Beastie
+ * {3}{G}
+ * Legendary Creature — Beast Survivor
+ * 4/3
+ *
+ * Survival — At the beginning of your second main phase, if Kona is tapped, you may put a
+ * permanent card from your hand onto the battlefield.
+ *
+ * The "you may" is satisfied by [Patterns.Hand.putFromHand] choosing *up to* one card — the
+ * player can decline by selecting none.
+ */
+val KonaRescueBeastie = card("Kona, Rescue Beastie") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Beast Survivor"
+    power = 4
+    toughness = 3
+    oracleText = "Survival — At the beginning of your second main phase, if Kona is tapped, you " +
+        "may put a permanent card from your hand onto the battlefield."
+
+    // Survival — second main phase, if tapped: you may put a permanent card from hand onto battlefield.
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.SourceIsTapped
+        effect = Patterns.Hand.putFromHand(filter = GameObjectFilter.Permanent)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "187"
+        artist = "Brian Valeza"
+        flavorText = "She's got a heart of gold, a nose for danger, and jaws that can pulverize a " +
+            "cellarspawn with a single snap."
+        imageUri = "https://cards.scryfall.io/normal/front/6/f/6f035294-2787-4719-8520-227bf03e84e7.jpg?1726286561"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MarvinMurderousMimic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MarvinMurderousMimic.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GainActivatedAbilitiesOfPermanents
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Marvin, Murderous Mimic
+ * {2}
+ * Legendary Artifact Creature — Toy
+ * 2/2
+ *
+ * Marvin has all activated abilities of creatures you control that don't have the same name as
+ * this creature.
+ *
+ * Modeled with [GainActivatedAbilitiesOfPermanents]: `grantedTo = GroupFilter.source()` (Marvin
+ * himself gains the abilities), `sourceFilter = creatures you control not named "Marvin,
+ * Murderous Mimic"`, and `includeManaAbilities = true` because the oracle text says *all*
+ * activated abilities (no "except mana abilities" clause, unlike Sharkey). The engine recomputes
+ * the gained set continuously from projected state, so the abilities track your other creatures
+ * entering/leaving and copies/tokens named Marvin are correctly excluded by the name predicate.
+ */
+val MarvinMurderousMimic = card("Marvin, Murderous Mimic") {
+    manaCost = "{2}"
+    typeLine = "Legendary Artifact Creature — Toy"
+    power = 2
+    toughness = 2
+    oracleText = "Marvin has all activated abilities of creatures you control that don't have the " +
+        "same name as this creature."
+
+    staticAbility {
+        ability = GainActivatedAbilitiesOfPermanents(
+            grantedTo = GroupFilter.source(),
+            sourceFilter = GameObjectFilter.Creature.youControl().notNamed("Marvin, Murderous Mimic"),
+            includeManaAbilities = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "253"
+        artist = "Mirko Failoni"
+        flavorText = "In a moment of bloodthirsty whimsy, a razorkin once picked up a " +
+            "ventriloquist's puppet and used it to terrorize a survivor. Now it hunts on its own, " +
+            "with no one pulling its strings."
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66898970-b99b-48f2-9240-68c301c95500.jpg?1726286819"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -190,6 +190,86 @@
     ]
 }
 
+// Altanak, the Thrice-Called
+{
+    "name": "Altanak, the Thrice-Called",
+    "manaCost": "{5}{G}{G}",
+    "typeLine": "Legendary Creature — Insect Beast",
+    "oracleText": "Trample\nWhenever Altanak becomes the target of a spell or ability an opponent controls, draw a card.\n{1}{G}, Discard this card: Return target land card from your graveyard to the battlefield tapped.",
+    "creatureStats": {
+        "power": 9,
+        "toughness": 9
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "BecomesTargetEvent",
+                    "byOpponent": true
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "land"
+                    },
+                    "destination": "Battlefield",
+                    "placement": "Tapped"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "land own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "land"
+                    }
+                ],
+                "activateFromZone": "Hand"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "UNCOMMON",
+        "artist": "Sam Wolfe Connelly",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/0/807b0674-8eba-4204-b6b6-fa2b785a79e9.jpg?1726286473"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Anthropede
 {
     "name": "Anthropede",
@@ -8392,6 +8472,79 @@
     ]
 }
 
+// Kona, Rescue Beastie
+{
+    "name": "Kona, Rescue Beastie",
+    "manaCost": "{3}{G}",
+    "typeLine": "Legendary Creature — Beast Survivor",
+    "oracleText": "Survival — At the beginning of your second main phase, if Kona is tapped, you may put a permanent card from your hand onto the battlefield.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": "permanent"
+                            },
+                            "storeAs": "put_candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "put_candidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "putting"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "putting",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "tapped"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "RARE",
+        "artist": "Brian Valeza",
+        "flavorText": "She's got a heart of gold, a nose for danger, and jaws that can pulverize a cellarspawn with a single snap.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/f/6f035294-2787-4719-8520-227bf03e84e7.jpg?1726286561"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Leyline of Hope
 {
     "name": "Leyline of Hope",
@@ -8788,6 +8941,50 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Marvin, Murderous Mimic
+{
+    "name": "Marvin, Murderous Mimic",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact Creature — Toy",
+    "oracleText": "Marvin has all activated abilities of creatures you control that don't have the same name as this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GainActivatedAbilitiesOfPermanents",
+                "grantedTo": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "sourceFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "Not",
+                            "predicate": {
+                                "type": "NameEquals",
+                                "name": "Marvin, Murderous Mimic"
+                            }
+                        }
+                    ],
+                    "controllerPredicate": "ControlledByYou"
+                },
+                "includeManaAbilities": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "rarity": "RARE",
+        "artist": "Mirko Failoni",
+        "flavorText": "In a moment of bloodthirsty whimsy, a razorkin once picked up a ventriloquist's puppet and used it to terrorize a survivor. Now it hunts on its own, with no one pulling its strings.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66898970-b99b-48f2-9240-68c301c95500.jpg?1726286819"
+    }
 }
 
 // Miasma Demon

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AltanakTheThriceCalledScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AltanakTheThriceCalledScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.AltanakTheThriceCalled
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Altanak, the Thrice-Called (DSK #166) — {5}{G}{G} 9/9 Legendary Creature — Insect Beast.
+ *
+ *  - Trample (keyword; covered by snapshot).
+ *  - "Whenever Altanak becomes the target of a spell or ability an opponent controls, draw a card."
+ *  - "{1}{G}, Discard this card: Return target land card from your graveyard to the battlefield
+ *    tapped." — a from-hand activated ability ([Costs.DiscardSelf], activateFromZone = HAND).
+ */
+class AltanakTheThriceCalledScenarioTest : FunSpec({
+
+    test("opponent targeting Altanak draws its controller a card") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Active player (player1) targets player2's Altanak with Doom Blade.
+        val caster = driver.player1
+        val controller = driver.player2
+        val altanak = driver.putCreatureOnBattlefield(controller, "Altanak, the Thrice-Called")
+        val doomBlade = driver.putCardInHand(caster, "Doom Blade")
+        driver.giveMana(caster, Color.BLACK, 2)
+
+        val handBefore = driver.getHand(controller).size
+
+        driver.castSpell(caster, doomBlade, targets = listOf(altanak)).isSuccess shouldBe true
+        // The targeting trigger goes on the stack above Doom Blade; resolve everything.
+        driver.bothPass()
+
+        // Altanak's controller (player2) drew a card from the targeting trigger.
+        driver.getHand(controller).size shouldBe handBefore + 1
+    }
+
+    test("your own spell targeting Altanak does not trigger the draw") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.player1
+        val altanak = driver.putCreatureOnBattlefield(player, "Altanak, the Thrice-Called")
+        val giantGrowth = driver.putCardInHand(player, "Giant Growth")
+        driver.giveMana(player, Color.GREEN, 1)
+
+        val handBefore = driver.getHand(player).size
+
+        driver.castSpell(player, giantGrowth, targets = listOf(altanak)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // No draw — the trigger only fires for an opponent's spell/ability. The hand only shrinks
+        // by the Giant Growth that was cast.
+        driver.getHand(player).size shouldBe handBefore - 1
+    }
+
+    test("from-hand ability returns a land from graveyard to the battlefield tapped, discarding Altanak") {
+        val abilityId = AltanakTheThriceCalled.activatedAbilities.first().id
+
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val altanak = driver.putCardInHand(player, "Altanak, the Thrice-Called")
+        val graveLand = driver.putCardInGraveyard(player, "Forest")
+        driver.giveMana(player, Color.GREEN, 2)
+
+        // Activate the from-hand ability, targeting the graveyard Forest and paying {1}{G} from the
+        // mana pool. The target is a graveyard card (ChosenTarget.Card in the GRAVEYARD zone).
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = altanak,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Card(graveLand, player, Zone.GRAVEYARD)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        driver.bothPass()
+
+        // Altanak was discarded as a cost; the land left the graveyard for the battlefield tapped.
+        driver.getHand(player).contains(altanak) shouldBe false
+        driver.getGraveyard(player).contains(altanak) shouldBe true
+        driver.getGraveyard(player).contains(graveLand) shouldBe false
+        driver.findPermanent(player, "Forest") shouldBe graveLand
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KonaRescueBeastieScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KonaRescueBeastieScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kona, Rescue Beastie (DSK #187) — {3}{G} 4/3 Legendary Creature — Beast Survivor.
+ *
+ * "Survival — At the beginning of your second main phase, if Kona is tapped, you may put a
+ *  permanent card from your hand onto the battlefield."
+ *
+ * Modeled as a [Triggers.YourPostcombatMain] intervening-if (SourceIsTapped) over
+ * [Patterns.Hand.putFromHand] with the Permanent filter; the "you may" is the up-to-one selection.
+ */
+class KonaRescueBeastieScenarioTest : ScenarioTestBase() {
+
+    private val p1 = EntityId.of("player-1")
+
+    init {
+        context("Survival — second main, if tapped, may put a permanent from hand onto battlefield") {
+
+            test("a tapped Kona puts a chosen permanent card from hand onto the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kona, Rescue Beastie", tapped = true)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                // Resolve the trigger; it pauses on a select-up-to-one decision. Choose the Bears.
+                var guard = 0
+                while (!game.isOnBattlefield("Grizzly Bears") && guard < 30) {
+                    val decision = game.state.pendingDecision
+                    if (decision is SelectCardsDecision) {
+                        val bears = game.state.getHand(p1).first { id ->
+                            game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                        }
+                        game.selectCards(listOf(bears))
+                    } else {
+                        game.resolveStack()
+                    }
+                    guard++
+                }
+
+                withClue("the chosen permanent entered the battlefield from hand") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("it is no longer in hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("the controller may decline (selecting nothing leaves the card in hand)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kona, Rescue Beastie", tapped = true)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+                var guard = 0
+                while (game.hasPendingDecision() && guard < 30) {
+                    val decision = game.state.pendingDecision
+                    if (decision is SelectCardsDecision) {
+                        game.skipSelection()
+                    } else {
+                        game.resolveStack()
+                    }
+                    guard++
+                }
+
+                withClue("declining the may keeps the permanent in hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+            }
+
+            test("an untapped Kona does NOT fire Survival") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kona, Rescue Beastie", tapped = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                repeat(5) { if (!game.hasPendingDecision()) game.resolveStack() }
+
+                withClue("no Survival decision — Kona is untapped, the intervening-if is false") {
+                    game.hasPendingDecision() shouldBe false
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarvinMurderousMimicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarvinMurderousMimicScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Marvin, Murderous Mimic (DSK #253) — {2} 2/2 Legendary Artifact Creature — Toy.
+ *
+ * "Marvin has all activated abilities of creatures you control that don't have the same name as
+ *  this creature."
+ *
+ * Modeled with [GainActivatedAbilitiesOfPermanents] (grantedTo = source, sourceFilter = creatures
+ * you control not named Marvin, includeManaAbilities = true). Unlike Sharkey, the oracle text says
+ * *all* activated abilities — mana abilities are included.
+ *
+ * Donor creatures: Llanowar Elves ({T}: Add {G}, a mana ability) and Prodigal Sorcerer
+ * ({T}: deal 1 damage, a non-mana ability).
+ */
+class MarvinMurderousMimicScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Marvin gains other creatures' activated abilities") {
+
+            test("Marvin gains a non-mana activated ability of another creature you control") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Marvin, Murderous Mimic", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Prodigal Sorcerer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val marvin = game.findPermanent("Marvin, Murderous Mimic")!!
+                val timDef = cardRegistry.getCard("Prodigal Sorcerer")!!
+                val pingAbility = timDef.script.activatedAbilities.first()
+
+                val legal = game.getLegalActions(1)
+                val marvinPing = legal.find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == marvin && a.abilityId == pingAbility.id
+                }
+                withClue("Marvin should have gained Prodigal Sorcerer's ping ability") {
+                    (marvinPing != null).shouldBeTrue()
+                }
+            }
+
+            test("Marvin gains a mana ability of another creature you control (all activated abilities)") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Marvin, Murderous Mimic", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Llanowar Elves", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val marvin = game.findPermanent("Marvin, Murderous Mimic")!!
+                val elvesDef = cardRegistry.getCard("Llanowar Elves")!!
+                val manaAbility = elvesDef.script.activatedAbilities.first { it.isManaAbility }
+
+                val legal = game.getLegalActions(1)
+                val marvinMana = legal.find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == marvin && a.abilityId == manaAbility.id
+                }
+                withClue("Marvin includes mana abilities ('all activated abilities')") {
+                    (marvinMana != null).shouldBeTrue()
+                }
+            }
+
+            test("Marvin does NOT gain abilities of a creature an opponent controls") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Marvin, Murderous Mimic", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Prodigal Sorcerer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val marvin = game.findPermanent("Marvin, Murderous Mimic")!!
+                val timDef = cardRegistry.getCard("Prodigal Sorcerer")!!
+                val pingAbility = timDef.script.activatedAbilities.first()
+
+                val legal = game.getLegalActions(1)
+                val marvinPing = legal.find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == marvin && a.abilityId == pingAbility.id
+                }
+                withClue("Marvin only copies creatures YOU control") {
+                    marvinPing shouldBe null
+                }
+            }
+
+            test("a lone Marvin (no other creatures) has no activated abilities to gain") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(1, "Marvin, Murderous Mimic", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Marvin's own card has no activated abilities, and "creatures you control that
+                // don't have the same name as this creature" matches nothing (only Marvin himself
+                // is out, and he's excluded by the name predicate). So Marvin offers no activations.
+                val marvin = game.findPermanent("Marvin, Murderous Mimic")!!
+                val legal = game.getLegalActions(1)
+                val marvinActivations = legal.filter {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == marvin
+                }
+                withClue("a lone Marvin grants himself no abilities (name predicate excludes himself)") {
+                    marvinActivations shouldBe emptyList()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three Duskmourn: House of Horror (DSK) legendary creatures using the `add-card` skill. The fourth requested card (Rip, Spawn Hunter) was skipped — see below.

## Cards landed

### Altanak, the Thrice-Called — {5}{G}{G} 9/9 Legendary Creature — Insect Beast (#166)
- **Trample**.
- **Whenever Altanak becomes the target of a spell or ability an opponent controls, draw a card** — `Triggers.BecomesTargetByOpponent`.
- **{1}{G}, Discard this card: Return target land card from your graveyard to the battlefield tapped** — a from-hand activated ability (`Costs.DiscardSelf` + `activateFromZone = Zone.HAND`) using `Effects.PutOntoBattlefield(tapped = true)` over a graveyard land target.

### Kona, Rescue Beastie — {3}{G} 4/3 Legendary Creature — Beast Survivor (#187)
- **Survival** — at your second main phase, if Kona is tapped, you may put a permanent card from hand onto the battlefield. Composed via `Patterns.Hand.putFromHand(filter = GameObjectFilter.Permanent)`; the "you may" is the up-to-one selection (decline = select nothing).

### Marvin, Murderous Mimic — {2} 2/2 Legendary Artifact Creature — Toy (#253)
- **Has all activated abilities of creatures you control that don't have the same name** — `GainActivatedAbilitiesOfPermanents(grantedTo = source, sourceFilter = Creature.youControl().notNamed("Marvin, Murderous Mimic"), includeManaAbilities = true)`. Unlike Sharkey, the oracle text says *all* activated abilities, so mana abilities are included.

## SDK addition
- `GameObjectFilter.notNamed(name)` (`Not(NameEquals)`) — for "… that don't have the same name as this creature" wording. SDK reference (`docs/card-sdk-language-reference.md`) updated in the same change.

## Card skipped
- **Rip, Spawn Hunter** — its Survival ability reveals the top X cards and lets you put "creature and/or Vehicle cards **with different powers**" into hand. The "different powers" *selection constraint* is a new `SelectionRestriction` (e.g. `OnePerPower`) that must be enforced across the `SelectFromCollectionExecutor` ceiling/normalization, the continuation resumer, the selection DTO, and the client selection UI. That is cross-layer `add-feature` work, not a single-card composition, so per the batch instructions it was deferred rather than half-built.

## Testing
- New scenario tests in `rules-engine` for all three cards — 10 tests, all passing (targeting trigger fires for opponents only; from-hand reanimation discards Altanak and returns the land tapped; Kona puts/declines/untapped-no-fire; Marvin gains non-mana + mana abilities, ignores opponents' creatures, lone Marvin grants nothing).
- `CardDefinitionSnapshotTest` golden for DSK re-blessed — additions only, no other card moved.
- `CardLintTest`, `:mtg-sdk:test`, and `:mtg-sets:test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)