### PR TITLE
Add Stolen Uniform (FIN) + "when you lose control of" delayed trigger

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -996,7 +996,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `MassAnimateEffect(filter, power, toughness, loseAllAbilities = true, duration = EndOfTurn)` — facade `Effects.MassAnimate(filter, power, toughness, loseAllAbilities, duration)`. One-shot: animate **every** permanent matching `filter` into a creature for `duration`, setting each one's base power and toughness to the `power`/`toughness` **`DynamicAmount`s** — resolved per affected permanent (Layer 7b `SetPowerToughnessDynamic`), so `EntityProperty(AffectedEntity, ManaValue)` gives "each equal to its own mana value" — and, when `loseAllAbilities`, stripping all of its abilities (Layer 6 `RemoveAllAbilities`); Layer 4 `AddType("CREATURE")` makes them creatures. The affected set is captured **once** at resolution against the current battlefield (CR 611.2c) and locked in for the duration. This is the fixed-set, one-shot companion to expressing the same effect *continuously* via the `GrantCardType` + `LoseAllAbilities` + `SetBasePowerToughnessDynamicStatic` group statics on a permanent (which take the same `DynamicAmount` P/T) — use the statics for the while-on-battlefield behavior and this effect for the "this effect continues until end of turn" linger when the generating permanent leaves. Used by **Titania's Song** ("Each noncreature artifact loses all abilities and becomes an artifact creature with power and toughness each equal to its mana value. If this enchantment leaves the battlefield, this effect continues until end of turn.") — a `LeavesBattlefield(SELF)` trigger replays the static set as until-EOT floating effects with `power = toughness = EntityProperty(AffectedEntity, ManaValue)`. The dynamic-P/T floating effect resolves its controller from the effect's captured controller (`ContinuousEffect.controllerId`) when the source has already left the battlefield.
 - `ExploreEffect(target)` — Explore mechanic (reveal top; land → battlefield, else hand + counter).
 - `MakePreparedEffect(target = Self)` — facade `Effects.MakePrepared(target)`. The target permanent **becomes prepared** (Prepare — Secrets of Strixhaven): gains the prepared status and gets a castable copy of its card's prepare spell (`cardFaces[0]`) in its controller's exile (same machinery as entering prepared, shared via `PreparedService.makePrepared`). No-op if already prepared, or the card has no prepare face. Use for cards that *become* prepared mid-game (e.g. Joined Researchers' end-step trigger); cards that "enter prepared" use `Keyword.PREPARED` on a `PREPARE`-layout card instead.
-- `AttachEquipmentEffect(equip, target)` — attach an Equipment.
+- `AttachEquipmentEffect(equip, target)` — attach an Equipment. Facade `Effects.AttachEquipment(...)`.
+  `Effects.AttachTargetEquipmentToCreature(equipmentTarget, creatureTarget)` force-attaches one
+  *targeted* Equipment to one *targeted* creature (both are explicit targets, not the source) — used
+  by Stolen Uniform's "Attach it to the chosen creature".
+- `UnattachEquipmentEffect(target = Self)` — facade `Effects.UnattachEquipment(target)`. The inverse of
+  the attach effects: **unattach** an Aura/Equipment from its host *without moving zones* (CR 701.3d) —
+  clears the attachment's `AttachedToComponent` and drops it from the host's attachment list, emitting
+  `PermanentUnattachedEvent`. A no-op (no event) when `target` isn't currently attached to anything.
+  `target` is usually `EffectTarget.TriggeringEntity` ("that Equipment" inside a delayed trigger) or
+  `EffectTarget.Self`. Used by Stolen Uniform's "when you lose control of that Equipment … unattach it".
 - `TapUntapEffect(target, isTap)` — tap or untap. Facade: `Effects.Tap` / `Effects.Untap`.
 - `Effects.TapEachTarget()` — "tap up to N target creatures": taps every object chosen as a target.
   Composes `ForEachTargetEffect` over `Effects.Tap(ContextTarget(0))`, so the count lives only on the
@@ -2095,6 +2104,15 @@ work for abilities-on-stack (which carry no `CardComponent`).
   to a creature". Reads the attached-to permanent's projected types, so a land animated
   into a creature still matches `LAND` and additionally matches `CREATURE`. False for
   entities with no `AttachedToComponent`.
+- `AttachedTo(filter)` (filter builder `attachedTo(hostFilter)`) — the **general** form of
+  `AttachedToCardType`: Aura/Equipment whose `AttachedToComponent` host matches an arbitrary nested
+  `GameObjectFilter`, evaluated against **projected** battlefield state, so the host's control (`a
+  creature you control`), card type, keywords, P/T, etc. all compose. The "you" of any controller
+  predicate in the nested filter resolves to the controller supplied in the evaluation context (the
+  ability's controller). False if not attached to anything; in group-static projection (which has no
+  ability controller) it never matches — it is only meaningful in target/condition contexts. Used by
+  Stolen Uniform's "if it's attached to a creature you control" guard
+  (`Conditions.EntityMatches(EffectTarget.TriggeringEntity, GameObjectFilter.Any.attachedTo(GameObjectFilter.Creature.youControl()))`).
 - `IsWarpExiled` (filter builder `warpExiled()`) — card in exile via warp's
   end-of-turn delayed trigger (CR 702.185b).
 - `WasCastForWarp` (filter builder `castForWarp()`) — battlefield permanent that
@@ -2594,7 +2612,16 @@ Triggers.youCastSpell(
 
 - `TurnedFaceUp` — source turns face up. Use `turnedFaceUp(binding)` for the ATTACHED-binding aura variant (Fatal Mutation).
 - `CreatureTurnedFaceUp(player?)` — when a creature you control turns face up.
-- `GainControlOfSelf` — you gain control of source.
+- `GainControlOfSelf` — you gain control of source. Built on `ControlChangeEvent(ControlChangeDirection.GAINED)`
+  + `TriggerBinding.SELF` — the resident "when you gain control of this" self-trigger (Risky Move).
+- `LoseControlOfWatched` — `ControlChangeEvent(ControlChangeDirection.LOST)` + `TriggerBinding.SELF`,
+  used as the `trigger` of an **event-based delayed trigger** scoped to a watched permanent
+  (`CreateDelayedTriggerEffect(trigger = Triggers.LoseControlOfWatched, watchedTarget = …)`): "when you
+  lose control of [that permanent] this turn …". It fires on any mid-turn control change of the watched
+  permanent *away from* the trigger's controller (the old controller was you). Stolen Uniform pairs it
+  with `DelayedTriggerExpiry.EndOfTurn` + `fireOnce`. `EventPattern.ControlChangeEvent(direction)` is the
+  underlying primitive: `direction` (`ControlChangeDirection.GAINED` default / `LOST`) selects which side
+  of the control change — relative to the ability's controller — the ability watches.
 - `BecomesTarget(filter?)` — source becomes target of spell/ability. The engine emits the
   underlying `BecomesTargetEvent` for both permanent targets and spell targets on the stack, but the
   trigger matches **permanent targets only** by default — "a creature you control" is a battlefield

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -3273,6 +3273,13 @@ object Effects {
     )
 
     /**
+     * Unattach an Aura/Equipment from its host without moving zones (CR 701.3d). No-op if [target]
+     * isn't currently attached. Inverse of [AttachEquipment] — e.g. Stolen Uniform's "unattach it".
+     */
+    fun UnattachEquipment(target: EffectTarget = EffectTarget.Self): Effect =
+        com.wingedsheep.sdk.scripting.effects.UnattachEquipmentEffect(target)
+
+    /**
      * Put a targeted Aura or Equipment card onto the battlefield attached to a permanent the
      * controller chooses at resolution (default: a creature you control). Works for both
      * Auras and Equipment; the host is chosen, not targeted (One Last Job).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.scripting.ControlChangeDirection
 import com.wingedsheep.sdk.scripting.EventPattern.*
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.TriggerBinding
@@ -648,7 +649,18 @@ object Triggers {
      * Used by Risky Move.
      */
     val GainControlOfSelf: TriggerSpec = TriggerSpec(
-        event = ControlChangeEvent,
+        event = ControlChangeEvent(ControlChangeDirection.GAINED),
+        binding = TriggerBinding.SELF
+    )
+
+    /**
+     * "When you lose control of [the watched permanent] …" — the reflexive delayed trigger on
+     * Stolen Uniform. Use as the [com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect.trigger]
+     * of an event-based delayed trigger scoped to a watched permanent (via `watchedTarget`); it then
+     * fires whenever control of that permanent moves away from the trigger's controller this turn.
+     */
+    val LoseControlOfWatched: TriggerSpec = TriggerSpec(
+        event = ControlChangeEvent(ControlChangeDirection.LOST),
         binding = TriggerBinding.SELF
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -18,6 +18,19 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
+ * Which side of a control change an [EventPattern.ControlChangeEvent] ability watches, relative to
+ * the ability's controller.
+ */
+@Serializable
+enum class ControlChangeDirection {
+    /** "When you **gain** control …": the ability's controller is the *new* controller. */
+    GAINED,
+
+    /** "When you **lose** control …": the ability's controller was the *old* controller. */
+    LOST
+}
+
+/**
  * Represents a game event type used by both replacement effects and triggered abilities.
  *
  * This is compositional - events are specified by combining an event type
@@ -1305,13 +1318,32 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
-     * When control of a permanent changes.
-     * Binding SELF = "when you gain control of this from another player".
+     * When control of a permanent changes, in a given [direction] relative to the ability's
+     * controller (CR 800.4 / 720). The [direction] selects which side of the control change the
+     * ability watches:
+     *  - [ControlChangeDirection.GAINED] (default): "when you **gain** control of this from another
+     *    player" — the new controller is the ability's controller. With [TriggerBinding.SELF] this
+     *    is the resident self-trigger (Risky Move). For an event-based **delayed** trigger scoped to
+     *    a watched permanent, it fires when that permanent's controller becomes the trigger's
+     *    controller.
+     *  - [ControlChangeDirection.LOST]: "when you **lose** control of [the watched permanent]" — the
+     *    *old* controller was the ability's controller. Used as the reflexive delayed trigger on
+     *    Stolen Uniform ("When you lose control of that Equipment this turn …"). A delayed trigger
+     *    of this shape fires on any mid-turn control change away from you (e.g. another player steals
+     *    the permanent).
+     *
+     * The default is [ControlChangeDirection.GAINED] so existing GAIN-control self-triggers keep
+     * their meaning.
      */
     @SerialName("ControlChangeEvent")
     @Serializable
-    data object ControlChangeEvent : EventPattern {
-        override val description: String = "control of this permanent changes"
+    data class ControlChangeEvent(
+        val direction: ControlChangeDirection = ControlChangeDirection.GAINED
+    ) : EventPattern {
+        override val description: String = when (direction) {
+            ControlChangeDirection.GAINED -> "you gain control of this permanent"
+            ControlChangeDirection.LOST -> "you lose control of this permanent"
+        }
     }
 
     // ---- Counter Triggers ----

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PermanentEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PermanentEffects.kt
@@ -363,6 +363,24 @@ data class AttachTargetEquipmentToCreatureEffect(
 }
 
 /**
+ * Unattach an Aura/Equipment from its host without moving it to another zone (CR 701.3d). Removes
+ * the [target] attachment's `AttachedToComponent` and drops it from the host's attachment list; a
+ * no-op if [target] isn't currently attached to anything. The inverse of [AttachEquipmentEffect] /
+ * [AttachTargetEquipmentToCreatureEffect] — used for "unattach it" riders such as Stolen Uniform's
+ * reflexive "when you lose control of that Equipment, … unattach it".
+ *
+ * @property target The attachment to unattach (e.g. [EffectTarget.TriggeringEntity] for "that
+ *   Equipment" inside a delayed trigger, or [EffectTarget.Self] when a permanent unattaches itself).
+ */
+@SerialName("UnattachEquipment")
+@Serializable
+data class UnattachEquipmentEffect(
+    val target: EffectTarget = EffectTarget.Self
+) : Effect {
+    override val description: String = "Unattach ${target.description}"
+}
+
+/**
  * Put a targeted Aura or Equipment card onto the battlefield **attached to a permanent the
  * effect's controller chooses** at resolution. The card is the [target] (e.g. a targeted
  * Aura/Equipment in a graveyard); the host is chosen as the effect resolves and is therefore

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -646,6 +646,15 @@ data class GameObjectFilter(
         statePredicates = statePredicates + StatePredicate.Not(StatePredicate.IsAttachedToBySource)
     )
 
+    /**
+     * Must be attached to a permanent matching [hostFilter] (general form of attachment matching —
+     * the host filter may carry a controller predicate, e.g. "a creature you control"). Used by
+     * Stolen Uniform's reflexive "if it's attached to a creature you control" guard.
+     */
+    fun attachedTo(hostFilter: GameObjectFilter) = copy(
+        statePredicates = statePredicates + StatePredicate.AttachedTo(hostFilter)
+    )
+
     /** Must be attacking or blocking */
     fun attackingOrBlocking() = copy(
         statePredicates = statePredicates + StatePredicate.Or(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -388,6 +388,23 @@ sealed interface StatePredicate {
         override val description: String = "attached to a ${cardType.displayName.lowercase()}"
     }
 
+    /**
+     * Attached to a permanent that matches [filter]. Reads the entity's `AttachedToComponent` and
+     * evaluates [filter] against the host using projected battlefield state — so card type, control
+     * ("a creature you control"), keywords, P/T, etc. all compose. This is the general form of
+     * [AttachedToCardType] (which only checks the host's top-level type): use it whenever the host
+     * constraint needs a controller predicate or any card/state predicate, e.g. Stolen Uniform's
+     * "if it's attached to a creature you control".
+     *
+     * The "you" of any controller predicate in [filter] is the controller supplied in the
+     * evaluation context (the ability's controller). False if the entity isn't attached to anything.
+     */
+    @SerialName("IsAttachedTo")
+    @Serializable
+    data class AttachedTo(val filter: com.wingedsheep.sdk.scripting.GameObjectFilter) : Entity {
+        override val description: String = "attached to ${filter.description}"
+    }
+
     // =============================================================================
     // Rooms (Entity)
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/StolenUniform.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/StolenUniform.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Stolen Uniform
+ * {U}
+ * Instant
+ *
+ * Choose target creature you control and target Equipment. Gain control of that Equipment until
+ * end of turn. Attach it to the chosen creature. When you lose control of that Equipment this turn,
+ * if it's attached to a creature you control, unattach it.
+ *
+ * Composition (no monolithic executor):
+ *  - [Effects.GainControl] of the targeted Equipment, [Duration.EndOfTurn].
+ *  - [Effects.AttachTargetEquipmentToCreature] force-attaches it to the chosen creature. Two
+ *    independent targets: if the creature target is illegal at resolution, the attach is a no-op but
+ *    you still gain control of the Equipment (per the card's ruling).
+ *  - A reflexive "when you lose control of that Equipment" delayed trigger
+ *    ([Triggers.LoseControlOfWatched] = `ControlChangeEvent(LOST)`) scoped to the Equipment. It
+ *    fires on any mid-turn control change away from you and, if the Equipment is still attached to a
+ *    creature you control, unattaches it ([Effects.UnattachEquipment]).
+ */
+val StolenUniform = card("Stolen Uniform") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Choose target creature you control and target Equipment. Gain control of that " +
+        "Equipment until end of turn. Attach it to the chosen creature. When you lose control of " +
+        "that Equipment this turn, if it's attached to a creature you control, unattach it."
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        val equipment = target(
+            "target Equipment",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT))
+            )
+        )
+        effect = Effects.Composite(
+            Effects.GainControl(equipment, Duration.EndOfTurn),
+            Effects.AttachTargetEquipmentToCreature(
+                equipmentTarget = equipment,
+                creatureTarget = creature
+            ),
+            CreateDelayedTriggerEffect(
+                trigger = Triggers.LoseControlOfWatched,
+                watchedTarget = equipment,
+                fireOnce = true,
+                expiry = DelayedTriggerExpiry.EndOfTurn,
+                effect = ConditionalEffect(
+                    condition = Conditions.EntityMatches(
+                        EffectTarget.TriggeringEntity,
+                        GameObjectFilter.Any.attachedTo(GameObjectFilter.Creature.youControl())
+                    ),
+                    effect = Effects.UnattachEquipment(EffectTarget.TriggeringEntity)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "75"
+        artist = "Chris Rallis"
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d80c511-2f4d-4f77-8143-7b49b2b19fae.jpg"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -8575,6 +8575,101 @@
     "colorIdentityOverride": []
 }
 
+// Stolen Uniform
+{
+    "name": "Stolen Uniform",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose target creature you control and target Equipment. Gain control of that Equipment until end of turn. Attach it to the chosen creature. When you lose control of that Equipment this turn, if it's attached to a creature you control, unattach it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Equipment"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "AttachTargetEquipmentToCreature",
+                    "equipmentTarget": {
+                        "type": "BoundVariable",
+                        "name": "target Equipment"
+                    },
+                    "creatureTarget": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.WhenCondition",
+                            "condition": {
+                                "type": "EntityMatches",
+                                "entity": "TriggeringEntity",
+                                "filter": {
+                                    "statePredicates": [
+                                        {
+                                            "type": "IsAttachedTo",
+                                            "filter": "creature ctrl:you"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "then": {
+                            "type": "UnattachEquipment",
+                            "target": "TriggeringEntity"
+                        }
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "ControlChangeEvent",
+                            "direction": "LOST"
+                        }
+                    },
+                    "watchedTarget": {
+                        "type": "BoundVariable",
+                        "name": "target Equipment"
+                    },
+                    "fireOnce": true
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            },
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact Equipment"
+                },
+                "id": "target Equipment"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Rallis",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d80c511-2f4d-4f77-8143-7b49b2b19fae.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Summon: Anima
 {
     "name": "Summon: Anima",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -467,5 +467,6 @@ class BeginningPhaseManager(
         StatePredicate.IsAttachedToBySource,
         StatePredicate.WasCastForWarp -> true
         is StatePredicate.AttachedToCardType -> true
+        is StatePredicate.AttachedTo -> true
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -833,6 +833,22 @@ data class PermanentAttachedEvent(
 ) : GameEvent
 
 /**
+ * An Aura/Equipment became unattached from its host without moving zones (CR 701.3d). Emitted by
+ * [com.wingedsheep.engine.handlers.effects.permanent.attachments.UnattachEquipmentExecutor] so
+ * "becomes unattached" reactions and animations can fire.
+ *
+ * @property attachmentId the aura/equipment that became unattached.
+ * @property attachedToId the permanent it was attached to (its former host).
+ */
+@Serializable
+@SerialName("PermanentUnattachedEvent")
+data class PermanentUnattachedEvent(
+    val attachmentId: EntityId,
+    val attachmentName: String,
+    val attachedToId: EntityId,
+) : GameEvent
+
+/**
  * A player tapped a land for mana (a land's mana ability resolved).
  *
  * Drives the "Whenever a player taps a land for mana" trigger family

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -79,6 +79,7 @@ val engineSerializersModule = SerializersModule {
         subclass(TappedEvent::class)
         subclass(BecameSaddledEvent::class)
         subclass(PermanentAttachedEvent::class)
+        subclass(PermanentUnattachedEvent::class)
         subclass(UntappedEvent::class)
         subclass(LandTappedForManaEvent::class)
         subclass(PhasedOutEvent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -869,6 +869,23 @@ class TriggerDetector(
                     matcher.matchesZoneChangeTrigger(specEvent, spec.binding, event, sourceId, controllerId, state)
                 }
             }
+            // Entity-scoped control-change delayed trigger ("when you lose control of *that*
+            // permanent this turn", Stolen Uniform). The watched entity is the permanent; the
+            // [com.wingedsheep.sdk.scripting.ControlChangeDirection] selects which side of the
+            // change relative to this trigger's controller:
+            //  - LOST: fires when the *old* controller was this trigger's controller.
+            //  - GAINED: fires when the *new* controller is this trigger's controller.
+            is com.wingedsheep.sdk.scripting.EventPattern.ControlChangeEvent -> {
+                if (event !is com.wingedsheep.engine.core.ControlChangedEvent) return false
+                if (event.oldControllerId == event.newControllerId) return false
+                if (watchedEntityId != null && event.permanentId != watchedEntityId) return false
+                when (specEvent.direction) {
+                    com.wingedsheep.sdk.scripting.ControlChangeDirection.LOST ->
+                        event.oldControllerId == controllerId
+                    com.wingedsheep.sdk.scripting.ControlChangeDirection.GAINED ->
+                        event.newControllerId == controllerId
+                }
+            }
             else -> false
         }
     }
@@ -2777,7 +2794,14 @@ class TriggerDetector(
         val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state)
 
         for (ability in abilities) {
-            if (ability.trigger is EventPattern.ControlChangeEvent && ability.binding == TriggerBinding.SELF) {
+            val controlTrigger = ability.trigger as? EventPattern.ControlChangeEvent
+            // Resident "when you gain control of this" self-trigger (Risky Move): only the GAINED
+            // direction fires here, where the *new* controller controls the ability. A LOST-shaped
+            // ControlChangeEvent is exclusively an entity-scoped delayed trigger (Stolen Uniform).
+            if (controlTrigger != null &&
+                controlTrigger.direction == com.wingedsheep.sdk.scripting.ControlChangeDirection.GAINED &&
+                ability.binding == TriggerBinding.SELF
+            ) {
                 // The new controller controls this triggered ability
                 triggers.add(
                     PendingTrigger(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1637,6 +1637,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttachedToBySource,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastForWarp,
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedToCardType -> true
+        is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedTo -> true
         // Counter predicates require last-known-info to evaluate a creature that has already left
         // the battlefield; the zone-change path ([matchesStatePredicateForZoneChangeTrigger])
         // handles them against the event's captured counters. This entity-only fallback has no LKI,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -568,7 +568,24 @@ class ConditionEvaluator(
             } ?: false
         is EffectTarget.TriggeringEntity ->
             (ctx as? Resolution)?.let {
-                evaluateTriggeringSpellFilterMatch(state, condition.filter, it.effectContext)
+                val triggeringId = it.effectContext.triggeringEntityId
+                if (triggeringId != null && state.getBattlefield().contains(triggeringId)) {
+                    // The triggering object is a battlefield permanent (e.g. a delayed trigger
+                    // watching "that Equipment"). Match against projected state so state predicates
+                    // (attachment) and the controller predicate ("a creature you control") resolve;
+                    // "you" is the ability's controller carried in the effect context.
+                    PredicateEvaluator().matches(
+                        state,
+                        state.projectedState,
+                        triggeringId,
+                        condition.filter,
+                        PredicateContext.fromEffectContext(it.effectContext)
+                    )
+                } else {
+                    // Stack / non-battlefield triggering object (the spell-cast case): match the
+                    // spell's static card characteristics.
+                    evaluateTriggeringSpellFilterMatch(state, condition.filter, it.effectContext)
+                }
             } ?: false
         is EffectTarget.DiscardedAsCost ->
             (ctx as? Resolution)?.let {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1016,6 +1016,21 @@ class PredicateEvaluator {
                 state.projectedState.hasType(attached.targetId, predicate.cardType.name)
             }
 
+            // General attachment match — entity is attached to a host that matches the nested
+            // filter, evaluated against projected battlefield state so the host's control ("a
+            // creature you control"), card type, keywords, P/T all compose (Stolen Uniform's
+            // "attached to a creature you control"). The "you" of any controller predicate is the
+            // controllerId carried in this evaluation context.
+            is StatePredicate.AttachedTo -> {
+                val attached = container.get<AttachedToComponent>() ?: return false
+                // A controller predicate in the nested filter needs a "you"; without an evaluation
+                // context fall back to the host's actual controller so the match can still run.
+                val ctx = context ?: PredicateContext(
+                    controllerId = state.projectedState.getController(attached.targetId) ?: return false
+                )
+                matches(state, state.projectedState, attached.targetId, predicate.filter, ctx)
+            }
+
             // Source-relative — the candidate is the permanent the effect's source is attached
             // to (its enchanted/equipped creature). Read the source's AttachedToComponent and
             // compare its targetId to the candidate. False with no source or an unattached source.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -20,6 +20,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.abilities.RemoveAllAbil
 import com.wingedsheep.engine.handlers.effects.permanent.abilities.RemoveKeywordExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.attachments.AttachEquipmentExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.attachments.AttachTargetEquipmentToCreatureExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.attachments.UnattachEquipmentExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.attachments.GrantExileOnLeaveExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.control.ExchangeControlExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.control.GainControlByActivePlayerExecutor
@@ -169,6 +170,7 @@ class PermanentExecutors(
         // attachments
         AttachEquipmentExecutor(),
         AttachTargetEquipmentToCreatureExecutor(),
+        UnattachEquipmentExecutor(),
         GrantExileOnLeaveExecutor(),
         // stats
         ModifyStatsExecutor(amountEvaluator),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/attachments/UnattachEquipmentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/attachments/UnattachEquipmentExecutor.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.handlers.effects.permanent.attachments
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.PermanentUnattachedEvent
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.UnattachEquipmentEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [UnattachEquipmentEffect].
+ *
+ * Unattaches an Aura/Equipment from its host without moving it to another zone (CR 701.3d): clears
+ * the attachment's [AttachedToComponent] and drops it from the host's [AttachmentsComponent]. A
+ * no-op when the target isn't currently attached, emitting no event. The inverse of the attach
+ * executors — used for "unattach it" riders (Stolen Uniform).
+ */
+class UnattachEquipmentExecutor : EffectExecutor<UnattachEquipmentEffect> {
+
+    override val effectType: KClass<UnattachEquipmentEffect> = UnattachEquipmentEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: UnattachEquipmentEffect,
+        context: EffectContext
+    ): EffectResult {
+        val attachmentId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.success(state) // target gone / illegal — nothing to unattach
+
+        val currentAttachment = state.getEntity(attachmentId)?.get<AttachedToComponent>()
+            ?: return EffectResult.success(state) // not attached to anything — no-op
+
+        val hostId = currentAttachment.targetId
+        var newState = state
+
+        // Drop the attachment id from the host's attachment list.
+        newState = newState.updateEntity(hostId) { container ->
+            val attachments = container.get<AttachmentsComponent>()
+            if (attachments != null) {
+                val updatedIds = attachments.attachedIds.filter { it != attachmentId }
+                if (updatedIds.isEmpty()) container.without<AttachmentsComponent>()
+                else container.with(AttachmentsComponent(updatedIds))
+            } else {
+                container
+            }
+        }
+
+        // Clear the attachment's own AttachedToComponent.
+        newState = newState.updateEntity(attachmentId) { container ->
+            container.without<AttachedToComponent>()
+        }
+
+        val attachmentName = state.getEntity(attachmentId)?.get<CardComponent>()?.name ?: ""
+        return EffectResult.success(
+            newState,
+            listOf(
+                PermanentUnattachedEvent(
+                    attachmentId = attachmentId,
+                    attachmentName = attachmentName,
+                    attachedToId = hostId
+                )
+            )
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -438,6 +438,11 @@ internal class AffectsFilterResolver {
             }
         }
         StatePredicate.IsModified -> com.wingedsheep.engine.handlers.predicates.isModified(state, entityId)
+        // A general "attached to <filter>" host constraint whose nested filter may carry a controller
+        // predicate ("a creature you control"). Group-static projection has no ability controller to
+        // resolve that "you", so this predicate is only meaningful in target/condition contexts via
+        // PredicateEvaluator (where the controllerId is supplied). Never match in projection.
+        is StatePredicate.AttachedTo -> false
         is StatePredicate.AttachedToCardType -> {
             val attached = container.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()
             attached != null &&

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientEvent.kt
@@ -1212,6 +1212,10 @@ is PermanentsSacrificedEvent -> {
             // reflected by the attachment's zone-change/move animation, so no separate client event.
             is PermanentAttachedEvent -> null
 
+            // Internal: the unattach is reflected by the attachment re-rendering loose on the
+            // battlefield, so no separate client event.
+            is PermanentUnattachedEvent -> null
+
             is TurnHijackedEvent,
             is CommitCrimeEvent,
             is CardPlayedFromPermissionEvent,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StolenUniformScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StolenUniformScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.StolenUniform
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Stolen Uniform.
+ *
+ * Stolen Uniform ({U}, Instant):
+ *   "Choose target creature you control and target Equipment. Gain control of that Equipment until
+ *    end of turn. Attach it to the chosen creature. When you lose control of that Equipment this
+ *    turn, if it's attached to a creature you control, unattach it."
+ *
+ * Exercises the new SDK plumbing:
+ *  - [com.wingedsheep.sdk.dsl.Effects.UnattachEquipment] / `UnattachEquipmentEffect` + its executor.
+ *  - The directional [com.wingedsheep.sdk.scripting.EventPattern.ControlChangeEvent] with
+ *    [com.wingedsheep.sdk.scripting.ControlChangeDirection.LOST] used as an entity-scoped delayed
+ *    trigger ([com.wingedsheep.sdk.dsl.Triggers.LoseControlOfWatched]) — "when you lose control of
+ *    that Equipment this turn".
+ *  - The general [com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedTo] host filter
+ *    ("attached to a creature you control") via `GameObjectFilter.attachedTo(...)`.
+ */
+class StolenUniformScenarioTest : FunSpec({
+
+    val MyBear = CardDefinition.creature(
+        name = "Uniform Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    // A vanilla Equipment the opponent controls; only the subtype matters for targeting.
+    val TestEquipment = CardDefinition.equipment(
+        name = "Borrowed Greatsword",
+        manaCost = ManaCost.parse("{2}"),
+        equipCost = ManaCost.parse("{2}")
+    )
+
+    // Lets the opponent take control of the Equipment back mid-turn, emitting the control-change
+    // event my "when you lose control" delayed trigger watches for.
+    val Reclaim = card("Reclaim") {
+        manaCost = "{1}"
+        typeLine = "Instant"
+        oracleText = "Gain control of target permanent."
+        spell {
+            val perm = target("target permanent", Targets.Permanent)
+            effect = Effects.GainControl(perm)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MyBear, TestEquipment, StolenUniform, Reclaim))
+        return driver
+    }
+
+    val projector = StateProjector()
+
+    fun GameTestDriver.attachmentHost(equipmentId: EntityId): EntityId? =
+        state.getEntity(equipmentId)?.get<AttachedToComponent>()?.targetId
+
+    fun GameTestDriver.hostAttachments(hostId: EntityId): List<EntityId> =
+        state.getEntity(hostId)?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+
+    // Control changes are floating effects; the base ControllerComponent is unchanged, so read the
+    // effective controller from projected state.
+    fun GameTestDriver.controllerOf(entityId: EntityId): EntityId? =
+        projector.project(state).getController(entityId)
+
+    test("gain control of the Equipment until end of turn and force-attach it to your creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val myCreature = driver.putCreatureOnBattlefield(me, "Uniform Bear")
+        val equipment = driver.putPermanentOnBattlefield(opponent, "Borrowed Greatsword")
+
+        // Sanity: opponent controls the Equipment, it isn't attached to anything yet.
+        driver.controllerOf(equipment) shouldBe opponent
+        driver.attachmentHost(equipment) shouldBe null
+
+        val spell = driver.putCardInHand(me, "Stolen Uniform")
+        driver.giveMana(me, Color.BLUE, 1)
+        val result = driver.castSpell(me, spell, targets = listOf(myCreature, equipment))
+        result.isSuccess shouldBe true
+        driver.bothPass() // resolve the spell
+
+        // Gained control of the Equipment, and it's force-attached to my creature.
+        driver.controllerOf(equipment) shouldBe me
+        driver.attachmentHost(equipment) shouldBe myCreature
+        driver.hostAttachments(myCreature).contains(equipment) shouldBe true
+    }
+
+    test("losing control of the Equipment fires the delayed trigger, which unattaches it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val myCreature = driver.putCreatureOnBattlefield(me, "Uniform Bear")
+        val equipment = driver.putPermanentOnBattlefield(opponent, "Borrowed Greatsword")
+
+        val spell = driver.putCardInHand(me, "Stolen Uniform")
+        driver.giveMana(me, Color.BLUE, 1)
+        driver.castSpell(me, spell, targets = listOf(myCreature, equipment)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.controllerOf(equipment) shouldBe me
+        driver.attachmentHost(equipment) shouldBe myCreature
+
+        // The opponent takes control of the Equipment back this turn — "you lose control of that
+        // Equipment" — which fires the delayed trigger. The Equipment is still attached to a creature
+        // I control, so the trigger's conditional unattaches it.
+        val reclaim = driver.putCardInHand(opponent, "Reclaim")
+        driver.giveMana(opponent, Color.BLUE, 1)
+        // Hand priority to the opponent so they can cast their instant.
+        driver.passPriority(me)
+        driver.castSpell(opponent, reclaim, targets = listOf(equipment)).isSuccess shouldBe true
+        driver.bothPass() // resolve Reclaim → control moves to opponent, delayed trigger fires
+        driver.bothPass() // resolve the delayed "unattach" trigger
+
+        // Opponent now controls the Equipment, and it has been unattached from my creature.
+        driver.controllerOf(equipment) shouldBe opponent
+        driver.attachmentHost(equipment) shouldBe null
+        driver.hostAttachments(myCreature).contains(equipment) shouldBe false
+    }
+})


### PR DESCRIPTION
## Stolen Uniform (Final Fantasy)

`{U}` Instant — *"Choose target creature you control and target Equipment. Gain control of that Equipment until end of turn. Attach it to the chosen creature. When you lose control of that Equipment this turn, if it's attached to a creature you control, unattach it."*

Implemented by composing existing facades — no monolithic executor:
`Effects.GainControl(equipment, EndOfTurn)` → `Effects.AttachTargetEquipmentToCreature(...)` → a reflexive `CreateDelayedTriggerEffect` scoped to the Equipment.

## New SDK plumbing

- **`Effects.UnattachEquipment` / `UnattachEquipmentEffect` + executor** — unattach an Aura/Equipment from its host without moving zones (CR 701.3d), emitting `PermanentUnattachedEvent`; no-op when not attached. The inverse of the attach effects.
- **`EventPattern.ControlChangeEvent(direction)`** gains a `ControlChangeDirection` (`GAINED` default / `LOST`). `GAINED` preserves the existing "when you gain control of this" self-trigger (Risky Move / `GainControlOfSelf`). `LOST` powers the new `Triggers.LoseControlOfWatched`, used as an **entity-scoped delayed trigger** that fires when the watched permanent's control moves away from its controller.
- **`StatePredicate.AttachedTo(filter)` + `GameObjectFilter.attachedTo(host)`** — the general form of `AttachedToCardType`, matching the host against an arbitrary filter (including a controller predicate) under projected state: "attached to a creature you control".
- **`ConditionEvaluator`** routes a battlefield `TriggeringEntity` match through the projected `PredicateEvaluator` so attachment + controller predicates resolve.

Engine wiring: the new `StatePredicate` is classified in the three exhaustive predicate `when`s (`BeginningPhaseManager`, `TriggerMatcher`, `AffectsFilterResolver`); the executor and serializer are registered.

## Notes / scope

The card's "when you lose control" trigger is exercised on the **mid-turn control-loss** path (an opponent reclaiming the Equipment). The *literal end-of-turn* reversion currently does not fire the trigger: `CleanupPhaseManager.cleanupEndOfTurn` drops the until-EOT control floating effect **silently** (no `ControlChangedEvent`) and purges EndOfTurn delayed triggers in the same pass. Wiring a control-reversion event + cleanup-step trigger handling into end-of-turn is a broader, cross-cutting engine change affecting every until-EOT control effect (Act of Treason, etc.), so it is intentionally left out of this card PR. At literal end of turn the Equipment reverts to its owner regardless, so the unattach is not observable there.

## Tests

- `StolenUniformScenarioTest`: gain-control-and-force-attach, and control-loss → delayed trigger → unattach.
- Re-blessed `FIN.json` snapshot (Stolen Uniform only).
- `CardLintTest`, full `:rules-engine` suite, `:mtg-sets` + `:mtg-sdk` suites all green.
- SDK reference updated (effect, trigger, predicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)