### PR TITLE
Add Saw and Underwater Tunnel // Slimy Aquarium (DSK)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Saw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/Saw.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+
+/**
+ * Saw
+ * {2}
+ * Artifact — Equipment
+ * Equipped creature gets +2/+0.
+ * Whenever equipped creature attacks, you may sacrifice a permanent other than that creature or
+ * this Equipment. If you do, draw a card.
+ * Equip {2}
+ *
+ * The static buff is the usual [ModifyStats] over [Filters.EquippedCreature]. The attack trigger
+ * binds to the attached creature ([TriggerBinding.ATTACHED] on [Triggers.attacks], i.e. "whenever
+ * equipped creature attacks"). The "you may sacrifice … If you do, draw" pay-then-payoff is a
+ * [GatedEffect] with a [Gate.MayPay] whose cost is a [SacrificeEffect] over permanents you control;
+ * `excludeSource = true` removes this Equipment from the choices and `notAttachedToBySource()`
+ * removes the equipped creature ("that creature"), so the sacrifice is "a permanent other than that
+ * creature or this Equipment". Declining (or controlling no other sacrificeable permanent) skips
+ * the draw.
+ */
+val Saw = card("Saw") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+0.\n" +
+        "Whenever equipped creature attacks, you may sacrifice a permanent other than that " +
+        "creature or this Equipment. If you do, draw a card.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = ModifyStats(+2, 0, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.attacks(binding = TriggerBinding.ATTACHED)
+        effect = GatedEffect(
+            gate = Gate.MayPay(
+                SacrificeEffect(
+                    filter = GameObjectFilter.Permanent.notAttachedToBySource(),
+                    count = 1,
+                    excludeSource = true
+                )
+            ),
+            then = Effects.DrawCards(1)
+        )
+        description = "Whenever equipped creature attacks, you may sacrifice a permanent other " +
+            "than that creature or this Equipment. If you do, draw a card."
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "254"
+        artist = "Jarel Threat"
+        imageUri = "https://cards.scryfall.io/normal/front/6/0/603c3ef4-4ef1-4db8-9ed2-e2b0926269d5.jpg?1726286820"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnderwaterTunnelSlimyAquarium.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnderwaterTunnelSlimyAquarium.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Underwater Tunnel // Slimy Aquarium (DSK 79) — split-layout Room (CR 709.5).
+ *
+ * Underwater Tunnel {U} — Enchantment — Room
+ *   When you unlock this door, surveil 2.
+ *
+ * Slimy Aquarium {3}{U} — Enchantment — Room
+ *   When you unlock this door, manifest dread, then put a +1/+1 counter on that creature.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ *
+ * Slimy Aquarium reuses the shared [Patterns.Library.manifestDread] recipe, which stores the
+ * manifested creature under the pipeline collection "manifestDreadManifested"; the follow-up
+ * +1/+1 counter targets that creature via [EffectTarget.PipelineTarget]. If the library is empty
+ * (no creature manifested), there is nothing to put a counter on and that step is a no-op.
+ */
+val UnderwaterTunnelSlimyAquarium = card("Underwater Tunnel // Slimy Aquarium") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "U"
+
+    face("Underwater Tunnel") {
+        manaCost = "{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, surveil 2."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Effects.Surveil(2)
+            description = "When you unlock this door, surveil 2."
+        }
+    }
+
+    face("Slimy Aquarium") {
+        manaCost = "{3}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, manifest dread, then put a +1/+1 counter on that creature."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Effects.Composite(
+                Patterns.Library.manifestDread(),
+                Effects.AddCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    1,
+                    EffectTarget.PipelineTarget("manifestDreadManifested")
+                )
+            )
+            description = "When you unlock this door, manifest dread, then put a +1/+1 counter on that creature."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "79"
+        artist = "Titus Lunter"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg?1726780798"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -12287,6 +12287,97 @@
     ]
 }
 
