### PR TITLE
Make prepared spell copies in hand read as "Prepared"

### DIFF
--- a/manual-scenarios/cards/e/elite-interceptor-prepared-hand-cue.json
+++ b/manual-scenarios/cards/e/elite-interceptor-prepared-hand-cue.json
@@ -1,0 +1,27 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Elite Interceptor"],
+    "battlefield": [
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -264,6 +264,11 @@ data class ClientCard(
      * prepare spell sits castable in its controller's exile until cast. Battlefield only. */
     val isPrepared: Boolean = false,
 
+    /** Whether this exiled card is the prepare-spell copy of a prepared permanent (Secrets of
+     * Strixhaven). It shows up as a castable ghost card in its controller's hand; this flag lets the
+     * client badge it so the player sees it originates from a prepared creature. Exile only. */
+    val isPreparedSpell: Boolean = false,
+
     /** Whether this permanent was cast for its warp cost (CR 702.185, Edge of Eternities): it will be
      * exiled at the beginning of the next end step, after which it can be recast from exile. Drives the
      * cosmic "warped" cue on the battlefield. Battlefield only. */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1075,6 +1075,12 @@ class ClientStateTransformer(
         val isPrepared = zoneKey.zoneType == Zone.BATTLEFIELD &&
             container.has<com.wingedsheep.engine.state.components.battlefield.PreparedComponent>()
 
+        // The exiled prepare-spell copy carries a PreparedSpellCopyComponent. It surfaces as a castable
+        // ghost card in the controller's hand; flag it so the client can badge it as coming from a
+        // prepared creature (rather than reading like a generic impulse-draw exile card).
+        val isPreparedSpell = zoneKey.zoneType == Zone.EXILE &&
+            container.has<com.wingedsheep.engine.state.components.battlefield.PreparedSpellCopyComponent>()
+
         // Warped permanents (CR 702.185, Edge of Eternities) carry a WarpedComponent until they're
         // exiled at the next end step; surface a flag so the client can show the cosmic warp cue.
         val isWarped = zoneKey.zoneType == Zone.BATTLEFIELD &&
@@ -1142,6 +1148,7 @@ class ClientStateTransformer(
             isSuspected = projectedValues?.isSuspected == true,
             isPlotted = isPlotted,
             isPrepared = isPrepared,
+            isPreparedSpell = isPreparedSpell,
             isWarped = isWarped,
             morphCost = if (isFaceDown && morphData != null) morphData.morphCost.description else null,
             targets = targets,

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1080,6 +1080,14 @@ function GameCardImpl({
     // Orange highlight for valid planeswalker attack targets
     borderStyle = '2px solid #ff8800'
     boxShadow = '0 0 12px rgba(255, 136, 0, 0.5), 0 0 24px rgba(255, 136, 0, 0.3)'
+  } else if (isGhost && card.isPreparedSpell && isHovered) {
+    // Prepared spell copy (Secrets of Strixhaven): brighter lavender rim matching its creature's
+    // "Prepared" badge, so the hand ghost card clearly reads as coming from a prepared creature.
+    borderStyle = '3px solid #cdb8ff'
+    boxShadow = '0 0 20px rgba(143, 111, 224, 0.95), 0 0 40px rgba(143, 111, 224, 0.5)'
+  } else if (isGhost && card.isPreparedSpell) {
+    borderStyle = '2px solid #a98bff'
+    boxShadow = '0 0 12px rgba(143, 111, 224, 0.7), 0 0 24px rgba(143, 111, 224, 0.35)'
   } else if (isPlayable && isGhost && isHovered) {
     // Bright purple highlight when hovering over a playable ghost card
     borderStyle = '3px solid #aa77ee'
@@ -1175,7 +1183,7 @@ function GameCardImpl({
         boxShadow: card.isCommander && !faceDown
           ? `${boxShadow}, 0 0 6px 2px rgba(212, 175, 55, 0.6), 0 0 14px 4px rgba(212, 175, 55, 0.3)`
           : boxShadow,
-        opacity: isPhasedOut ? 0.4 : isBeingDragged ? 0.6 : isGhost ? 0.55 : isBystanderAttacker ? 0.45 : (inHand && isInTargetingMode && !isValidTarget && !isBeingCast) ? 0.35 : 1,
+        opacity: isPhasedOut ? 0.4 : isBeingDragged ? 0.6 : (isGhost && card.isPreparedSpell) ? 0.82 : isGhost ? 0.55 : isBystanderAttacker ? 0.45 : (inHand && isInTargetingMode && !isValidTarget && !isBeingCast) ? 0.35 : 1,
         // Phased-out permanents (Rule 702.26) are treated as though they don't exist —
         // desaturate so they read as "not really there" while still showing the board slot.
         ...(isPhasedOut ? { filter: 'grayscale(0.7)' } : {}),
@@ -1453,6 +1461,14 @@ function GameCardImpl({
       {card.isPrepared && (
         <div style={styles.preparedBadge} title="Prepared (Secrets of Strixhaven) — cast a copy of its spell from exile; doing so unprepares it">
           Prepared
+        </div>
+      )}
+
+      {/* Prepared spell copy (Secrets of Strixhaven): the castable exile copy shown as a ghost card in
+          hand. Same lavender badge as the creature's "Prepared" cue so the link is obvious. */}
+      {card.isPreparedSpell && (
+        <div style={styles.preparedBadge} title="Prepared spell (Secrets of Strixhaven) — a copy from your prepared creature; casting it unprepares that creature">
+          ✦ Prepared
         </div>
       )}
 

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -238,6 +238,11 @@ export interface ClientCard {
    * prepare spell sits castable in its controller's exile. Battlefield only. */
   readonly isPrepared?: boolean
 
+  /** Whether this exiled card is the prepare-spell copy of a prepared permanent (Secrets of
+   * Strixhaven). It appears as a castable ghost card in the controller's hand; drives the
+   * "Prepared" badge that links it back to the prepared creature. Exile only. */
+  readonly isPreparedSpell?: boolean
+
   /** Whether this permanent was cast for its warp cost (CR 702.185, Edge of Eternities): it will be
    * exiled at the next end step, then can be recast from exile. Drives the cosmic warp cue. Battlefield only. */
   readonly isWarped?: boolean


### PR DESCRIPTION
## What & why

A prepared creature (Secrets of Strixhaven — *Prepared*) keeps a castable copy of its prepare spell in exile. That copy surfaces as a translucent **ghost card appended to the controller's hand** (the same mechanism Mind's Desire impulse-draws use). Until now it looked like any other impulse-draw exile ghost — dim purple, heavily see-through — so there was no hint it came from a prepared creature on the battlefield.

This makes the hand copy clearly read as **"Prepared"**, visually linking it back to its creature.

## Changes

- **Engine/DTO** — new additive `isPreparedSpell` flag on `ClientCard`. The transformer sets it for an exiled card that carries `PreparedSpellCopyComponent` (the prepare-spell copy). No behavioural change.
- **Client** — when a hand ghost card is a prepared spell:
  - a lavender **"✦ Prepared"** badge, matching the **"Prepared"** badge shown on the creature itself on the battlefield;
  - a matching lavender rim (brighter on hover) instead of the generic ghost purple;
  - reduced translucency (`0.82` vs the generic ghost `0.55`) so the card art and badge read clearly.

The shared lavender cue ties the in-hand copy to its prepared creature at a glance.

## Screenshots

Prepared creature on the battlefield (**Prepared**) and its castable copy in hand (**✦ Prepared**, lavender glow, legible rather than faded):

![Full board](https://raw.githubusercontent.com/wingedsheep/argentum-engine/improve-prepared-hand-cue-screenshots/prepared-hand-full.png)

Hover state — brighter lavender rim on the hand copy (the split view shows the creature + its "Rejoinder" prepare spell):

![Hover](https://raw.githubusercontent.com/wingedsheep/argentum-engine/improve-prepared-hand-cue-screenshots/prepared-hand-hover.png)

<details><summary>With a card hover-preview open</summary>

![Context](https://raw.githubusercontent.com/wingedsheep/argentum-engine/improve-prepared-hand-cue-screenshots/prepared-hand-context.png)

</details>

> Screenshots are hosted on the throwaway branch `improve-prepared-hand-cue-screenshots` (not part of this PR's diff). Captured via `manual-scenarios/cards/e/elite-interceptor-prepared-hand-cue.json` (included) — cast Elite Interceptor, let it resolve, and its prepare-spell copy appears in hand.

## Verification

- `npm run typecheck` (web-client) ✅
- `:rules-engine:compileKotlin` ✅
- Manually verified end-to-end against the running stack (see screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)