### PR TITLE
Add The Swarmweaver and Funeral Room // Awakening Hall (DSK)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FuneralRoomAwakeningHall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/FuneralRoomAwakeningHall.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Funeral Room // Awakening Hall (DSK 100) — split-layout Room (CR 709.5).
+ *
+ * Funeral Room {2}{B} — Enchantment — Room
+ *   Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.
+ *
+ * Awakening Hall {6}{B}{B} — Enchantment — Room
+ *   When you unlock this door, return all creature cards from your graveyard to the battlefield.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked face's
+ * printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ *
+ * Funeral Room is a [Triggers.YourCreatureDies] drain — `LoseLife(1, EachOpponent)` +
+ * `GainLife(1)`, the canonical "each opponent loses 1 life and you gain 1 life" composite (cf.
+ * Acolyte of Aclazotz). Awakening Hall is a "when you unlock this door" trigger
+ * ([Triggers.OnDoorUnlocked], CR 709.5h) whose mass reanimation gathers every creature card in
+ * *your* graveyard and returns them under your control — the Twilight's Call
+ * `GatherCards → MoveCollection` pipeline scoped to [Player.You].
+ */
+val FuneralRoomAwakeningHall = card("Funeral Room // Awakening Hall") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "B"
+
+    face("Funeral Room") {
+        manaCost = "{2}{B}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life."
+
+        triggeredAbility {
+            trigger = Triggers.YourCreatureDies
+            effect = Effects.Composite(
+                Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                Effects.GainLife(1)
+            )
+        }
+    }
+
+    face("Awakening Hall") {
+        manaCost = "{6}{B}{B}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, return all creature cards from your graveyard to the battlefield."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Effects.Composite(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(
+                        zone = Zone.GRAVEYARD,
+                        player = Player.You,
+                        filter = GameObjectFilter.Creature
+                    ),
+                    storeAs = "graveyardCreatures"
+                ),
+                MoveCollectionEffect(
+                    from = "graveyardCreatures",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    underOwnersControl = true
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "100"
+        artist = "Miklós Ligeti"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg?1726867790"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TheSwarmweaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TheSwarmweaver.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * The Swarmweaver
+ * {2}{B}{G}
+ * Legendary Artifact Creature — Scarecrow
+ * 2/3
+ *
+ * When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.
+ * Delirium — As long as there are four or more card types among cards in your graveyard, Insects
+ * and Spiders you control get +1/+1 and have deathtouch.
+ *
+ * The ETB makes two 1/1 black-green flying Insect tokens (DSK Insect token). Delirium is an ability
+ * word with no rules meaning; the conditional lord is two static abilities over `Insects and Spiders
+ * you control` ([GameObjectFilter.Creature].withAnyOfSubtypes(Insect, Spider).youControl()), each
+ * gated by [Conditions.Delirium] (four+ distinct card types in your graveyard): a +1/+1 [ModifyStats]
+ * (layer 7c) and a deathtouch [GrantKeyword] (layer 6). The filter carries no `excludeSelf` because
+ * the printed text says "Insects and Spiders you control", not "other" — and The Swarmweaver is a
+ * Scarecrow, so it never matches the filter anyway.
+ */
+val TheSwarmweaver = card("The Swarmweaver") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Artifact Creature — Scarecrow"
+    power = 2
+    toughness = 3
+    oracleText = "When The Swarmweaver enters, create two 1/1 black and green Insect creature " +
+        "tokens with flying.\n" +
+        "Delirium — As long as there are four or more card types among cards in your graveyard, " +
+        "Insects and Spiders you control get +1/+1 and have deathtouch."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK, Color.GREEN),
+            creatureTypes = setOf("Insect"),
+            keywords = setOf(Keyword.FLYING),
+            count = 2,
+            imageUri = "https://cards.scryfall.io/normal/front/3/7/377f1a20-b270-4b07-9892-7170cd0bee38.jpg?1726236771"
+        )
+        description = "When The Swarmweaver enters, create two 1/1 black and green Insect creature " +
+            "tokens with flying."
+    }
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature
+                    .withAnyOfSubtypes(listOf(Subtype.INSECT, Subtype.SPIDER))
+                    .youControl()
+            )
+        )
+        condition = Conditions.Delirium()
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.DEATHTOUCH,
+            GroupFilter(
+                GameObjectFilter.Creature
+                    .withAnyOfSubtypes(listOf(Subtype.INSECT, Subtype.SPIDER))
+                    .youControl()
+            )
+        )
+        condition = Conditions.Delirium()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "236"
+        artist = "Helge C. Balzer"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dcf3b17b-f2f6-4702-864d-8c96100b0563.jpg?1726286750"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -6176,6 +6176,106 @@
     "colorIdentityOverride": []
 }
 