+// Saw
+{
+    "name": "Saw",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+0.\nWhenever equipped creature attacks, you may sacrifice a permanent other than that creature or this Equipment. If you do, draw a card.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "binding": "ATTACHED",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": {
+                                "cardPredicates": [
+                                    "IsPermanent"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "StateNot",
+                                        "predicate": "IsAttachedToBySource"
+                                    }
+                                ]
+                            },
+                            "excludeSource": true
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "descriptionOverride": "Whenever equipped creature attacks, you may sacrifice a permanent other than that creature or this Equipment. If you do, draw a card."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 0
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "254",
+        "rarity": "UNCOMMON",
+        "artist": "Jarel Threat",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/0/603c3ef4-4ef1-4db8-9ed2-e2b0926269d5.jpg?1726286820"
+    },
+    "colorIdentityOverride": []
+}
+
 // Sawblade Skinripper
 {
     "name": "Sawblade Skinripper",
@@ -14923,6 +15014,122 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Underwater Tunnel // Slimy Aquarium
+{
+    "name": "Underwater Tunnel // Slimy Aquarium",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, surveil 2.\n//\nWhen you unlock this door, manifest dread, then put a +1/+1 counter on that creature.",
+    "metadata": {
+        "collectorNumber": "79",
+        "artist": "Titus Lunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2dd69f2d-8c9c-41fc-93ea-48fc7a6d5272.jpg?1726780798"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Underwater Tunnel",
+            "manaCost": "{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, surveil 2.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Surveil",
+                            "count": 2
+                        },
+                        "descriptionOverride": "When you unlock this door, surveil 2."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Slimy Aquarium",
+            "manaCost": "{3}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, manifest dread, then put a +1/+1 counter on that creature.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "TopOfLibrary",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 2
+                                                }
+                                            },
+                                            "storeAs": "manifestDreadLooked"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "manifestDreadLooked",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "manifestDreadManifested",
+                                            "storeRemainder": "manifestDreadGraveyard",
+                                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                            "remainderLabel": "Put into your graveyard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "manifestDreadManifested",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Battlefield"
+                                            },
+                                            "faceDown": "MANIFEST"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "manifestDreadGraveyard",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            }
+                                        },
+                                        "EmitManifestedDreadEvent"
+                                    ]
+                                },
+                                {
+                                    "type": "AddCounters",
+                                    "counterType": "+1/+1",
+                                    "count": 1,
+                                    "target": {
+                                        "type": "PipelineTarget",
+                                        "collectionName": "manifestDreadManifested"
+                                    }
+                                }
+                            ]
+                        },
+                        "descriptionOverride": "When you unlock this door, manifest dread, then put a +1/+1 counter on that creature."
+                    }
+                ]
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SawScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SawScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Saw (DSK #254) — {2} Artifact — Equipment.
+ *
+ * "Equipped creature gets +2/+0.
+ *  Whenever equipped creature attacks, you may sacrifice a permanent other than that creature or
+ *  this Equipment. If you do, draw a card.
+ *  Equip {2}"
+ */
+class SawScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private val sawEquipId by lazy {
+        cardRegistry.requireCard("Saw").activatedAbilities[0].id
+    }
+
+    init {
+        test("equipped creature gets +2/+0") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 base
+                .withCardOnBattlefield(1, "Saw")
+                .withLandsOnBattlefield(1, "Forest", 2)    // pay Equip {2}
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val saw = game.findPermanent("Saw")!!
+
+            game.execute(
+                com.wingedsheep.engine.core.ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = saw,
+                    abilityId = sawEquipId,
+                    targets = listOf(ChosenTarget.Permanent(bears))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            val projected = stateProjector.project(game.state)
+            withClue("Equipped Bears should be 4/2 (2/2 + 2/+0)") {
+                projected.getPower(bears) shouldBe 4
+                projected.getToughness(bears) shouldBe 2
+            }
+        }
+
+        test("attacking and sacrificing another permanent draws a card") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")  // becomes the equipped attacker
+                .withCardOnBattlefield(1, "Saw")
+                .withCardOnBattlefield(1, "Food", isToken = true) // the sacrifice fodder
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withCardInLibrary(1, "Centaur Courser")    // the card drawn by the trigger
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val saw = game.findPermanent("Saw")!!
+
+            game.execute(
+                com.wingedsheep.engine.core.ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = saw,
+                    abilityId = sawEquipId,
+                    targets = listOf(ChosenTarget.Permanent(bears))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Grizzly Bears" to 2))
+            game.resolveStack() // attack trigger goes on the stack; resolving pauses at the "may"
+
+            withClue("attack offers the optional sacrifice") {
+                (game.getPendingDecision() is YesNoDecision) shouldBe true
+            }
+            game.answerYesNo(true)
+
+            withClue("a select-a-permanent-to-sacrifice prompt is offered") {
+                (game.getPendingDecision() is SelectCardsDecision) shouldBe true
+            }
+            val food = game.findPermanents("Food")
+            game.selectCards(food)
+            game.resolveStack()
+
+            withClue("the Food was sacrificed (no longer in play)") {
+                game.findPermanents("Food").isEmpty() shouldBe true
+            }
+            withClue("the trigger drew a card") {
+                game.isInHand(1, "Centaur Courser") shouldBe true
+            }
+        }
+
+        test("declining the attack 'may' draws nothing and sacrifices nothing") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardOnBattlefield(1, "Saw")
+                .withCardOnBattlefield(1, "Food", isToken = true)
+                .withLandsOnBattlefield(1, "Forest", 2)
+                .withCardInLibrary(1, "Centaur Courser")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val saw = game.findPermanent("Saw")!!
+
+            game.execute(
+                com.wingedsheep.engine.core.ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = saw,
+                    abilityId = sawEquipId,
+                    targets = listOf(ChosenTarget.Permanent(bears))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Grizzly Bears" to 2))
+            game.resolveStack()
+
+            (game.getPendingDecision() is YesNoDecision) shouldBe true
+            game.answerYesNo(false)
+            game.resolveStack()
+
+            withClue("Food remains; nothing drawn") {
+                game.findPermanents("Food").isEmpty() shouldBe false
+                game.isInHand(1, "Centaur Courser") shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnderwaterTunnelSlimyAquariumScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnderwaterTunnelSlimyAquariumScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.OrderedResponse
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnderwaterTunnelSlimyAquarium
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario for `Underwater Tunnel // Slimy Aquarium` (DSK 79), a split-layout Room (CR 709.5).
+ *
+ * Underwater Tunnel {U}  — "When you unlock this door, surveil 2." Casting the half enters it
+ *                          unlocked, firing the trigger.
+ * Slimy Aquarium {3}{U}  — "When you unlock this door, manifest dread, then put a +1/+1 counter
+ *                          on that creature."
+ */
+class UnderwaterTunnelSlimyAquariumScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(UnderwaterTunnelSlimyAquarium)
+        d.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("casting Underwater Tunnel unlocks its door and surveils 2") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Stack the top two cards so we know what surveil looks at.
+        val bottom = d.putCardOnTopOfLibrary(p1, "Island")
+        val top = d.putCardOnTopOfLibrary(p1, "Centaur Courser") // now the top card
+
+        // Cast Underwater Tunnel ({U}, face 0); the cast face enters unlocked, firing the trigger.
+        val roomId = d.putCardInHand(p1, UnderwaterTunnelSlimyAquarium.name)
+        d.giveMana(p1, Color.BLUE, 1)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe
+            setOf(RoomFaceId("Underwater Tunnel"))
+
+        // The surveil 2 trigger resolves: choose to put the top creature into the graveyard.
+        d.bothPass()
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(p1, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(top)))
+
+        // If a reorder of the remaining card is offered, keep it on top.
+        (d.pendingDecision as? ReorderLibraryDecision)?.let {
+            d.submitDecision(p1, OrderedResponse(it.id, it.cards))
+        }
+
+        d.getGraveyard(p1) shouldContainCardId top
+        d.getGraveyard(p1) shouldNotContainCardId bottom
+    }
+
+    test("casting Slimy Aquarium unlocks its door, manifests dread, and adds a +1/+1 counter") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top two: a creature (to manifest) and a land beneath it.
+        d.putCardOnTopOfLibrary(p1, "Island")
+        val creature = d.putCardOnTopOfLibrary(p1, "Centaur Courser") // now the top card
+
+        // Cast Slimy Aquarium ({3}{U}, face 1); the cast face enters unlocked, firing the trigger.
+        val roomId = d.putCardInHand(p1, UnderwaterTunnelSlimyAquarium.name)
+        d.giveMana(p1, Color.BLUE, 4)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+        d.bothPass()
+
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe
+            setOf(RoomFaceId("Slimy Aquarium"))
+
+        // The trigger resolves: manifest dread pauses to choose which looked-at card to manifest.
+        d.bothPass()
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(p1, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The creature is a manifested 2/2 with a +1/+1 counter from the second clause = 3/3.
+        d.state.getEntity(creature)?.get<ManifestedComponent>() shouldBe ManifestedComponent
+        val counters = d.state.getEntity(creature)?.get<CountersComponent>()
+        counters shouldNotBe null
+        counters!!.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+        d.state.projectedState.getPower(creature) shouldBe 3
+        d.state.projectedState.getToughness(creature) shouldBe 3
+    }
+})
+
+private infix fun List<com.wingedsheep.sdk.model.EntityId>.shouldContainCardId(
+    id: com.wingedsheep.sdk.model.EntityId
+) {
+    (id in this) shouldBe true
+}
+
+private infix fun List<com.wingedsheep.sdk.model.EntityId>.shouldNotContainCardId(
+    id: com.wingedsheep.sdk.model.EntityId
+) {
+    (id in this) shouldBe false
+}


