### PR TITLE
Add Stay Hidden, Stay Silent (DSK); skip Greenhouse & Rip (need add-feature)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/StayHiddenStaySilent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/StayHiddenStaySilent.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stay Hidden, Stay Silent — Duskmourn: House of Horror #74
+ * {1}{U} · Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, tap enchanted creature.
+ * Enchanted creature doesn't untap during its controller's untap step.
+ * {4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. Activate
+ * only as a sorcery.
+ *
+ * Modeled as:
+ *  - `auraTarget = Targets.Creature` (Enchant creature).
+ *  - ETB trigger ([Triggers.EntersBattlefield], SELF binding) taps the enchanted creature
+ *    ([Effects.Tap] on [EffectTarget.EnchantedCreature]).
+ *  - "doesn't untap" is the [AbilityFlag.DOESNT_UNTAP] keyword granted to the enchanted creature
+ *    via an unfiltered aura static (same shape as Frozen Solid). The untap step reads the flag.
+ *  - The sorcery-speed activated ability composes [Effects.ShuffleIntoLibrary] (the enchanted
+ *    creature goes to its owner's library — the Aura then falls off as an SBA, but the ability
+ *    keeps resolving) followed by the shared [Patterns.Library.manifestDread] recipe (CR 701.62).
+ */
+val StayHiddenStaySilent = card("Stay Hidden, Stay Silent") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, tap enchanted creature.\n" +
+        "Enchanted creature doesn't untap during its controller's untap step.\n" +
+        "{4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. " +
+        "Activate only as a sorcery."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedCreature)
+        description = "When this Aura enters, tap enchanted creature."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{U}{U}")
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Composite(
+            listOf(
+                Effects.ShuffleIntoLibrary(EffectTarget.EnchantedCreature),
+                Patterns.Library.manifestDread()
+            )
+        )
+        description = "{4}{U}{U}: Shuffle enchanted creature into its owner's library, then " +
+            "manifest dread. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Josu Hernaiz"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b661ffe7-4f58-43fe-a1f1-dd7a6d4d28a7.jpg?1726286129"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -13700,6 +13700,125 @@
     ]
 }
 
