### PR TITLE
Add FIN spells: Commune with Beavers, Poison the Waters, Moogles' Valor

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CommuneWithBeavers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CommuneWithBeavers.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Commune with Beavers
+ * {G}
+ * Sorcery
+ *
+ * Look at the top three cards of your library. You may reveal an artifact, creature, or land
+ * card from among them and put it into your hand. Put the rest on the bottom of your library
+ * in any order.
+ */
+val CommuneWithBeavers = card("Commune with Beavers") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Look at the top three cards of your library. You may reveal an artifact, creature, or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order."
+
+    spell {
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(3),
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature or GameObjectFilter.Land,
+            prompt = "You may reveal an artifact, creature, or land card and put it into your hand",
+            restDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+            restOrder = CardOrder.ControllerChooses
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "hippo"
+        flavorText = "\"Guy speak beaver.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/784287c2-43c5-4210-93ae-cdd33b9acb1b.jpg?1748706441"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MooglesValor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MooglesValor.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Moogles' Valor
+ * {3}{W}{W}
+ * Instant
+ *
+ * For each creature you control, create a 1/2 white Moogle creature token with lifelink.
+ * Then creatures you control gain indestructible until end of turn.
+ *
+ * The token count is evaluated as this resolves (before any tokens are made), so it counts
+ * only the creatures already in play. The indestructible grant resolves afterward over
+ * "creatures you control", which now also includes the freshly-created Moogles.
+ */
+val MooglesValor = card("Moogles' Valor") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "For each creature you control, create a 1/2 white Moogle creature token with lifelink. Then creatures you control gain indestructible until end of turn."
+
+    spell {
+        effect = Effects.CreateToken(
+            count = DynamicAmounts.creaturesYouControl(),
+            power = 1,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Moogle"),
+            keywords = setOf(Keyword.LIFELINK),
+            imageUri = "https://cards.scryfall.io/normal/front/2/9/295b78dc-b26d-4e92-8f75-916566c4db14.jpg?1748704063"
+        ).then(
+            Patterns.Group.grantKeywordToAll(Keyword.INDESTRUCTIBLE, Filters.Group.creaturesYouControl)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "27"
+        artist = "Kotakan"
+        flavorText = "\"Thanks, moogles! We're in your debt!\"\n—Locke Cole"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/caa838a7-60a9-4791-af5b-194f7574c4c8.jpg?1748705854"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PoisonTheWaters.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PoisonTheWaters.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Poison the Waters
+ * {1}{B}
+ * Sorcery
+ *
+ * Choose one —
+ * • All creatures get -1/-1 until end of turn.
+ * • Target player reveals their hand. You choose an artifact or creature card from it.
+ *   That player discards that card.
+ */
+val PoisonTheWaters = card("Poison the Waters") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n• All creatures get -1/-1 until end of turn.\n• Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("All creatures get -1/-1 until end of turn") {
+                effect = Effects.ForEachInGroup(
+                    filter = GroupFilter.AllCreatures,
+                    effect = ModifyStatsEffect(-1, -1, EffectTarget.Self)
+                )
+            }
+            mode("Target player reveals their hand; discard an artifact or creature card") {
+                val t = target("target", TargetPlayer())
+                effect = Effects.Composite(
+                    listOf(
+                        RevealHandEffect(t),
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                            storeAs = "hand"
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "hand",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                            chooser = Chooser.Controller,
+                            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature,
+                            storeSelected = "toDiscard",
+                            prompt = "Choose an artifact or creature card to discard",
+                            alwaysPrompt = true,
+                            showAllCards = true
+                        ),
+                        MoveCollectionEffect(
+                            from = "toDiscard",
+                            destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                            moveType = MoveType.Discard
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "111"
+        artist = "Arif Wijaya"
+        flavorText = "\"Hee-hee... Nothing beats the sweet music of hundreds of voices screaming in unison! Uwee-hee-hee!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff2bafe7-4d0f-464d-b7ba-55a54366fc68.jpg?1748706178"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -2797,6 +2797,76 @@
     ]
 }
 
+// Commune with Beavers
+{
+    "name": "Commune with Beavers",
+    "manaCost": "{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Look at the top three cards of your library. You may reveal an artifact, creature, or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "artifact|creature|land",
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "prompt": "You may reveal an artifact, creature, or land card and put it into your hand",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Library",
+                        "placement": "Bottom"
+                    },
+                    "order": "ControllerChooses"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "hippo",
+        "flavorText": "\"Guy speak beaver.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/784287c2-43c5-4210-93ae-cdd33b9acb1b.jpg?1748706441"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Coral Sword
 {
     "name": "Coral Sword",
@@ -6638,6 +6708,65 @@
     "colorIdentityOverride": []
 }
 
+// Moogles' Valor
+{
+    "name": "Moogles' Valor",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Instant",
+    "oracleText": "For each creature you control, create a 1/2 white Moogle creature token with lifelink. Then creatures you control gain indestructible until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature"
+                    },
+                    "power": 1,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Moogle"
+                    ],
+                    "keywords": [
+                        "LIFELINK"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/2/9/295b78dc-b26d-4e92-8f75-916566c4db14.jpg?1748704063"
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "INDESTRUCTIBLE",
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "RARE",
+        "artist": "Kotakan",
+        "flavorText": "\"Thanks, moogles! We're in your debt!\"\n—Locke Cole",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/caa838a7-60a9-4791-af5b-194f7574c4c8.jpg?1748705854"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Mysidian Elder
 {
     "name": "Mysidian Elder",
@@ -6914,6 +7043,117 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Poison the Waters
+{
+    "name": "Poison the Waters",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• All creatures get -1/-1 until end of turn.\n• Target player reveals their hand. You choose an artifact or creature card from it. That player discards that card.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "All creatures get -1/-1 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "RevealHand",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "filter": "artifact|creature",
+                                "storeSelected": "toDiscard",
+                                "prompt": "Choose an artifact or creature card to discard",
+                                "showAllCards": true,
+                                "alwaysPrompt": true
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "toDiscard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetPlayer",
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Target player reveals their hand; discard an artifact or creature card"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "111",
+        "rarity": "UNCOMMON",
+        "artist": "Arif Wijaya",
+        "flavorText": "\"Hee-hee... Nothing beats the sweet music of hundreds of voices screaming in unison! Uwee-hee-hee!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff2bafe7-4d0f-464d-b7ba-55a54366fc68.jpg?1748706178"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CommuneWithBeaversScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CommuneWithBeaversScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Commune with Beavers (FIN #182).
+ *
+ * Commune with Beavers — {G} Sorcery
+ *   "Look at the top three cards of your library. You may reveal an artifact, creature, or land
+ *    card from among them and put it into your hand. Put the rest on the bottom of your library
+ *    in any order."
+ *
+ * Verifies the `Patterns.Library.lookAtTopRevealMatchingToHand` pipeline with an
+ * artifact-or-creature-or-land filter: matching cards are selectable, a non-matching card is
+ * shown but not selectable, the reveal is optional (0..1), and the rest go to the bottom.
+ */
+class CommuneWithBeaversScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Commune with Beavers") {
+
+            test("reveal a creature; only artifact/creature/land selectable; rest go to bottom") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Commune with Beavers")
+                    .withLandsOnBattlefield(1, "Forest", 1) // {G}
+                    // Top three: a creature, a land, and an instant (non-matching).
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Commune with Beavers")
+                withClue("Casting Commune with Beavers should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val decision = game.state.pendingDecision
+                withClue("A selection decision should be presented") { (decision != null) shouldBe true }
+                val select = decision as SelectCardsDecision
+
+                // "May" reveal → 0..1 selections.
+                select.minSelections shouldBe 0
+                select.maxSelections shouldBe 1
+
+                val bear = game.findCardsInLibrary(1, "Grizzly Bears").first()
+                val forest = game.findCardsInLibrary(1, "Forest").first()
+                val bolt = game.findCardsInLibrary(1, "Lightning Bolt").first()
+
+                // Creature and land are selectable; the instant is shown but not selectable.
+                select.options shouldContainExactlyInAnyOrder listOf(bear, forest)
+                select.nonSelectableOptions shouldContainExactlyInAnyOrder listOf(bolt)
+
+                game.selectCards(listOf(bear))
+                game.resolveStack()
+
+                withClue("The revealed creature ends up in hand") {
+                    game.findCardsInHand(1, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("The other two looked-at cards remain in the library (put on bottom)") {
+                    game.findCardsInLibrary(1, "Forest").isNotEmpty() shouldBe true
+                    game.findCardsInLibrary(1, "Lightning Bolt").size shouldBe 1
+                }
+                withClue("Nothing was milled to the graveyard") {
+                    game.findCardsInGraveyard(1, "Forest").size shouldBe 0
+                    game.findCardsInGraveyard(1, "Lightning Bolt").size shouldBe 0
+                }
+                game.findCardsInGraveyard(1, "Commune with Beavers").size shouldBe 1
+            }
+
+            test("the reveal is optional — declining keeps all three in the library") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Commune with Beavers")
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Commune with Beavers")
+                game.resolveStack()
+
+                val select = game.state.pendingDecision as SelectCardsDecision
+                select.minSelections shouldBe 0
+
+                // Decline the optional reveal.
+                game.selectCards(emptyList())
+                game.resolveStack()
+
+                withClue("Nothing went to hand from the look") {
+                    game.findCardsInHand(1, "Grizzly Bears").size shouldBe 0
+                }
+                withClue("All looked-at cards remain in the library (none milled)") {
+                    game.findCardsInLibrary(1, "Grizzly Bears").size shouldBe 1
+                    game.findCardsInLibrary(1, "Lightning Bolt").size shouldBe 1
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MooglesValorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MooglesValorScenarioTest.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.MooglesValor
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Moogles' Valor — {3}{W}{W} Instant
+ *   "For each creature you control, create a 1/2 white Moogle creature token with lifelink.
+ *    Then creatures you control gain indestructible until end of turn."
+ *
+ * The token count is locked in before any tokens exist (counts only the original creatures),
+ * but the indestructible grant resolves afterward over "creatures you control" — which now
+ * includes the freshly-created Moogles.
+ */
+class MooglesValorScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(MooglesValor)
+        return d
+    }
+
+    fun moogleCount(d: GameTestDriver, player: EntityId): Int =
+        d.getCreatures(player).count {
+            d.state.getEntity(it)?.get<CardComponent>()?.name?.contains("Moogle") == true
+        }
+
+    test("creates one Moogle per existing creature; all your creatures (incl. tokens) gain indestructible") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two creatures already in play under our control.
+        d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        d.putCreatureOnBattlefield(p1, "Centaur Courser")
+        val originals = d.getCreatures(p1)
+        originals.size shouldBe 2
+
+        val spell = d.putCardInHand(p1, "Moogles' Valor")
+        d.giveColorlessMana(p1, 3)
+        d.giveMana(p1, Color.WHITE, 2)
+        val cast = d.castSpell(p1, spell)
+        cast.isSuccess shouldBe true
+        d.bothPass()
+
+        // Exactly two Moogle tokens were created (one per original creature).
+        moogleCount(d, p1) shouldBe 2
+
+        // Four creatures total, every one of them indestructible.
+        val all = d.getCreatures(p1)
+        all.size shouldBe 4
+        all.forEach { id ->
+            projector.hasProjectedKeyword(d.state, id, Keyword.INDESTRUCTIBLE) shouldBe true
+        }
+
+        // The Moogle tokens have lifelink.
+        all.filter {
+            d.state.getEntity(it)?.get<CardComponent>()?.name?.contains("Moogle") == true
+        }.forEach { id ->
+            projector.hasProjectedKeyword(d.state, id, Keyword.LIFELINK) shouldBe true
+        }
+    }
+
+    test("with no creatures in play, creates no tokens") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val spell = d.putCardInHand(p1, "Moogles' Valor")
+        d.giveColorlessMana(p1, 3)
+        d.giveMana(p1, Color.WHITE, 2)
+        d.castSpell(p1, spell)
+        d.bothPass()
+
+        moogleCount(d, p1) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PoisonTheWatersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PoisonTheWatersScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.PoisonTheWaters
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Poison the Waters — {1}{B} Sorcery, "Choose one —"
+ *   • All creatures get -1/-1 until end of turn.
+ *   • Target player reveals their hand. You choose an artifact or creature card from it.
+ *     That player discards that card.
+ *
+ * Mode 0 is the Infest-style group debuff; mode 1 is the Despise-style reveal-and-discard
+ * filtered to artifact-or-creature cards.
+ */
+class PoisonTheWatersScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A vanilla 1/1 that dies to -1/-1.
+    val Squire = CardDefinition.creature("Test Squire", ManaCost.parse("{W}"), setOf(Subtype("Human")), 1, 1)
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(PoisonTheWaters)
+        d.registerCard(Squire)
+        return d
+    }
+
+    fun setup(d: GameTestDriver): Pair<com.wingedsheep.sdk.model.EntityId, com.wingedsheep.sdk.model.EntityId> {
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Forest" to 20), startingLife = 20)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveColorlessMana(p1, 1)
+        d.giveMana(p1, Color.BLACK, 1)
+        return p1 to d.getOpponent(p1)
+    }
+
+    test("mode 0 — all creatures get -1/-1: a 1/1 dies, a 2/2 shrinks to 1/1") {
+        val d = driver()
+        val (p1, p2) = setup(d)
+
+        d.putCreatureOnBattlefield(p2, "Test Squire") // 1/1 → dies
+        d.putCreatureOnBattlefield(p1, "Grizzly Bears") // 2/2 → 1/1
+        val bears = d.getCreatures(p1).first()
+
+        val spell = d.putCardInHand(p1, "Poison the Waters")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = emptyList(),
+            chosenModes = listOf(0),
+            modeTargetsOrdered = emptyList()
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+        d.bothPass()
+
+        d.findPermanent(p2, "Test Squire").shouldBeNull()
+        d.getGraveyardCardNames(p2) shouldContain "Test Squire"
+
+        d.findPermanent(p1, "Grizzly Bears").shouldNotBeNull()
+        projector.getProjectedPower(d.state, bears) shouldBe 1
+        projector.getProjectedToughness(d.state, bears) shouldBe 1
+    }
+
+    test("mode 1 — target player reveals hand; you discard a chosen artifact or creature card") {
+        val d = driver()
+        val (p1, p2) = setup(d)
+
+        // Opponent's hand: a creature (selectable), a land (not selectable).
+        d.putCardInHand(p2, "Grizzly Bears")
+        d.putCardInHand(p2, "Forest")
+
+        val spell = d.putCardInHand(p1, "Poison the Waters")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Player(p2)),
+            chosenModes = listOf(1),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(p2)))
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+        d.bothPass() // resolve → reveal + select decision
+
+        val select = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val bears = d.getHand(p2).first {
+            d.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Grizzly Bears"
+        }
+        val forest = d.getHand(p2).first {
+            d.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Forest"
+        }
+        // Only the creature is selectable; the land is shown but not selectable.
+        select.options shouldContainExactlyInAnyOrder listOf(bears)
+        select.nonSelectableOptions shouldContain forest
+
+        d.submitCardSelection(p1, listOf(bears))
+
+        // The chosen creature is discarded to the opponent's graveyard.
+        d.getGraveyardCardNames(p2) shouldContain "Grizzly Bears"
+        // The land stays in hand.
+        d.getHand(p2).any {
+            d.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Forest"
+        } shouldBe true
+    }
+})


### PR DESCRIPTION
Implements three Final Fantasy (FIN) spells, each composed entirely from existing SDK facades — no new engine primitives.

## Cards

- **Commune with Beavers** `{G}` Sorcery — Look at the top three cards of your library. You may reveal an artifact, creature, or land card from among them and put it into your hand. Put the rest on the bottom of your library in any order.
  - `Patterns.Library.lookAtTopRevealMatchingToHand` with an `Artifact or Creature or Land` filter and `CardOrder.ControllerChooses` (any order).
- **Poison the Waters** `{1}{B}` Sorcery (modal, choose one) —
  - Mode 0: All creatures get -1/-1 until end of turn (Infest-style `ForEachInGroup` + `ModifyStats`).
  - Mode 1: Target player reveals their hand; you choose an artifact or creature card; that player discards it (Despise-style reveal → gather → select → discard, targeting any player).
- **Moogles' Valor** `{3}{W}{W}` Instant — For each creature you control, create a 1/2 white Moogle creature token with lifelink. Then creatures you control gain indestructible until end of turn.
  - Token count via `DynamicAmounts.creaturesYouControl()` is locked in before tokens exist; the `Patterns.Group.grantKeywordToAll(INDESTRUCTIBLE, creaturesYouControl)` grant resolves afterward, so it also covers the freshly-made Moogles.

## Tests

Each card has a `rules-engine` scenario test (all passing) covering its key timing and edge cases: optional-reveal decline and filter selectability (Commune), modal player targeting and the -1/-1 group debuff (Poison), and the dynamic token count incl. the zero-creature case plus the indestructible grant reaching the new tokens (Moogles). The FIN card snapshot golden is re-blessed (only the three new card trees added).

## Skipped

**Sorceress's Schemes** — its target ("instant or sorcery card from your graveyard *or* exiled card with flashback you own") needs a cross-zone union target (graveyard ∪ exile) with per-zone filters plus an "exiled card with flashback you own" predicate. `TargetFilter` only supports a single zone today and there is no such predicate, so this is an `add-feature` task rather than pure card authoring. Left for a dedicated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)