+// Funeral Room // Awakening Hall
+{
+    "name": "Funeral Room // Awakening Hall",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.\n//\nWhen you unlock this door, return all creature cards from your graveyard to the battlefield.",
+    "metadata": {
+        "collectorNumber": "100",
+        "rarity": "MYTHIC",
+        "artist": "Miklós Ligeti",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48237c98-5067-47a8-af74-7b9bce57c6a4.jpg?1726867790"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Funeral Room",
+            "manaCost": "{2}{B}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": {
+                            "type": "ZoneChangeEvent",
+                            "filter": "creature ctrl:you",
+                            "from": "Battlefield",
+                            "to": "Graveyard"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "LoseLife",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "target": {
+                                        "type": "PlayerRef",
+                                        "player": "EachOpponent"
+                                    }
+                                },
+                                {
+                                    "type": "GainLife",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Awakening Hall",
+            "manaCost": "{6}{B}{B}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, return all creature cards from your graveyard to the battlefield.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Graveyard",
+                                        "filter": "creature"
+                                    },
+                                    "storeAs": "graveyardCreatures"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "graveyardCreatures",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    },
+                                    "underOwnersControl": true
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Get Out
 {
     "name": "Get Out",
@@ -13826,6 +13926,135 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// The Swarmweaver
+{
+    "name": "The Swarmweaver",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Legendary Artifact Creature — Scarecrow",
+    "oracleText": "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.\nDelirium — As long as there are four or more card types among cards in your graveyard, Insects and Spiders you control get +1/+1 and have deathtouch.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK",
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Insect"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/7/377f1a20-b270-4b07-9892-7170cd0bee38.jpg?1726236771"
+                },
+                "descriptionOverride": "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "HasAnyOfSubtypes",
+                                    "subtypes": [
+                                        "Insect",
+                                        "Spider"
+                                    ]
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "HasAnyOfSubtypes",
+                                    "subtypes": [
+                                        "Insect",
+                                        "Spider"
+                                    ]
+                                }
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "RARE",
+        "artist": "Helge C. Balzer",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dcf3b17b-f2f6-4702-864d-8c96100b0563.jpg?1726286750"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FuneralRoomAwakeningHallTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FuneralRoomAwakeningHallTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.FuneralRoomAwakeningHall
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario for `Funeral Room // Awakening Hall` (DSK 100), a split-layout Room (CR 709.5).
+ *
+ * Funeral Room {2}{B}   — "Whenever a creature you control dies, each opponent loses 1 life and you
+ *                          gain 1 life."
+ * Awakening Hall {6}{B}{B} — "When you unlock this door, return all creature cards from your
+ *                            graveyard to the battlefield."
+ */
+class FuneralRoomAwakeningHallTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(FuneralRoomAwakeningHall)
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingLife = 20)
+        return d
+    }
+
+    fun GameTestDriver.bearsOnBattlefield(playerId: EntityId): Int =
+        getCreatures(playerId).count { getCardName(it) == "Grizzly Bears" }
+
+    test("Funeral Room drains each opponent and gains you life when your creature dies") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast Funeral Room (face 0, {2}{B}); it enters unlocked, arming the dies trigger.
+        val roomId = d.putCardInHand(me, FuneralRoomAwakeningHall.name)
+        d.giveMana(me, Color.BLACK, 3)
+        d.submitSuccess(CastSpell(me, roomId, faceIndex = 0))
+        d.bothPass()
+
+        // A creature I control dies.
+        val bears = d.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val bolt = d.putCardInHand(me, "Lightning Bolt")
+        d.giveMana(me, Color.RED, 1)
+        val myLifeBefore = d.getLifeTotal(me)
+        val oppLifeBefore = d.getLifeTotal(opp)
+        d.castSpell(me, bolt, listOf(bears))
+        d.bothPass() // resolve Bolt → Bears dies → Funeral Room trigger on stack
+        d.bothPass() // resolve the drain trigger
+
+        d.getLifeTotal(opp) shouldBe (oppLifeBefore - 1)
+        d.getLifeTotal(me) shouldBe (myLifeBefore + 1)
+    }
+
+    test("Awakening Hall returns all creature cards from your graveyard to the battlefield") {
+        val d = driver()
+        val me = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Three creature cards (and a noncreature) in my graveyard.
+        d.putCardInGraveyard(me, "Grizzly Bears")
+        d.putCardInGraveyard(me, "Grizzly Bears")
+        d.putCardInGraveyard(me, "Centaur Courser")
+        d.putCardInGraveyard(me, "Lightning Bolt") // noncreature — stays put
+
+        // Cast Awakening Hall (face 1, {6}{B}{B}); entering unlocked fires "when you unlock this door".
+        val roomId = d.putCardInHand(me, FuneralRoomAwakeningHall.name)
+        d.giveMana(me, Color.BLACK, 8)
+        d.submitSuccess(CastSpell(me, roomId, faceIndex = 1))
+        // Resolve the Room spell onto the battlefield, then its "when you unlock this door" trigger.
+        var guard = 0
+        while ((d.state.stack.isNotEmpty() || d.pendingDecision != null) && guard++ < 10) d.bothPass()
+
+        // All three creatures are back on the battlefield; the instant remains in the graveyard.
+        d.bearsOnBattlefield(me) shouldBe 2
+        d.getCreatures(me).count { d.getCardName(it) == "Centaur Courser" } shouldBe 1
+        d.getGraveyard(me).mapNotNull { d.getCardName(it) } shouldBe listOf("Lightning Bolt")
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSwarmweaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheSwarmweaverScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.TheSwarmweaver
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Swarmweaver (DSK #236) — {2}{B}{G} Legendary Artifact Creature — Scarecrow 2/3.
+ *
+ * "When The Swarmweaver enters, create two 1/1 black and green Insect creature tokens with flying.
+ * Delirium — As long as there are four or more card types among cards in your graveyard, Insects and
+ * Spiders you control get +1/+1 and have deathtouch."
+ *
+ * Exercises: the ETB token creation (two 1/1 flying Insects), and the Delirium-gated conditional
+ * lord (Insects/Spiders are 1/1 without four card types in the graveyard, and 2/2 with deathtouch
+ * once Delirium is satisfied).
+ */
+class TheSwarmweaverScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheSwarmweaver))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    // Four distinct card types in the graveyard so Delirium is satisfied.
+    fun GameTestDriver.fillGraveyardForDelirium(player: EntityId) {
+        putCardInGraveyard(player, "Centaur Courser")   // creature
+        putCardInGraveyard(player, "Lightning Bolt")     // instant
+        putCardInGraveyard(player, "Careful Study")      // sorcery
+        putCardInGraveyard(player, "Test Enchantment")   // enchantment
+    }
+
+    fun GameTestDriver.insectTokens(player: EntityId): List<EntityId> =
+        getCreatures(player).filter { id ->
+            projector.project(state).getSubtypes(id).contains("Insect")
+        }
+
+    // Cast The Swarmweaver from hand and resolve it (and its ETB trigger) onto the battlefield.
+    fun GameTestDriver.castAndResolveSwarmweaver(player: EntityId) {
+        giveMana(player, Color.BLACK, 3)
+        giveMana(player, Color.GREEN, 1)
+        val card = putCardInHand(player, "The Swarmweaver")
+        castSpell(player, card)
+        var guard = 0
+        while ((state.stack.isNotEmpty() || pendingDecision != null) && guard++ < 20) bothPass()
+    }
+
+    test("ETB creates two 1/1 black-green flying Insect tokens") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        driver.castAndResolveSwarmweaver(me)
+
+        val tokens = driver.insectTokens(me)
+        tokens.size shouldBe 2
+        val projected = projector.project(driver.state)
+        tokens.forEach { id ->
+            projected.getPower(id) shouldBe 1
+            projected.getToughness(id) shouldBe 1
+            projected.hasKeyword(id, Keyword.FLYING) shouldBe true
+        }
+    }
+
+    test("without Delirium, Insect tokens stay 1/1 with no deathtouch") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        driver.castAndResolveSwarmweaver(me)
+        // Only one card type in graveyard — Delirium not satisfied.
+        driver.putCardInGraveyard(me, "Lightning Bolt")
+
+        val token = driver.insectTokens(me).first()
+        val projected = projector.project(driver.state)
+        projected.getPower(token) shouldBe 1
+        projected.getToughness(token) shouldBe 1
+        projected.hasKeyword(token, Keyword.DEATHTOUCH) shouldBe false
+    }
+
+    test("with Delirium, Insects and Spiders get +1/+1 and deathtouch") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        driver.castAndResolveSwarmweaver(me)
+        driver.fillGraveyardForDelirium(me)
+
+        val token = driver.insectTokens(me).first()
+        val projected = projector.project(driver.state)
+        projected.getPower(token) shouldBe 2
+        projected.getToughness(token) shouldBe 2
+        projected.hasKeyword(token, Keyword.DEATHTOUCH) shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary

