### PR TITLE
Add Sage's Nouliths (FIN); defer 3 add-feature cards

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -288,3 +288,33 @@ so a land // spell Adventure offers *both* "play the land" (PlayLandEnumerator) 
 
 The four headline mechanics (Summon Sagas + their eikon backs, Job select, Tiered, the Town DFC) cover the bulk of
 the genuinely-blocked cards; once they land, the remaining ~120 are standard material built on today's SDK.
+
+---
+
+## Implementation pass — 2026-06-26 (add-card batch)
+
+Implemented:
+- **Sage's Nouliths** (#70) — Job-select Equipment; +1/+0, grants the equipped creature
+  "Whenever this creature attacks, untap target attacking creature" (Web-Shooters–style
+  `GrantTriggeredAbility` with an attacking-creature target), Cleric subtype, `Hagneia — Equip {3}`
+  ("Hagneia" is a rules-inert ability word). Pure authoring, no engine change.
+
+Deferred (need `add-feature`, not pure authoring):
+- **Crystal Fragments** (#13) — transforming Equipment // `Summon: Alexander` Saga creature DFC.
+  Falls under the headline §1/§2 work: the back is an Enchantment Creature — Saga whose chapters need
+  "prevent all damage to creatures you control this turn" (a damage-prevention chapter primitive the
+  engine lacks), and the front is an *Equipment* that exiles-and-returns-transformed (the
+  `ExileAndReturnTransformed` helper today targets creature // creature flips). Not straightforward.
+- **Stolen Uniform** (#75) — "Gain control of target Equipment until end of turn, attach it to a
+  chosen creature you control; when you lose control of it this turn, unattach it." Needs a
+  *temporary control change of an Equipment* + a forced *attach* effect + a brand-new
+  "**when you lose control of …**" delayed trigger (no such trigger exists today).
+- **Blazing Bomb** (#130) — the cast trigger ("noncreature spell, ≥4 mana spent → +1/+1 counter") is
+  fully buildable today via `Conditions.TriggeringSpellManaSpentAtLeast(4)`. The **Blow Up** half
+  ("{T}, Sacrifice this creature: it deals damage equal to its power") is blocked: `AbilityCost.SacrificeSelf`
+  does **not** populate `EffectContext.sacrificedPermanents`, so `DynamicAmounts.sacrificedPower()`
+  (and `sourcePower()`) resolve to **0** at resolution — the self-sacrificed source's last-known
+  power is never snapshotted. Fix is a small reusable engine addition mirroring the existing
+  `lastKnownSourceCounters` capture (snapshot the self-sacrificed source's P/T, or add a
+  `DynamicAmount.LastKnownSourcePower`). Note: **Cinder Shade (INV)** and **Ghitu Fire-Eater (ULG)**
+  share this latent gap.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SagesNouliths.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SagesNouliths.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sage's Nouliths
+ * {1}{U}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +1/+0, has "Whenever this creature attacks, untap target attacking
+ *   creature," and is a Cleric in addition to its other types.
+ * Hagneia — Equip {3}
+ *
+ * "Hagneia" is a Final Fantasy ability word that flavors the Equip ability — it carries no rules
+ * meaning, so it lives only in the oracle text; mechanically the ability is a plain Equip {3}.
+ * The granted "Whenever this creature attacks, untap target attacking creature" ability lives on
+ * the equipped creature (GrantTriggeredAbility over the attached-creature filter, SELF binding),
+ * mirroring Web-Shooters' "Whenever this creature attacks, tap target …" shape.
+ */
+val SagesNouliths = card("Sage's Nouliths") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +1/+0, has \"Whenever this creature attacks, untap target attacking creature,\" and is a Cleric in addition to its other types.\n" +
+        "Hagneia — Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = ModifyStats(1, 0, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = Effects.Untap(EffectTarget.ContextTarget(0)),
+                targetRequirement = Targets.AttackingCreature,
+            ),
+            filter = Filters.EquippedCreature,
+        )
+    }
+    staticAbility {
+        ability = GrantSubtype("Cleric", Filters.EquippedCreature)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Justyna Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a12ff7c3-6ae0-4098-9240-ff3fd16a5288.jpg?1748706016"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -7784,6 +7784,126 @@
     ]
 }
 
