### PR TITLE
Add opponent-decides-or-you-steal death trigger; implement Meathook Massacre II

### DIFF
--- a/backlog/dsk-engine-gaps.md
+++ b/backlog/dsk-engine-gaps.md
@@ -216,15 +216,21 @@ to a **player** that have no home yet.
       with a `Ninjas get +1/+1` static, `Surveil 2`, draw-per-`TurnTracker.OPPONENTS_WHO_LOST_LIFE`,
       tap + two `STUN` counters).
 
-16. **Opponent-decides-or-you-steal death trigger.** `PayOrSuffer` routes its decision to the
-    *source's* controller; here the decision belongs to the **dying creature's controller** and the
-    consequence is *you* reanimating their card under your control with a finality counter. Needs the
-    pay/suffer decision routed to a non-source player with a theft (controller-override return)
-    consequence. (The `you`-side half — "your creature dies, you may pay 3 life, return it under your
-    control with a finality counter" — composes from `TriggeringEntity` + `MoveToZoneEffect(controllerOverride)`
-    + entering finality counter, but is untested end-to-end and should get a scenario test. `{X}{X}`
-    → X-driven `each player sacrifices X`, and `CounterType.FINALITY`, all exist.)
-    → **Meathook Massacre II**.
+16. **Opponent-decides-or-you-steal death trigger.** ✅ DONE (`add-feature`). Two root-cause engine
+    fixes, no new SDK type — the card composes existing primitives:
+    - `TriggerContext.fromEvent(ZoneChangeEvent)` now populates `triggeringPlayerId` from
+      `lastKnownController ?: ownerId`, so `Player.TriggeringPlayer` resolves to the **dying
+      permanent's last-known controller** on any death / leaves trigger (it previously fell through to
+      the dead creature's entity id). This is what lets `PayOrSufferEffect(player = TriggeringPlayer)`
+      route the pay/suffer decision *and* the life payment to the opponent.
+    - The `PayOrSuffer` continuation now runs the `suffer` consequence under the **ability's
+      controller** (carried as `abilityControllerId`), not the payer — so "return that card under
+      *your* control" (`controllerOverride = Controller`) is the theft, matching the already-correct
+      auto-suffer path.
+    The `you`-side half is the opt-in `OptionalCostEffect(PayLife(3), reanimate)`; `{X}{X}` →
+    `Effects.Sacrifice(Creature, CastX, Player.Each)`; finality = `Move + AddCounters`. All three
+    abilities have paired scenario tests (`MeathookMassacreIIScenarioTest`).
+    → **Meathook Massacre II** (implemented).
 
 17. **Linked exile populated by a *replacement* effect.** `RedirectZoneChange` can send "a card you
     didn't control that would hit an opponent's graveyard" to exile (Anafenza precedent with an

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -272,6 +272,15 @@ unless you Y") and by `morphCost` (non-mana face-up cost). Distinct from `Abilit
 which model an ability's activation cost; `PayCost` models a single cost the engine prompts the
 player to pay against an alternative consequence.
 
