### PR TITLE
FIN: Aerith Gainsborough, Barret Wallace, Prompto Argentum

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AerithGainsborough.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AerithGainsborough.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersToCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aerith Gainsborough
+ * {2}{W}
+ * Legendary Creature — Human Cleric
+ * 2/2
+ *
+ * Lifelink
+ * Whenever you gain life, put a +1/+1 counter on Aerith Gainsborough.
+ * When Aerith Gainsborough dies, put X +1/+1 counters on each legendary creature you control,
+ * where X is the number of +1/+1 counters on Aerith Gainsborough.
+ *
+ * The dies ability uses last-known information for X: the +1/+1 counter count Aerith had as it
+ * last existed on the battlefield ([ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT], the
+ * same primitive Hooded Hydra's dies trigger uses). X is locked in when the ability resolves, so
+ * a simultaneous lethal -1/-1 counter influx still uses the pre-removal +1/+1 count (Scryfall
+ * ruling 2025-06-06). The recipients are gathered fresh at resolution (legendary creatures you
+ * control), so Aerith — already in the graveyard — does not buff itself.
+ */
+val AerithGainsborough = card("Aerith Gainsborough") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "Lifelink\nWhenever you gain life, put a +1/+1 counter on Aerith Gainsborough.\n" +
+        "When Aerith Gainsborough dies, put X +1/+1 counters on each legendary creature you control, " +
+        "where X is the number of +1/+1 counters on Aerith Gainsborough."
+
+    keywords(Keyword.LIFELINK)
+
+    // Whenever you gain life, put a +1/+1 counter on Aerith.
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    // When Aerith dies, put X +1/+1 counters on each legendary creature you control,
+    // where X is the number of +1/+1 counters Aerith had as it last existed on the battlefield.
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.BattlefieldMatching(
+                    filter = GameObjectFilter.Creature.youControl().legendary()
+                ),
+                storeAs = "legendaryCreatures"
+            ),
+            AddCountersToCollectionEffect(
+                collectionName = "legendaryCreatures",
+                counterType = Counters.PLUS_ONE_PLUS_ONE,
+                amount = DynamicAmount.ContextProperty(ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "4"
+        artist = "Nakamura8"
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e86328b6-ded2-41df-8b6e-4a770e7b171e.jpg?1748705770"
+
+        ruling("2025-06-06", "If Aerith Gainsborough is dealt lethal damage at the same time that you gain life, it will die before its second ability would resolve. Its last ability will use the number of counters that were on it when it was last on the battlefield.")
+        ruling("2025-06-06", "In the rare case where enough -1/-1 counters are put on Aerith Gainsborough at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got those -1/-1 counters will be used to determine the value of X in its third ability.")
+        ruling("2025-06-06", "Aerith Gainsborough's second ability triggers just once for each life-gaining event, no matter how much life was gained.")
+        ruling("2025-06-06", "Each creature with lifelink dealing combat damage causes a separate life-gaining event, so Aerith's second ability triggers once per such event.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BarretWallace.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BarretWallace.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Barret Wallace
+ * {3}{R}
+ * Legendary Creature — Human Rebel
+ * 4/4
+ *
+ * Reach
+ * Whenever Barret Wallace attacks, it deals damage equal to the number of equipped creatures
+ * you control to defending player.
+ *
+ * The attack trigger deals damage from Barret (the default source for a triggered ability) to the
+ * defending player; the amount is the count of equipped creatures you control
+ * ([DynamicAmounts.equippedCreaturesYouControl] — creatures with at least one Equipment attached,
+ * each counted once, CR 301.5). Evaluated at resolution, so it includes Barret itself if equipped.
+ */
+val BarretWallace = card("Barret Wallace") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Rebel"
+    power = 4
+    toughness = 4
+    oracleText = "Reach\nWhenever Barret Wallace attacks, it deals damage equal to the number of " +
+        "equipped creatures you control to defending player."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.DealDamage(
+            DynamicAmounts.equippedCreaturesYouControl(),
+            EffectTarget.PlayerRef(Player.DefendingPlayer)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "129"
+        artist = "Patrik Hell"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a504dff-5857-4a61-ab99-616d5df7cf5a.jpg?1748706246"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PromptoArgentum.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PromptoArgentum.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Prompto Argentum
+ * {1}{R}
+ * Legendary Creature — Human Scout
+ * 2/2
+ *
+ * Haste
+ * Selfie Shot — Whenever you cast a noncreature spell, if at least four mana was spent to cast it,
+ * create a Treasure token.
+ *
+ * "Selfie Shot" is an ability word (flavor only — no rules meaning). "If at least four mana was
+ * spent to cast it" is an intervening-if on the noncreature-cast trigger, modeled by
+ * [Conditions.TriggeringSpellManaSpentAtLeast] reading the triggering spell's recorded total mana
+ * paid — so an {X} spell that paid four or more qualifies, while a four-mana-value spell cast for
+ * less (cost reduction) does not. Shares its trigger shape with Sahagin.
+ */
+val PromptoArgentum = card("Prompto Argentum") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Scout"
+    power = 2
+    toughness = 2
+    oracleText = "Haste\nSelfie Shot — Whenever you cast a noncreature spell, if at least four mana " +
+        "was spent to cast it, create a Treasure token."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        triggerCondition = Conditions.TriggeringSpellManaSpentAtLeast(4)
+        effect = Effects.CreateTreasure()
+        description = "Selfie Shot — Whenever you cast a noncreature spell, if at least four mana " +
+            "was spent to cast it, create a Treasure token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Billy Christian"
+        flavorText = "\"Look out world, here we come!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c617bcd-05f8-40c2-bb38-489bc863ce6b.jpg?1748706313"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -214,6 +214,99 @@
     "colorIdentityOverride": []
 }
 
+// Aerith Gainsborough
+{
+    "name": "Aerith Gainsborough",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "Lifelink\nWhenever you gain life, put a +1/+1 counter on Aerith Gainsborough.\nWhen Aerith Gainsborough dies, put X +1/+1 counters on each legendary creature you control, where X is the number of +1/+1 counters on Aerith Gainsborough.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        "IsLegendary"
+                                    ],
+                                    "controllerPredicate": "ControlledByYou"
+                                }
+                            },
+                            "storeAs": "legendaryCreatures"
+                        },
+                        {
+                            "type": "AddCountersToCollection",
+                            "collectionName": "legendaryCreatures",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "ContextProperty",
+                                "key": "LAST_KNOWN_PLUS_ONE_COUNTER_COUNT"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "RARE",
+        "artist": "Nakamura8",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e86328b6-ded2-41df-8b6e-4a770e7b171e.jpg?1748705770",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "If Aerith Gainsborough is dealt lethal damage at the same time that you gain life, it will die before its second ability would resolve. Its last ability will use the number of counters that were on it when it was last on the battlefield."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "In the rare case where enough -1/-1 counters are put on Aerith Gainsborough at the same time to make its toughness 0 or less, the number of +1/+1 counters on it before it got those -1/-1 counters will be used to determine the value of X in its third ability."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "Aerith Gainsborough's second ability triggers just once for each life-gaining event, no matter how much life was gained."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "Each creature with lifelink dealing combat damage causes a separate life-gaining event, so Aerith's second ability triggers once per such event."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Aettir and Priwen
 {
     "name": "Aettir and Priwen",
@@ -908,6 +1001,57 @@
     },
     "colorIdentityOverride": [
         "BLUE",
+        "RED"
+    ]
+}
+
+// Barret Wallace
+{
+    "name": "Barret Wallace",
+    "manaCost": "{3}{R}",
+    "typeLine": "Legendary Creature — Human Rebel",
+    "oracleText": "Reach\nWhenever Barret Wallace attacks, it deals damage equal to the number of equipped creatures you control to defending player.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature"
+                            ],
+                            "statePredicates": [
+                                "IsEquipped"
+                            ]
+                        }
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "DefendingPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "UNCOMMON",
+        "artist": "Patrik Hell",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a504dff-5857-4a61-ab99-616d5df7cf5a.jpg?1748706246"
+    },
+    "colorIdentityOverride": [
         "RED"
     ]
 }
