### PR TITLE
Add Blazing Bomb (FIN) + last-known source P/T on self-sacrifice

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4581,6 +4581,17 @@ Numbers computed at resolution time.
   `EntityProperty(Source, CounterCount(filter))`, which reads counters on the still-present source (zero after a
   self-exile cost).
 
+- **Last-known source P/T (self-exile / self-sacrifice cost)** — the P/T analogue of
+  `LastKnownSourceCounters`, applied automatically to `EntityProperty(EntityReference.Source, Power|Toughness)`
+  (i.e. `DynamicAmounts.sourcePower()` / `sourceToughness()`). When an activated ability's cost sacrifices or
+  exiles its own source, the source is off the battlefield by resolution, so `ActivateAbilityHandler` snapshots
+  its projected P/T at cost-payment time (CR 112.7a / 608.2h, mirroring the counter snapshot) and
+  `DynamicAmountEvaluator` reads the snapshot back when the source is no longer on the battlefield. This makes
+  "{T}, Sacrifice this creature: it deals damage equal to its power" (Ghitu Fire-Eater, Cinder Shade, Blazing
+  Bomb's Blow Up) read the pre-sacrifice power including counters/buffs rather than zero. No DSL change: existing
+  `sourcePower()` reads simply become correct after a self-sacrifice. Live on-battlefield `Source` reads are
+  unaffected (the snapshot is only consulted when the source has left).
+
 ### Station
 
 - `StationCharge` — the number of charge counters a Station ability puts on its permanent: the power of the creature

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BlazingBomb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BlazingBomb.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Blazing Bomb
+ * {R}
+ * Creature — Elemental
+ * 1/1
+ * Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a +1/+1
+ * counter on this creature.
+ * Blow Up — {T}, Sacrifice this creature: It deals damage equal to its power to target creature.
+ * Activate only as a sorcery.
+ *
+ * The cast trigger uses an intervening-if (CR 603.4) comparing the *triggering* spell's mana spent
+ * (`ContextProperty(MANA_SPENT_ON_TRIGGERING_SPELL)`) to 4 — distinct from `TotalManaSpent`, which
+ * reads the resolving object's own cast.
+ *
+ * Blow Up sacrifices the source as part of its cost, so the creature is gone by the time the ability
+ * resolves. `DynamicAmounts.sourcePower()` reads the source's **last-known** power (captured at
+ * cost-payment time, CR 112.7a / 608.2h), so a buffed Bomb deals its accumulated power rather than 0.
+ */
+val BlazingBomb = card("Blazing Bomb") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever you cast a noncreature spell, if at least four mana was spent to cast " +
+        "it, put a +1/+1 counter on this creature.\n" +
+        "Blow Up — {T}, Sacrifice this creature: It deals damage equal to its power to target " +
+        "creature. Activate only as a sorcery."
+
+    // Whenever you cast a noncreature spell, if at least four mana was spent to cast it,
+    // put a +1/+1 counter on this creature.
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(4),
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    // Blow Up — {T}, Sacrifice this creature: It deals damage equal to its power to target
+    // creature. Activate only as a sorcery.
+    activatedAbility {
+        description = "Blow Up"
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        timing = TimingRule.SorcerySpeed
+        val victim = target("target", Targets.Creature)
+        effect = Effects.DealDamage(DynamicAmounts.sourcePower(), victim)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "130"
+        artist = "Andrea Radeck"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70f47277-ca47-428a-808f-0fb32e820a71.jpg?1748706252"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1333,6 +1333,95 @@
     ]
 }
 
