### PR TITLE
FIN: Edgar King of Figaro, Freya Crescent, Ignis Scientia

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IgnisScientia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/IgnisScientia.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ignis Scientia
+ * {1}{G}{U}
+ * Legendary Creature — Human Advisor
+ * 2/2
+ * When Ignis Scientia enters, look at the top six cards of your library. You may put a land
+ * card from among them onto the battlefield tapped. Put the rest on the bottom of your library
+ * in a random order.
+ * I've Come Up with a New Recipe! — {1}{G}{U}, {T}: Exile target card from a graveyard. If a
+ * creature card was exiled this way, create a Food token.
+ */
+val IgnisScientia = card("Ignis Scientia") {
+    manaCost = "{1}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Human Advisor"
+    oracleText = "When Ignis Scientia enters, look at the top six cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.\nI've Come Up with a New Recipe! — {1}{G}{U}, {T}: Exile target card from a graveyard. If a creature card was exiled this way, create a Food token."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                // Look at the top six cards of your library.
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(count = DynamicAmount.Fixed(6), player = Player.You),
+                    storeAs = "looked"
+                ),
+                // You may put a land card from among them onto the battlefield tapped.
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Land,
+                    showAllCards = true,
+                    storeSelected = "toBattlefield",
+                    storeRemainder = "toBottom",
+                    prompt = "You may put a land card onto the battlefield tapped",
+                    selectedLabel = "Put onto the battlefield tapped",
+                    remainderLabel = "Put on the bottom of your library"
+                ),
+                MoveCollectionEffect(
+                    from = "toBattlefield",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You, ZonePlacement.Tapped)
+                ),
+                // Put the rest on the bottom of your library in a random order.
+                MoveCollectionEffect(
+                    from = "toBottom",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}{G}{U}"), Costs.Tap)
+        target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
+        effect = Effects.Composite(
+            listOf(
+                // Gather the targeted graveyard card so we can both exile it and test its type.
+                GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "exiled"),
+                // "If a creature card was exiled this way, create a Food token." The targeted card
+                // is always exiled, so its type (read from the gathered collection, base card type is
+                // zone-independent) determines the Food. Evaluated before the move so the collection's
+                // entity ids are still live.
+                ConditionalEffect(
+                    condition = Conditions.CollectionContainsMatch("exiled", GameObjectFilter.Creature),
+                    effect = Effects.CreateFood()
+                ),
+                // Exile target card from a graveyard.
+                MoveCollectionEffect(
+                    from = "exiled",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Mingchen Shen"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab4f9721-5b2c-4371-98a5-3f6714265e57.jpg?1748706619"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -4461,6 +4461,153 @@
     ]
 }
 
