### PR TITLE
Add OnePerPower selection restriction + Rip, Spawn Hunter (DSK)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1800,8 +1800,9 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   creature" leg of the Terror template ("destroy target nonartifact, nonblack creature") — pair with
   `IsCreature` + `.notColor(...)`. FQL keys: `nonland` / `noncreature` / `nonartifact`.
 - **Combined-type filters** — `GameObjectFilter.InstantOrSorcery` / `CreatureOrPlaneswalker` /
-  `CreatureOrEnchantment` / `ArtifactOrEnchantment` / `CreatureOrArtifact` / `ArtifactOrLand` /
-  `ArtifactCreatureOrEnchantment` each wrap a `CardPredicate.Or` of the named top-level types.
+  `CreatureOrEnchantment` / `ArtifactOrEnchantment` / `CreatureOrArtifact` / `CreatureOrVehicle` /
+  `ArtifactOrLand` / `ArtifactCreatureOrEnchantment` each wrap a `CardPredicate.Or` of the named
+  types (`CreatureOrVehicle` matches a creature or any object with the Vehicle subtype).
   `ArtifactCreatureOrEnchantment` (the three-type O-Ring restriction) has matching target constants
   `TargetFilter.ArtifactCreatureOrEnchantment` and
   `TargetFilter.ArtifactCreatureOrEnchantmentOpponentControls` — the latter for "exile target
