### PR TITLE
Add cross-zone union target; implement Sorceress's Schemes

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1673,6 +1673,31 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 for "an instant or sorcery spell that targets a creature" — Forum Necroscribe, Lecturing Scornmage);
 plus `TargetFilter.excludeSelf` to exclude the source.
 
+### Cross-zone union targets (`TargetFilter.or` / `TargetFilter.anyOf`)
+
+A **single** target whose legal objects can come from more than one zone, each with its own predicate —
+the cross-zone "or" wording. `TargetFilter` carries `alternatives: List<TargetFilter>`, additional
+zone-scoped clauses unioned with the primary one; build it with `clauseA.or(clauseB)` or
+`TargetFilter.anyOf(clauseA, clauseB, …)`. The legal-target set is the union over every clause and a
+chosen target is legal iff it satisfies *any* clause. This is **not** a multi-target requirement (still
+one target), and it is distinct from the player/permanent unions (`TargetSpellOrPermanent`,
+`TargetCreatureOrPlayer`). `GameObjectFilter.anyOf` is the same idea *within one zone*; this lifts it
+across zones, which the flat `baseFilter` can't express because each zone needs its own predicate and
+the engine dispatches target-finding/validation per `TargetFilter.zone`.
+
+```kotlin
+// Sorceress's Schemes — "instant or sorcery card from your graveyard or exiled card with flashback you own"
+val union = TargetFilter.InstantOrSorceryInGraveyard.ownedByYou()
+    .or(TargetFilter(GameObjectFilter.Any).withKeyword(Keyword.FLASHBACK).ownedByYou().inZone(Zone.EXILE))
+val t = target("…", TargetObject(filter = union))
+effect = Effects.Composite(Effects.ReturnToHand(t), Effects.AddMana(Color.RED))
+```
+
+"Card with flashback" is just `withKeyword(Keyword.FLASHBACK)`: a flashback ability adds
+`Keyword.FLASHBACK` to the card's base keywords, so the predicate matches even on a card sitting in
+exile (no projection needed). The client routes a union to its cross-zone card picker, grouping the
+valid targets into per-(owner, zone) tabs — "Your Graveyard", "Your Exile", etc.
+
 ### Named multi-target binding
 
 ```kotlin

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/TargetFilter.kt
@@ -46,12 +46,47 @@ data class TargetFilter(
      * triggering entity (e.g., the creature that became the target of an opponent's spell),
      * not the source of the ability.
      */
-    val excludeTriggeringEntity: Boolean = false
+    val excludeTriggeringEntity: Boolean = false,
+    /**
+     * Additional zone-scoped clauses unioned with this one, for a single target that may be
+     * chosen from several zones each with its own predicate — the cross-zone "or" wording
+     * (Sorceress's Schemes: "instant or sorcery card from your graveyard *or* exiled card with
+     * flashback you own"). The legal-target set is the union over [clauses] (this filter plus all
+     * [alternatives]), and a chosen target is legal iff it satisfies *any* clause. Each alternative
+     * carries its own [zone]/[baseFilter], so the clauses can span graveyard, exile, the
+     * battlefield, etc.
+     *
+     * This is *not* a multi-target requirement — it is still a single target. Build it through
+     * [or] / [anyOf]; the common single-zone filter leaves this empty. `GameObjectFilter.anyOf`
+     * is the same idea *within one zone*; this lifts it across zones, which the flat `baseFilter`
+     * can't express because each zone needs its own predicate.
+     */
+    val alternatives: List<TargetFilter> = emptyList()
 ) : TextReplaceable<TargetFilter> {
     val description: String
         get() = buildDescription()
 
-    private fun buildDescription(): String = buildString {
+    /** True when this filter is a cross-zone union (has at least one [alternatives] clause). */
+    val isUnion: Boolean get() = alternatives.isNotEmpty()
+
+    /**
+     * Flatten this filter into its single-zone clauses: this filter (with [alternatives] stripped)
+     * followed by every alternative's own clauses. Each returned filter has an empty [alternatives],
+     * so dispatch sites can branch on [zone] without re-checking for unions. A non-union filter
+     * returns just itself.
+     */
+    fun clauses(): List<TargetFilter> =
+        listOf(if (alternatives.isEmpty()) this else copy(alternatives = emptyList())) +
+            alternatives.flatMap { it.clauses() }
+
+    /** Union this filter with [other] — adds [other] as an alternative clause. */
+    fun or(other: TargetFilter): TargetFilter = copy(alternatives = alternatives + other)
+
+    private fun buildDescription(): String =
+        if (alternatives.isEmpty()) describeClause()
+        else clauses().joinToString(" or ") { it.describeClause() }
+
+    private fun describeClause(): String = buildString {
         if (excludeSelf) append("other ")
         append(baseFilter.description)
         if (zone != Zone.BATTLEFIELD) {
@@ -65,6 +100,14 @@ data class TargetFilter(
     // =============================================================================
 
     companion object {
+        /**
+         * A cross-zone union target: a single target chosen from any of the given clauses, each
+         * with its own zone/predicate (Sorceress's Schemes). The first clause's zone is treated as
+         * the primary one for display/zone purposes. See [alternatives].
+         */
+        fun anyOf(first: TargetFilter, vararg rest: TargetFilter): TargetFilter =
+            first.copy(alternatives = first.alternatives + rest.toList())
+
         /** Target any creature */
         val Creature = TargetFilter(GameObjectFilter.Companion.Creature)
 
@@ -380,6 +423,10 @@ data class TargetFilter(
 
     override fun applyTextReplacement(replacer: TextReplacer): TargetFilter {
         val newBase = baseFilter.applyTextReplacement(replacer)
-        return if (newBase !== baseFilter) copy(baseFilter = newBase) else this
+        val newAlternatives = alternatives.map { it.applyTextReplacement(replacer) }
+        val alternativesChanged = newAlternatives.indices.any { newAlternatives[it] !== alternatives[it] }
+        return if (newBase !== baseFilter || alternativesChanged) {
+            copy(baseFilter = newBase, alternatives = newAlternatives)
+        } else this
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SorceressSchemes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SorceressSchemes.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sorceress's Schemes
+ * {3}{R}
+ * Sorcery
+ * Return target instant or sorcery card from your graveyard or exiled card with flashback you own
+ * to your hand. Add {R}.
+ * Flashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ *
+ * The target is a cross-zone union (CR 115.1 single target, two zone clauses): an instant or sorcery
+ * card in your graveyard, OR a card with flashback in your exile that you own — built with
+ * [TargetFilter.or]. "Card with flashback" is just the FLASHBACK keyword, which lives in the card's
+ * base keywords (derived from its flashback ability) and so matches even on a card in exile.
+ */
+val SorceressSchemes = card("Sorceress's Schemes") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Return target instant or sorcery card from your graveyard or exiled card with flashback you own to your hand. Add {R}.\n" +
+        "Flashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        // Clause A: instant or sorcery card in your graveyard.
+        // Clause B: a card you own with flashback in exile.
+        val union = TargetFilter.InstantOrSorceryInGraveyard.ownedByYou()
+            .or(TargetFilter(GameObjectFilter.Any).withKeyword(Keyword.FLASHBACK).ownedByYou().inZone(Zone.EXILE))
+        val t = target(
+            "instant or sorcery card from your graveyard or exiled card with flashback you own",
+            TargetObject(filter = union)
+        )
+        effect = Effects.Composite(
+            Effects.ReturnToHand(t),
+            Effects.AddMana(Color.RED)
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{4}{R}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Jessica Fong"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7efd7627-0754-4685-9d04-8f5f82f45632.jpg?1748706360"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -8515,6 +8515,67 @@
     ]
 }
 
+// Sorceress's Schemes
+{
+    "name": "Sorceress's Schemes",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target instant or sorcery card from your graveyard or exiled card with flashback you own to your hand. Add {R}.\nFlashback {4}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{4}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "instant or sorcery card from your graveyard or exiled card with flashback you own"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "AddMana",
+                    "color": "RED"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "instant|sorcery own:you",
+                    "zone": "Graveyard",
+                    "alternatives": [
+                        {
+                            "baseFilter": "kw:flashback own:you",
+                            "zone": "Exile"
+                        }
+                    ]
+                },
+                "id": "instant or sorcery card from your graveyard or exiled card with flashback you own"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Jessica Fong",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7efd7627-0754-4685-9d04-8f5f82f45632.jpg?1748706360"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Starting Town
 {
     "name": "Starting Town",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -488,6 +488,15 @@ class TargetFinder(
         pipelineContext: PredicateContext? = null
     ): List<EntityId> {
         val filter = requirement.filter
+        // Cross-zone union ("from your graveyard or exiled card with flashback"): the legal set is
+        // the union over each single-zone clause. Recurse per clause (each has no alternatives, so
+        // this terminates) and dedupe — a single object can't legally match two clauses anyway, but
+        // distinct() guards against overlapping filters.
+        if (filter.isUnion) {
+            return filter.clauses().flatMap { clause ->
+                findObjectTargets(state, requirement.copy(filter = clause), controllerId, sourceId, ignoreTargetingRestrictions, targetingSourceType, triggeringEntityId, pipelineContext)
+            }.distinct()
+        }
         return when (filter.zone) {
             Zone.BATTLEFIELD -> findPermanentTargets(state, requirement, controllerId, sourceId, ignoreTargetingRestrictions, targetingSourceType, triggeringEntityId, pipelineContext)
             Zone.GRAVEYARD -> findGraveyardTargets(state, filter, controllerId, sourceId, pipelineContext)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/TargetEnumerationUtils.kt
@@ -177,6 +177,13 @@ class TargetEnumerationUtils(
         filter: TargetFilter,
         sourceId: EntityId? = null
     ): List<EntityId> {
+        // Cross-zone union: surface the union of legal targets across each single-zone clause
+        // (Sorceress's Schemes offers both graveyard instants/sorceries and exiled flashback cards).
+        if (filter.isUnion) {
+            return filter.clauses().flatMap { clause ->
+                findValidObjectTargets(state, playerId, clause, sourceId)
+            }.distinct()
+        }
         return when (filter.zone) {
             Zone.BATTLEFIELD -> findValidPermanentTargets(state, playerId, filter, sourceId)
             Zone.GRAVEYARD -> findValidGraveyardTargets(state, playerId, filter, sourceId)
@@ -230,7 +237,11 @@ class TargetEnumerationUtils(
 
     fun getTargetZone(requirement: TargetRequirement): String? {
         return when (requirement) {
-            is TargetObject -> requirement.filter.zone.takeIf { it != Zone.BATTLEFIELD }?.let {
+            // A cross-zone union spans several card zones, so no single zone label applies; the
+            // client detects card-zone targets from the valid-target set itself and shows the
+            // cross-zone card picker.
+            is TargetObject -> if (requirement.filter.isUnion) null else
+                requirement.filter.zone.takeIf { it != Zone.BATTLEFIELD }?.let {
                 when (requirement.filter.zone) {
                     Zone.GRAVEYARD -> "Graveyard"
                     Zone.STACK -> "Stack"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -743,6 +743,18 @@ class TargetValidator {
         xValue: Int? = null,
         targetPlayerId: EntityId? = null
     ): String? {
+        // Cross-zone union: the target is legal if it satisfies *any* clause. Validate against each
+        // single-zone clause; succeed on the first that accepts, otherwise report that clause's
+        // error (the most informative — the target type matched a clause's zone but failed its
+        // filter). Each clause has no alternatives, so this recursion terminates.
+        if (filter.isUnion) {
+            val clauseErrors = filter.clauses().map { clause ->
+                validateObjectTarget(state, target, clause, casterId, sourceId, xValue, targetPlayerId)
+            }
+            if (clauseErrors.any { it == null }) return null
+            return clauseErrors.firstOrNull { it != null }
+                ?: "Target does not match filter: ${filter.description}"
+        }
         return when (filter.zone) {
             Zone.GRAVEYARD -> validateGraveyardTarget(state, target, filter, casterId, sourceId, xValue, targetPlayerId)
             Zone.BATTLEFIELD -> validatePermanentTarget(state, target, filter, casterId, sourceId, xValue)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SorceressSchemesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SorceressSchemesScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sorceress's Schemes (Final Fantasy, {3}{R} Sorcery):
+ *
+ *   "Return target instant or sorcery card from your graveyard or exiled card with flashback you
+ *    own to your hand. Add {R}."
+ *
+ * The target is a cross-zone union ([com.wingedsheep.sdk.scripting.filters.unified.TargetFilter.or]):
+ *   clause A = instant or sorcery card in your graveyard,
+ *   clause B = a card you own with flashback in your exile.
+ *
+ * These tests pin both clauses of the union, the ownership/type filters that scope each clause, and
+ * the resulting "Add {R}" — the exact behaviour the cross-zone target feature exists to support.
+ */
+class SorceressSchemesScenarioTest : ScenarioTestBase() {
+
+    private fun TestGame.exileCardId(playerNumber: Int, name: String): EntityId {
+        val playerId = if (playerNumber == 1) player1Id else player2Id
+        return state.getExile(playerId).first { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+    }
+
+    /** Cast Sorceress's Schemes from player 1's hand at an explicit card target in a given zone. */
+    private fun TestGame.castSchemesAt(targetId: EntityId, ownerPlayer: Int, zone: Zone): ExecutionResult {
+        val ownerId = if (ownerPlayer == 1) player1Id else player2Id
+        val cardId = state.getHand(player1Id).first { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == "Sorceress's Schemes"
+        }
+        return execute(CastSpell(player1Id, cardId, listOf(ChosenTarget.Card(targetId, ownerId, zone))))
+    }
+
+    init {
+        context("Sorceress's Schemes — cross-zone union target") {
+
+            test("returns an instant or sorcery from your graveyard to hand and adds {R}") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sorceress's Schemes")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bolt = game.findCardsInGraveyard(1, "Lightning Bolt").first()
+                val result = game.castSchemesAt(bolt, ownerPlayer = 1, zone = Zone.GRAVEYARD)
+                withClue("cast targeting a graveyard instant should be legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Lightning Bolt returns to its owner's hand") {
+                    game.isInHand(1, "Lightning Bolt") shouldBe true
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe false
+                }
+                withClue("Sorceress's Schemes also adds {R}") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.getAmount(Color.RED) shouldBe 1
+                }
+            }
+
+            test("returns an exiled card with flashback you own to hand") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sorceress's Schemes")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    // Gysahl Greens is a sorcery with Flashback — a legal clause-B target while exiled.
+                    .withCardInExile(1, "Gysahl Greens")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val greens = game.exileCardId(1, "Gysahl Greens")
+                val result = game.castSchemesAt(greens, ownerPlayer = 1, zone = Zone.EXILE)
+                withClue("cast targeting an exiled flashback card you own should be legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Gysahl Greens returns from exile to its owner's hand") {
+                    game.isInHand(1, "Gysahl Greens") shouldBe true
+                    game.isInExile(1, "Gysahl Greens") shouldBe false
+                }
+            }
+
+            test("legal targets are the union of both clauses and exclude illegal candidates") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sorceress's Schemes")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    // clause A legal: instant you own in your graveyard.
+                    .withCardInGraveyard(1, "Lightning Bolt")
+                    // illegal: a creature in your graveyard (not instant/sorcery).
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    // clause B legal: a flashback card you own in your exile.
+                    .withCardInExile(1, "Gysahl Greens")
+                    // illegal: an exiled card you own with no flashback.
+                    .withCardInExile(1, "Mountain")
+                    // illegal: instant in the OPPONENT's graveyard (not owned by you).
+                    .withCardInGraveyard(2, "Lightning Bolt")
+                    // illegal: flashback card in the OPPONENT's exile (not owned by you).
+                    .withCardInExile(2, "Gysahl Greens")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val myBolt = game.findCardsInGraveyard(1, "Lightning Bolt").first()
+                val myGreens = game.exileCardId(1, "Gysahl Greens")
+
+                val cast = game.getLegalActions(1).first { it.description.contains("Sorceress's Schemes") }
+                withClue("only the graveyard instant and the exiled flashback card you own are legal") {
+                    val validTargets = cast.validTargets.shouldNotBeNull()
+                    validTargets.shouldContainExactlyInAnyOrder(listOf(myBolt, myGreens))
+                }
+            }
+
+            test("rejects targeting a creature card in your graveyard (fails clause A's type filter)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sorceress's Schemes")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").first()
+                val result = game.castSchemesAt(bears, ownerPlayer = 1, zone = Zone.GRAVEYARD)
+                withClue("a creature in the graveyard matches neither clause, so the cast is illegal") {
+                    result.error.shouldNotBeNull()
+                }
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+            }
+
+            test("rejects targeting an exiled card you own without flashback (fails clause B's keyword filter)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Sorceress's Schemes")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardInExile(1, "Mountain")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val mountain = game.exileCardId(1, "Mountain")
+                val result = game.castSchemesAt(mountain, ownerPlayer = 1, zone = Zone.EXILE)
+                withClue("an exiled card without flashback matches neither clause, so the cast is illegal") {
+                    result.error.shouldNotBeNull()
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/components/game/overlay/TargetingOverlay.tsx
+++ b/web-client/src/components/game/overlay/TargetingOverlay.tsx
@@ -11,11 +11,13 @@ import { TARGET_COLOR, TARGET_COLOR_BRIGHT } from '@/styles/targetingColors.ts'
 import { CraftMaterialOverlay } from '@/components/decisions/CraftMaterialOverlay'
 
 /**
- * Graveyard targeting overlay - shows when targeting mode requires selecting cards from graveyards.
- * Similar to GraveyardTargetingUI in DecisionUI but for client-side spell casting targeting.
+ * Cross-zone card targeting overlay — shows when targeting mode requires selecting card(s) from a
+ * card zone (graveyard or exile), possibly a union of both (Sorceress's Schemes). Cards are grouped
+ * into tabs by (owner, zone) so e.g. "Your Graveyard" and "Your Exile" are distinct, browsable
+ * piles. Similar to GraveyardTargetingUI in DecisionUI but for client-side spell casting targeting.
  */
-function GraveyardTargetingOverlay({
-  graveyardCards,
+function ZoneCardTargetingOverlay({
+  zoneCards,
   targetingState,
   responsive,
   onSelect,
@@ -23,7 +25,7 @@ function GraveyardTargetingOverlay({
   onConfirm,
   onCancel,
 }: {
-  graveyardCards: ClientCard[]
+  zoneCards: ClientCard[]
   targetingState: { selectedTargets: readonly EntityId[]; minTargets: number; maxTargets: number; targetDescription?: string; currentRequirementIndex?: number; totalRequirements?: number; sourceCardName?: string }
   responsive: ResponsiveSizes
   onSelect: (cardId: EntityId) => void
@@ -42,32 +44,39 @@ function GraveyardTargetingOverlay({
   const hasEnoughTargets = selectedCount >= minTargets
   const hasMaxTargets = selectedCount >= maxTargets
 
-  // Group cards by graveyard owner
-  const cardsByOwner = React.useMemo(() => {
-    const grouped = new Map<EntityId, ClientCard[]>()
-    for (const card of graveyardCards) {
-      const ownerId = card.zone?.ownerId ?? card.ownerId
-      if (!grouped.has(ownerId)) {
-        grouped.set(ownerId, [])
+  // A group key combines the owning player and the card's zone, so graveyard and exile piles for
+  // the same player are separate tabs. Zone defaults to Graveyard when the card carries none.
+  const groupKeyOf = (card: ClientCard): string =>
+    `${card.zone?.ownerId ?? card.ownerId}|${card.zone?.zoneType ?? 'Graveyard'}`
+
+  // Group cards by (owner, zone)
+  const cardsByGroup = React.useMemo(() => {
+    const grouped = new Map<string, ClientCard[]>()
+    for (const card of zoneCards) {
+      const key = groupKeyOf(card)
+      if (!grouped.has(key)) {
+        grouped.set(key, [])
       }
-      grouped.get(ownerId)!.push(card)
+      grouped.get(key)!.push(card)
     }
     return grouped
-  }, [graveyardCards])
+  }, [zoneCards])
 
-  // Get owner IDs sorted (viewer's graveyard first)
-  const ownerIds = React.useMemo(() => {
-    const ids = Array.from(cardsByOwner.keys())
+  // Get group keys sorted (viewer's piles first)
+  const groupKeys = React.useMemo(() => {
+    const ids = Array.from(cardsByGroup.keys())
     return ids.sort((a, b) => {
-      if (a === viewingPlayerId) return -1
-      if (b === viewingPlayerId) return 1
-      return 0
+      const aMine = a.startsWith(`${viewingPlayerId}|`)
+      const bMine = b.startsWith(`${viewingPlayerId}|`)
+      if (aMine && !bMine) return -1
+      if (bMine && !aMine) return 1
+      return a.localeCompare(b)
     })
-  }, [cardsByOwner, viewingPlayerId])
+  }, [cardsByGroup, viewingPlayerId])
 
-  const [selectedOwnerId, setSelectedOwnerId] = React.useState<EntityId | null>(() => ownerIds[0] ?? null)
-  const currentOwnerId = selectedOwnerId && ownerIds.includes(selectedOwnerId) ? selectedOwnerId : ownerIds[0] ?? null
-  const currentCards = currentOwnerId ? (cardsByOwner.get(currentOwnerId) ?? []) : []
+  const [selectedGroupKey, setSelectedGroupKey] = React.useState<string | null>(() => groupKeys[0] ?? null)
+  const currentGroupKey = selectedGroupKey && groupKeys.includes(selectedGroupKey) ? selectedGroupKey : groupKeys[0] ?? null
+  const currentCards = currentGroupKey ? (cardsByGroup.get(currentGroupKey) ?? []) : []
 
   // Sort cards by type then name
   const sortedCards = React.useMemo(() => {
@@ -87,10 +96,12 @@ function GraveyardTargetingOverlay({
     })
   }, [currentCards])
 
-  const getPlayerLabel = (ownerId: EntityId): string => {
-    if (ownerId === viewingPlayerId) return 'Your Graveyard'
+  const getGroupLabel = (groupKey: string): string => {
+    const [ownerId, zoneType = 'Graveyard'] = groupKey.split('|')
+    const zoneLabel = zoneType === 'Exile' ? 'Exile' : 'Graveyard'
+    if (ownerId === viewingPlayerId) return `Your ${zoneLabel}`
     const player = gameState?.players.find((p) => p.playerId === ownerId)
-    return player ? `${player.name}'s Graveyard` : "Opponent's Graveyard"
+    return player ? `${player.name}'s ${zoneLabel}` : `Opponent's ${zoneLabel}`
   }
 
   const toggleCard = (cardId: EntityId) => {
@@ -133,7 +144,7 @@ function GraveyardTargetingOverlay({
           zIndex: 100,
         }}
       >
-        ↑ Return to Graveyard Selection
+        ↑ Return to Card Selection
       </button>
     )
   }