+// Ignis Scientia
+{
+    "name": "Ignis Scientia",
+    "manaCost": "{1}{G}{U}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "When Ignis Scientia enters, look at the top six cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.\nI've Come Up with a New Recipe! — {1}{G}{U}, {T}: Exile target card from a graveyard. If a creature card was exiled this way, create a Food token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "land",
+                            "storeSelected": "toBattlefield",
+                            "storeRemainder": "toBottom",
+                            "prompt": "You may put a land card onto the battlefield tapped",
+                            "selectedLabel": "Put onto the battlefield tapped",
+                            "remainderLabel": "Put on the bottom of your library",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBattlefield",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBottom",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}{G}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "exiled"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "CollectionContainsMatch",
+                                    "collection": "exiled",
+                                    "filter": "creature"
+                                }
+                            },
+                            "then": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Food"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "UNCOMMON",
+        "artist": "Mingchen Shen",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab4f9721-5b2c-4371-98a5-3f6714265e57.jpg?1748706619"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Il Mheg Pixie
 {
     "name": "Il Mheg Pixie",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IgnisScientiaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IgnisScientiaScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.IgnisScientia
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ignis Scientia — {1}{G}{U} Legendary Creature — Human Advisor, 2/2
+ *
+ *   ETB: "look at the top six cards of your library. You may put a land card from among them
+ *         onto the battlefield tapped. Put the rest on the bottom of your library in a random order."
+ *   {1}{G}{U}, {T}: "Exile target card from a graveyard. If a creature card was exiled this way,
+ *                    create a Food token."
+ *
+ * The card is pure composition over existing pipeline primitives (GatherCards / SelectFromCollection /
+ * MoveCollection / ConditionalEffect + CollectionContainsMatch), so this test is the behavioural gate.
+ */
+class IgnisScientiaScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(IgnisScientia)
+        driver.registerCard(PredefinedTokens.Food) // GameTestDriver doesn't auto-register tokens
+        return driver
+    }
+
+    fun countFood(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.getPermanents(playerId).count { entityId ->
+            driver.state.getEntity(entityId)?.get<CardComponent>()?.name == "Food"
+        }
+
+    val abilityId = IgnisScientia.activatedAbilities[0].id
+
+    test("activated ability: exiling a creature card from a graveyard creates a Food token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ignis = driver.putCreatureOnBattlefield(p1, "Ignis Scientia")
+        driver.removeSummoningSickness(ignis) // {T} cost needs it not summoning-sick
+
+        // A creature card in a graveyard to exile.
+        val bearInGy = driver.putCardInGraveyard(p1, "Grizzly Bears")
+
+        // Pay {1}{G}{U}.
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.giveMana(p1, Color.BLUE, 1)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = ignis,
+                abilityId = abilityId,
+                targets = listOf(entityIdToChosenTarget(driver.state, bearInGy))
+            )
+        )
+        withClue("error=${result.error}") { result.isSuccess shouldBe true }
+        driver.bothPass()
+
+        // The creature card is exiled and a Food token was created.
+        driver.getExile(p1).contains(bearInGy) shouldBe true
+        countFood(driver, p1) shouldBe 1
+    }
+
+    test("activated ability: exiling a non-creature card creates no Food token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ignis = driver.putCreatureOnBattlefield(p1, "Ignis Scientia")
+        driver.removeSummoningSickness(ignis)
+
+        // A land card (non-creature) in the graveyard.
+        val landInGy = driver.putCardInGraveyard(p1, "Forest")
+
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.giveMana(p1, Color.BLUE, 1)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = ignis,
+                abilityId = abilityId,
+                targets = listOf(entityIdToChosenTarget(driver.state, landInGy))
+            )
+        )
+        withClue("error=${result.error}") { result.isSuccess shouldBe true }
+        driver.bothPass()
+
+        driver.getExile(p1).contains(landInGy) shouldBe true
+        countFood(driver, p1) shouldBe 0
+    }
+
+    test("ETB: puts a land onto the battlefield tapped, bottoming the rest") {
+        val driver = createDriver()
+        // All-Forest library guarantees a land is among the top six looked at.
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val landsBefore = driver.getLands(p1).size
+
+        // Cast Ignis from hand so its enters trigger actually fires (direct placement helpers don't).
+        val ignis = driver.putCardInHand(p1, "Ignis Scientia")
+        driver.giveMana(p1, Color.GREEN, 2)
+        driver.giveMana(p1, Color.BLUE, 1)
+        driver.castSpell(p1, ignis)
+
+        // Resolve until the ETB trigger pauses for the "you may" land selection.
+        var guard = 0
+        while (driver.pendingDecision == null && driver.stackSize > 0 && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        val decision = driver.pendingDecision
+        withClue("Ignis ETB should prompt a land selection, got $decision") {
+            (decision is SelectCardsDecision) shouldBe true
+        }
+        decision as SelectCardsDecision
+        driver.submitCardSelection(p1, listOf(decision.options.first()))
+        driver.bothPass()
+
+        // A land entered the battlefield (tapped) from the top six.
+        withClue("Ignis ETB should have put one Forest onto the battlefield") {
+            driver.getLands(p1).size shouldBe landsBefore + 1
+        }
+        val newLand = driver.getLands(p1).first { driver.state.getEntity(it)?.get<CardComponent>()?.name == "Forest" }
+        withClue("The land Ignis puts onto the battlefield enters tapped") {
+            driver.isTapped(newLand) shouldBe true
+        }
+    }
+})


### PR DESCRIPTION
## Summary

Batch of three Final Fantasy (FIN) cards. **One implemented, two deferred** to add-feature.

### Implemented
- **Ignis Scientia** (FIN #227, {1}{G}{U} Legendary Creature — Human Advisor, 2/2)
  - ETB: look at the top six cards of your library; you may put a land card onto the battlefield **tapped**; put the rest on the bottom in a random order.
  - `{1}{G}{U}, {T}`: exile target card from a graveyard; if a creature card was exiled this way, create a Food token.
  - Pure pipeline composition — no new SDK/engine types: `GatherCards` + `SelectFromCollection(ChooseUpTo, land)` + `MoveCollection` for the ETB; `GatherCards(ChosenTargets)` + `ConditionalEffect(CollectionContainsMatch creature → CreateFood)` + `MoveCollection(EXILE)` for the activated ability.
  - Scenario test (`IgnisScientiaScenarioTest`, 3 cases, all green): Food on creature exile, no Food on non-creature exile, tapped-land ETB.
  - FIN card snapshot re-blessed (only Ignis added).

### Deferred (add-feature territory — intentionally skipped, not approximated)
- **Edgar, King of Figaro** — "Two-Headed Coin": the first time you flip one or more coins each turn, those coins come up heads and you win those flips. No coin-flip-result replacement/continuous effect exists in the engine; faithfully modeling it is add-feature work.
- **Freya Crescent** — `{T}: Add {R}. Spend this mana only to cast an Equipment spell or activate an equip ability.` Needs a new `ManaRestriction` variant + `SpellPaymentContext.isEquipAbility` plumbing. The closest existing restriction (`SubtypeSpellsOrAbilitiesOnly("Equipment")`) would wrongly also allow non-equip activated abilities of Equipment sources, so it's not a faithful substitute. (The "Jump" conditional-flying half is already supported; the mana ability is the blocker.)

## Testing
- `IgnisScientiaScenarioTest` — 3/3 pass.
- `CardDefinitionSnapshotTest` (FIN) re-blessed; diff is purely additive (Ignis only).
- `CardLintTest` green.
- `check-card-printing "Ignis Scientia"` — canonical correctly in FIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)