### PR TITLE
Fix Pyrrhic Strike blight path: collect blight target so both modes unlock

### DIFF
--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PyrrhicStrikeModalBlightTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PyrrhicStrikeModalBlightTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.legalactions.support.EnumerationTestDriver
+import com.wingedsheep.engine.legalactions.support.setupP1
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.mtg.sets.definitions.ecl.cards.PyrrhicStrike
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pyrrhic Strike (ECL #30) — {2}{W} Instant.
+ *
+ *   "As an additional cost to cast this spell, you may blight 2.
+ *    Choose one. If this spell's additional cost was paid, choose both instead.
+ *    • Destroy target artifact or enchantment.
+ *    • Destroy target creature with mana value 3 or greater."
+ *
+ * Regression for a "can only choose one mode" bug on the blight path: the engine surfaces the
+ * blight path as a distinct `CastSpellModal` variant whose `modalEnumeration` forces every mode,
+ * but it only unlocks those extra modes once the submitted action actually carries `blightTargets`
+ * (and it reads the same field to apply the −1/−1 counters). The web client's modal pipeline used
+ * to submit `chosenModes` without ever collecting the blight target, so the engine rejected the
+ * two-mode cast with "Too many modes chosen". These tests pin the engine contract the client must
+ * satisfy.
+ */
+class PyrrhicStrikeModalBlightTest : FunSpec({
+
+    fun setup(): EnumerationTestDriver = setupP1(
+        hand = listOf("Pyrrhic Strike"),
+        battlefield = listOf(
+            "Force of Nature",  // 5/5 blight fodder
+            "Centaur Courser",  // 3/3, mana value 3 → "creature with MV 3 or greater"
+            "Test Enchantment", // enchantment → "artifact or enchantment"
+            "Plains", "Plains", "Plains",
+        ),
+        extraSetCards = listOf(PyrrhicStrike),
+    )
+
+    fun EnumerationTestDriver.bf(name: String): EntityId =
+        game.state.getZone(ZoneKey(player1, Zone.BATTLEFIELD))
+            .first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    fun EnumerationTestDriver.handCard(name: String): EntityId =
+        game.state.getZone(ZoneKey(player1, Zone.HAND))
+            .first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+    test("blight path is a distinct modal variant that forces choosing both modes") {
+        val driver = setup()
+        val casts = driver.enumerateFor(driver.player1).castActionsFor("Pyrrhic Strike")
+
+        // Pay path: "choose one" → one CastSpellMode per mode (the player picks exactly one).
+        val payModes = casts.filter { it.actionType == "CastSpellMode" }
+        payModes shouldHaveSize 2
+
+        // Blight path: a single CastSpellModal whose enumeration locks the player into both modes.
+        val blightVariant = casts.single { it.actionType == "CastSpellModal" }
+        val enumeration = blightVariant.modalEnumeration.shouldNotBeNull()
+        enumeration.chooseCount shouldBe 2
+        enumeration.minChooseCount shouldBe 2
+    }
+
+    test("casting via the blight path destroys both targets and blights the fodder") {
+        val driver = setup()
+        val p1 = driver.player1
+        val fodder = driver.bf("Force of Nature")
+        val enchantment = driver.bf("Test Enchantment")
+        val creature = driver.bf("Centaur Courser")
+        val pyrrhic = driver.handCard("Pyrrhic Strike")
+
+        // The payload the (fixed) client submits to take the blight path: both modes chosen and
+        // the blight target that commits the player to "choose both". Per-mode targeting is then
+        // driven server-side (CR 601.2c), exactly as in-game — the client supplies no flat targets.
+        val result = driver.game.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = pyrrhic,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                chosenModes = listOf(0, 1),
+                additionalCostPayment = AdditionalCostPayment(
+                    blightAmount = 2,
+                    blightTargets = listOf(fodder),
+                ),
+            )
+        )
+        result.error shouldBe null
+
+        // Answer the per-mode target prompts: mode 0 → the enchantment, mode 1 → Centaur Courser.
+        val desiredPerMode = mapOf(0 to enchantment, 1 to creature)
+        var safety = 0
+        while (driver.game.pendingDecision is ChooseTargetsDecision && safety < 10) {
+            val decision = driver.game.pendingDecision as ChooseTargetsDecision
+            val req = decision.targetRequirements.first()
+            val legal = decision.legalTargets[req.index].orEmpty()
+            // Pick whichever of the two intended targets is legal for the mode being resolved.
+            val pick = desiredPerMode.values.first { it in legal }
+            driver.game.submitDecision(
+                p1, TargetsResponse(decision.id, mapOf(req.index to listOf(pick)))
+            )
+            safety++
+        }
+
+        // Resolve the spell off the stack.
+        safety = 0
+        while (driver.game.stackSize > 0 && safety < 20) { driver.game.bothPass(); safety++ }
+
+        // Both targets destroyed.
+        driver.game.findPermanent(p1, "Test Enchantment") shouldBe null
+        driver.game.findPermanent(p1, "Centaur Courser") shouldBe null
+
+        // Fodder took blight 2 (and survives as a 3/3).
+        driver.game.findPermanent(p1, "Force of Nature").shouldNotBeNull()
+        driver.game.state.getEntity(fodder)?.get<CountersComponent>()
+            ?.getCount(CounterType.MINUS_ONE_MINUS_ONE) shouldBe 2
+    }
+
+    test("choosing both modes without paying blight is rejected") {
+        // The "choose one" floor without blight is exactly one mode (CR 700.2 / the printed
+        // "Choose one"). The two-mode cast is only legal on the blight path, so an action that
+        // claims both modes but carries no blight payment must be refused.
+        val driver = setup()
+        val p1 = driver.player1
+        val pyrrhic = driver.handCard("Pyrrhic Strike")
+
+        val result = driver.game.submit(
+            CastSpell(
+                playerId = p1,
+                cardId = pyrrhic,
+                paymentStrategy = PaymentStrategy.AutoPay,
+                chosenModes = listOf(0, 1),
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/web-client/src/store/slices/ui/pipelinePhases.test.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { computePhases } from './pipelinePhases'
+import type { LegalActionInfo } from '@/types/messages'
+
+/**
+ * Minimal CastSpell LegalActionInfo factory — only the fields computePhases reads matter.
+ */
+function castAction(over: Record<string, unknown>): LegalActionInfo {
+  return {
+    actionType: 'CastSpellModal',
+    description: 'Cast Test',
+    action: { type: 'CastSpell', playerId: 'p1', cardId: 'c1' },
+    ...over,
+  } as unknown as LegalActionInfo
+}
+
+describe('computePhases — choose-N modal', () => {
+  it('plain choose-N modal (Spree) runs only the modalModes phase', () => {
+    const info = castAction({
+      modalEnumeration: {
+        chooseCount: 3,
+        minChooseCount: 1,
+        allowRepeat: true,
+        modes: [],
+      },
+    })
+    expect(computePhases(info)).toEqual([{ type: 'modalModes' }])
+  })
+
+  it('"choose both if you blight" modal (Pyrrhic Strike) also collects the blight target', () => {
+    // The engine forces every mode on the blight variant but only unlocks the extra modes
+    // once the submitted action carries blightTargets. The client must therefore run a
+    // costPayment phase to pick the creature to blight — otherwise the action submits with
+    // no blight and the engine rejects it ("Too many modes chosen").
+    const info = castAction({
+      modalEnumeration: {
+        chooseCount: 2,
+        minChooseCount: 2,
+        allowRepeat: false,
+        modes: [],
+      },
+      additionalCostInfo: {
+        costType: 'Blight',
+        description: 'creature to blight',
+        validBlightTargets: ['fodder1'],
+        blightAmount: 2,
+      },
+    })
+    expect(computePhases(info)).toEqual([{ type: 'modalModes' }, { type: 'costPayment' }])
+  })
+})

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -56,16 +56,28 @@ export function computePhases(actionInfo: LegalActionInfo, options?: ComputePhas
   const phases: PipelinePhase[] = []
 
   // 0. Choose-N modal (Spree / "choose one or more"): the player picks the mode subset in a
-  //    single panel. This is the ONLY client phase — the additional cost depends on which
-  //    modes are chosen, and per-mode targeting happens on the battlefield afterward, so the
-  //    server drives targeting and mana payment once `chosenModes` is submitted. Return early
-  //    so no manaSource/targeting phase runs against the (incomplete) base cost.
+  //    single panel. Usually this is the ONLY client phase — the additional cost depends on
+  //    which modes are chosen, and per-mode targeting happens on the battlefield afterward, so
+  //    the server drives targeting and mana payment once `chosenModes` is submitted. Return
+  //    early so no manaSource/targeting phase runs against the (incomplete) base cost.
+  //
+  //    Exception: a "choose both if you blight" modal (Pyrrhic Strike) surfaces its blight path
+  //    as a distinct cast variant whose `modalEnumeration` forces every mode. The engine only
+  //    unlocks those extra modes once the submitted action carries `blightTargets` (and it reads
+  //    the same field to apply the −1/−1 counters) — so we must collect the blight target via a
+  //    `costPayment` phase here rather than dropping it. Without this, the action submits with
+  //    no blight and the engine rejects it ("Too many modes chosen"). Per-mode targeting + mana
+  //    still run server-side after submit.
   if (
     actionInfo.action.type === 'CastSpell' &&
     actionInfo.modalEnumeration &&
     actionInfo.modalEnumeration.chooseCount > 1
   ) {
-    return [{ type: 'modalModes' }]
+    const modalPhases: PipelinePhase[] = [{ type: 'modalModes' }]
+    if (actionInfo.additionalCostInfo?.costType === 'Blight') {
+      modalPhases.push({ type: 'costPayment' })
+    }
+    return modalPhases
   }
 
   // 1. Counter distribution


### PR DESCRIPTION
## Problem

Pyrrhic Strike (ECL #30) — *"As an additional cost to cast this spell, you may blight 2. Choose one. If this spell's additional cost was paid, choose both instead."* — was bugged in play: **you could only ever choose one mode**, even when taking the blight path.

## Root cause

The engine surfaces the blight path as a distinct `CastSpellModal` cast variant whose `modalEnumeration` forces every mode (`chooseCount = 2`, `minChooseCount = 2`). But `effectiveModalChooseCounts` only unlocks those extra modes once the submitted action actually carries `blightTargets` (it reads the same field to apply the −1/−1 counters). Without blight in the action it caps the mode count at `minChooseCount` (= 1).

The web client's choose-N modal pipeline (`computePhases`) returned `[modalModes]` and submitted `chosenModes` **without ever collecting the blight target**, so the engine rejected the two-mode cast:

```
Too many modes chosen: 2 (maximum 1)
```

From the player's seat that reads as "can only choose 1 mode."

## Fix

When the choose-N modal variant carries a `Blight` additional cost, append a `costPayment` phase so the client collects the creature to blight and attaches `blightTargets` before submitting. This reuses the exact `costPayment` `Blight` flow non-modal blight cards already use. Per-mode targeting + mana still run server-side after submit, unchanged. One-file behavioural change in `pipelinePhases.ts`.

## Tests

- **web-client** `pipelinePhases.test.ts` — blight modal variant → `[modalModes, costPayment]`; a plain Spree modal still → `[modalModes]`.
- **rules-engine** `PyrrhicStrikeModalBlightTest` — pins the engine contract the client must satisfy:
  - the blight path is a distinct variant that forces choosing both modes;
  - the full blight payload destroys both targets and blights the fodder (−1/−1 ×2);
  - claiming both modes without paying blight is rejected.

All 167 web-client vitest tests pass; the 3 new engine scenario tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)