@@ -6511,6 +6655,56 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Prompto Argentum
+{
+    "name": "Prompto Argentum",
+    "manaCost": "{1}{R}",
+    "typeLine": "Legendary Creature — Human Scout",
+    "oracleText": "Haste\nSelfie Shot — Whenever you cast a noncreature spell, if at least four mana was spent to cast it, create a Treasure token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "triggerCondition": {
+                    "type": "TriggeringSpellManaSpentAtLeast",
+                    "amount": 4
+                },
+                "descriptionOverride": "Selfie Shot — Whenever you cast a noncreature spell, if at least four mana was spent to cast it, create a Treasure token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Billy Christian",
+        "flavorText": "\"Look out world, here we come!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c617bcd-05f8-40c2-bb38-489bc863ce6b.jpg?1748706313"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AerithGainsboroughScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AerithGainsboroughScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.AerithGainsborough
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Aerith Gainsborough — {2}{W} Legendary Creature — Human Cleric 2/2
+ *   Lifelink
+ *   Whenever you gain life, put a +1/+1 counter on Aerith Gainsborough.
+ *   When Aerith Gainsborough dies, put X +1/+1 counters on each legendary creature you control,
+ *   where X is the number of +1/+1 counters on Aerith Gainsborough.
+ *
+ * Covers: the life-gain → counter trigger (driven by a real lifelink combat life-gain event), and
+ * the dies trigger distributing last-known-information counters to legendary creatures you control
+ * (non-legendary and opponent-controlled creatures excluded).
+ */
+class AerithGainsboroughScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AerithGainsborough))
+        return driver
+    }
+
+    fun addCounters(driver: GameTestDriver, entityId: EntityId, type: CounterType, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withAdded(type, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("gaining life via lifelink combat puts a +1/+1 counter on Aerith") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        val aerith = driver.putCreatureOnBattlefield(active, "Aerith Gainsborough")
+        driver.removeSummoningSickness(aerith)
+
+        plusOneCounters(driver, aerith) shouldBe 0
+        val lifeBefore = driver.getLifeTotal(active)
+
+        // Attack unblocked: lifelink gains 2 life from the 2 combat damage dealt to the opponent,
+        // and Aerith survives so the "whenever you gain life" counter trigger has a home (a blocker
+        // trade would kill Aerith first — per ruling that fizzles the counter).
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(aerith), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareNoBlockers(opponent).error shouldBe null
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        if (driver.pendingDecision is com.wingedsheep.engine.core.CombatResolutionDecision) {
+            driver.confirmCombatDamage()
+        }
+        // Resolve the "whenever you gain life" trigger that the lifelink life-gain queued.
+        driver.bothPass()
+
+        // Lifelink: Aerith dealt 2 combat damage, so its controller gained 2 life — one event.
+        driver.getLifeTotal(active) shouldBe (lifeBefore + 2)
+        // That single life-gain event triggers the counter ability exactly once.
+        plusOneCounters(driver, aerith) shouldBe 1
+    }
+
+    test("when Aerith dies, each legendary creature you control gets X +1/+1 counters (X = Aerith's +1/+1 counters)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        val aerith = driver.putCreatureOnBattlefield(active, "Aerith Gainsborough")
+        // Aerith has accumulated three +1/+1 counters (e.g. from life gain).
+        addCounters(driver, aerith, CounterType.PLUS_ONE_PLUS_ONE, 3)
+
+        // A legendary creature you control should receive the counters (distinct name, so no
+        // legend-rule conflict with Aerith).
+        val myLegend = driver.putCreatureOnBattlefield(active, "Ragavan, Nimble Pilferer")
+        // A non-legendary creature you control must NOT receive counters.
+        val myNonLegend = driver.putCreatureOnBattlefield(active, "Grizzly Bears")
+        // An opponent's legendary creature must NOT receive counters (legendary "you control").
+        val theirLegend = driver.putCreatureOnBattlefield(opponent, "Ghalta, Primal Hunger")
+
+        // Kill Aerith for real (Doom Blade -> destroy) so the dies trigger fires with last-known
+        // counter information captured on the ZoneChangeEvent.
+        val doomBlade = driver.putCardInHand(active, "Doom Blade")
+        driver.giveMana(active, com.wingedsheep.sdk.core.Color.BLACK, 2)
+        driver.castSpell(active, doomBlade, targets = listOf(aerith)).isSuccess shouldBe true
+        driver.bothPass() // resolve Doom Blade -> Aerith is destroyed, queuing its dies trigger
+        driver.state.getBattlefield().contains(aerith) shouldBe false
+        driver.bothPass() // resolve Aerith's dies trigger
+
+        // X = 3 counters were on Aerith; each legendary creature you control gains 3.
+        plusOneCounters(driver, myLegend) shouldBe 3
+        // Non-legendary creature unaffected.
+        plusOneCounters(driver, myNonLegend) shouldBe 0
+        // Opponent's legendary creature unaffected.
+        plusOneCounters(driver, theirLegend) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarretWallaceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BarretWallaceScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Barret Wallace — {3}{R} Legendary Creature — Human Rebel 4/4
+ *   Reach
+ *   Whenever Barret Wallace attacks, it deals damage equal to the number of equipped creatures
+ *   you control to defending player.
+ *
+ * The attack trigger deals damage equal to the count of equipped creatures you control (creatures
+ * with at least one Equipment attached, CR 301.5) to the defending player. We attach real Equipment
+ * via the builder so the creatures read as "equipped"; an unequipped creature you control and an
+ * opponent's equipped creature must not count.
+ */
+class BarretWallaceScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("Barret's attack deals damage equal to the number of equipped creatures you control") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Barret Wallace")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Centaur Courser") // left unequipped — must not count
+                .withCardOnBattlefield(2, "Hill Giant")       // opponent's creature
+                // Two equipped creatures you control: Barret (Buster Sword) and Bears (Coral Sword).
+                .withCardAttachedTo(1, "Buster Sword", "Barret Wallace")
+                .withCardAttachedTo(1, "Coral Sword", "Grizzly Bears")
+                // Opponent's equipped creature — must not count ("you control").
+                .withCardAttachedTo(2, "Lion Heart", "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lifeBefore = game.getLifeTotal(2)
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Barret Wallace" to 2))
+            // The attack trigger goes on the stack; resolve it.
+            game.resolveStack()
+
+            withClue("Defending player takes damage = 2 equipped creatures you control") {
+                game.getLifeTotal(2) shouldBe (lifeBefore - 2)
+            }
+        }
+
+        test("Barret deals no damage when you control no equipped creatures") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Barret Wallace")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lifeBefore = game.getLifeTotal(2)
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Barret Wallace" to 2))
+            game.resolveStack()
+
+            withClue("No equipped creatures -> 0 damage from the trigger") {
+                game.getLifeTotal(2) shouldBe lifeBefore
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PromptoArgentumScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PromptoArgentumScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.PromptoArgentum
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Prompto Argentum (FIN #148) — {1}{R} Legendary Creature — Human Scout 2/2
+ *   Haste
+ *   Selfie Shot — Whenever you cast a noncreature spell, if at least four mana was spent to cast it,
+ *   create a Treasure token.
+ *
+ * Mirrors Sahagin's trigger shape: a 4-mana noncreature spell creates a Treasure; a 1-mana one does
+ * not (the intervening-if reads the mana actually spent).
+ */
+class PromptoArgentumScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all +
+                com.wingedsheep.mtg.sets.tokens.PredefinedTokens.allTokens +
+                listOf(PromptoArgentum)
+        )
+        return driver
+    }
+
+    fun treasureCount(driver: GameTestDriver, owner: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getBattlefield().count { id ->
+            val card = driver.state.getEntity(id)?.get<CardComponent>()
+            card?.name == "Treasure" &&
+                driver.state.getEntity(id)
+                    ?.get<com.wingedsheep.engine.state.components.identity.ControllerComponent>()
+                    ?.playerId == owner
+        }
+
+    test("casting a 4-mana noncreature spell creates a Treasure token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(active, "Prompto Argentum")
+        treasureCount(driver, active) shouldBe 0
+
+        // Stoke the Flames ({2}{R}{R}) — a 4-mana instant — paid in full.
+        val stoke = driver.putCardInHand(active, "Stoke the Flames")
+        driver.giveMana(active, Color.RED, 2)
+        driver.giveColorlessMana(active, 2)
+        driver.castSpellWithTargets(
+            active,
+            stoke,
+            listOf(entityIdToChosenTarget(driver.state, opponent)),
+        ).isSuccess shouldBe true
+        // Resolve Prompto's trigger (on top of the stack), then the spell.
+        driver.bothPass()
+        driver.bothPass()
+
+        treasureCount(driver, active) shouldBe 1
+    }
+
+    test("casting a sub-4-mana noncreature spell creates no Treasure") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(active, "Prompto Argentum")
+
+        // Lightning Bolt ({R}) — a 1-mana noncreature spell, below the four-mana threshold.
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.giveMana(active, Color.RED, 1)
+        driver.castSpellWithTargets(
+            active,
+            bolt,
+            listOf(entityIdToChosenTarget(driver.state, opponent)),
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        treasureCount(driver, active) shouldBe 0
+    }
+})


