### PR TITLE
FIN: Kefka Court Mage, Hope Estheim, G'raha Tia

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GrahaTia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GrahaTia.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * G'raha Tia
+ * {4}{W}
+ * Legendary Creature — Cat Archer
+ * 3/5
+ *
+ * Reach
+ * The Allagan Eye — Whenever one or more other creatures and/or artifacts you control die,
+ * draw a card. This ability triggers only once each turn.
+ *
+ * Implementation notes:
+ *  - "The Allagan Eye" is an ability word (flavor only, no rules meaning); kept in the oracle
+ *    text / description for display but carries no mechanics.
+ *  - Modeled as the batched death trigger [Triggers.OneOrMoreCreaturesYouControlDie] over
+ *    [GameObjectFilter.CreatureOrArtifact] with `excludeSelf = true` (the "other" wording).
+ *    The batch fires at most once per simultaneous death event (CR 603.3b), so a board wipe
+ *    that kills several of your creatures/artifacts draws one card, not one per permanent.
+ *  - `oncePerTurn = true` enforces "This ability triggers only once each turn".
+ */
+val GrahaTia = card("G'raha Tia") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Cat Archer"
+    oracleText = "Reach\n" +
+        "The Allagan Eye — Whenever one or more other creatures and/or artifacts you control " +
+        "die, draw a card. This ability triggers only once each turn."
+    power = 3
+    toughness = 5
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.OneOrMoreCreaturesYouControlDie(
+            filter = GameObjectFilter.CreatureOrArtifact,
+            excludeSelf = true,
+        )
+        oncePerTurn = true
+        effect = Effects.DrawCards(1)
+        description = "The Allagan Eye — Whenever one or more other creatures and/or artifacts " +
+            "you control die, draw a card. This ability triggers only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "21"
+        artist = "Narendra Bintara Adi"
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/076a8eca-ed73-4ee9-aab4-d9d43d394ee6.jpg?1748705832"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/HopeEstheim.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/HopeEstheim.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hope Estheim
+ * {W}{U}
+ * Legendary Creature — Human Wizard
+ * 2/2
+ *
+ * Lifelink
+ * At the beginning of your end step, each opponent mills X cards, where X is the amount of
+ * life you gained this turn.
+ *
+ * Implementation notes:
+ *  - The mill amount is the life *you* gained this turn ([DynamicAmounts.lifeGainedThisTurn],
+ *    backed by the LIFE_GAINED turn tracker). If you gained no life, X = 0 and each opponent
+ *    mills nothing (the gather of zero cards is a no-op).
+ *  - "Each opponent mills X" mills each opponent's own library top via a single mill pipeline
+ *    targeted at [Player.EachOpponent] (the gather fans out over each opponent in turn order).
+ *    The count is *not* wrapped in a per-player iteration so `Player.You` in
+ *    [DynamicAmounts.lifeGainedThisTurn] keeps resolving to the ability's controller rather than
+ *    being rebound to the milling opponent.
+ */
+val HopeEstheim = card("Hope Estheim") {
+    manaCost = "{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Wizard"
+    oracleText = "Lifelink\n" +
+        "At the beginning of your end step, each opponent mills X cards, where X is the amount " +
+        "of life you gained this turn."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Patterns.Library.mill(
+            count = DynamicAmounts.lifeGainedThisTurn(),
+            target = EffectTarget.PlayerRef(Player.EachOpponent),
+        )
+        description = "At the beginning of your end step, each opponent mills X cards, where X " +
+            "is the amount of life you gained this turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "226"
+        artist = "Fariba Khamseh"
+        flavorText = "\"If we have the power to destroy Cocoon, then we have the power to save it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbdb68cc-5516-481a-94c5-59f6c69b8a17.jpg?1748706615"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -3525,6 +3525,52 @@
     ]
 }
 
