### PR TITLE
Engine bug fixes from TMT self-play: cleanup damage, trigger slots, cast-from-library, enters-with-counters

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4170,9 +4170,13 @@ answer it and would silently return `false`.
 - `WasCastFromHand` — cast specifically from hand.
 - `WasCastFromZone(zone)` — cast from a specific zone. For resolving spells it reads the spell's
   cast-origin; for a permanent already on the battlefield it falls back to the cast-origin marker
-  stamped as it entered (`HAND` → `CastFromHandComponent`, `GRAVEYARD` → `CastFromGraveyardComponent`),
-  so it can gate an entering permanent's own replacement effect (Hundred-Battle Veteran: "enters with
-  a finality counter if cast from your graveyard").
+  stamped as it entered (`HAND` → `CastFromHandComponent`, `GRAVEYARD` → `CastFromGraveyardComponent`,
+  `LIBRARY` → `CastFromLibraryComponent`), so it can gate an entering permanent's own replacement
+  effect (Hundred-Battle Veteran: "enters with a finality counter if cast from your graveyard") or a
+  *non-self* `EntersWithCounters` (`selfOnly = false`), whose condition is evaluated against the
+  entering creature — Leonardo, Sewer Samurai ("creatures you cast from your graveyard enter with a
+  finality counter") and Mikey & Don ("creatures you cast from the top of your library enter with an
+  extra +1/+1 counter", `WasCastFromZone(Zone.LIBRARY)`).
 - `WasKicked` — cast with kicker / multikicker / offspring (i.e. an `OptionalAdditionalCost` with `branchesEffect = true` whose extra cost was paid). FlashKicker payments are intentionally invisible to this condition.
 - `SneakCostWasPaid` — the source was cast for its `Sneak` cost (CR 702.190 — mana + returning an unblocked attacker). Reads the durable `ChoiceSlot.SNEAK` flag on a resolved permanent, falling back to the resolution context for a non-permanent spell's own effect. Backs riders like Leonardo, Leader in Blue and The Last Ronin's Technique.
 - `NoManaSpentToCast` — "it wasn't cast or no mana was spent to cast it": the standard free-cast

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirement.kt
@@ -452,6 +452,35 @@ data class TargetOther(
 }
 
 /**
+ * Return a copy of this requirement whose maximum [count] is narrowed to [newCount], clamping
+ * [minCount] down so it never exceeds the new maximum. A no-op when [newCount] already equals
+ * [count].
+ *
+ * Used when a chosen target set is smaller than a requirement's declared maximum (a partially
+ * filled "up to N" slot). The flattened target↔requirement index walks
+ * (`StackResolver.getRequirementForTargetIndex`, `EffectContext.buildNamedTargets`) advance by
+ * `count`, so an over-wide requirement would absorb a *later* slot's targets and validate them
+ * against the wrong filter. Shrinking the requirement to the targets actually chosen keeps those
+ * walks aligned.
+ */
+fun TargetRequirement.withCount(newCount: Int): TargetRequirement {
+    if (newCount == count) return this
+    val clampedMin = minOf(minCount, newCount)
+    return when (this) {
+        is TargetPlayer -> copy(count = newCount)
+        is TargetOpponent -> copy(count = newCount)
+        is AnyTarget -> copy(count = newCount, minCount = clampedMin)
+        is TargetCreatureOrPlayer -> copy(count = newCount)
+        is TargetOpponentOrPlaneswalker -> copy(count = newCount)
+        is TargetPlayerOrPlaneswalker -> copy(count = newCount)
+        is TargetCreatureOrPlaneswalker -> copy(count = newCount)
+        is TargetSpellOrPermanent -> copy(count = newCount)
+        is TargetObject -> copy(count = newCount, minCount = clampedMin)
+        is TargetOther -> copy(baseRequirement = baseRequirement.withCount(newCount))
+    }
+}
+
+/**
  * Create a copy of this TargetRequirement with the given id set.
  * Used by the DSL to stamp an id onto requirements passed to target(name, requirement).
  */

--- a/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirementWithCountTest.kt
+++ b/mtg-sdk/src/test/kotlin/com/wingedsheep/sdk/scripting/targets/TargetRequirementWithCountTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.sdk.scripting.targets
+
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [TargetRequirement.withCount] — narrowing a requirement's maximum target [count] to
+ * the number of targets actually chosen for its slot.
+ *
+ * This backs the trigger-target resumer's slot alignment: a partially filled "up to N" slot must
+ * shrink to the chosen count so the flattened target↔requirement index walks
+ * (`StackResolver.getRequirementForTargetIndex`, `EffectContext.buildNamedTargets`) don't let an
+ * over-wide requirement absorb the next slot's targets.
+ */
+class TargetRequirementWithCountTest : FunSpec({
+
+    test("narrows the max count and clamps the minCount field down with it") {
+        // minCount defaults to count (2), so narrowing to 1 clamps the field to 1; `optional` is
+        // what keeps the *effective* minimum at 0 ("up to one").
+        val req = TargetObject(count = 2, optional = true, filter = TargetFilter.Creature)
+        val narrowed = req.withCount(1) as TargetObject
+        narrowed.count shouldBe 1
+        narrowed.minCount shouldBe 1
+        narrowed.effectiveMinCount shouldBe 0
+        narrowed.optional shouldBe true
+        narrowed.filter shouldBe TargetFilter.Creature
+    }
+
+    test("clamps a non-optional minCount that would exceed the new count") {
+        // "one or two target creatures": count=2, minCount=1. Narrowed to a single chosen target,
+        // minCount must drop to 1 (still ≤ 1) — and to 0 if narrowed below it.
+        val req = TargetObject(count = 2, minCount = 1, filter = TargetFilter.Creature)
+        (req.withCount(1) as TargetObject).minCount shouldBe 1
+        (req.withCount(0) as TargetObject).minCount shouldBe 0
+    }
+
+    test("is a no-op when the count is unchanged") {
+        val req = TargetObject(count = 1, filter = TargetFilter.Artifact)
+        (req.withCount(1) === req) shouldBe true
+    }
+
+    test("recurses through TargetOther into its base requirement") {
+        val base = TargetObject(count = 2, optional = true, filter = TargetFilter.Creature)
+        val other = TargetOther(baseRequirement = base)
+        other.count shouldBe 2
+        val narrowed = other.withCount(1)
+        narrowed.count shouldBe 1
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -152,45 +152,11 @@ class CleanupPhaseManager(
             )
         }
 
-        // Remove damage from all permanents on the battlefield (Rule 514.2).
-        // Includes vehicles that reverted from creature status this turn — their damage
-        // (and P/T from the expired floating effect) must be cleared.
-        val battlefield = newState.getBattlefield().toSet()
-        val permanentsWithDamage = newState.entities.filter { (entityId, container) ->
-            entityId in battlefield && container.has<DamageComponent>()
-        }.keys
-
-        for (entityId in permanentsWithDamage) {
-            newState = newState.updateEntity(entityId) { it.without<DamageComponent>() }
-        }
-
-        // Remove MustAttackThisTurnComponent from all creatures (Walking Desecration effect)
-        val creaturesWithMustAttack = newState.entities.filter { (_, container) ->
-            container.has<MustAttackThisTurnComponent>()
-        }.keys
-        for (entityId in creaturesWithMustAttack) {
-            newState = newState.updateEntity(entityId) { it.without<MustAttackThisTurnComponent>() }
-        }
-
-        // Remove CanAttackDespiteDefenderThisTurnComponent (Krotiq Nestguard's "can attack
-        // this turn as though it didn't have defender" activated ability).
-        val creaturesWithCanAttackDespiteDefender = newState.entities.filter { (_, container) ->
-            container.has<CanAttackDespiteDefenderThisTurnComponent>()
-        }.keys
-        for (entityId in creaturesWithCanAttackDespiteDefender) {
-            newState = newState.updateEntity(entityId) { it.without<CanAttackDespiteDefenderThisTurnComponent>() }
-        }
-
-        // Close any open miracle windows (CR 702.94 — the chance to cast for the miracle cost lasts
-        // only the turn the card was drawn).
-        val cardsWithMiracleWindow = newState.entities.filter { (_, container) ->
-            container.has<com.wingedsheep.engine.state.components.identity.MiracleWindowComponent>()
-        }.keys
-        for (entityId in cardsWithMiracleWindow) {
-            newState = newState.updateEntity(entityId) {
-                it.without<com.wingedsheep.engine.state.components.identity.MiracleWindowComponent>()
-            }
-        }
+        // CR 514.2 turn-based actions: remove marked damage and end the per-turn markers that
+        // expire with the cleanup step. The hand-size discard (CR 514.1) above early-returns
+        // *before* this point; its continuation re-runs the same actions via
+        // [applyCleanupTurnBasedActions], so this block must stay side-effect-equivalent there.
+        newState = applyCleanupTurnBasedActions(newState)
 
         // No priority during cleanup (normally)
         newState = newState.copy(priorityPlayerId = null)
@@ -925,5 +891,65 @@ class CleanupPhaseManager(
         }
 
         return newState
+    }
+
+    companion object {
+        /**
+         * Apply the CR 514.2 turn-based cleanup actions: remove all marked damage from
+         * permanents and end the per-turn combat/miracle markers that expire with the cleanup
+         * step. Extracted from [performCleanupStep] so it can run in *both* cleanup paths.
+         *
+         * [performCleanupStep] performs the CR 514.1 hand-size discard first, and when a discard
+         * is required it early-returns to ask the player — *before* these 514.2 actions. That
+         * pause is resumed by [com.wingedsheep.engine.core.HandSizeDiscardContinuation], whose
+         * resumer must call this to finish the step. If it doesn't, marked damage survives into
+         * the next turn — most visibly deathtouch damage that an expiring "until end of turn"
+         * indestructible (e.g. Saved by the Shell) had been suppressing, which then kills the
+         * creature on the following turn's state-based-action check.
+         */
+        fun applyCleanupTurnBasedActions(state: GameState): GameState {
+            var newState = state
+
+            // Remove damage from all permanents on the battlefield (Rule 514.2).
+            // Includes vehicles that reverted from creature status this turn — their damage
+            // (and P/T from the expired floating effect) must be cleared.
+            val battlefield = newState.getBattlefield().toSet()
+            val permanentsWithDamage = newState.entities.filter { (entityId, container) ->
+                entityId in battlefield && container.has<DamageComponent>()
+            }.keys
+            for (entityId in permanentsWithDamage) {
+                newState = newState.updateEntity(entityId) { it.without<DamageComponent>() }
+            }
+
+            // Remove MustAttackThisTurnComponent from all creatures (Walking Desecration effect)
+            val creaturesWithMustAttack = newState.entities.filter { (_, container) ->
+                container.has<MustAttackThisTurnComponent>()
+            }.keys
+            for (entityId in creaturesWithMustAttack) {
+                newState = newState.updateEntity(entityId) { it.without<MustAttackThisTurnComponent>() }
+            }
+
+            // Remove CanAttackDespiteDefenderThisTurnComponent (Krotiq Nestguard's "can attack
+            // this turn as though it didn't have defender" activated ability).
+            val creaturesWithCanAttackDespiteDefender = newState.entities.filter { (_, container) ->
+                container.has<CanAttackDespiteDefenderThisTurnComponent>()
+            }.keys
+            for (entityId in creaturesWithCanAttackDespiteDefender) {
+                newState = newState.updateEntity(entityId) { it.without<CanAttackDespiteDefenderThisTurnComponent>() }
+            }
+
+            // Close any open miracle windows (CR 702.94 — the chance to cast for the miracle cost lasts
+            // only the turn the card was drawn).
+            val cardsWithMiracleWindow = newState.entities.filter { (_, container) ->
+                container.has<com.wingedsheep.engine.state.components.identity.MiracleWindowComponent>()
+            }.keys
+            for (entityId in cardsWithMiracleWindow) {
+                newState = newState.updateEntity(entityId) {
+                    it.without<com.wingedsheep.engine.state.components.identity.MiracleWindowComponent>()
+                }
+            }
+
+            return newState
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -365,6 +365,7 @@ val engineSerializersModule = SerializersModule {
         subclass(PhasedOutComponent::class)
         subclass(CastFromHandComponent::class)
         subclass(CastFromGraveyardComponent::class)
+        subclass(CastFromLibraryComponent::class)
         subclass(EnteredFromGraveyardComponent::class)
         subclass(CountersComponent::class)
         subclass(DamageComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -84,6 +84,7 @@ import com.wingedsheep.sdk.scripting.conditions.WasCast
 import com.wingedsheep.sdk.scripting.conditions.WasCastFromHand
 import com.wingedsheep.sdk.scripting.conditions.WasCastFromZone
 import com.wingedsheep.engine.state.components.battlefield.CastFromGraveyardComponent
+import com.wingedsheep.engine.state.components.battlefield.CastFromLibraryComponent
 import com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentHadSubtype
 import com.wingedsheep.sdk.scripting.conditions.SacrificedPermanentWasLegendary
 import com.wingedsheep.sdk.scripting.conditions.YouSacrificedPermanentThisWay
@@ -957,6 +958,7 @@ class ConditionEvaluator(
         return when (condition.zone) {
             Zone.HAND -> entity.has<CastFromHandComponent>()
             Zone.GRAVEYARD -> entity.has<CastFromGraveyardComponent>()
+            Zone.LIBRARY -> entity.has<CastFromLibraryComponent>()
             else -> false
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DiscardAndDrawContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DiscardAndDrawContinuationResumer.kt
@@ -29,7 +29,13 @@ class DiscardAndDrawContinuationResumer(
         }
 
         val result = ZoneTransitionService.discardCards(state, continuation.playerId, response.selectedCards)
-        return checkForMore(result.state, result.events)
+        // The hand-size discard (CR 514.1) interrupted the cleanup step: performCleanupStep
+        // early-returned to ask for this discard before performing the CR 514.2 turn-based
+        // actions. Finish them now — otherwise marked damage (notably deathtouch damage that an
+        // expiring "until end of turn" indestructible had suppressed) persists into the next turn
+        // and kills the creature on the following turn's state-based-action check.
+        val cleanedState = CleanupPhaseManager.applyCleanupTurnBasedActions(result.state)
+        return checkForMore(cleanedState, result.events)
     }
 
     fun resumeEachPlayerDiscardsOrLoseLife(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -3,12 +3,14 @@ package com.wingedsheep.engine.handlers.continuations
 import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.engine.handlers.effects.composite.asMayDecide
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import com.wingedsheep.sdk.scripting.targets.withCount
 import java.util.UUID
 
@@ -83,8 +85,8 @@ class EffectAndTriggerContinuationResumer(
         // slot left at its declared max would absorb the next slot's target into its own range and
         // validate it against the wrong filter.
         val orderedSlots = response.selectedTargets.entries.sortedBy { it.key }
-        val selectedTargets = mutableListOf<com.wingedsheep.engine.state.components.stack.ChosenTarget>()
-        val alignedRequirements = mutableListOf<com.wingedsheep.sdk.scripting.targets.TargetRequirement>()
+        val selectedTargets = mutableListOf<ChosenTarget>()
+        val alignedRequirements = mutableListOf<TargetRequirement>()
         for ((slotIndex, targetIds) in orderedSlots) {
             if (targetIds.isEmpty()) continue
             targetIds.forEach { entityId -> selectedTargets.add(entityIdToChosenTarget(state, entityId)) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -69,8 +69,19 @@ class EffectAndTriggerContinuationResumer(
             return ExecutionResult.error(state, "Expected target selection response for triggered ability")
         }
 
-        val selectedTargets = response.selectedTargets.flatMap { (_, targetIds) ->
-            targetIds.map { entityId -> entityIdToChosenTarget(state, entityId) }
+        // Build the chosen-targets list in requirement-slot order, keeping it PARALLEL to the
+        // requirements that actually received a target. A declined "up to one" slot (empty list)
+        // drops out of BOTH lists together, so a later target never shifts forward into an earlier
+        // requirement's position. Without this, exiling only a creature with Don & Leo, Problem
+        // Solvers (declining the "up to one artifact" slot) validated the creature against the
+        // artifact requirement at resolution and fizzled with "all targets invalid" (CR 608.2b).
+        val orderedSlots = response.selectedTargets.entries.sortedBy { it.key }
+        val selectedTargets = mutableListOf<com.wingedsheep.engine.state.components.stack.ChosenTarget>()
+        val alignedRequirements = mutableListOf<com.wingedsheep.sdk.scripting.targets.TargetRequirement>()
+        for ((slotIndex, targetIds) in orderedSlots) {
+            if (targetIds.isEmpty()) continue
+            targetIds.forEach { entityId -> selectedTargets.add(entityIdToChosenTarget(state, entityId)) }
+            continuation.targetRequirements.getOrNull(slotIndex)?.let { alignedRequirements.add(it) }
         }
 
         // Zero-target resolution path. Two cases:
@@ -160,7 +171,7 @@ class EffectAndTriggerContinuationResumer(
         )
 
         val stackResult = services.stackResolver.putTriggeredAbility(
-            state, abilityComponent, selectedTargets, continuation.targetRequirements
+            state, abilityComponent, selectedTargets, alignedRequirements
         )
 
         if (!stackResult.isSuccess) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/EffectAndTriggerContinuationResumer.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.sdk.scripting.effects.DividedDamageEffect
 import com.wingedsheep.engine.handlers.effects.composite.asMayDecide
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.targets.withCount
 import java.util.UUID
 
 /**
@@ -75,13 +76,20 @@ class EffectAndTriggerContinuationResumer(
         // requirement's position. Without this, exiling only a creature with Don & Leo, Problem
         // Solvers (declining the "up to one artifact" slot) validated the creature against the
         // artifact requirement at resolution and fizzled with "all targets invalid" (CR 608.2b).
+        //
+        // Each kept requirement is also narrowed (`withCount`) to the number of targets actually
+        // chosen for its slot: the downstream index walks (StackResolver.getRequirementForTargetIndex,
+        // EffectContext.buildNamedTargets) advance by `count`, so a partially filled "up to two"
+        // slot left at its declared max would absorb the next slot's target into its own range and
+        // validate it against the wrong filter.
         val orderedSlots = response.selectedTargets.entries.sortedBy { it.key }
         val selectedTargets = mutableListOf<com.wingedsheep.engine.state.components.stack.ChosenTarget>()
         val alignedRequirements = mutableListOf<com.wingedsheep.sdk.scripting.targets.TargetRequirement>()
         for ((slotIndex, targetIds) in orderedSlots) {
             if (targetIds.isEmpty()) continue
             targetIds.forEach { entityId -> selectedTargets.add(entityIdToChosenTarget(state, entityId)) }
-            continuation.targetRequirements.getOrNull(slotIndex)?.let { alignedRequirements.add(it) }
+            continuation.targetRequirements.getOrNull(slotIndex)
+                ?.let { alignedRequirements.add(it.withCount(targetIds.size)) }
         }
 
         // Zero-target resolution path. Two cases:

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithCountersHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithCountersHelper.kt
@@ -146,9 +146,15 @@ object EntersWithCountersHelper {
                         if (effect.selfOnly) continue
                         if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceControllerId, newState)) continue
                         if (effect.condition != null) {
+                            // A non-self "enters with counters" condition describes the ENTERING
+                            // creature ("it was cast from your graveyard", Leonardo), not the
+                            // replacement source — evaluate it against the entering entity, mirroring
+                            // the EntersWithDynamicCounters path below. controllerId stays the source's
+                            // controller so "you control" resolves to the effect's controller.
                             val condContext = EffectContext(
-                                sourceId = sourceId,
+                                sourceId = enteringEntityId,
                                 controllerId = sourceControllerId,
+                                affectedEntityId = enteringEntityId,
                             )
                             if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
                         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -312,6 +312,7 @@ object ZoneMovementUtils {
             .without<SummoningSicknessComponent>()
             .without<CastFromHandComponent>()
             .without<com.wingedsheep.engine.state.components.battlefield.CastFromGraveyardComponent>()
+            .without<com.wingedsheep.engine.state.components.battlefield.CastFromLibraryComponent>()
             .without<com.wingedsheep.engine.state.components.battlefield.EnteredFromGraveyardComponent>()
             .without<WarpedComponent>()
             .without<EvokedComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1124,6 +1124,12 @@ class StackResolver(
                 updated = updated.with(com.wingedsheep.engine.state.components.battlefield.CastFromGraveyardComponent)
             }
 
+            // Track if this permanent was cast from a library (e.g. "cast from the top of your
+            // library" permissions — Mikey & Don's +1/+1 rider on creatures cast this way).
+            if (spellComponent.castFromZone == Zone.LIBRARY) {
+                updated = updated.with(com.wingedsheep.engine.state.components.battlefield.CastFromLibraryComponent)
+            }
+
             // Carry the cast-time choices durably onto the permanent (CR 601.2b choices ride the
             // stable entity onto the battlefield) so triggered/activated abilities can read "the X
             // / color / type / kicked-ness this was cast with" via DynamicAmount.CastX /

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -66,6 +66,15 @@ data object CastFromHandComponent : Component
 data object CastFromGraveyardComponent : Component
 
 /**
+ * Marks a permanent as having been cast from a library (e.g. an ongoing "you may cast … from
+ * the top of your library" permission). Added when a spell resolves with castFromZone == LIBRARY.
+ * Used by riders that care whether an entering creature was cast from the library (e.g. Mikey &
+ * Don: "if you cast a creature spell this way, it enters with an additional +1/+1 counter").
+ */
+@Serializable
+data object CastFromLibraryComponent : Component
+
+/**
  * Marks a permanent that entered the battlefield directly from a graveyard via a
  * reanimation effect (not via casting). Added in the battlefield-entry path when
  * the zone transition's fromZone is GRAVEYARD. Used by triggers that care whether

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/TriggerTargetSlotAlignmentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/TriggerTargetSlotAlignmentTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.handlers
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
+import com.wingedsheep.sdk.scripting.targets.withCount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression guard for the multi-target trigger-slot alignment in
+ * [com.wingedsheep.engine.handlers.continuations.EffectAndTriggerContinuationResumer].
+ *
+ * When a triggered ability has several "up to N" target slots, the resumer drops declined slots
+ * and narrows each kept slot's requirement to the targets actually chosen. The flattened
+ * target↔requirement index walk in [EffectContext.buildNamedTargets] (and the structurally
+ * identical `StackResolver.getRequirementForTargetIndex`) advances by `count`, so a partially
+ * filled "up to two" slot left at its declared max would absorb the NEXT slot's target into its
+ * own range — validating it against the wrong filter and mis-binding its named target.
+ *
+ * This test reproduces the resumer's slot-flattening on a two-slot trigger — "up to two creatures"
+ * (one chosen) followed by "up to one artifact" (one chosen) — and asserts the named targets bind
+ * to the right requirement only when the requirements are narrowed.
+ */
+class TriggerTargetSlotAlignmentTest : FunSpec({
+
+    val creature = ChosenTarget.Permanent(EntityId("creature-1"))
+    val artifact = ChosenTarget.Permanent(EntityId("artifact-1"))
+
+    // Slot 0: "up to two target creatures"; Slot 1: "up to one target artifact".
+    val creatureSlot = TargetObject(count = 2, optional = true, filter = TargetFilter.Creature, id = "creatures")
+    val artifactSlot = TargetObject(count = 1, optional = true, filter = TargetFilter.Artifact, id = "artifact")
+
+    // Mirror the resumer: one target chosen in each slot, requirement narrowed to the chosen count.
+    val chosenPerSlot = listOf(creatureSlot to listOf(creature), artifactSlot to listOf(artifact))
+
+    test("narrowed requirements bind each named target to its own slot") {
+        val targets = chosenPerSlot.flatMap { it.second }
+        val requirements: List<TargetRequirement> =
+            chosenPerSlot.map { (req, chosen) -> req.withCount(chosen.size) }
+
+        val named = EffectContext.buildNamedTargets(requirements, targets)
+
+        named["creatures"] shouldBe creature
+        named["artifact"] shouldBe artifact
+    }
+
+    test("without narrowing, the wide creature slot swallows the artifact (documents the bug)") {
+        val targets = chosenPerSlot.flatMap { it.second }
+        val requirements: List<TargetRequirement> = chosenPerSlot.map { it.first } // un-narrowed
+
+        val named = EffectContext.buildNamedTargets(requirements, targets)
+
+        // count=2 creature slot consumes both flat targets; the artifact lands under "creatures[1]"
+        // and the artifact slot (now past the end of the list) binds nothing.
+        named["creatures[1]"] shouldBe artifact
+        (named["artifact"] == null) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CleanupHandSizeDiscardDamageRemovalTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CleanupHandSizeDiscardDamageRemovalTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.FloatingEffectData
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression: marked damage must be removed at the cleanup step (CR 514.2) even when the
+ * active player has to discard down to maximum hand size (CR 514.1) in the same step.
+ *
+ * The hand-size discard is a player decision, so
+ * [com.wingedsheep.engine.core.CleanupPhaseManager.performCleanupStep] early-returns to ask for it
+ * *before* it reaches the 514.2 damage-removal block. Previously the discard's continuation only
+ * discarded and resumed — it never finished 514.2 — so marked damage survived into the next turn.
+ * With deathtouch damage that an expiring "until end of turn" indestructible (Saved by the Shell)
+ * had been suppressing, the creature then died on the following turn's state-based-action check,
+ * with no destroy/sacrifice event.
+ *
+ * Fixed by extracting the 514.2 actions into
+ * [com.wingedsheep.engine.core.CleanupPhaseManager.applyCleanupTurnBasedActions] and invoking it
+ * from both the normal cleanup path and `resumeHandSizeDiscard`.
+ */
+class CleanupHandSizeDiscardDamageRemovalTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    /** Grant indestructible until end of turn (the relevant half of Saved by the Shell). */
+    fun GameTestDriver.grantIndestructibleUntilEndOfTurn(entityId: EntityId, controllerId: EntityId) {
+        val floatingEffect = ActiveFloatingEffect(
+            id = EntityId.generate(),
+            effect = FloatingEffectData(
+                layer = Layer.ABILITY,
+                modification = SerializableModification.GrantKeyword(Keyword.INDESTRUCTIBLE.name),
+                affectedEntities = setOf(entityId)
+            ),
+            duration = Duration.EndOfTurn,
+            sourceId = null,
+            controllerId = controllerId,
+            timestamp = System.currentTimeMillis()
+        )
+        replaceState(state.copy(floatingEffects = state.floatingEffects + floatingEffect))
+    }
+
+    /** Pad [playerId]'s hand well past the maximum hand size so cleanup forces a discard. */
+    fun GameTestDriver.padHand(playerId: EntityId, cardName: String, count: Int) {
+        repeat(count) { putCardInHand(playerId, cardName) }
+    }
+
+    test("deathtouch damage is cleared at cleanup despite a hand-size discard — creature survives next turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30, "Swamp" to 10), startingLife = 20)
+
+        val attackerController = driver.activePlayer!!
+        val opponent = driver.getOpponent(attackerController)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // 3/3 vanilla attacker, granted indestructible until end of turn (Saved by the Shell).
+        val attacker = driver.putCreatureOnBattlefield(attackerController, "Centaur Courser")
+        driver.removeSummoningSickness(attacker)
+        driver.grantIndestructibleUntilEndOfTurn(attacker, attackerController)
+
+        // 1/1 deathtouch blocker — any damage it deals is lethal.
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Deathtouch Rat")
+
+        // Push the attacking player over maximum hand size so the cleanup step forces a discard.
+        driver.padHand(attackerController, "Forest", 8)
+
+        // Attack into the deathtouch blocker; the attacker takes 1 deathtouch damage. Let
+        // passPriorityUntil auto-resolve the combat-damage assignment.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attackerController, listOf(attacker), opponent).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(blocker to listOf(attacker))).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // Indestructible kept the attacker alive through the deathtouch damage this turn.
+        driver.findPermanent(attackerController, "Centaur Courser") shouldNotBe null
+
+        // Advance into the opponent's upkeep — through this turn's cleanup (forcing the discard,
+        // which passPriorityUntil auto-resolves) and into the next turn, where state-based actions
+        // are checked. By then indestructible has worn off, so the only thing keeping the
+        // now-mortal attacker alive is that its deathtouch damage was removed at cleanup.
+        driver.passPriorityUntil(Step.UPKEEP)
+
+        driver.activePlayer shouldBe opponent
+        driver.findPermanent(attackerController, "Centaur Courser") shouldNotBe null
+        driver.state.getEntity(attacker)?.has<DamageComponent>() shouldBe false
+    }
+
+    test("ordinary marked damage is removed at cleanup even when a hand-size discard interrupts the step") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30, "Swamp" to 10), startingLife = 20)
+
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(player, "Centaur Courser") // 3/3
+        driver.addComponent(creature, DamageComponent(amount = 2))
+        driver.padHand(player, "Forest", 8)
+
+        // Advance through this turn's cleanup (which forces a discard) into the opponent's upkeep.
+        // Targeting UPKEEP (a step with a priority window) rather than the transient UNTAP step.
+        driver.passPriorityUntil(Step.UPKEEP)
+
+        // CR 514.2 still ran after the discard: the marked damage is gone.
+        driver.activePlayer shouldBe opponent
+        driver.state.getEntity(creature)?.has<DamageComponent>() shouldBe false
+    }
+})


### PR DESCRIPTION
Five tightly-scoped engine fixes surfaced during TMT self-play.

- **Cleanup damage removal.** Extract the CR 514.2 turn-based actions (remove marked
  damage; end per-turn combat/miracle markers) into
  `CleanupPhaseManager.applyCleanupTurnBasedActions` and run it on both cleanup paths.
  The CR 514.1 hand-size discard early-returns *before* 514.2, so its continuation now
  finishes the step — fixes marked damage (notably deathtouch suppressed by an expiring
  until-end-of-turn indestructible) surviving into the next turn.
- **Trigger target-slot alignment.** Multi-"up to N" triggers: drop declined slots and
  narrow each kept slot's requirement to the chosen count via new `TargetRequirement.withCount`,
  keeping the flat target↔requirement index walks aligned. Fixes Don & Leo-style fizzles
  where a partially-filled slot absorbed a later slot's target.
- **Cast-from-library tracking.** Add `CastFromLibraryComponent` (full parity with the
  hand/graveyard markers) so `WasCastFromZone(LIBRARY)` works for permanents — e.g. Mikey
  & Don's "+1/+1 if cast from the top of your library."
- **Non-self enters-with-counters condition** now evaluates against the *entering*
  creature, mirroring the dynamic-counters path (Leonardo, Sewer Samurai).

New tests cover each fix; `docs/card-sdk-language-reference.md` updated.
Cited CR numbers (514.1/514.2/608.2b/702.94) verified. `:rules-engine` compiles green.