@@ -182,7 +193,7 @@ function GraveyardTargetingOverlay({
         >
           {targetingState.targetDescription
             ? `Select ${targetingState.targetDescription}`
-            : 'Choose Target from Graveyard'}
+            : 'Choose Target'}
         </h2>
         {targetingState.sourceCardName && (
           <p
@@ -209,8 +220,8 @@ function GraveyardTargetingOverlay({
         </p>
       </div>
 
-      {/* Graveyard tabs (if multiple graveyards) */}
-      {ownerIds.length > 1 && (
+      {/* Zone tabs (if multiple graveyard/exile piles) */}
+      {groupKeys.length > 1 && (
         <div
           style={{
             display: 'flex',
@@ -220,24 +231,24 @@ function GraveyardTargetingOverlay({
             borderRadius: 8,
           }}
         >
-          {ownerIds.map((ownerId) => {
-            const isActive = ownerId === currentOwnerId
-            const ownerCards = cardsByOwner.get(ownerId) ?? []
-            const cardCount = ownerCards.length
-            // Count how many cards are selected from this graveyard
-            const selectedFromThisGraveyard = ownerCards.filter((c) =>
+          {groupKeys.map((groupKey) => {
+            const isActive = groupKey === currentGroupKey
+            const groupCards = cardsByGroup.get(groupKey) ?? []
+            const cardCount = groupCards.length
+            // Count how many cards are selected from this pile
+            const selectedFromThisGroup = groupCards.filter((c) =>
               targetingState.selectedTargets.includes(c.id)
             ).length
             return (
               <button
-                key={ownerId}
-                onClick={() => setSelectedOwnerId(ownerId)}
+                key={groupKey}
+                onClick={() => setSelectedGroupKey(groupKey)}
                 style={{
                   padding: responsive.isMobile ? '8px 16px' : '10px 24px',
                   fontSize: responsive.fontSize.normal,
                   backgroundColor: isActive ? '#4a5568' : 'transparent',
                   color: isActive ? 'white' : '#888',
-                  border: selectedFromThisGraveyard > 0 && !isActive ? '2px solid #fbbf24' : 'none',
+                  border: selectedFromThisGroup > 0 && !isActive ? '2px solid #fbbf24' : 'none',
                   borderRadius: 6,
                   cursor: 'pointer',
                   fontWeight: isActive ? 600 : 400,
@@ -245,8 +256,8 @@ function GraveyardTargetingOverlay({
                   position: 'relative',
                 }}
               >
-                {getPlayerLabel(ownerId)} ({cardCount})
-                {selectedFromThisGraveyard > 0 && (
+                {getGroupLabel(groupKey)} ({cardCount})
+                {selectedFromThisGroup > 0 && (
                   <span
                     style={{
                       position: 'absolute',
@@ -264,7 +275,7 @@ function GraveyardTargetingOverlay({
                       fontWeight: 'bold',
                     }}
                   >
-                    {selectedFromThisGraveyard}
+                    {selectedFromThisGroup}
                   </span>
                 )}
               </button>
@@ -377,7 +388,7 @@ function GraveyardTargetingOverlay({
       {/* No cards message */}
       {sortedCards.length === 0 && (
         <p style={{ color: '#666', fontSize: responsive.fontSize.normal }}>
-          No valid targets in this graveyard.
+          No valid targets here.
         </p>
       )}
 
@@ -473,40 +484,34 @@ export function TargetingOverlay() {
   const isReveal = targetingState.isRevealSelection
   const isBehold = targetingState.isBeholdSelection
 
-  // Check if targets are graveyard cards — use explicit targetZone when available,
-  // fall back to inspecting gameState.cards for backward compatibility
-  const graveyardCards: ClientCard[] = []
-  const isGraveyardTargeting = targetingState.targetZone === 'Graveyard'
-  if (isGraveyardTargeting) {
-    // Server told us this is a graveyard targeting requirement — collect cards
-    for (const targetId of targetingState.validTargets) {
-      const card = gameState?.cards[targetId]
-      if (card) {
-        graveyardCards.push(card)
-      }
-    }
-  } else {
-    // Fallback: check if all valid targets happen to be graveyard cards
-    let allTargetsAreGraveyard = targetingState.validTargets.length > 0
-    for (const targetId of targetingState.validTargets) {
-      const card = gameState?.cards[targetId]
-      if (card && card.zone?.zoneType === 'Graveyard') {
-        graveyardCards.push(card)
-      } else {
-        allTargetsAreGraveyard = false
-        break
-      }
-    }
-    if (!allTargetsAreGraveyard) {
-      graveyardCards.length = 0
+  // Collect valid-target cards that live in a selectable card zone (graveyard or exile). These
+  // route to the cross-zone card picker rather than on-battlefield clicking — the picker shows
+  // the actual cards (a graveyard/exile pile isn't individually clickable on the board). This
+  // covers single-zone graveyard targeting (the common case), exile targeting (Blade of the
+  // Swarm), and cross-zone unions (Sorceress's Schemes: graveyard ∪ exile). `targetZone` is the
+  // server's single-zone hint when present; when absent (single-target or union) we detect from
+  // the valid-target set, requiring *every* valid target to be a card-zone card so we don't
+  // hijack mixed battlefield/player targeting.
+  const CARD_ZONES = new Set(['Graveyard', 'Exile'])
+  const zoneCards: ClientCard[] = []
+  let allTargetsAreZoneCards = targetingState.validTargets.length > 0
+  for (const targetId of targetingState.validTargets) {
+    const card = gameState?.cards[targetId]
+    const zoneType = card?.zone?.zoneType
+    if (card && (zoneType ? CARD_ZONES.has(zoneType) : targetingState.targetZone === 'Graveyard')) {
+      zoneCards.push(card)
+    } else {
+      allTargetsAreZoneCards = false
     }
   }
+  const useCardPicker =
+    (targetingState.targetZone === 'Graveyard' || allTargetsAreZoneCards) && zoneCards.length > 0
 
-  // If targets are graveyard cards, show graveyard selection UI
-  if (graveyardCards.length > 0) {
+  // If targets are graveyard/exile cards, show the cross-zone card selection UI
+  if (useCardPicker) {
     return (
-      <GraveyardTargetingOverlay
-        graveyardCards={graveyardCards}
+      <ZoneCardTargetingOverlay
+        zoneCards={zoneCards}
         targetingState={targetingState}
         responsive={responsive}
         onSelect={addTarget}

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -23,6 +23,13 @@ import type {
   DamageDistributionState,
 } from '../types'
 
+/**
+ * Non-battlefield, non-stack zones a targeted card can live in. A target whose card is in one of
+ * these is sent to the server as a `Card` target tagged with its zone, so a cross-zone union
+ * requirement (Sorceress's Schemes: graveyard ∪ exile) matches it to the correct clause.
+ */
+const CARD_TARGET_ZONES = new Set(['Graveyard', 'Exile', 'Hand', 'Library', 'Command'])
+
 // ---------------------------------------------------------------------------
 // Store method interface (decouples pure logic from Zustand)
 // ---------------------------------------------------------------------------
@@ -458,16 +465,19 @@ export function mergeResult(
           return { type: 'Player' as const, playerId: targetId }
         }
         const card = gameState.cards[targetId]
-        if (card && card.zone?.zoneType === 'Graveyard') {
+        const zoneType = card?.zone?.zoneType
+        if (card && zoneType === 'Stack') {
+          return { type: 'Spell' as const, spellEntityId: targetId }
+        }
+        // Card target in a non-battlefield zone — carry its actual zone so the server matches it
+        // to the right clause (a cross-zone union like Sorceress's Schemes spans graveyard ∪ exile).
+        if (card && zoneType && CARD_TARGET_ZONES.has(zoneType)) {
           return {
             type: 'Card' as const,
             cardId: targetId,
-            ownerId: card.zone.ownerId,
-            zone: 'Graveyard' as const,
+            ownerId: card.zone!.ownerId,
+            zone: zoneType,
           }
-        }
-        if (card && card.zone?.zoneType === 'Stack') {
-          return { type: 'Spell' as const, spellEntityId: targetId }
         }
         return { type: 'Permanent' as const, entityId: targetId }
       })


### PR DESCRIPTION
## What

Adds a **cross-zone union target** to the SDK and implements **Sorceress's Schemes** (Final Fantasy, `{3}{R}` Sorcery):

> Return target instant or sorcery card from your graveyard **or** exiled card with flashback you own to your hand. Add `{R}`.
> Flashback `{4}{R}`

The target spans two zones with per-zone predicates — an instant/sorcery in your graveyard **or** a flashback card you own in exile. `TargetFilter` previously supported only a single zone and there was no way to express the union, so this was an `add-feature` task.

## The feature: `TargetFilter.alternatives`

`TargetFilter` now carries `alternatives: List<TargetFilter>` — additional zone-scoped clauses unioned with the primary one. Build it with `clauseA.or(clauseB)` or `TargetFilter.anyOf(...)`. The legal-target set is the union over every clause; a chosen target is legal iff it satisfies **any** clause. It stays a *single* target (not a multi-target requirement), and is distinct from the player/permanent unions (`TargetSpellOrPermanent`, `TargetCreatureOrPlayer`). `GameObjectFilter.anyOf` is the same idea within one zone; this lifts it across zones, which the flat `baseFilter` can't express because each zone needs its own predicate.

Because the union lives inside the filter, every consumer that just carries `TargetObject.filter` along is untouched — only the **three sites that dispatch on `filter.zone`** needed a union branch:

- `TargetFinder.findObjectTargets` — finds the union of legal targets across clauses.
- `TargetValidator.validateObjectTarget` — accepts a target that satisfies any clause.
- `TargetEnumerationUtils.findValidObjectTargets` / `getTargetZone` — enumerates the union for legal actions; reports no single zone for a union.

"Card with flashback" needed **no new predicate**: a flashback ability adds `Keyword.FLASHBACK` to the card's base keywords, so `withKeyword(Keyword.FLASHBACK)` matches even a card sitting in exile (no projection needed).

## Client

The targeting overlay's graveyard picker is generalized to a **cross-zone card picker** (graveyard ∪ exile), grouping valid targets into per-(owner, zone) tabs ("Your Graveyard", "Your Exile", …). Critically, the client's target-action builder now tags a chosen card with its **actual** zone (`Graveyard`/`Exile`/…) instead of hardcoding `Graveyard`, so the server matches it to the correct clause — without this, selecting an exiled card was silently sent as a `Permanent` and rejected.

## Tests

`SorceressSchemesScenarioTest` (rules-engine) — passes:
- returns an instant/sorcery from your graveyard to hand and adds `{R}`;
- returns an exiled flashback card you own to hand;
- legal targets are exactly the union and **exclude** illegal candidates (creature in your graveyard, exiled card without flashback, instant in opponent's graveyard, flashback card in opponent's exile);
- rejects targeting a graveyard creature (clause-A type filter);
- rejects targeting an exiled non-flashback card you own (clause-B keyword filter).

Web-client `tsc --noEmit` clean. `CardDefinitionSnapshotTest` golden re-blessed for the new card; `CardLintTest` green.

## mtgish

Intentionally **not** taught to the mtgish generator: a cross-zone union is a target *shape*, not an effect/primitive that maps to an mtgish IR tag, and rendering it exactly would require substantial `TargetRecovery` work for a niche construct. Per "decline→SCAFFOLD, don't widen," the emitter declines rather than emitting a lossy single-zone approximation.

## Docs

`docs/card-sdk-language-reference.md` §6 documents the new union target shape (`TargetFilter.or` / `anyOf`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
