### PR TITLE
Add basic lands to Duskmourn (DSK) and Final Fantasy (FIN)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/DuskmournSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/DuskmournSet.kt
@@ -22,6 +22,10 @@ object DuskmournSet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DuskmournBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DuskmournBasicLands.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Duskmourn: House of Horror Basic Lands
+ *
+ * Duskmourn contains 3 art variants of each basic land type.
+ * Cards 272-276 (Dan Mumford full set) and 277-286 (two additional artists per type).
+ */
+
+// =============================================================================
+// Plains (Cards 272, 277, 278)
+// =============================================================================
+
+val DuskmournPlains272 = basicLand("Plains") {
+    collectorNumber = "272"
+    artist = "Dan Mumford"
+    imageUri = "https://cards.scryfall.io/normal/front/e/6/e67ce864-bf29-42f1-81ca-a98022892eec.jpg?1726286890"
+}
+
+val DuskmournPlains277 = basicLand("Plains") {
+    collectorNumber = "277"
+    artist = "Marco Gorlei"
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b499b37-efaf-4484-95e8-a70a9778c804.jpg?1726286908"
+}
+
+val DuskmournPlains278 = basicLand("Plains") {
+    collectorNumber = "278"
+    artist = "Josu Hernaiz"
+    imageUri = "https://cards.scryfall.io/normal/front/7/5/756abff9-9810-4e2d-b1d7-ec4e2d6d5187.jpg?1726286912"
+}
+
+// =============================================================================
+// Island (Cards 273, 279, 280)
+// =============================================================================
+
+val DuskmournIsland273 = basicLand("Island") {
+    collectorNumber = "273"
+    artist = "Dan Mumford"
+    imageUri = "https://cards.scryfall.io/normal/front/4/0/40e3bf00-84cc-498c-b214-1052b4904d92.jpg?1726286894"
+}
+
+val DuskmournIsland279 = basicLand("Island") {
+    collectorNumber = "279"
+    artist = "Raymond Bonilla"
+    imageUri = "https://cards.scryfall.io/normal/front/9/4/947702ca-d065-4368-9f26-f859d4642cb6.jpg?1726286915"
+}
+
+val DuskmournIsland280 = basicLand("Island") {
+    collectorNumber = "280"
+    artist = "Leonardo Borazio"
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1d10d9c-8771-4870-aebf-e767d0fada32.jpg?1726286920"
+}
+
+// =============================================================================
+// Swamp (Cards 274, 281, 282)
+// =============================================================================
+
+val DuskmournSwamp274 = basicLand("Swamp") {
+    collectorNumber = "274"
+    artist = "Dan Mumford"
+    imageUri = "https://cards.scryfall.io/normal/front/7/4/7442c1c7-1c10-4387-92e6-4bdea263064f.jpg?1726286897"
+}
+
+val DuskmournSwamp281 = basicLand("Swamp") {
+    collectorNumber = "281"
+    artist = "Martin de Diego Sádaba"
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c51de66-a3ed-4ca9-befb-9813e96c4ade.jpg?1726286923"
+}
+
+val DuskmournSwamp282 = basicLand("Swamp") {
+    collectorNumber = "282"
+    artist = "Néstor Ossandón Leal"
+    imageUri = "https://cards.scryfall.io/normal/front/c/b/cbd95de0-702a-4b88-a1cc-981cf1d9673e.jpg?1726286927"
+}
+
+// =============================================================================
+// Mountain (Cards 275, 283, 284)
+// =============================================================================
+
+val DuskmournMountain275 = basicLand("Mountain") {
+    collectorNumber = "275"
+    artist = "Dan Mumford"
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8c8841b2-9b4e-4f65-8e30-1e9423cb8fbc.jpg?1726286901"
+}
+
+val DuskmournMountain283 = basicLand("Mountain") {
+    collectorNumber = "283"
+    artist = "Ralph Horsley"
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/accb56f0-3903-4894-86f0-3965162064d4.jpg?1726286930"
+}
+
+val DuskmournMountain284 = basicLand("Mountain") {
+    collectorNumber = "284"
+    artist = "Néstor Ossandón Leal"
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1a44d8a4-21de-497d-9eed-702d7b592728.jpg?1726286935"
+}
+
+// =============================================================================
+// Forest (Cards 276, 285, 286)
+// =============================================================================
+
+val DuskmournForest276 = basicLand("Forest") {
+    collectorNumber = "276"
+    artist = "Dan Mumford"
+    imageUri = "https://cards.scryfall.io/normal/front/b/a/ba2a4cbb-f325-4178-80db-7090f5672414.jpg?1726286905"
+}
+
+val DuskmournForest285 = basicLand("Forest") {
+    collectorNumber = "285"
+    artist = "Martin de Diego Sádaba"
+    imageUri = "https://cards.scryfall.io/normal/front/e/8/e84c0880-728d-4ac2-b685-4f18f66c24db.jpg?1726286938"
+}
+
+val DuskmournForest286 = basicLand("Forest") {
+    collectorNumber = "286"
+    artist = "Josu Hernaiz"
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0da5fbc2-24ad-4520-a60a-436d3a485fec.jpg?1726286943"
+}
+
+/**
+ * All Duskmourn: House of Horror basic land variants.
+ */
+val DuskmournBasicLands = listOf(
+    DuskmournPlains272, DuskmournPlains277, DuskmournPlains278,
+    DuskmournIsland273, DuskmournIsland279, DuskmournIsland280,
+    DuskmournSwamp274, DuskmournSwamp281, DuskmournSwamp282,
+    DuskmournMountain275, DuskmournMountain283, DuskmournMountain284,
+    DuskmournForest276, DuskmournForest285, DuskmournForest286,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/FinalFantasySet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/FinalFantasySet.kt
@@ -22,6 +22,10 @@ object FinalFantasySet : MtgSet {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     override val printings: List<Printing> by lazy {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FinalFantasyBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FinalFantasyBasicLands.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Final Fantasy Basic Lands
+ *
+ * Final Fantasy contains 3 art variants of each colored basic land type (cards 294-308)
+ * plus a borderless variant of each (cards 572-576).
+ *
+ * Note: FIN also prints a colorless Wastes (#309), which the `basicLand` DSL does not yet model.
+ */
+
+// =============================================================================
+// Plains (Cards 294-296, 572)
+// =============================================================================
+
+val FinalFantasyPlains294 = basicLand("Plains") {
+    collectorNumber = "294"
+    artist = "Shahab Alizadeh"
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9dd2d666-7c6b-48ce-93dc-c004ebdd1fe9.jpg?1748706876"
+}
+
+val FinalFantasyPlains295 = basicLand("Plains") {
+    collectorNumber = "295"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/e/6/e623b058-76d2-476b-9ee6-82807f7992c3.jpg?1748706882"
+}
+
+val FinalFantasyPlains296 = basicLand("Plains") {
+    collectorNumber = "296"
+    artist = "Eddie Mendoza"
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee86ac2f-f398-4422-8721-8ac859fbf5bc.jpg?1748706884"
+}
+
+val FinalFantasyPlains572 = basicLand("Plains") {
+    collectorNumber = "572"
+    artist = "Jonas De Ro"
+    imageUri = "https://cards.scryfall.io/normal/front/d/e/dec72b07-8f41-4d42-a455-794bf106302c.jpg?1748707607"
+}
+
+// =============================================================================
+// Island (Cards 297-299, 573)
+// =============================================================================
+
+val FinalFantasyIsland297 = basicLand("Island") {
+    collectorNumber = "297"
+    artist = "Fariba Khamseh"
+    imageUri = "https://cards.scryfall.io/normal/front/b/9/b92ec9f6-a56d-40c6-aee2-7d5e1524c985.jpg?1749278110"
+}
+
+val FinalFantasyIsland298 = basicLand("Island") {
+    collectorNumber = "298"
+    artist = "Eddie Mendoza"
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/eeecf096-87dd-4dcb-953f-700445bf3f3a.jpg?1748706891"
+}
+
+val FinalFantasyIsland299 = basicLand("Island") {
+    collectorNumber = "299"
+    artist = "Jeremy Paillotin"
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/347e00db-abcf-4053-aa27-4a5b42e1da55.jpg?1748706896"
+}
+
+val FinalFantasyIsland573 = basicLand("Island") {
+    collectorNumber = "573"
+    artist = "Eddie Mendoza"
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/46255a65-b735-4888-85db-3ab2ab3d903c.jpg?1748707607"
+}
+
+// =============================================================================
+// Swamp (Cards 300-302, 574)
+// =============================================================================
+
+val FinalFantasySwamp300 = basicLand("Swamp") {
+    collectorNumber = "300"
+    artist = "Domenico Cava"
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f66094ef-059b-4511-aa6e-835906736de4.jpg?1748706900"
+}
+
+val FinalFantasySwamp301 = basicLand("Swamp") {
+    collectorNumber = "301"
+    artist = "Fang Xinyu"
+    imageUri = "https://cards.scryfall.io/normal/front/a/7/a7f56d20-16dc-4b7f-98bf-124817a83bae.jpg?1748706903"
+}
+
+val FinalFantasySwamp302 = basicLand("Swamp") {
+    collectorNumber = "302"
+    artist = "Sean Vo"
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/08ec1e4f-e284-4216-a022-bd94c4dae02b.jpg?1748706908"
+}
+
+val FinalFantasySwamp574 = basicLand("Swamp") {
+    collectorNumber = "574"
+    artist = "Domenico Cava"
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/1176ebbf-4130-4e4e-ad49-65101a7357b4.jpg?1748707608"
+}
+
+// =============================================================================
+// Mountain (Cards 303-305, 575)
+// =============================================================================
+
+val FinalFantasyMountain303 = basicLand("Mountain") {
+    collectorNumber = "303"
+    artist = "Domenico Cava"
+    imageUri = "https://cards.scryfall.io/normal/front/a/1/a18ef64b-a9de-4548-b4d5-168758442db7.jpg?1748706910"
+}
+
+val FinalFantasyMountain304 = basicLand("Mountain") {
+    collectorNumber = "304"
+    artist = "Randy Gallegos"
+    imageUri = "https://cards.scryfall.io/normal/front/d/0/d061b9a8-e95d-48ec-a1c9-337433b62dfc.jpg?1748706915"
+}
+
+val FinalFantasyMountain305 = basicLand("Mountain") {
+    collectorNumber = "305"
+    artist = "Sean Vo"
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/ea1735b9-fd10-4c9c-b9d3-046d8c22b852.jpg?1748706917"
+}
+
+val FinalFantasyMountain575 = basicLand("Mountain") {
+    collectorNumber = "575"
+    artist = "Domenico Cava"
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0cef98b7-d54a-456e-8240-1c5af3a72a04.jpg?1748707608"
+}
+
+// =============================================================================
+// Forest (Cards 306-308, 576)
+// =============================================================================
+
+val FinalFantasyForest306 = basicLand("Forest") {
+    collectorNumber = "306"
+    artist = "Alayna Danner"
+    imageUri = "https://cards.scryfall.io/normal/front/b/e/be72862d-d71e-4b18-98a6-59019399f631.jpg?1748706924"
+}
+
+val FinalFantasyForest307 = basicLand("Forest") {
+    collectorNumber = "307"
+    artist = "Leon Tukker"
+    imageUri = "https://cards.scryfall.io/normal/front/3/d/3d08f6a6-316d-45d8-aabe-1760a20903ac.jpg?1748706925"
+}
+
+val FinalFantasyForest308 = basicLand("Forest") {
+    collectorNumber = "308"
+    artist = "Sean Vo"
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c52038c8-5bba-4d8e-845f-30af44300acc.jpg?1748706931"
+}
+
+val FinalFantasyForest576 = basicLand("Forest") {
+    collectorNumber = "576"
+    artist = "Leon Tukker"
+    imageUri = "https://cards.scryfall.io/normal/front/2/0/2036f825-ef57-4a40-b45f-0668d9c8ec6a.jpg?1748707608"
+}
+
+/**
+ * All Final Fantasy colored basic land variants.
+ */
+val FinalFantasyBasicLands = listOf(
+    FinalFantasyPlains294, FinalFantasyPlains295, FinalFantasyPlains296, FinalFantasyPlains572,
+    FinalFantasyIsland297, FinalFantasyIsland298, FinalFantasyIsland299, FinalFantasyIsland573,
+    FinalFantasySwamp300, FinalFantasySwamp301, FinalFantasySwamp302, FinalFantasySwamp574,
+    FinalFantasyMountain303, FinalFantasyMountain304, FinalFantasyMountain305, FinalFantasyMountain575,
+    FinalFantasyForest306, FinalFantasyForest307, FinalFantasyForest308, FinalFantasyForest576,
+)


### PR DESCRIPTION
## Summary
Define the colored basic land variants for Duskmourn: House of Horror and Final Fantasy, and wire up the `basicLands` override on each `MtgSet`. Both sets previously had no basic lands.

- **DSK**: 15 variants (3 art per type, collector numbers 272–286) → new `dsk/cards/DuskmournBasicLands.kt`
- **FIN**: 20 variants (3 art per type 294–308 + borderless 572–576) → new `fin/cards/FinalFantasyBasicLands.kt`

Scryfall data (collector numbers, artists, image URIs) was pulled live from the Scryfall API, following the existing Bloomburrow basic-lands pattern.

## Note
FIN's colorless **Wastes (#309)** is omitted — the `basicLand` DSL only models the five colored types and throws on anything else. Adding Wastes would require extending the SDK builder (an `add-feature` change), so it's left as a possible follow-up rather than approximated.

## Testing
- `:mtg-sets` compiles clean
- Full `:mtg-sets:test` suite passes (snapshot, lint, discovery)
- Snapshot goldens unchanged — the snapshot net deliberately excludes basic lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)