+`PayOrSufferEffect(cost, suffer, player = EffectTarget.Controller)` defaults to charging the ability's
+controller, but **`player` may route the decision *and* the payment to any other player** — most
+usefully `EffectTarget.PlayerRef(Player.TriggeringPlayer)` on a death trigger, which resolves to the
+dying permanent's last-known controller. The `suffer` consequence still resolves under the **ability's
+controller** (not the payer), so `EffectTarget.Controller` inside it means *you*: Meathook Massacre II's
+"whenever a creature an opponent controls dies, *they* may pay 3 life. If they don't, return that card
+under *your* control" is `PayOrSufferEffect(player = PlayerRef(TriggeringPlayer), cost = Costs.pay.PayLife(3),
+suffer = Composite(Move(TriggeringEntity → battlefield, controllerOverride = Controller), AddCounters(finality)))`.
+
 Non-mana `morphCost` payment is routed through the shared engine `CostPaymentService`, so **every
 `Costs.pay` variant below works as a morph cost** (including `Tap` / `Choice` / `OwnManaCost`): turning
 the creature face up pauses for the cost-specific decision and only flips once the cost is paid.
@@ -1596,8 +1605,12 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   mills four cards", "that player sacrifices a creature").
 - `Player.TriggeringPlayer` — the player bound by the trigger (the caster for `SpellCastEvent`,
   the active player for per-player step triggers — "at the beginning of each opponent's upkeep,
-  *that player* …", **and the player dealt the damage** for a `DealsDamageEvent` trigger whose
-  recipient is a player). It resolves inside a target's controller filter, so "deals noncombat
+  *that player* …", **the player dealt the damage** for a `DealsDamageEvent` trigger whose
+  recipient is a player, **and the dying/leaving permanent's last-known controller** for a
+  death / leaves-the-battlefield trigger — so "whenever a creature an opponent controls dies,
+  *they* may pay 3 life" binds *that creature's controller*, the opponent, not the ability's
+  controller (Meathook Massacre II). This is populated from `ZoneChangeEvent.lastKnownController`
+  (CR 603.10/608.2h last-known information), falling back to the owner). It resolves inside a target's controller filter, so "deals noncombat
   damage to an opponent, … to target creature **that player** controls" is
   `TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.targetPlayerControls(EffectTarget.PlayerRef(Player.TriggeringPlayer))))`
   on the damage trigger — the legality check and resolution both bind it to the damaged player

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MeathookMassacreII.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MeathookMassacreII.kt
@@ -1,0 +1,155 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Meathook Massacre II
+ * {X}{X}{B}{B}{B}{B}
+ * Legendary Enchantment
+ *
+ * When Meathook Massacre II enters, each player sacrifices X creatures of their choice.
+ * Whenever a creature you control dies, you may pay 3 life. If you do, return that card
+ * under your control with a finality counter on it.
+ * Whenever a creature an opponent controls dies, they may pay 3 life. If they don't,
+ * return that card under your control with a finality counter on it.
+ *
+ * The three abilities all key off the dying creature (`EffectTarget.TriggeringEntity`) and reanimate
+ * it under *your* control (the ability's controller) with a finality counter — the established
+ * "return … with a finality counter" composition (Rite of the Moth, Zoraline): `Move(GRAVEYARD →
+ * BATTLEFIELD)` + `AddCounters(FINALITY)`.
+ *
+ *  - **ETB** — [DynamicAmount.CastX] reads the `{X}{X}` value off the cast enchantment and rides it
+ *    onto the permanent, so `Effects.Sacrifice(Creature, count = CastX, target = Each)` makes each
+ *    player choose X of their creatures to sacrifice (APNAP order, CR 101.4).
+ *
+ *  - **Your creature dies** — opt-in [OptionalCostEffect] (Gate.MayPay): *you* may pay 3 life, and
+ *    only then is the card returned. Cost and decision default to the ability's controller (you).
+ *
+ *  - **An opponent's creature dies** — pay-to-prevent, the inverse reading, via [PayOrSufferEffect]
+ *    with `player = Player.TriggeringPlayer`: the *dying creature's last-known controller* (the
+ *    opponent) decides and pays. If they decline, the suffer effect — returning the card under your
+ *    control — resolves as part of *your* ability, so it runs under the ability's controller (you
+ *    steal it). Routing the pay/suffer decision and the life payment to a non-controller, and running
+ *    the consequence under the ability's controller, is the engine work this card needed (DSK engine
+ *    gap #16): `Player.TriggeringPlayer` now resolves to a dying creature's last-known controller
+ *    (TriggerContext populates `triggeringPlayerId` from `ZoneChangeEvent.lastKnownController`), and
+ *    the PayOrSuffer consequence runs under the ability controller, not the payer.
+ *
+ * Per the printed rulings, tokens (no card to return) and creatures that have already left the
+ * graveyard simply don't come back — both fall out naturally because `EffectTarget.TriggeringEntity`
+ * finds nothing to move.
+ */
+val MeathookMassacreII = card("Meathook Massacre II") {
+    manaCost = "{X}{X}{B}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Enchantment"
+    oracleText = "When Meathook Massacre II enters, each player sacrifices X creatures of their choice.\n" +
+        "Whenever a creature you control dies, you may pay 3 life. If you do, return that card under " +
+        "your control with a finality counter on it.\n" +
+        "Whenever a creature an opponent controls dies, they may pay 3 life. If they don't, return " +
+        "that card under your control with a finality counter on it."
+
+    // When Meathook Massacre II enters, each player sacrifices X creatures of their choice.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Sacrifice(
+            filter = GameObjectFilter.Creature,
+            count = DynamicAmount.CastX,
+            target = EffectTarget.PlayerRef(Player.Each)
+        )
+    }
+
+    // Whenever a creature you control dies, you may pay 3 life. If you do, return that card under
+    // your control with a finality counter on it.
+    triggeredAbility {
+        trigger = Triggers.YourCreatureDies
+        effect = OptionalCostEffect(
+            cost = PayLifeEffect(3),
+            ifPaid = returnDeadCreatureUnderYourControl(),
+            descriptionOverride = "You may pay 3 life. If you do, return that card under your control " +
+                "with a finality counter on it."
+        )
+    }
+
+    // Whenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that
+    // card under your control with a finality counter on it.
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.opponentControls(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = PayOrSufferEffect(
+            // The dying creature's last-known controller (the opponent) decides and pays the 3 life.
+            player = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+            cost = Costs.pay.PayLife(3),
+            // If they don't pay, you (the ability's controller) steal the card.
+            suffer = returnDeadCreatureUnderYourControl()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "108"
+        artist = "Tiffany Turrill"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3db59d06-a226-42b2-8f01-6b63a6eea83f.jpg?1726286251"
+
+        ruling(
+            "2024-09-20",
+            "If a creature that dies leaves the graveyard before Meathook Massacre II's second or " +
+                "third ability (as appropriate) resolves, that creature won't return to the " +
+                "battlefield regardless of whether or not life was paid."
+        )
+        ruling(
+            "2024-09-20",
+            "When a token creature dies, Meathook Massacre II's second or third ability (as " +
+                "appropriate) will trigger. The appropriate player has the option to pay 3 life, but " +
+                "regardless of their choice, the token won't return to the battlefield."
+        )
+        ruling(
+            "2024-09-20",
+            "Finality counters work on any permanent, not only creatures. If a permanent with a " +
+                "finality counter on it would be put into a graveyard from the battlefield, exile it instead."
+        )
+        ruling(
+            "2024-09-20",
+            "Multiple finality counters on a single permanent are redundant."
+        )
+    }
+}
+
+/**
+ * "Return that card under your control with a finality counter on it." Shared by Meathook Massacre
+ * II's second and third abilities: move the dying creature ([EffectTarget.TriggeringEntity]) from
+ * the graveyard onto the battlefield under the ability's controller, then add a finality counter
+ * (CR 122.6). The move is a no-op for tokens or for a card that has
+ * already left the graveyard, exactly as the printed rulings require.
+ */
+private fun returnDeadCreatureUnderYourControl() = Effects.Composite(
+    Effects.Move(
+        target = EffectTarget.TriggeringEntity,
+        destination = Zone.BATTLEFIELD,
+        fromZone = Zone.GRAVEYARD,
+        controllerOverride = EffectTarget.Controller
+    ),
+    AddCountersEffect(
+        counterType = Counters.FINALITY,
+        count = 1,
+        target = EffectTarget.TriggeringEntity
+    )
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -9301,6 +9301,142 @@
     }
 }
 
+// Meathook Massacre II
+{
+    "name": "Meathook Massacre II",
+    "manaCost": "{X}{X}{B}{B}{B}{B}",
+    "typeLine": "Legendary Enchantment",
+    "oracleText": "When Meathook Massacre II enters, each player sacrifices X creatures of their choice.\nWhenever a creature you control dies, you may pay 3 life. If you do, return that card under your control with a finality counter on it.\nWhenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that card under your control with a finality counter on it.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    },
+                    "dynamicCount": "CastX"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayLife",
+                            "amount": 3
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": "TriggeringEntity",
+                                "destination": "Battlefield",
+                                "controllerOverride": "Controller",
+                                "fromZone": "Graveyard"
+                            },
+                            {
+                                "type": "AddCounters",
+                                "counterType": "finality",
+                                "count": 1,
+                                "target": "TriggeringEntity"
+                            }
+                        ]
+                    },
+                    "descriptionOverride": "You may pay 3 life. If you do, return that card under your control with a finality counter on it."
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "PayOrSuffer",
+                    "cost": {
+                        "type": "PayAtom",
+                        "atom": {
+                            "type": "AtomPayLife",
+                            "amount": 3
+                        }
+                    },
+                    "suffer": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": "TriggeringEntity",
+                                "destination": "Battlefield",
+                                "controllerOverride": "Controller",
+                                "fromZone": "Graveyard"
+                            },
+                            {
+                                "type": "AddCounters",
+                                "counterType": "finality",
+                                "count": 1,
+                                "target": "TriggeringEntity"
+                            }
+                        ]
+                    },
+                    "player": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "108",
+        "rarity": "MYTHIC",
+        "artist": "Tiffany Turrill",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3db59d06-a226-42b2-8f01-6b63a6eea83f.jpg?1726286251",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "If a creature that dies leaves the graveyard before Meathook Massacre II's second or third ability (as appropriate) resolves, that creature won't return to the battlefield regardless of whether or not life was paid."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "When a token creature dies, Meathook Massacre II's second or third ability (as appropriate) will trigger. The appropriate player has the option to pay 3 life, but regardless of their choice, the token won't return to the battlefield."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "Finality counters work on any permanent, not only creatures. If a permanent with a finality counter on it would be put into a graveyard from the battlefield, exile it instead."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "Multiple finality counters on a single permanent are redundant."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Miasma Demon
 {
     "name": "Miasma Demon",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/SacrificeAndPayContinuations.kt
@@ -86,7 +86,17 @@ data class PayOrSufferContinuation(
      * and the effect silently fizzles.
      */
     val triggeringEntityId: EntityId? = null,
-    val triggeringPlayerId: EntityId? = null
+    val triggeringPlayerId: EntityId? = null,
+    /**
+     * The triggered/activated ability's controller — distinct from [playerId], which is the player
+     * who must *pay* the cost (the two diverge when the cost is routed to a non-controller via
+     * `PayOrSufferEffect.player`, e.g. Meathook Massacre II's "a creature an opponent controls dies,
+     * they may pay 3 life"). The suffer effect is part of that ability, so it resolves under the
+     * ability's controller: `EffectTarget.Controller` inside the consequence means the ability's
+     * controller (you steal the card), not the player who declined to pay. Falls back to [playerId]
+     * for the common case where the payer *is* the controller.
+     */
+    val abilityControllerId: EntityId? = null
 ) : ContinuationFrame
 
 /**
@@ -125,7 +135,9 @@ data class PayOrSufferChoiceContinuation(
     /** Mirror of [PayOrSufferContinuation.triggeringEntityId] for the multi-option path. */
     val triggeringEntityId: EntityId? = null,
     /** Mirror of [PayOrSufferContinuation.triggeringPlayerId] for the multi-option path. */
-    val triggeringPlayerId: EntityId? = null
+    val triggeringPlayerId: EntityId? = null,
+    /** Mirror of [PayOrSufferContinuation.abilityControllerId] for the multi-option path. */
+    val abilityControllerId: EntityId? = null
 ) : ContinuationFrame
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -152,6 +152,14 @@ data class TriggerContext(
             return when (event) {
                 is ZoneChangeEvent -> TriggerContext(
                     triggeringEntityId = event.entityId,
+                    // The player associated with a zone change is the object's controller as it
+                    // changed zones — its last-known controller when leaving the battlefield (CR
+                    // 603.10/608.2h last-known information; differs from the owner for stolen
+                    // permanents), falling back to the owner for non-battlefield origins. This is
+                    // what "that creature's controller" / "they" mean in a dies/leaves trigger, so
+                    // Player.TriggeringPlayer resolves to the dying creature's controller rather than
+                    // (previously) falling through to the dead creature's entity id.
+                    triggeringPlayerId = event.lastKnownController ?: event.ownerId,
                     counterCount = if (event.lastKnownCounterCount > 0) event.lastKnownCounterCount else null,
                     totalCounterCount = if (event.lastKnownTotalCounterCount > 0) event.lastKnownTotalCounterCount else null,
                     minusOneMinusOneCounterCount = if (event.lastKnownMinusOneMinusOneCounterCount > 0)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/SacrificeAndPayContinuationResumer.kt
@@ -194,10 +194,11 @@ class SacrificeAndPayContinuationResumer(
 
         // Last option is always the suffer effect
         if (chosenIndex >= continuation.options.size) {
-            // Player chose the suffer option
+            // Player chose the suffer option — runs under the ability's controller (see
+            // executePayOrSufferConsequence), not the player who declined the costs.
             val context = EffectContext(
                 sourceId = continuation.sourceId,
-                controllerId = continuation.playerId,
+                controllerId = continuation.abilityControllerId ?: continuation.playerId,
                 targets = continuation.targets,
                 pipeline = PipelineState(namedTargets = continuation.namedTargets),
                 triggeringEntityId = continuation.triggeringEntityId,
@@ -551,15 +552,23 @@ class SacrificeAndPayContinuationResumer(
         checkForMore: CheckForMore
     ): ExecutionResult {
         val sourceId = continuation.sourceId
-        val playerId = continuation.playerId
         val sufferEffect = continuation.sufferEffect
 
         // Create context for executing the suffer effect, preserving targets AND the original
         // trigger context. Without the latter, effects like LoseLifeEffect(1, PlayerRef(TriggeringPlayer))
         // (Nafs Asp's bite when the damaged player declines to pay {1}) silently fizzle.
+        //
+        // The suffer effect belongs to the triggered ability, so it resolves under the ability's
+        // controller — not [playerId], which is the player who declined to pay. The two diverge
+        // only when the cost was routed to a non-controller (Meathook Massacre II: an opponent
+        // declines to pay 3 life, and *you* — the ability's controller — return the dead creature
+        // under your control). `EffectTarget.Controller` in the consequence must mean the ability's
+        // controller for that theft to work. The auto-suffer path already runs under the original
+        // (ability-controller) context, so this keeps both paths consistent. Falls back to the payer
+        // for the common case where the payer is the controller.
         val context = EffectContext(
             sourceId = sourceId,
-            controllerId = playerId,
+            controllerId = continuation.abilityControllerId ?: continuation.playerId,
             targets = continuation.targets,
             pipeline = PipelineState(namedTargets = continuation.namedTargets),
             triggeringEntityId = continuation.triggeringEntityId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PayOrSufferExecutor.kt
@@ -140,7 +140,8 @@ class PayOrSufferExecutor(
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
             triggeringEntityId = context.triggeringEntityId,
-            triggeringPlayerId = context.triggeringPlayerId
+            triggeringPlayerId = context.triggeringPlayerId,
+            abilityControllerId = context.controllerId
         )
 
         val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
@@ -202,7 +203,8 @@ class PayOrSufferExecutor(
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
             triggeringEntityId = context.triggeringEntityId,
-            triggeringPlayerId = context.triggeringPlayerId
+            triggeringPlayerId = context.triggeringPlayerId,
+            abilityControllerId = context.controllerId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)
@@ -273,7 +275,8 @@ class PayOrSufferExecutor(
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
             triggeringEntityId = context.triggeringEntityId,
-            triggeringPlayerId = context.triggeringPlayerId
+            triggeringPlayerId = context.triggeringPlayerId,
+            abilityControllerId = context.controllerId
         )
 
         val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
@@ -341,7 +344,8 @@ class PayOrSufferExecutor(
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
             triggeringEntityId = context.triggeringEntityId,
-            triggeringPlayerId = context.triggeringPlayerId
+            triggeringPlayerId = context.triggeringPlayerId,
+            abilityControllerId = context.controllerId
         )
 
         val stateWithContinuation = decisionResult.state.pushContinuation(continuation)
@@ -404,7 +408,8 @@ class PayOrSufferExecutor(
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
             triggeringEntityId = context.triggeringEntityId,
-            triggeringPlayerId = context.triggeringPlayerId
+            triggeringPlayerId = context.triggeringPlayerId,
+            abilityControllerId = context.controllerId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)
@@ -471,6 +476,7 @@ class PayOrSufferExecutor(
             namedTargets = context.pipeline.namedTargets,
             triggeringEntityId = context.triggeringEntityId,
             triggeringPlayerId = context.triggeringPlayerId,
+            abilityControllerId = context.controllerId,
             zone = cost.zone
         )
 
@@ -533,6 +539,7 @@ class PayOrSufferExecutor(
             namedTargets = context.pipeline.namedTargets,
             triggeringEntityId = context.triggeringEntityId,
             triggeringPlayerId = context.triggeringPlayerId,
+            abilityControllerId = context.controllerId,
             manaCost = cost.cost
         )
 
@@ -608,7 +615,8 @@ class PayOrSufferExecutor(
             targets = context.targets,
             namedTargets = context.pipeline.namedTargets,
             triggeringEntityId = context.triggeringEntityId,
-            triggeringPlayerId = context.triggeringPlayerId
+            triggeringPlayerId = context.triggeringPlayerId,
+            abilityControllerId = context.controllerId
         )
 
         val stateWithDecision = state.withPendingDecision(decision)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MeathookMassacreIIScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MeathookMassacreIIScenarioTest.kt
@@ -1,0 +1,257 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Meathook Massacre II (DSK) — the death-trigger pay/suffer-or-steal flow (DSK engine gap #16).
+ *
+ * Oracle:
+ *  1. When Meathook Massacre II enters, each player sacrifices X creatures of their choice.
+ *  2. Whenever a creature you control dies, you may pay 3 life. If you do, return that card under
+ *     your control with a finality counter on it.
+ *  3. Whenever a creature an opponent controls dies, they may pay 3 life. If they don't, return that
+ *     card under your control with a finality counter on it.
+ *
+ * The headline coverage is the third ability: the pay/suffer decision and the life payment are
+ * routed to the *dying creature's controller* (the opponent, via `Player.TriggeringPlayer` now that
+ * a dies trigger populates `triggeringPlayerId` from `ZoneChangeEvent.lastKnownController`), while
+ * the consequence — returning the card under *your* control — runs under the ability's controller
+ * (not the payer). Deaths are driven through the real resolution pipeline (Doom Blade destroying a
+ * creature) so the dies-trigger detection actually fires.
+ */
+class MeathookMassacreIIScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(
+            TestCards.all + com.wingedsheep.mtg.sets.tokens.PredefinedTokens.allTokens
+        )
+        return d
+    }
+
+    fun GameTestDriver.creatureCount(playerId: EntityId, name: String): Int =
+        state.getBattlefield().count { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name &&
+                state.projectedState.getController(id) == playerId
+        }
+
+    fun GameTestDriver.finalityCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.FINALITY) ?: 0
+
+    /** Pass priority until a pending decision appears (the resolving trigger pauses there). */
+    fun GameTestDriver.passUntilDecision(maxPasses: Int = 12) {
+        repeat(maxPasses) { if (pendingDecision == null) bothPass() }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Ability 1 — ETB: each player sacrifices X creatures of their choice.
+    // ---------------------------------------------------------------------------------------------
+
+    test("ETB: each player sacrifices X creatures of their choice (X = cast value)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Each player controls two TOKEN creatures; X = 1 means each chooses ONE to sacrifice.
+        // Tokens keep the test focused on the sacrifice clause: when they die to the sacrifice,
+        // Meathook's own "a creature dies" abilities trigger, but a token has no card to return,
+        // so the reanimation is a no-op and the surviving counts stay clean (per the printed ruling).
+        val tokens = listOf(active, active, opp, opp).map { d.putCreatureOnBattlefield(it, "Grizzly Bears") }
+        tokens.forEach { id ->
+            d.replaceState(d.state.updateEntity(id) {
+                it.with(com.wingedsheep.engine.state.components.identity.TokenComponent)
+            })
+        }
+
+        val meathook = d.putCardInHand(active, "Meathook Massacre II")
+        // {X}{X}{B}{B}{B}{B} with X = 1 → six mana, four of them black; black covers the generic too.
+        d.giveMana(active, Color.BLACK, 6)
+        d.castXSpell(active, meathook, xValue = 1).isSuccess shouldBe true
+
+        // Resolve the spell + ETB trigger, answering each player's "sacrifice 1" selection and
+        // declining the follow-on "may pay 3 life" prompts from the death of each sacrificed token.
+        repeat(30) {
+            when (val dec = d.pendingDecision) {
+                is SelectCardsDecision -> d.submitCardSelection(dec.playerId, dec.options.take(dec.minSelections))
+                is YesNoDecision -> d.submitYesNo(dec.playerId, false)
+                null -> d.bothPass()
+                else -> error("Unexpected decision: $dec")
+            }
+        }
+
+        withClue("Each player sacrificed exactly one of their two creatures") {
+            d.creatureCount(active, "Grizzly Bears") shouldBe 1
+            d.creatureCount(opp, "Grizzly Bears") shouldBe 1
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Ability 2 — your creature dies: you MAY pay 3 life; if you DO, reanimate under your control.
+    // ---------------------------------------------------------------------------------------------
+
+    test("your creature dies: pay 3 life → return it under your control with a finality counter") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(active, "Meathook Massacre II")
+        val bear = d.putCreatureOnBattlefield(active, "Grizzly Bears")
+
+        val lifeBefore = d.getLifeTotal(active)
+
+        // Kill your own creature with Doom Blade (a real death drives the dies trigger).
+        val doomBlade = d.putCardInHand(active, "Doom Blade")
+        d.giveMana(active, Color.BLACK, 2)
+        d.castSpell(active, doomBlade, listOf(bear)).isSuccess shouldBe true
+        d.passUntilDecision()
+
+        withClue("The 'creature you control dies' trigger asks YOU whether to pay") {
+            (d.pendingDecision as? YesNoDecision)?.playerId shouldBe active
+        }
+
+        d.submitYesNo(active, true)
+        d.passUntilDecision()
+
+        withClue("You paid 3 life") { d.getLifeTotal(active) shouldBe lifeBefore - 3 }
+        withClue("The card is back under your control") { d.getController(bear) shouldBe active }
+        withClue("It returned with a finality counter") { d.finalityCounters(bear) shouldBe 1 }
+    }
+
+    test("your creature dies: decline to pay → the card is not returned") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(active, "Meathook Massacre II")
+        val bear = d.putCreatureOnBattlefield(active, "Grizzly Bears")
+
+        val lifeBefore = d.getLifeTotal(active)
+
+        val doomBlade = d.putCardInHand(active, "Doom Blade")
+        d.giveMana(active, Color.BLACK, 2)
+        d.castSpell(active, doomBlade, listOf(bear)).isSuccess shouldBe true
+        d.passUntilDecision()
+
+        d.submitYesNo(active, false)
+        d.passUntilDecision()
+
+        withClue("Declining costs no life") { d.getLifeTotal(active) shouldBe lifeBefore }
+        withClue("The creature stays dead — not on the battlefield") {
+            d.getController(bear) shouldBe null
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Ability 3 — an opponent's creature dies: THEY may pay 3 life; if they DON'T, YOU steal it.
+    // This is the engine gap: decision + life routed to the opponent, theft under your control.
+    // ---------------------------------------------------------------------------------------------
+
+    test("opponent's creature dies + they decline: YOU steal the card under your control with a finality counter") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(active, "Meathook Massacre II")
+        val bear = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        val yourLifeBefore = d.getLifeTotal(active)
+        val oppLifeBefore = d.getLifeTotal(opp)
+
+        val doomBlade = d.putCardInHand(active, "Doom Blade")
+        d.giveMana(active, Color.BLACK, 2)
+        d.castSpell(active, doomBlade, listOf(bear)).isSuccess shouldBe true
+        d.passUntilDecision()
+
+        withClue("The decision is routed to the OPPONENT (the dying creature's controller), not you") {
+            (d.pendingDecision as? YesNoDecision)?.playerId shouldBe opp
+        }
+
+        // They decline to pay → you steal the card.
+        d.submitYesNo(opp, false)
+        d.passUntilDecision()
+
+        withClue("Neither player loses life when the opponent declines") {
+            d.getLifeTotal(opp) shouldBe oppLifeBefore
+            d.getLifeTotal(active) shouldBe yourLifeBefore
+        }
+        withClue("The opponent's card returns under YOUR control (theft), even though they own it") {
+            d.getController(bear) shouldBe active
+        }
+        withClue("It returns with a finality counter") { d.finalityCounters(bear) shouldBe 1 }
+    }
+
+    test("opponent's creature dies + they pay 3 life: the OPPONENT loses the life and keeps their card") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(active, "Meathook Massacre II")
+        val bear = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        val yourLifeBefore = d.getLifeTotal(active)
+        val oppLifeBefore = d.getLifeTotal(opp)
+
+        val doomBlade = d.putCardInHand(active, "Doom Blade")
+        d.giveMana(active, Color.BLACK, 2)
+        d.castSpell(active, doomBlade, listOf(bear)).isSuccess shouldBe true
+        d.passUntilDecision()
+
+        // They pay 3 life to keep the card out of your hands.
+        d.submitYesNo(opp, true)
+        d.passUntilDecision()
+
+        withClue("The 3 life is charged to the OPPONENT, not to you (the ability's controller)") {
+            d.getLifeTotal(opp) shouldBe oppLifeBefore - 3
+            d.getLifeTotal(active) shouldBe yourLifeBefore
+        }
+        withClue("They paid, so you do NOT get the card") {
+            d.getController(bear) shouldBe null
+        }
+    }
+
+    test("opponent can't afford 3 life: you steal the card automatically, charging them nothing") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(active, "Meathook Massacre II")
+        val bear = d.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        // Opponent at 2 life cannot pay 3 — the suffer (theft) resolves automatically.
+        d.setLifeTotal(opp, 2)
+
+        val doomBlade = d.putCardInHand(active, "Doom Blade")
+        d.giveMana(active, Color.BLACK, 2)
+        d.castSpell(active, doomBlade, listOf(bear)).isSuccess shouldBe true
+
+        // No pay-or-suffer decision is offered when the opponent can't afford it.
+        repeat(8) { if (d.pendingDecision == null) d.bothPass() }
+
+        withClue("They couldn't pay, so they keep their 2 life") { d.getLifeTotal(opp) shouldBe 2 }
+        withClue("You steal the card under your control") { d.getController(bear) shouldBe active }
+        withClue("It returns with a finality counter") { d.finalityCounters(bear) shouldBe 1 }
+    }
+})


### PR DESCRIPTION
## Summary

Closes **DSK engine gap #16** (`backlog/dsk-engine-gaps.md`) and implements **Meathook Massacre II** (DSK 108, `{X}{X}{B}{B}{B}{B}` Legendary Enchantment).

The blocker was the third ability — *"Whenever a creature an opponent controls dies, **they** may pay 3 life. If they don't, return that card under **your** control with a finality counter on it."* This needs the pay/suffer **decision and the life payment** routed to the dying creature's controller (the opponent), and the consequence (theft) to resolve under **your** control. Two root-cause engine fixes make this work — **no new SDK type**; the card composes existing primitives.

## Engine fixes

1. **`TriggerContext.fromEvent(ZoneChangeEvent)` now populates `triggeringPlayerId`** from `lastKnownController ?: ownerId` (CR 603.10 / 608.2h last-known information). `Player.TriggeringPlayer` now resolves to the **dying/leaving permanent's last-known controller** on any death/leaves trigger — previously it fell through to the dead creature's *entity id* (a non-player), silently breaking "that creature's controller" / "they". This is what lets `PayOrSufferEffect(player = TriggeringPlayer)` charge the opponent.

2. **The `PayOrSuffer` continuation runs the `suffer` consequence under the ability's controller** (new `abilityControllerId`), not the payer. So `EffectTarget.Controller` inside the consequence means *you* — the theft. This makes the resumed (declined) path consistent with the already-correct synchronous auto-suffer path. The only other card routing `player` to a non-controller is Nafs Asp, whose suffer targets via `TriggeringPlayer`, so it is unaffected.

## The card (pure composition)

- **ETB** — `Effects.Sacrifice(Creature, count = DynamicAmount.CastX, target = Player.Each)` (each player sacrifices X, APNAP CR 101.4).
- **Your creature dies** — opt-in `OptionalCostEffect(PayLife(3), reanimate)`.
- **Opponent's creature dies** — `PayOrSufferEffect(player = TriggeringPlayer, PayLife(3), suffer = steal)`.
- **Reanimate** = `Move(TriggeringEntity → battlefield, controllerOverride = Controller)` + `AddCounters(finality)`. No-op for tokens / cards that left the graveyard, per the printed rulings.

## Tests & verification

- `MeathookMassacreIIScenarioTest` — 6 scenario tests covering every clause: ETB sacrifice; you-side pay→reanimate and decline; **opponent-side decline→you steal** (decision + finality), **opponent pays→life charged to them, no theft**, and **opponent can't afford→auto-steal**.
- Full `:rules-engine:test` suite green (fix #1 touches all death/zone-change triggers — no regressions).
- DSK card snapshot golden re-blessed; `CardLintTest` green; `:game-server` compiles.
- Docs updated: `card-sdk-language-reference.md` (`Player.TriggeringPlayer` on death triggers + `PayOrSuffer` non-controller payer routing); gap #16 marked done.

mtgish generator (Step 8b): N/A — no new IR-tagged SDK effect; the card is composition of primitives the emitter already knows, and the pay-or-suffer-with-theft shape is X-carrying/card-specific (emitter would decline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)