### PR TITLE
Fix flaky StayHiddenStaySilent scenario test

### DIFF
--- a/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
+++ b/rules-engine/src/testFixtures/kotlin/com/wingedsheep/engine/support/GameTestDriver.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.combat.AttackersDeclaredThisCombatComponent
 import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombatComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.identity.PlayerComponent
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
@@ -506,11 +507,17 @@ class GameTestDriver {
 
     /**
      * Find a card by name on a player's battlefield.
+     *
+     * Face-down permanents (morph/manifest) are skipped: per CR 708.2 a face-down permanent has
+     * no name, so a name lookup must not match one even though its hidden [CardComponent] still
+     * carries the underlying card's name. (Without this, a card shuffled away and then re-manifested
+     * face-down — e.g. via manifest dread off the top of the library — would spuriously match.)
      */
     fun findPermanent(playerId: EntityId, cardName: String): EntityId? {
         val battlefieldZone = ZoneKey(playerId, Zone.BATTLEFIELD)
         return state.getZone(battlefieldZone).find { entityId ->
-            state.getEntity(entityId)?.get<CardComponent>()?.name == cardName
+            val entity = state.getEntity(entityId) ?: return@find false
+            !entity.has<FaceDownComponent>() && entity.get<CardComponent>()?.name == cardName
         }
     }
 


### PR DESCRIPTION
## Problem

`StayHiddenStaySilentScenarioTest > activated ability shuffles the enchanted creature away and manifests dread` was flaky, failing intermittently with `AssertionFailedError` at line 103:

```kotlin
d.findPermanent(me, "Grizzly Bears") shouldBe null
```

## Root cause

The test deck is 40 Islands plus the Grizzly Bears that the activated ability shuffles into the library. Manifest dread then looks at the **top two cards** of that library and manifests one **face-down**. When the shuffle happened to land Grizzly Bears in the top two and it was the card picked (`options.first()`), a face-down 2/2 re-entered the battlefield.

A face-down (morph/manifest) permanent keeps its underlying `CardComponent` — including `name = "Grizzly Bears"` — and is masked only via projection. The test helper `findPermanent(playerId, cardName)` matched on that base name, so it spuriously found the manifested creature and the assertion failed. Failure probability ≈ (2/40) × (1/2) ≈ 2.5% per run.

## Fix

Per CR 708.2 a face-down permanent has **no name**, so a name-based lookup must not match one. `findPermanent` now skips permanents carrying `FaceDownComponent`. This removes the flakiness and corrects the helper's semantics for every caller — all existing face-down assertions in the suite are `shouldBe null`, which this only makes more correct.

## Verification

- Target test run 5× with `--rerun-tasks` (fresh shuffle each time): all passed.
- Re-ran morph/manifest tests that also use the two-arg `findPermanent` (Dermoplasm, VoidmageProdigy, NosyGoblin, QuicksilverDragon, SerpentineBasilisk, DawningPurist): all passed. Their `shouldNotBe null` cases all reference face-up permanents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)