Implements two Duskmourn: House of Horror cards as compositions of existing SDK primitives, each backed by a passing rules-engine scenario test.

### The Swarmweaver — {2}{B}{G} Legendary Artifact Creature — Scarecrow (2/3)
- **ETB:** create two 1/1 black-green Insect tokens with flying (`Effects.CreateToken`).
- **Delirium lord:** two conditional static abilities (`ModifyStats` +1/+1 and `GrantKeyword(DEATHTOUCH)` over `Insects and Spiders you control`), each gated by `Conditions.Delirium()`. Mirrors Gisa, the Hellraiser's two-static lord shape.
- Tests: ETB token creation; lord inactive without four card types; +1/+1 + deathtouch once Delirium is satisfied.

### Funeral Room // Awakening Hall — DSK 100 split Room
- **Funeral Room {2}{B}:** `Triggers.YourCreatureDies` drain — `LoseLife(1, EachOpponent)` + `GainLife(1)` (the Acolyte of Aclazotz composite).
- **Awakening Hall {6}{B}{B}:** `Triggers.OnDoorUnlocked` mass reanimation — `GatherCards(FromZone GRAVEYARD, Player.You, Creature) → MoveCollection(BATTLEFIELD, underOwnersControl)` (the Twilight's Call pipeline scoped to you).
- Tests: the death-drain life swing; unlocking returns all creature cards (leaving noncreatures in the graveyard).

Both cards verified against Scryfall (`set=dsk`); image URIs HEAD-checked 200; `just check-card-printing` clean; DSK card snapshot re-blessed (only these two cards added); `CardLintTest` clean.

## Deferred: Meathook Massacre II

Attempted but **not shipped**. Its third ability — *"Whenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that card under your control with a finality counter on it"* — requires routing the pay/suffer decision **and** the life payment to the dying creature's last-known controller. `PayOrSufferExecutor` resolves its payer with the state-less `resolvePlayerTarget` overload (no `ControllerOfTriggeringEntity` support → falls back to the ability's controller), and `GatedEffect` charges the gate cost to the ability's controller regardless of `decisionMaker`. So neither path can faithfully charge the opponent's life. The first two abilities (X-driven `each player sacrifices X`, and the you-side optional reanimation with a finality counter) were prototyped and worked, but the card as a whole can't be modeled correctly without engine work.

This is the already-documented DSK engine gap **#16** (*opponent-decides-or-you-steal death-trigger flow*, lift M) in `backlog/dsk-engine-gaps.md`, where it's explicitly held out of autonomous card-authoring scope pending add-feature work. Left unimplemented rather than approximated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)