### PR DESCRIPTION
Implements two Duskmourn: House of Horror cards, both composed entirely from existing SDK primitives (no new engine features).

## Cards

**Saw** (DSK 254) — `{2}` Artifact — Equipment
- Equipped creature gets +2/+0 (`ModifyStats` over `Filters.EquippedCreature`).
- "Whenever equipped creature attacks, you may sacrifice a permanent other than that creature or this Equipment. If you do, draw a card." — `Triggers.attacks(binding = ATTACHED)` → `GatedEffect(Gate.MayPay(SacrificeEffect(...)), then = DrawCards(1))`. The "other than that creature or this Equipment" exclusion is `excludeSource = true` (the Equipment) + `notAttachedToBySource()` (the equipped creature).
- Equip `{2}`.

**Underwater Tunnel // Slimy Aquarium** (DSK 79) — split-layout Room (CR 709.5)
- Underwater Tunnel `{U}`: "When you unlock this door, surveil 2." (`Triggers.OnDoorUnlocked` → `Effects.Surveil(2)`).
- Slimy Aquarium `{3}{U}`: "When you unlock this door, manifest dread, then put a +1/+1 counter on that creature." (`Patterns.Library.manifestDread()` + `AddCounters` on `EffectTarget.PipelineTarget("manifestDreadManifested")`).

## Tests
- `SawScenarioTest` — +2/+0 buff; attack → sacrifice fodder → draw; declining the "may" draws/sacrifices nothing.
- `UnderwaterTunnelSlimyAquariumScenarioTest` — door unlock + surveil 2 binning a chosen card; door unlock + manifest dread producing a 3/3 (2/2 manifest + one +1/+1 counter).
- Re-blessed the DSK card snapshot golden (diff adds only the two new card trees). `CardLintTest` passes.

## Skipped
**Keys to the House** — its second ability ("lock or unlock a door of target Room you control") requires a lock-a-door effect (the engine only has `UnlockDoorEffect`) plus a lock/unlock modal choice. That is add-feature work, so the card was left out rather than shipping a lossy unlock-only approximation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)