### PR DESCRIPTION
Implements three Final Fantasy (FIN) legendary creatures via the `add-card` skill. All three compose existing SDK primitives — **no engine/SDK changes**.

## Cards

### Aerith Gainsborough — {2}{W} Legendary Creature — Human Cleric 2/2
- Lifelink
- Whenever you gain life, put a +1/+1 counter on Aerith (`Triggers.YouGainLife`).
- When Aerith dies, put X +1/+1 counters on each legendary creature you control, where X = its +1/+1 counters. X uses last-known information via `ContextPropertyKey.LAST_KNOWN_PLUS_ONE_COUNTER_COUNT` (the same primitive Hooded Hydra's dies trigger uses), so a simultaneous lethal −1/−1 influx still uses the pre-removal count (Scryfall ruling). Recipients are gathered fresh at resolution (`Gather(legendary creatures you control) → AddCountersToCollection`), so the dead Aerith doesn't buff itself.

### Barret Wallace — {3}{R} Legendary Creature — Human Rebel 4/4
- Reach
- Whenever Barret attacks, it deals damage equal to the number of equipped creatures you control to the defending player (`DynamicAmounts.equippedCreaturesYouControl()` → `DealDamage` to `Player.DefendingPlayer`).

### Prompto Argentum — {1}{R} Legendary Creature — Human Scout 2/2
- Haste
- Selfie Shot — Whenever you cast a noncreature spell, if at least four mana was spent to cast it, create a Treasure token (`Triggers.YouCastNoncreature` + intervening-if `Conditions.TriggeringSpellManaSpentAtLeast(4)`, same shape as Sahagin).

## Tests
Scenario tests (`rules-engine`) — all passing:
- Aerith: lifelink life-gain adds a +1/+1 counter; dies distributes last-known X to legendary creatures you control only (non-legendary and opponent-controlled excluded).
- Barret: attack damage equals equipped-creature count (you-control only); zero case when none equipped.
- Prompto: 4-mana noncreature cast mints a Treasure; sub-4-mana does not.

Also: FIN `CardDefinitionSnapshotTest` golden re-blessed (only these three cards added), `CardLintTest` passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)