+// Blazing Bomb
+{
+    "name": "Blazing Bomb",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a +1/+1 counter on this creature.\nBlow Up — {T}, Sacrifice this creature: It deals damage equal to its power to target creature. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "ContextProperty",
+                        "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Blow Up"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "130",
+        "artist": "Andrea Radeck",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70f47277-ca47-428a-808f-0fb32e820a71.jpg?1748706252"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Blitzball Shot
 {
     "name": "Blitzball Shot",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -332,6 +332,22 @@ class DynamicAmountEvaluator(
                     }
                     return resolveNumericProperty(state, entityId, amount.numericProperty, context, useProjected = false)
                 }
+                // The source sacrificing/exiling itself as a cost has already left the battlefield
+                // by resolution — consult the P/T snapshot captured at cost-payment time (CR 112.7a /
+                // 608.2h) so "Sacrifice this creature: it deals damage equal to its power" reads the
+                // pre-sacrifice power rather than zero (Ghitu Fire-Eater, Cinder Shade, Blazing Bomb's
+                // Blow Up). Mirrors LastKnownSourceCounters. Only intercepts when a snapshot exists,
+                // so live on-battlefield Source reads are unaffected.
+                if (amount.entity is EntityReference.Source &&
+                    entityId !in state.getBattlefield()
+                ) {
+                    val snapshot = context.lastKnownSourceSnapshot?.takeIf { it.entityId == entityId }
+                    when (amount.numericProperty) {
+                        is EntityNumericProperty.Power -> snapshot?.power?.let { return it }
+                        is EntityNumericProperty.Toughness -> snapshot?.toughness?.let { return it }
+                        else -> { /* fall through */ }
+                    }
+                }
                 // Cost-storage reads of Power/Toughness mirror the Sacrificed path — the
                 // chosen entity may have left the battlefield (or never been on it, for an
                 // exile-zone pick) between cost payment and resolution (Rule 112.7a).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -133,6 +133,16 @@ data class EffectContext(
      */
     val lastKnownSourceCounters: Map<String, Int> = emptyMap(),
     /**
+     * Frozen projected P/T (and subtypes/supertypes) the source had the moment a self-exile /
+     * self-sacrifice cost moved it off the battlefield (CR 112.7a / 608.2h — "as it last existed
+     * on the battlefield"). Mirrors [lastKnownSourceCounters]. Read by [DynamicAmountEvaluator]
+     * when an `EntityProperty(EntityReference.Source, …)` power/toughness read resolves after the
+     * source is gone, so "Sacrifice this creature: it deals damage equal to its power" reads the
+     * pre-sacrifice power rather than zero (Blazing Bomb's Blow Up, Cinder Shade, Ghitu Fire-Eater).
+     * Null when the cost did not sacrifice/exile the source.
+     */
+    val lastKnownSourceSnapshot: PermanentSnapshot? = null,
+    /**
      * LKI snapshots (Rule 112.7a) for entities chosen via an additional cost
      * step like [com.wingedsheep.sdk.scripting.AdditionalCost.ChooseEntity]
      * with `captureSnapshot = true`. Indexed by entity id via

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -844,6 +844,16 @@ class ActivateAbilityHandler(
                     } ?: emptyMap()
             } else emptyMap()
 
+        // Snapshot the source's projected P/T before a self-exile / self-sacrifice cost moves it
+        // off the battlefield (CR 112.7a / 608.2h), so an effect that reads its own power — e.g.
+        // "Sacrifice this creature: it deals damage equal to its power" (Ghitu Fire-Eater, Cinder
+        // Shade, Blazing Bomb's Blow Up) — sees the pre-sacrifice power rather than zero. Mirrors
+        // lastKnownSourceCounters above.
+        val lastKnownSourceSnapshot: com.wingedsheep.engine.state.components.stack.PermanentSnapshot? =
+            if (costExilesOrSacrificesSelf(effectiveCost)) {
+                capturePermanentSnapshots(listOf(action.sourceId), currentState.projectedState).firstOrNull()
+            } else null
+
         // When using Explicit payment, mana sources were already tapped above —
         // strip the Mana portion so payAbilityCost doesn't try to deduct from the pool.
         // When convoke was applied, replace the mana portion with the reduced cost.
@@ -1297,6 +1307,7 @@ class ActivateAbilityHandler(
             tappedPermanents = firstTapSlice,
             tappedPermanentSnapshots = tappedSnapshots,
             lastKnownSourceCounters = lastKnownSourceCounters,
+            lastKnownSourceSnapshot = lastKnownSourceSnapshot,
             descriptionOverride = ability.descriptionOverride,
             abilityIdentity = com.wingedsheep.sdk.scripting.AbilityIdentity(
                 cardComponent.cardDefinitionId, ability.id

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2080,6 +2080,7 @@ class StackResolver(
             tappedPermanents = abilityComponent.tappedPermanents,
             tappedPermanentSnapshots = abilityComponent.tappedPermanentSnapshots,
             lastKnownSourceCounters = abilityComponent.lastKnownSourceCounters,
+            lastKnownSourceSnapshot = abilityComponent.lastKnownSourceSnapshot,
             pipeline = PipelineState(namedTargets = EffectContext.buildNamedTargets(activatedReqs, activatedTargets))
         )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -199,6 +199,14 @@ data class ActivatedAbilityOnStackComponent(
      * [com.wingedsheep.sdk.scripting.values.DynamicAmount.LastKnownSourceCounters] (Lost Isle Calling).
      */
     val lastKnownSourceCounters: Map<String, Int> = emptyMap(),
+    /**
+     * Frozen projected P/T of the source captured before a self-exile / self-sacrifice cost moved
+     * it off the battlefield (CR 112.7a). Mirrors [lastKnownSourceCounters]; read at resolution via
+     * [com.wingedsheep.engine.handlers.EffectContext.lastKnownSourceSnapshot] so an
+     * `EntityProperty(Source, Power)` read (Ghitu Fire-Eater / Blazing Bomb's Blow Up) sees the
+     * pre-sacrifice power. Null when the cost did not sacrifice/exile the source.
+     */
+    val lastKnownSourceSnapshot: PermanentSnapshot? = null,
     /** Optional human-readable description from `ActivatedAbility.descriptionOverride`,
      *  used when displaying the ability on the stack instead of the auto-generated effect text. */
     val descriptionOverride: String? = null,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlazingBombScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlazingBombScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Blazing Bomb (FIN #130) — {R} 1/1 Elemental.
+ *
+ * "Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a +1/+1
+ *  counter on this creature.
+ *  Blow Up — {T}, Sacrifice this creature: It deals damage equal to its power to target creature.
+ *  Activate only as a sorcery."
+ *
+ * Proves the cast trigger's intervening-if (≥4 mana) and that Blow Up reads the Bomb's *last-known*
+ * power after it sacrifices itself (CR 112.7a / 608.2h) — so a Bomb pumped to 2 power kills a 2/2,
+ * rather than dealing the pre-fix 0 (or its printed 1).
+ */
+class BlazingBombScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    fun resolveStack(d: GameTestDriver) {
+        var guard = 0
+        while (d.state.stack.isNotEmpty() && guard < 30) {
+            d.bothPass()
+            guard++
+        }
+    }
+
+    test("casting a 5-mana noncreature spell adds a +1/+1 counter; a 3-mana one does not") {
+        val d = driver()
+        val me = d.player1
+        val foe = d.player2
+
+        val bomb = d.putCreatureOnBattlefield(me, "Blazing Bomb")
+
+        // Cast Zap ({2}{R} = 3 mana): below the threshold, so no counter.
+        val zap = d.putCardInHand(me, "Zap")
+        d.giveMana(me, Color.RED, 1)
+        d.giveColorlessMana(me, 2)
+        d.castSpell(me, zap, listOf(foe)).isSuccess shouldBe true
+        resolveStack(d)
+        d.state.projectedState.getPower(bomb) shouldBe 1 // still 1/1 — trigger did not fire
+
+        // Cast Lava Axe ({4}{R} = 5 mana): at/above the threshold, so +1/+1.
+        val lavaAxe = d.putCardInHand(me, "Lava Axe")
+        d.giveMana(me, Color.RED, 1)
+        d.giveColorlessMana(me, 4)
+        d.castSpell(me, lavaAxe, listOf(foe)).isSuccess shouldBe true
+        resolveStack(d)
+        d.state.projectedState.getPower(bomb) shouldBe 2 // now a 2/2
+    }
+
+    test("Blow Up: sacrifices the Bomb and deals damage equal to its (buffed) power") {
+        val d = driver()
+        val me = d.player1
+        val foe = d.player2
+
+        val bomb = d.putCreatureOnBattlefield(me, "Blazing Bomb")
+        d.removeSummoningSickness(bomb)
+
+        // Pump the Bomb to 2/2 by casting a 5-mana noncreature spell.
+        val lavaAxe = d.putCardInHand(me, "Lava Axe")
+        d.giveMana(me, Color.RED, 1)
+        d.giveColorlessMana(me, 4)
+        d.castSpell(me, lavaAxe, listOf(foe)).isSuccess shouldBe true
+        resolveStack(d)
+        d.state.projectedState.getPower(bomb) shouldBe 2
+
+        // A 2/2 victim: it dies only to ≥2 damage, so this distinguishes the buffed power (2) from
+        // the printed power (1) and from the pre-fix bug (0).
+        val victim = d.putCreatureOnBattlefield(foe, "Grizzly Bears") // 2/2
+
+        val blowUp = d.cardRegistry.requireCard("Blazing Bomb").activatedAbilities[0].id
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = bomb,
+                abilityId = blowUp,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        )
+        resolveStack(d)
+
+        // The Bomb sacrificed itself to pay the cost…
+        d.getGraveyard(me).any { d.getCardName(it) == "Blazing Bomb" } shouldBe true
+        // …and dealt 2 damage (its last-known power) to the 2/2, killing it.
+        d.findPermanent(foe, "Grizzly Bears") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfSacrificeSourcePowerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelfSacrificeSourcePowerScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Last-known source P/T on a self-sacrifice cost (CR 112.7a / 608.2h).
+ *
+ * "{T}, Sacrifice this creature: It deals damage equal to its power …" — the source is gone by the
+ * time the ability resolves, so `EntityProperty(Source, Power)` (`DynamicAmounts.sourcePower()`)
+ * must read the power the source *last had on the battlefield*, not zero. `ActivateAbilityHandler`
+ * snapshots the source's projected P/T at cost-payment time (mirroring the
+ * `LastKnownSourceCounters` snapshot) and `DynamicAmountEvaluator` reads it back.
+ *
+ * Proven here with Ghitu Fire-Eater (2/2), an already-registered card that shares this latent gap
+ * with Cinder Shade and Blazing Bomb's Blow Up. Before the fix the ability dealt 0 damage.
+ */
+class SelfSacrificeSourcePowerScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("Ghitu Fire-Eater: {T}, Sacrifice: deals damage equal to its power (2), not zero") {
+        val d = driver()
+        val me = d.player1
+        val foe = d.player2
+
+        val fireEater = d.putCreatureOnBattlefield(me, "Ghitu Fire-Eater") // 2/2
+        d.removeSummoningSickness(fireEater)
+
+        val abilityId = d.cardRegistry.requireCard("Ghitu Fire-Eater").activatedAbilities[0].id
+
+        d.getLifeTotal(foe) shouldBe 20
+
+        // Activate "{T}, Sacrifice this creature: It deals damage equal to its power to any target",
+        // aimed at the opponent. The sacrifice removes the source before the effect resolves.
+        d.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = fireEater,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(foe))
+            )
+        )
+
+        // Resolve the ability off the stack.
+        var guard = 0
+        while (d.state.stack.isNotEmpty() && guard < 20) {
+            d.bothPass()
+            guard++
+        }
+
+        // It was sacrificed to pay the cost…
+        d.getGraveyard(me).any { d.getCardName(it) == "Ghitu Fire-Eater" } shouldBe true
+        // …and dealt 2 damage (its last-known power) — NOT 0 as before the LKI snapshot fix.
+        d.getLifeTotal(foe) shouldBe 18
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Blazing Bomb** (FIN #130) — `{R}` 1/1 Elemental:
- *Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a +1/+1 counter on this creature.* (intervening-if comparing `MANA_SPENT_ON_TRIGGERING_SPELL` ≥ 4)
- *Blow Up — {T}, Sacrifice this creature: It deals damage equal to its power to target creature. Activate only as a sorcery.*

## Engine change: last-known source P/T on a self-sacrifice/exile cost

Blow Up sacrifices its own source as part of its cost, so the source is off the battlefield by the time the ability resolves. Previously `DynamicAmounts.sourcePower()` (an `EntityProperty(Source, Power)` read) returned 0 in that case.

This adds a frozen projected-P/T snapshot that mirrors the existing `lastKnownSourceCounters` mechanism:

- `ActivateAbilityHandler` captures the source's projected P/T at cost-payment time when the cost sacrifices/exiles self (`costExilesOrSacrificesSelf`), reusing `capturePermanentSnapshots`.
- The snapshot is threaded through `ActivatedAbilityOnStackComponent` → `EffectContext.lastKnownSourceSnapshot`.
- `DynamicAmountEvaluator` consults the snapshot for `EntityProperty(Source, Power|Toughness)` only when the source has left the battlefield (CR 112.7a / 608.2h).

Live on-battlefield `Source` reads are unaffected — the snapshot is only consulted once the source is gone. This also corrects already-registered cards with the same shape (Ghitu Fire-Eater, Cinder Shade).

No DSL change: existing `sourcePower()` / `sourceToughness()` reads simply become correct after a self-sacrifice.

## Tests

- `BlazingBombScenarioTest` — a 3-mana noncreature spell (Zap) adds **no** counter; a 5-mana one (Lava Axe) adds +1/+1; Blow Up sacrifices the buffed Bomb and deals its last-known power (2), killing a 2/2.
- `SelfSacrificeSourcePowerScenarioTest` — Ghitu Fire-Eater's {T}, Sacrifice ability deals 2 (its last-known power), not 0.
- Re-blessed the FIN card snapshot golden.
- `CardLintTest` and the full `:rules-engine` suite pass.

Updated `docs/card-sdk-language-reference.md` to document the new last-known source P/T behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)