@@ -5390,9 +5391,12 @@ Counter effects live in §4 (`AddCounters`, `RemoveCounters`, `Proliferate`, `Mo
   split are unaffected).
 - `SelectFromCollectionEffect(from, into, selectCount?, allowZero?, alwaysPrompt?, restrictions?)` — let a player pick
   from a collection. `restrictions` (`List<SelectionRestriction>`) cap and trim the picks server-side: `OnePerCardType`,
-  `OnePerColor(matchControllerPermanentColors?)`, `OnePerCardName`, `TotalManaValueAtMost(max)`,
+  `OnePerColor(matchControllerPermanentColors?)`, `OnePerCardName`, `OnePerPower`, `TotalManaValueAtMost(max)`,
   `OnePerBasicLandType`, `ReducedMinimumIfMatches(reducedMinimum, filter, requiredMatches?)`, and
-  `MaxAffordablePayment(manaPerSelected, payer?)`. `OnePerBasicLandType` keeps at most one
+  `MaxAffordablePayment(manaPerSelected, payer?)`. `OnePerPower` keeps at most one card of each *printed* power
+  (a card with no fixed power — no printed P/T, or a characteristic-defining `*` — can't be kept and bottoms out,
+  like a typeless land under `OnePerBasicLandType`); pair it with the `CreatureOrVehicle` filter for "any number of
+  creature and/or Vehicle cards with different powers" (Rip, Spawn Hunter). `OnePerBasicLandType` keeps at most one
   land of each basic land type (a kept land claims
   *every* basic type it has) and — unlike `OnePerColor`, where a colourless card is unconstrained — a land with no
   basic land type can't be kept at all (Global Ruin: "chooses a land of each basic land type, then sacrifices the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -427,6 +427,29 @@ sealed interface SelectionRestriction {
     }
 
     /**
+     * At most one card of each power may be selected. A card's power is its printed
+     * (base) power read off the card definition. A card with no *fixed* power — no
+     * printed P/T at all, or a characteristic-defining `*` power that can only be
+     * computed on the battlefield — can't be kept under this restriction and falls
+     * into the remainder, mirroring [OnePerBasicLandType]'s handling of a typeless
+     * land. In practice the paired [GameObjectFilter] already restricts the eligible
+     * set to objects that have a power (creatures and Vehicles), so this only bites
+     * the rare `*`-power member of that set.
+     *
+     * Used for "creature and/or Vehicle cards with different powers from among them"
+     * wording (Rip, Spawn Hunter).
+     *
+     * The executor enforces this server-side: if the player's response names multiple
+     * cards sharing a power, only the first such card (in response order) is kept; the
+     * rest fall through into the remainder collection.
+     */
+    @SerialName("OnePerPower")
+    @Serializable
+    data object OnePerPower : SelectionRestriction {
+        override val description: String = "at most one card of each power"
+    }
+
+    /**
      * The sum of selected cards' mana values must not exceed [max]. {X} contributes 0
      * (per CR 202.3e for cards not on the stack). Used for "with total mana value N or
      * less" wording like Scout for Survivors.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -146,6 +146,13 @@ data class GameObjectFilter(
                 CardPredicate.Or(listOf(CardPredicate.IsCreature, CardPredicate.IsArtifact))
             )
         )
+        // A Vehicle is always an artifact carrying the Vehicle subtype, so matching the subtype
+        // alone identifies it. Used for "creature and/or Vehicle" wording (Rip, Spawn Hunter).
+        val CreatureOrVehicle = GameObjectFilter(
+            cardPredicates = listOf(
+                CardPredicate.Or(listOf(CardPredicate.IsCreature, CardPredicate.HasSubtype(Subtype.VEHICLE)))
+            )
+        )
         val ArtifactOrLand = GameObjectFilter(
             cardPredicates = listOf(
                 CardPredicate.Or(listOf(CardPredicate.IsArtifact, CardPredicate.IsLand))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RipSpawnHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RipSpawnHunter.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.SelectionRestriction
+
+/**
+ * Rip, Spawn Hunter — Duskmourn: House of Horror #228
+ * {2}{G}{W} · Legendary Creature — Human Survivor · 4/4
+ *
+ * Survival — At the beginning of your second main phase, if Rip is tapped, reveal the top X
+ * cards of your library, where X is its power. Put any number of creature and/or Vehicle cards
+ * with different powers from among them into your hand. Put the rest on the bottom of your
+ * library in a random order.
+ *
+ * "Survival" is the DSK ability word — mechanically an intervening-"if" postcombat-main trigger
+ * gated on the source being tapped (`Triggers.YourPostcombatMain` + `Conditions.SourceIsTapped`),
+ * exactly like the other DSK Survival creatures.
+ *
+ * The payoff is a pure Gather → Select → Move pipeline over existing atoms:
+ *  - reveal the top X cards, where X = Rip's power (`CardSource.TopOfLibrary(sourcePower())`);
+ *  - the controller keeps any number of creature/Vehicle cards (`GameObjectFilter.CreatureOrVehicle`)
+ *    with *different powers* — modeled by the `SelectionRestriction.OnePerPower` restriction on a
+ *    `chooseAnyNumberSplit`, which caps the selection at one card per distinct printed power and
+ *    rejects any duplicate-power picks server-side;
+ *  - the kept cards go to hand; the remainder (unpicked cards plus every non-creature/non-Vehicle
+ *    card revealed) goes to the bottom of the library in a random order (`CardOrder.Random`).
+ *
+ * No new pipeline step is needed: `CardOrder.Random` to the library bottom and a dynamic
+ * `TopOfLibrary` count already exist; only `OnePerPower` is new SDK vocabulary.
+ */
+val RipSpawnHunter = card("Rip, Spawn Hunter") {
+    manaCost = "{2}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Survivor"
+    power = 4
+    toughness = 4
+    oracleText = "Survival — At the beginning of your second main phase, if Rip is tapped, " +
+        "reveal the top X cards of your library, where X is its power. Put any number of " +
+        "creature and/or Vehicle cards with different powers from among them into your hand. " +
+        "Put the rest on the bottom of your library in a random order."
+
+    triggeredAbility {
+        trigger = Triggers.YourPostcombatMain
+        triggerCondition = Conditions.SourceIsTapped
+        effect = Effects.Pipeline {
+            val revealed = gather(
+                source = CardSource.TopOfLibrary(DynamicAmounts.sourcePower()),
+                revealed = true,
+            )
+            val split = chooseAnyNumberSplit(
+                from = revealed,
+                filter = GameObjectFilter.CreatureOrVehicle,
+                restrictions = listOf(SelectionRestriction.OnePerPower),
+                prompt = "Put any number of creature and/or Vehicle cards with different powers into your hand",
+                selectedLabel = "Into your hand",
+                remainderLabel = "Bottom of library (random order)",
+            )
+            toHand(split.selected)
+            toLibraryBottom(split.remainder, order = CardOrder.Random)
+        }
+        description = "Survival — At the beginning of your second main phase, if Rip is tapped, " +
+            "reveal the top X cards of your library, where X is its power. Put any number of " +
+            "creature and/or Vehicle cards with different powers from among them into your hand. " +
+            "Put the rest on the bottom of your library in a random order."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Justine Cruz"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f12e3b3-a260-4913-b13a-7fbb753dd702.jpg"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -11938,6 +11938,96 @@
     ]
 }
 
+// Rip, Spawn Hunter
+{
+    "name": "Rip, Spawn Hunter",
+    "manaCost": "{2}{G}{W}",
+    "typeLine": "Legendary Creature — Human Survivor",
+    "oracleText": "Survival — At the beginning of your second main phase, if Rip is tapped, reveal the top X cards of your library, where X is its power. Put any number of creature and/or Vehicle cards with different powers from among them into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "POSTCOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "EntityProperty",
+                                    "entity": "Source",
+                                    "numericProperty": "Power"
+                                }
+                            },
+                            "storeAs": "gathered0",
+                            "revealed": true
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": "ChooseAnyNumber",
+                            "filter": "creature|Vehicle",
+                            "storeSelected": "selected1",
+                            "storeRemainder": "remainder1",
+                            "prompt": "Put any number of creature and/or Vehicle cards with different powers into your hand",
+                            "selectedLabel": "Into your hand",
+                            "remainderLabel": "Bottom of library (random order)",
+                            "restrictions": [
+                                "OnePerPower"
+                            ]
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "remainder1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "tapped"
+                },
+                "descriptionOverride": "Survival — At the beginning of your second main phase, if Rip is tapped, reveal the top X cards of your library, where X is its power. Put any number of creature and/or Vehicle cards with different powers from among them into your hand. Put the rest on the bottom of your library in a random order."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Justine Cruz",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f12e3b3-a260-4913-b13a-7fbb753dd702.jpg"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Ripchain Razorkin
 {
     "name": "Ripchain Razorkin",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/PendingDecision.kt
@@ -174,6 +174,12 @@ data class SelectCardsDecision(
      */
     val onePerBasicLandType: Boolean = false,
     /**
+     * When true, at most one card of each (printed) power may be selected. A card with no
+     * fixed power can't be selected at all (Rip, Spawn Hunter). The server enforces this; the
+     * UI should disable cards sharing an already-claimed power.
+     */
+    val onePerPower: Boolean = false,
+    /**
      * Maximum sum of mana values across selected cards (Scout for Survivors). null
      * means no cap. {X} contributes 0 (CR 202.3e for cards not on the stack). The
      * UI is expected to disable cards whose mana value would push the running total
@@ -472,7 +478,13 @@ data class SearchCardInfo(
     val typeLine: String,
     val imageUri: String? = null,
     /** Colour identity letters (e.g. ["W","U"]); empty for colourless cards */
-    val colors: List<String> = emptyList()
+    val colors: List<String> = emptyList(),
+    /**
+     * Printed (base) power, when fixed. Null for cards with no printed P/T or a
+     * characteristic-defining `*` power. Lets a hidden-zone selection UI group cards
+     * by power for [SelectCardsDecision.onePerPower].
+     */
+    val power: Int? = null
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -427,7 +427,13 @@ class LibraryAndZoneContinuationResumer(
             val claimedColors = mutableSetOf<com.wingedsheep.sdk.core.Color>()
             val claimedNames = mutableSetOf<String>()
             val claimedLandTypes = mutableSetOf<com.wingedsheep.sdk.core.Subtype>()
+            val claimedPowers = mutableSetOf<Int>()
             var runningManaValue = 0
+            // A card's fixed (printed) power, or null for cards with no fixed power.
+            fun fixedPowerOf(cardId: EntityId): Int? =
+                state.getEntity(cardId)
+                    ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+                    ?.baseStats?.basePower
             // Basic land subtypes a card has (Plains/Island/Swamp/Mountain/Forest), for OnePerBasicLandType.
             fun basicLandTypesOf(cardId: EntityId): Set<com.wingedsheep.sdk.core.Subtype> =
                 state.getEntity(cardId)
@@ -468,6 +474,11 @@ class LibraryAndZoneContinuationResumer(
                             // A typeless land can't be kept; a typed land needs all its types free.
                             types.isNotEmpty() && types.none { it in claimedLandTypes }
                         }
+                        is SelectionRestriction.OnePerPower -> {
+                            // A card with no fixed power can't be kept; otherwise its power must be free.
+                            val power = fixedPowerOf(cardId)
+                            power != null && power !in claimedPowers
+                        }
                         is SelectionRestriction.ReducedMinimumIfMatches -> true
                         is SelectionRestriction.MaxAffordablePayment ->
                             // A pure count cap, already folded into the decision's maxSelections
@@ -505,6 +516,9 @@ class LibraryAndZoneContinuationResumer(
                             }
                             is SelectionRestriction.OnePerBasicLandType -> {
                                 claimedLandTypes += basicLandTypesOf(cardId)
+                            }
+                            is SelectionRestriction.OnePerPower -> {
+                                fixedPowerOf(cardId)?.let { claimedPowers += it }
                             }
                             is SelectionRestriction.ReducedMinimumIfMatches -> {
                                 // Response validation enforces the conditional minimum.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -305,6 +305,13 @@ class SelectFromCollectionExecutor(
                         state.getEntity(cardId)?.get<CardComponent>()?.name
                     }.toSet().size.coerceAtLeast(0)
                 }
+                is SelectionRestriction.OnePerPower -> {
+                    // One slot per distinct fixed power present. Cards with no fixed power
+                    // (mapNotNull drops them) can't be kept and so add no slots.
+                    eligibleCards.mapNotNull { cardId ->
+                        state.getEntity(cardId)?.get<CardComponent>()?.baseStats?.basePower
+                    }.toSet().size
+                }
                 is SelectionRestriction.TotalManaValueAtMost -> {
                     // Greedy upper bound: how many cards fit under the cap when picking
                     // the cheapest first. Any selection of more cards than this is
@@ -383,7 +390,8 @@ class SelectFromCollectionExecutor(
                 manaCost = cardComponent?.manaCost?.toString() ?: "",
                 typeLine = cardComponent?.typeLine?.toString() ?: "",
                 imageUri = null,
-                colors = cardComponent?.colors?.map { it.name }?.toList() ?: emptyList()
+                colors = cardComponent?.colors?.map { it.name }?.toList() ?: emptyList(),
+                power = cardComponent?.baseStats?.basePower
             )
         }
 
@@ -416,6 +424,7 @@ class SelectFromCollectionExecutor(
             availableColors = controllerPermanentColors?.map { it.name },
             onePerCardName = effect.restrictions.any { it is SelectionRestriction.OnePerCardName },
             onePerBasicLandType = effect.restrictions.any { it is SelectionRestriction.OnePerBasicLandType },
+            onePerPower = effect.restrictions.any { it is SelectionRestriction.OnePerPower },
             maxTotalManaValue = effect.restrictions
                 .filterIsInstance<SelectionRestriction.TotalManaValueAtMost>()
                 .also {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RipSpawnHunterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RipSpawnHunterScenarioTest.kt
@@ -1,0 +1,261 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rip, Spawn Hunter (DSK #228) — {2}{G}{W} 4/4 Legendary Creature — Human Survivor.
+ *
+ * "Survival — At the beginning of your second main phase, if Rip is tapped, reveal the top X
+ *  cards of your library, where X is its power. Put any number of creature and/or Vehicle cards
+ *  with different powers from among them into your hand. Put the rest on the bottom of your
+ *  library in a random order."
+ *
+ * Exercises the `SelectionRestriction.OnePerPower` capability end-to-end through the
+ * reveal → select → bottom pipeline:
+ *  - X equals the source's power (reveals exactly that many cards);
+ *  - the controller keeps any number of creature/Vehicle cards with *different* powers;
+ *  - a second card sharing an already-chosen power is rejected server-side and bottoms instead;
+ *  - non-creature/non-Vehicle revealed cards and unpicked cards go to the bottom of the library;
+ *  - the intervening-if (Rip tapped) gates the whole trigger.
+ */
+class RipSpawnHunterScenarioTest : ScenarioTestBase() {
+
+    private val p1 = EntityId.of("player-1")
+
+    private fun testCreature(name: String, power: Int): CardDefinition =
+        CardDefinition.creature(
+            name = name,
+            manaCost = ManaCost.parse("{2}"),
+            subtypes = setOf(Subtype("Beast")),
+            power = power,
+            toughness = power,
+        )
+
+    /** A Vehicle: a non-creature artifact carrying the Vehicle subtype, with printed power. */
+    private fun testVehicle(name: String, power: Int): CardDefinition =
+        CardDefinition(
+            name = name,
+            manaCost = ManaCost.parse("{3}"),
+            typeLine = TypeLine(cardTypes = setOf(CardType.ARTIFACT), subtypes = setOf(Subtype.VEHICLE)),
+            creatureStats = CreatureStats(power, power),
+        )
+
+    init {
+        // Inline test cards with deterministic printed powers, including a Vehicle.
+        cardRegistry.register(
+            listOf(
+                testCreature("Spawn Two A", 2),
+                testCreature("Spawn Two B", 2),
+                testCreature("Spawn Three", 3),
+                testCreature("Spawn Six", 6),
+                testCreature("Spawn Seven", 7),
+                testVehicle("Hunt Rig", 5),
+            )
+        )
+
+        fun libraryNames(game: TestGame): List<String> =
+            game.state.getZone(ZoneKey(p1, com.wingedsheep.sdk.core.Zone.LIBRARY))
+                .mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+
+        fun handNames(game: TestGame): List<String> =
+            game.state.getHand(p1)
+                .mapNotNull { game.state.getEntity(it)?.get<CardComponent>()?.name }
+
+        fun optionFor(game: TestGame, decision: SelectCardsDecision, name: String): EntityId =
+            decision.options.first { game.state.getEntity(it)?.get<CardComponent>()?.name == name }
+
+        fun resolveToSelection(game: TestGame): SelectCardsDecision {
+            game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+            var guard = 0
+            while (game.getPendingDecision() !is SelectCardsDecision && guard++ < 20) {
+                game.resolveStack()
+            }
+            return game.getPendingDecision() as? SelectCardsDecision
+                ?: error("expected a SelectCardsDecision; got ${game.getPendingDecision()}")
+        }
+
+        context("Survival — reveal top X (= power), keep distinct-power creatures/Vehicles") {
+
+            test("reveals exactly X cards where X is Rip's power") {
+                // Library top→bottom: 5 creatures/Vehicles; Rip's power is 4, so only the top 4
+                // are revealed and offered — the fifth (Spawn Seven) is never seen.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rip, Spawn Hunter", tapped = true, summoningSickness = false)
+                    .withCardInLibrary(1, "Spawn Two A")   // power 2
+                    .withCardInLibrary(1, "Spawn Three")   // power 3
+                    .withCardInLibrary(1, "Hunt Rig")      // Vehicle, power 5
+                    .withCardInLibrary(1, "Spawn Six")     // power 6
+                    .withCardInLibrary(1, "Spawn Seven")   // power 7 — below the top 4
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val decision = resolveToSelection(game)
+
+                withClue("X = Rip's power (4): exactly the top four cards are offered") {
+                    decision.options.size shouldBe 4
+                }
+
+                // All four have different powers (2, 3, 5, 6) — keep them all.
+                game.selectCards(
+                    listOf(
+                        optionFor(game, decision, "Spawn Two A"),
+                        optionFor(game, decision, "Spawn Three"),
+                        optionFor(game, decision, "Hunt Rig"),
+                        optionFor(game, decision, "Spawn Six"),
+                    )
+                )
+                game.resolveStack()
+
+                withClue("the four distinct-power cards went to hand") {
+                    handNames(game) shouldContainExactlyInAnyOrder
+                        listOf("Spawn Two A", "Spawn Three", "Hunt Rig", "Spawn Six")
+                }
+                withClue("the un-revealed fifth card stayed in the library") {
+                    libraryNames(game) shouldBe listOf("Spawn Seven")
+                }
+            }
+
+            test("a non-creature/non-Vehicle card in the reveal goes to the bottom") {
+                // Top 4: three creature/Vehicle cards + a Forest. Keep the three; the Forest bottoms.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rip, Spawn Hunter", tapped = true, summoningSickness = false)
+                    .withCardInLibrary(1, "Spawn Two A")
+                    .withCardInLibrary(1, "Spawn Three")
+                    .withCardInLibrary(1, "Hunt Rig")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val decision = resolveToSelection(game)
+
+                withClue("the land is not an eligible (selectable) option") {
+                    decision.options.size shouldBe 3
+                }
+
+                game.selectCards(
+                    listOf(
+                        optionFor(game, decision, "Spawn Two A"),
+                        optionFor(game, decision, "Spawn Three"),
+                        optionFor(game, decision, "Hunt Rig"),
+                    )
+                )
+                game.resolveStack()
+
+                withClue("creatures/Vehicle into hand") {
+                    handNames(game) shouldContainExactlyInAnyOrder
+                        listOf("Spawn Two A", "Spawn Three", "Hunt Rig")
+                }
+                withClue("the rest (the Forest) went to the bottom of the library") {
+                    libraryNames(game) shouldBe listOf("Forest")
+                }
+            }
+        }
+
+        context("Survival — different-powers restriction (OnePerPower)") {
+
+            test("a second card sharing an already-chosen power is rejected and bottoms instead") {
+                // Top 4: two power-2 creatures, a power-3 creature, a power-5 Vehicle.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rip, Spawn Hunter", tapped = true, summoningSickness = false)
+                    .withCardInLibrary(1, "Spawn Two A")
+                    .withCardInLibrary(1, "Spawn Two B")
+                    .withCardInLibrary(1, "Spawn Three")
+                    .withCardInLibrary(1, "Hunt Rig")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val decision = resolveToSelection(game)
+
+                // Try to keep both power-2 creatures plus the power-3 creature. The second power-2
+                // pick is rejected (different powers required); Hunt Rig was never selected.
+                game.selectCards(
+                    listOf(
+                        optionFor(game, decision, "Spawn Two A"),
+                        optionFor(game, decision, "Spawn Two B"),
+                        optionFor(game, decision, "Spawn Three"),
+                    )
+                )
+                game.resolveStack()
+
+                withClue("only the first power-2 card and the power-3 card reached hand") {
+                    handNames(game) shouldContainExactlyInAnyOrder listOf("Spawn Two A", "Spawn Three")
+                }
+                withClue("the duplicate-power card was rejected and is no longer in hand") {
+                    handNames(game) shouldNotContain "Spawn Two B"
+                }
+                withClue("the rejected duplicate and the un-picked Vehicle bottomed out") {
+                    libraryNames(game) shouldContainExactlyInAnyOrder listOf("Spawn Two B", "Hunt Rig")
+                }
+            }
+        }
+
+        context("Survival — gating and declining") {
+
+            test("selecting nothing bottoms every revealed card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rip, Spawn Hunter", tapped = true, summoningSickness = false)
+                    .withCardInLibrary(1, "Spawn Two A")
+                    .withCardInLibrary(1, "Spawn Three")
+                    .withCardInLibrary(1, "Hunt Rig")
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                resolveToSelection(game)
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("no card entered hand") {
+                    handNames(game).any { it in setOf("Spawn Two A", "Spawn Three", "Hunt Rig") } shouldBe false
+                }
+                withClue("every revealed card is back on the bottom of the library") {
+                    libraryNames(game) shouldContainExactlyInAnyOrder
+                        listOf("Spawn Two A", "Spawn Three", "Hunt Rig", "Forest")
+                }
+            }
+
+            test("an untapped Rip does not trigger Survival") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Rip, Spawn Hunter", tapped = false, summoningSickness = false)
+                    .withCardInLibrary(1, "Spawn Two A")
+                    .withCardInLibrary(1, "Spawn Three")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                repeat(5) { if (!game.hasPendingDecision()) game.resolveStack() }
+
+                withClue("intervening-if (Rip is tapped) is false — no decision, library intact") {
+                    game.hasPendingDecision() shouldBe false
+                    libraryNames(game) shouldBe listOf("Spawn Two A", "Spawn Three")
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/components/decisions/CardSelectionDecisionUI.tsx
+++ b/web-client/src/components/decisions/CardSelectionDecisionUI.tsx
@@ -159,6 +159,27 @@ export function CardSelectionDecision({
     return types
   }, [decision.onePerBasicLandType, decision.cardInfo, selectedCards, gameState?.cards])
 
+  /** Read a card's fixed (printed) power from the decision's card info or gameState; null if unknown. */
+  const powerForCard = (cardId: EntityId): number | null => {
+    const fromInfo = decision.cardInfo?.[cardId]?.power
+    if (typeof fromInfo === 'number') return fromInfo
+    const fromState = gameState?.cards[cardId]?.power
+    if (typeof fromState === 'number') return fromState
+    return null
+  }
+
+  // OnePerPower: compute which powers are already claimed by selected cards.
+  const claimedPowers = useMemo(() => {
+    if (!decision.onePerPower) return new Set<number>()
+    const powers = new Set<number>()
+    for (const id of selectedCards) {
+      const p = powerForCard(id)
+      if (p != null) powers.add(p)
+    }
+    return powers
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [decision.onePerPower, decision.cardInfo, selectedCards, gameState?.cards])
+
   /** Read a card's mana value: prefer gameState (server-computed), fall back to parsing the cost string. */
   const manaValueForCard = (cardId: EntityId): number => {
     const fromState = gameState?.cards[cardId]?.manaValue
@@ -195,6 +216,11 @@ export function CardSelectionDecision({
       const landTypes = extractBasicLandTypes(typeLine)
       // A land with no basic land type can't be kept; one sharing a claimed type is blocked.
       if (landTypes.length === 0 || landTypes.some((t) => claimedLandTypes.has(t))) return true
+    }
+    if (decision.onePerPower) {
+      const power = powerForCard(cardId)
+      // A card with no fixed power can't be kept; one sharing a claimed power is blocked.
+      if (power == null || claimedPowers.has(power)) return true
     }
     return false
   }

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -338,6 +338,12 @@ export interface SelectCardsDecision extends PendingDecisionBase {
    */
   readonly onePerBasicLandType?: boolean
   /**
+   * When true, at most one card of each (printed) power may be selected; a card with no fixed
+   * power can't be selected at all (Rip, Spawn Hunter). The server enforces this; the UI
+   * disables cards sharing an already-claimed power.
+   */
+  readonly onePerPower?: boolean
+  /**
    * The colour budget for [onePerColor] when restricted to the chooser's permanent colours
    * (e.g., Sanar's Vivid trigger). One pip per colour name (e.g., ["WHITE","BLUE"]). When
    * undefined or empty, the UI shows the generic five-colour list.
@@ -399,6 +405,8 @@ export interface SearchCardInfo {
   readonly imageUri: string | null
   /** Colour names for cards backed by hidden zone info (e.g. ["WHITE","BLUE"]); empty for colourless. */
   readonly colors?: readonly string[]
+  /** Printed (base) power, when fixed; null/undefined for cards with no fixed power. */
+  readonly power?: number | null
 }
 
 /**


### PR DESCRIPTION
## What

Implements **Rip, Spawn Hunter** (DSK #228 — `{2}{G}{W}` Legendary Creature — Human Survivor, 4/4) and the one genuinely-new SDK primitive it needs, per the DSK engine-gap map (#228).

> Survival — At the beginning of your second main phase, if Rip is tapped, reveal the top X cards of your library, where X is its power. Put any number of creature and/or Vehicle cards with different powers from among them into your hand. Put the rest on the bottom of your library in a random order.

## The new primitive: `SelectionRestriction.OnePerPower`

The core selection — "any number of creature and/or Vehicle cards **with different powers**" — was the only real gap. It joins the existing `SelectionRestriction` family (`OnePerCardType` / `OnePerCardName` / `OnePerBasicLandType` / `TotalManaValueAtMost` / …) and composes with the selection pipeline identically:

- **`restrictionCeiling`** caps the pick count at the number of distinct *fixed* powers among eligible cards.
- **Response normalization** in `LibraryAndZoneContinuationResumer` trims duplicate-power picks in response order — the first card of a given power is kept, later same-power picks fall through into the remainder.
- A card with **no fixed power** (no printed P/T, or a `*` characteristic-defining power that can only be computed on the battlefield) can't be kept and bottoms out — mirroring how `OnePerBasicLandType` treats a typeless land. In practice the paired filter already restricts the set to objects with a power, so this only bites the rare `*` member.

## What was *already* covered (no new effect needed)

The issue flagged "reveal-top-X-equal-to-source-power" and "random-order-to-bottom" as gaps, but both already exist:

- `CardSource.TopOfLibrary` already takes a `DynamicAmount` → X = its power via `DynamicAmounts.sourcePower()`.
- `CardOrder.Random` to the library bottom already shuffles the cards and strips reveals.

So Rip's payoff is a pure `Effects.Pipeline { }` composition of existing atoms — gather → `chooseAnyNumberSplit` → `toHand` / `toLibraryBottom(Random)` — with `OnePerPower` the only new vocabulary.

## Cross-layer trace

| Layer | Change |
|---|---|
| SDK | `SelectionRestriction.OnePerPower`; reusable `GameObjectFilter.CreatureOrVehicle` |
| Engine | `restrictionCeiling` arm + continuation normalization; `SearchCardInfo.power` and `SelectCardsDecision.onePerPower` so the chooser UI can group by power |
| Client | `messages.ts` fields; `CardSelectionDecisionUI` disables cards sharing an already-claimed power — reuses the existing disabled-card treatment (like `onePerCardType`), **no new visual element** |
| Card | Rip as a `Triggers.YourPostcombatMain` + `Conditions.SourceIsTapped` (Survival intervening-if) trigger over the pipeline |
| Docs | `card-sdk-language-reference.md` restriction + filter catalog updated |

## Tests

`RipSpawnHunterScenarioTest` (rules-engine) proves every clause:
- X equals Rip's power (reveals *exactly* that many — the 5th library card is never seen);
- keeps distinct-power creatures/Vehicles into hand;
- a second card sharing an already-chosen power is rejected server-side and bottoms;
- non-creature/non-Vehicle revealed cards and un-picked cards go to the bottom;
- selecting nothing bottoms everything;
- an untapped Rip doesn't trigger (intervening-if).

All green; snapshot re-blessed; `CardLintTest` / `CardDefinitionSnapshotTest` / full `:mtg-sets:test` / `MagneticMountainTest` (existing `SelectFromCollection` restriction) still pass; `web-client` typecheck passes; `game-server` compiles.

## mtgish

Declined an emitter/bridge entry: `OnePerPower` never appears as a standalone mtgish IR tag — it only manifests embedded in Rip's bespoke, X-carrying reveal-and-keep shape, which is the "too card-specific to render exactly" case Step 8b says to leave at SCAFFOLD rather than widen the emitter lossily (DSK isn't in the corpus either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)