+// G'raha Tia
+{
+    "name": "G'raha Tia",
+    "manaCost": "{4}{W}",
+    "typeLine": "Legendary Creature — Cat Archer",
+    "oracleText": "Reach\nThe Allagan Eye — Whenever one or more other creatures and/or artifacts you control die, draw a card. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "CreaturesYouControlDiedEvent",
+                    "filter": "creature|artifact",
+                    "excludeSelf": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "oncePerTurn": true,
+                "descriptionOverride": "The Allagan Eye — Whenever one or more other creatures and/or artifacts you control die, draw a card. This ability triggers only once each turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "UNCOMMON",
+        "artist": "Narendra Bintara Adi",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/076a8eca-ed73-4ee9-aab4-d9d43d394ee6.jpg?1748705832"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Gaelicat
 {
     "name": "Gaelicat",
@@ -4301,6 +4347,72 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Hope Estheim
+{
+    "name": "Hope Estheim",
+    "manaCost": "{W}{U}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Lifelink\nAt the beginning of your end step, each opponent mills X cards, where X is the amount of life you gained this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "TurnTracking",
+                                    "player": "You",
+                                    "tracker": "LIFE_GAINED"
+                                },
+                                "player": "EachOpponent"
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "EachOpponent"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your end step, each opponent mills X cards, where X is the amount of life you gained this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "RARE",
+        "artist": "Fariba Khamseh",
+        "flavorText": "\"If we have the power to destroy Cocoon, then we have the power to save it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbdb68cc-5516-481a-94c5-59f6c69b8a17.jpg?1748706615"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinHopeGrahaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinHopeGrahaScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for two FIN cards built from existing primitives:
+ *
+ *  - Hope Estheim — "At the beginning of your end step, each opponent mills X cards, where X is
+ *    the amount of life you gained this turn." Verifies the mill scales with life gained this turn
+ *    and is a no-op when no life was gained.
+ *  - G'raha Tia — "Whenever one or more other creatures and/or artifacts you control die, draw a
+ *    card. This ability triggers only once each turn." Verifies the batched once-per-turn draw,
+ *    that artifacts count, and that it does not fire on the source's own death.
+ */
+class FinHopeGrahaScenarioTest : ScenarioTestBase() {
+
+    init {
+        // Gains the controller 4 life so Hope's "amount of life you gained this turn" is non-zero.
+        cardRegistry.register(
+            CardDefinition.instant(
+                name = "Test Healing Light",
+                manaCost = ManaCost.parse("{W}"),
+                oracleText = "You gain 4 life.",
+                script = CardScript.spell(effect = GainLifeEffect(4, EffectTarget.Controller)),
+            ),
+        )
+
+        context("Hope Estheim — end-step mill scales with life gained") {
+
+            test("each opponent mills equal to the life you gained this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hope Estheim")
+                    .withCardInHand(1, "Test Healing Light")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    // Seed the opponent's library so there is something to mill.
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val oppLibraryBefore = game.librarySize(2)
+                val oppGraveBefore = game.graveyardSize(2)
+
+                // Gain 4 life this turn.
+                game.castSpell(1, "Test Healing Light").error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Opponent milled exactly the 4 life Hope's controller gained this turn") {
+                    game.librarySize(2) shouldBe oppLibraryBefore - 4
+                    game.graveyardSize(2) shouldBe oppGraveBefore + 4
+                }
+            }
+
+            test("no life gained means no mill") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hope Estheim")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withCardInLibrary(2, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val oppLibraryBefore = game.librarySize(2)
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("No life gained → X = 0 → opponent mills nothing") {
+                    game.librarySize(2) shouldBe oppLibraryBefore
+                }
+            }
+        }
+
+        context("G'raha Tia — once-per-turn draw on creature/artifact death") {
+
+            test("drawing only once even when several controlled permanents die in a turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "G'raha Tia")
+                    .withCardOnBattlefield(1, "Centaur Courser")
+                    .withCardOnBattlefield(1, "Frogmite") // an artifact creature — counts as an artifact
+                    .withCardsInHand(1, "Doom Blade", 2)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val courser = game.findPermanent("Centaur Courser")!!
+                val frogmite = game.findPermanent("Frogmite")!!
+                val handBefore = game.handSize(1)
+
+                // Kill the first nonblack creature (Centaur Courser).
+                game.castSpell(1, "Doom Blade", targetId = courser).error shouldBe null
+                game.resolveStack()
+
+                withClue("First controlled death this turn draws exactly one card") {
+                    // hand: -1 Doom Blade cast, +1 drawn from G'raha = net 0 vs handBefore.
+                    game.handSize(1) shouldBe handBefore - 1 + 1
+                }
+                withClue("Centaur Courser died") {
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe true
+                }
+
+                val handAfterFirst = game.handSize(1)
+
+                // Kill a second controlled permanent (the artifact creature Frogmite) the same turn.
+                game.castSpell(1, "Doom Blade", targetId = frogmite).error shouldBe null
+                game.resolveStack()
+
+                withClue("Second controlled death the same turn does NOT draw again (once per turn)") {
+                    // Only the Doom Blade leaves hand; no extra G'raha draw.
+                    game.handSize(1) shouldBe handAfterFirst - 1
+                }
+                withClue("Frogmite (an artifact) still died and is in the graveyard") {
+                    game.isInGraveyard(1, "Frogmite") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements two of the three requested Final Fantasy (FIN) cards. Both use only existing SDK primitives — no engine changes.

## Implemented

- **Hope Estheim** `{W}{U}` Legendary Creature — Human Wizard 2/2
  - Lifelink
  - "At the beginning of your end step, each opponent mills X cards, where X is the amount of life you gained this turn."
  - Modeled as a single mill pipeline targeted at `Player.EachOpponent` (the gather fans out over each opponent's own library). The count is deliberately **not** wrapped in a per-player iteration, so `Player.You` inside `DynamicAmounts.lifeGainedThisTurn()` keeps resolving to the ability's controller rather than being rebound to the milling opponent.

- **G'raha Tia** `{4}{W}` Legendary Creature — Cat Archer 3/5
  - Reach
  - "The Allagan Eye — Whenever one or more other creatures and/or artifacts you control die, draw a card. This ability triggers only once each turn."
  - Batched death trigger (`OneOrMoreCreaturesYouControlDie`) over `GameObjectFilter.CreatureOrArtifact` with `excludeSelf = true` and `oncePerTurn = true`. "The Allagan Eye" is an ability word (flavor only). A board wipe that kills several of your permanents draws once, not once per permanent.

## Skipped

- **Kefka, Court Mage** — *not* in this batch. Its front face reads "Whenever Kefka enters or attacks, each player discards a card. Then you draw a card **for each card type among cards discarded this way**." There is no `DynamicAmount` that counts distinct card types across a named pipeline collection (only `SpellsCastThisTurn` and linked-exile expose distinct-card-type counts). Adding such a primitive + evaluator branch is `add-feature` territory, so the card was deferred rather than approximated with a lossy shortcut. The rest of the card (each-opponent-sacrifice `{8}` transform, the back face's "opponent loses life during your turn → draw that many") is already expressible with existing primitives.

## Tests

- `FinHopeGrahaScenarioTest` (rules-engine) — all green:
  - Hope: opponent mills exactly the life gained this turn; no life gained → no mill.
  - G'raha: once-per-turn batched draw, including an artifact-creature death; second controlled death the same turn does not draw again.
- Re-blessed `CardDefinitionSnapshotTest` FIN golden — diff is only the two new cards.
- `CardLintTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)