+// Sage's Nouliths
+{
+    "name": "Sage's Nouliths",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +1/+0, has \"Whenever this creature attacks, untap target attacking creature,\" and is a Cleric in addition to its other types.\nHagneia — Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "tap": false
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        }
+                    }
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Cleric",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Justyna Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a12ff7c3-6ae0-4098-9240-ff3fd16a5288.jpg?1748706016"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sahagin
 {
     "name": "Sahagin",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SagesNoulithsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SagesNoulithsScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sage's Nouliths (FIN) — {1}{U} Artifact — Equipment (job select).
+ *
+ *  "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)
+ *   Equipped creature gets +1/+0, has 'Whenever this creature attacks, untap target attacking creature,'
+ *   and is a Cleric in addition to its other types.
+ *   Hagneia — Equip {3}"
+ *
+ * The job-select ETB shell (Hero token + auto-attach) is proven by JobSelectScenarioTest; this test
+ * focuses on the equipped-creature bonus (+1/+0, Cleric) and the granted attack trigger that untaps a
+ * target attacking creature.
+ */
+class SagesNoulithsScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        test("Sage's Nouliths: +1/+0, Cleric, and the granted attack trigger untaps a target attacking creature") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "Sage's Nouliths")
+                .withLandsOnBattlefield(1, "Island", 2)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(2, "Island")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Sage's Nouliths").error shouldBe null
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            val hero = game.findPermanent("Hero Token")!!
+            val projected = stateProjector.project(game.state)
+            withClue("Equipped Hero token should be 2/1 (1/1 base + 1/+0)") {
+                projected.getPower(hero) shouldBe 2
+                projected.getToughness(hero) shouldBe 1
+            }
+            withClue("Equipped Hero token should be a Cleric in addition to its other types") {
+                projected.hasSubtype(hero, "Cleric") shouldBe true
+            }
+
+            // Attack with the equipped Hero token: it taps, then the granted trigger fires and
+            // (with the Hero as the only attacking creature) untaps that same attacker.
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Hero Token" to 2))
+            withClue("Hero is tapped right after being declared as an attacker") {
+                game.state.getEntity(hero)?.has<TappedComponent>() shouldBe true
+            }
+            if (game.hasPendingDecision()) game.selectTargets(listOf(hero))
+            game.passPriority()
+            game.resolveStack()
+
+            withClue("The granted trigger untapped the attacking equipped creature") {
+                game.state.getEntity(hero)?.has<TappedComponent>() shouldBe false
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

From a 4-card Final Fantasy (`fin`) batch (Crystal Fragments, Stolen Uniform, Sage's Nouliths, Blazing Bomb), this lands the one card that's pure authoring and defers the three that need engine features.

### Implemented
- **Sage's Nouliths** (#70) — `{1}{U}` Artifact — Equipment (Job select). Equipped creature gets **+1/+0**, has **"Whenever this creature attacks, untap target attacking creature"** (a `GrantTriggeredAbility` over the equipped creature with an attacking-creature target, mirroring Web-Shooters' "attacks → tap target ..." shape), and is a **Cleric**. `Hagneia — Equip {3}` — "Hagneia" is a rules-inert Final Fantasy ability word, so it lives only in the oracle text; mechanically it's a plain Equip {3}. No new SDK; covered by `SagesNoulithsScenarioTest` and the re-blessed FIN card snapshot.

### Deferred (add-feature, not pure authoring)
- **Crystal Fragments** — transforming Equipment // `Summon: Alexander` Saga-creature DFC. The headline FIN Saga + transform area: the back needs a damage-prevention chapter primitive the engine lacks, and the front is an *Equipment* (not the creature // creature case the transform helper handles).
- **Stolen Uniform** — gain control of a target Equipment until end of turn + forced attach + a brand-new **"when you lose control of ..."** delayed trigger (no such trigger today).
- **Blazing Bomb** — the cast trigger ("noncreature spell, ≥4 mana spent → +1/+1 counter") is buildable today, but **Blow Up** ("{T}, Sacrifice this creature: it deals damage equal to its power") resolves to **0** damage: `AbilityCost.SacrificeSelf` never snapshots the self-sacrificed source's last-known P/T, so `DynamicAmounts.sacrificedPower()`/`sourcePower()` read 0. Fix is a small reusable engine addition mirroring the existing `lastKnownSourceCounters` capture. (Cinder Shade and Ghitu Fire-Eater share this latent gap.)

Details for all three deferrals are documented in `backlog/fin-engine-gaps.md`.

## Testing
- `./gradlew :rules-engine:test --tests "SagesNoulithsScenarioTest"` — pass
- `./gradlew :mtg-sets:test --tests "*CardLintTest" --tests "*CardDefinitionSnapshotTest"` — pass
- `just check-card-printing "Sage's Nouliths"` — canonical in FIN, ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)