+// Stay Hidden, Stay Silent
+{
+    "name": "Stay Hidden, Stay Silent",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, tap enchanted creature.\nEnchanted creature doesn't untap during its controller's untap step.\n{4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. Activate only as a sorcery.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EnchantedCreature"
+                },
+                "descriptionOverride": "When this Aura enters, tap enchanted creature."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{U}{U}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "EnchantedCreature",
+                            "destination": "Library",
+                            "placement": "Shuffled"
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeAs": "manifestDreadLooked"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "manifestDreadLooked",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "manifestDreadManifested",
+                                    "storeRemainder": "manifestDreadGraveyard",
+                                    "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                    "remainderLabel": "Put into your graveyard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadManifested",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    },
+                                    "faceDown": "MANIFEST"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadGraveyard",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                },
+                                "EmitManifestedDreadEvent"
+                            ]
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. Activate only as a sorcery."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b661ffe7-4f58-43fe-a1f1-dd7a6d4d28a7.jpg?1726286129"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Strangled Cemetery
 {
     "name": "Strangled Cemetery",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StayHiddenStaySilentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StayHiddenStaySilentScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Stay Hidden, Stay Silent (DSK #74) — {1}{U} Enchantment — Aura.
+ *
+ * Enchant creature
+ * When this Aura enters, tap enchanted creature.
+ * Enchanted creature doesn't untap during its controller's untap step.
+ * {4}{U}{U}: Shuffle enchanted creature into its owner's library, then manifest dread. Activate
+ * only as a sorcery.
+ *
+ * Exercises:
+ *  - the ETB trigger tapping the enchanted creature;
+ *  - the "doesn't untap" static keeping it tapped through its controller's untap step;
+ *  - the sorcery-speed activated ability shuffling the enchanted creature away (the Aura falls off
+ *    as an SBA) and then manifesting dread (a new face-down 2/2 appears).
+ */
+class StayHiddenStaySilentScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("ETB trigger taps the enchanted creature and it stays tapped through untap") {
+        val d = driver()
+        val me = d.player1
+
+        val creature = d.putCreatureOnBattlefield(me, "Grizzly Bears")
+        d.removeSummoningSickness(creature)
+        d.isTapped(creature) shouldBe false
+
+        val aura = d.putCardInHand(me, "Stay Hidden, Stay Silent")
+        d.giveMana(me, Color.BLUE, 2)
+        d.castSpell(me, aura, listOf(creature))
+        // Resolve the aura, then its ETB tap trigger.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.isTapped(creature) shouldBe true
+        d.findPermanent(me, "Stay Hidden, Stay Silent") shouldNotBe null
+
+        // Advance to this player's next untap step; the creature must NOT untap.
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.activePlayer shouldBe me
+        d.isTapped(creature) shouldBe true
+    }
+
+    test("activated ability shuffles the enchanted creature away and manifests dread") {
+        val d = driver()
+        val me = d.player1
+
+        val creature = d.putCreatureOnBattlefield(me, "Grizzly Bears")
+        d.removeSummoningSickness(creature)
+
+        val aura = d.putCardInHand(me, "Stay Hidden, Stay Silent")
+        d.giveMana(me, Color.BLUE, 2)
+        d.castSpell(me, aura, listOf(creature))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        val auraPermanent = d.findPermanent(me, "Stay Hidden, Stay Silent")!!
+
+        // A manifested permanent is a face-down 2/2 regardless of its underlying card type, so
+        // count by FaceDownComponent over all permanents (not getCreatures, which reads the base
+        // type line and would miss a manifested land).
+        val faceDownBefore = d.getPermanents(me).count {
+            d.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+
+        val abilityId = d.cardRegistry.requireCard("Stay Hidden, Stay Silent").activatedAbilities[0].id
+        d.giveMana(me, Color.BLUE, 6)
+        d.submit(
+            ActivateAbility(playerId = me, sourceId = auraPermanent, abilityId = abilityId)
+        )
+        // Resolve: shuffle the creature into library, then manifest dread (pick which to manifest).
+        var guard = 0
+        while (guard++ < 30) {
+            val pd = d.pendingDecision
+            if (pd is SelectCardsDecision) {
+                d.submitDecision(me, CardsSelectedResponse(pd.id, listOf(pd.options.first())))
+            } else if (d.state.stack.isNotEmpty()) {
+                d.bothPass()
+            } else break
+        }
+
+        // The Grizzly Bears (as itself) is gone from the battlefield, and the Aura fell off.
+        d.findPermanent(me, "Grizzly Bears") shouldBe null
+        d.findPermanent(me, "Stay Hidden, Stay Silent") shouldBe null
+
+        // Manifest dread put a new face-down 2/2 onto the battlefield.
+        val faceDownAfter = d.getPermanents(me).count {
+            d.state.getEntity(it)?.has<FaceDownComponent>() == true
+        }
+        faceDownAfter shouldBe faceDownBefore + 1
+    }
+})


### PR DESCRIPTION
## Summary

Batch of three Duskmourn: House of Horror (DSK) cards requested. One implemented; two skipped because they require engine features that don't yet exist (add-feature territory, not a lossy approximation).

### Implemented
- **Stay Hidden, Stay Silent** (DSK #74) — `{1}{U}` Enchantment — Aura
  - Enchant creature
  - ETB trigger taps the enchanted creature
  - "doesn't untap" granted to the enchanted creature (`AbilityFlag.DOESNT_UNTAP`)
  - `{4}{U}{U}`, sorcery-speed: shuffle enchanted creature into its owner's library, then manifest dread (reuses `Patterns.Library.manifestDread`)
  - Composes only existing SDK primitives. Scenario test covers tap-on-enter, doesn't-untap across an untap step, and the activated ability (shuffle-away + manifest dread). DSK snapshot re-blessed (this card only).

### Skipped — need `add-feature` first
- **Greenhouse // Rickety Gazebo** (DSK #181) — split Room.
  - *Rickety Gazebo* (unlock → mill four, return up to two permanents) works with existing primitives.
  - *Greenhouse* ("Lands you control have '{T}: Add one mana of any color.'") does **not** work: static abilities printed on a Room **face** are not projected. `StackResolver`/`StaticAbilityHandler.addContinuousEffectComponent` and `CastPermissionUtils.getStaticGrantedActivatedAbilities` read only the top-level `cardDef.script`, never the unlocked face's `script.staticAbilities`. Confirmed empirically (granted ability "not found on this card") and structurally (the existing Steaming Sauna `NoMaximumHandSize` face static is untested and unsupported by the same path). Triggered abilities on Room faces are face-aware, but static abilities are not. Shipping this card would silently no-op the mana-fixing half, so it's skipped pending an add-feature pass that makes room-face static-ability projection (continuous + granted-activated, with re-projection on door unlock) work.
- **Rip, Spawn Hunter** (DSK #228) — `{2}{G}{W}` Legendary Creature.
  - Survival trigger and "X = its power" are expressible, but the core selection — "put any number of creature and/or Vehicle cards **with different powers** from among them into your hand" — needs a new `SelectionRestriction` (distinct power per chosen card). The existing restrictions are only `OnePerCardType` / `OnePerCardName` / `OnePerBasicLandType` / `TotalManaValueAtMost`. Requires a new SDK type + executor validation (+ a reveal-top-X-equal-to-source-power pipeline and random-order-to-bottom). Skipped pending add-feature.

## Tests
- `StayHiddenStaySilentScenarioTest` — passes (2 tests)
- `:mtg-sets` `CardDefinitionSnapshotTest` + `CardLintTest` — pass; snapshot diff is additions-only for Stay Hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)