### PR TITLE
Add three Job-select Equipment to Final Fantasy (FIN)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DarkKnightsGreatsword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DarkKnightsGreatsword.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Dark Knight's Greatsword
+ * {2}{B}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +3/+0 and is a Knight in addition to its other types.
+ * Chaosbringer — Equip—Pay 3 life. Activate only once each turn.
+ *
+ * "Chaosbringer" is the flavor name on the equip ability. The equip cost is a non-mana cost
+ * ("Pay 3 life"), so it is modeled as an equip-flagged activated ability (isEquipAbility, so
+ * it is sorcery-speed and eligible for equip-cost rules) with Costs.PayLife(3), restricted to
+ * once per turn (ActivationRestriction.OncePerTurn), following Shredder's Armor's
+ * "Equip—Sacrifice ... Activate only once each turn." pattern.
+ */
+val DarkKnightsGreatsword = card("Dark Knight's Greatsword") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +3/+0 and is a Knight in addition to its other types.\n" +
+        "Chaosbringer — Equip—Pay 3 life. Activate only once each turn."
+
+    jobSelect()
+
+    staticAbility {
+        ability = ModifyStats(3, 0, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantSubtype("Knight", Filters.EquippedCreature)
+    }
+
+    activatedAbility {
+        isEquipAbility = true
+        cost = Costs.PayLife(3)
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AttachEquipment(creature)
+        timing = TimingRule.SorcerySpeed
+        restrictions = listOf(ActivationRestriction.OncePerTurn)
+        description = "Chaosbringer — Equip—Pay 3 life. Activate only once each turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "95"
+        artist = "Narendra Bintara Adi"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b50dcc7c-260f-4d8c-9a9e-9244ec23a91e.jpg?1748706120"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DragoonsLance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DragoonsLance.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Dragoon's Lance
+ * {1}{W}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +1/+0 and is a Knight in addition to its other types.
+ * During your turn, equipped creature has flying.
+ * Gae Bolg — Equip {4}
+ *
+ * "During your turn, equipped creature has flying" is a conditional static grant gated on
+ * Conditions.IsYourTurn (the Equipment's controller's turn), matching Blacksmith's Talent's
+ * "during your turn" keyword grants. "Gae Bolg" is the flavor name on the equip ability; it
+ * resolves as a standard equip {4}.
+ */
+val DragoonsLance = card("Dragoon's Lance") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +1/+0 and is a Knight in addition to its other types.\n" +
+        "During your turn, equipped creature has flying.\n" +
+        "Gae Bolg — Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = ModifyStats(1, 0, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantSubtype("Knight", Filters.EquippedCreature)
+    }
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(Keyword.FLYING, Filters.EquippedCreature)
+    }
+
+    equipAbility("{4}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "17"
+        artist = "Josephine Chang"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96630531-8eb7-4e3e-8d63-60c562a5571b.jpg?1748705819"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RedMagesRapier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RedMagesRapier.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Red Mage's Rapier
+ * {1}{R}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature has "Whenever you cast a noncreature spell, this creature gets +2/+0
+ *   until end of turn" and is a Wizard in addition to its other types.
+ * Equip {3}
+ *
+ * The granted "Whenever you cast a noncreature spell, this creature gets +2/+0 until end of
+ * turn" ability lives on the equipped creature (GrantTriggeredAbility over the attached-
+ * creature filter). "You" resolves to the creature's controller, and "this creature" is the
+ * pumped permanent (EffectTarget.Self relative to the bearer).
+ */
+val RedMagesRapier = card("Red Mage's Rapier") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature has \"Whenever you cast a noncreature spell, this creature gets +2/+0 until end of turn\" and is a Wizard in addition to its other types.\n" +
+        "Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.YouCastNoncreature.event,
+                binding = Triggers.YouCastNoncreature.binding,
+                effect = Effects.ModifyStats(2, 0, EffectTarget.Self, Duration.EndOfTurn)
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+    staticAbility {
+        ability = GrantSubtype("Wizard", Filters.EquippedCreature)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "152"
+        artist = "Alexandre Honoré"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0579955-75f9-47a9-8b03-e287d120826a.jpg?1748706327"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -3291,6 +3291,109 @@
     ]
 }
 
+// Dark Knight's Greatsword
+{
+    "name": "Dark Knight's Greatsword",
+    "manaCost": "{2}{B}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +3/+0 and is a Knight in addition to its other types.\nChaosbringer — Equip—Pay 3 life. Activate only once each turn.",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomPayLife",
+                        "amount": 3
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "restrictions": [
+                    "OncePerTurn"
+                ],
+                "isEquipAbility": true,
+                "descriptionOverride": "Chaosbringer — Equip—Pay 3 life. Activate only once each turn."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 3,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Knight",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "rarity": "UNCOMMON",
+        "artist": "Narendra Bintara Adi",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b50dcc7c-260f-4d8c-9a9e-9244ec23a91e.jpg?1748706120"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Delivery Moogle
 {
     "name": "Delivery Moogle",
@@ -3422,6 +3525,114 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Dragoon's Lance
+{
+    "name": "Dragoon's Lance",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +1/+0 and is a Knight in addition to its other types.\nDuring your turn, equipped creature has flying.\nGae Bolg — Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Knight",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING"
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "equipCost": "{4}",
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "UNCOMMON",
+        "artist": "Josephine Chang",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96630531-8eb7-4e3e-8d63-60c562a5571b.jpg?1748705819"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -7968,6 +8179,127 @@
         "rarity": "UNCOMMON",
         "artist": "Ben Wootten",
         "imageUri": "https://cards.scryfall.io/normal/front/3/6/3618e283-2df9-4eb9-97b0-96b55ee31cc0.jpg?1748706320"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Red Mage's Rapier
+{
+    "name": "Red Mage's Rapier",
+    "manaCost": "{1}{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature has \"Whenever you cast a noncreature spell, this creature gets +2/+0 until end of turn\" and is a Wizard in addition to its other types.\nEquip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "SpellCastEvent",
+                        "spellFilter": {
+                            "cardPredicates": [
+                                "IsNoncreature"
+                            ]
+                        }
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Wizard",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "152",
+        "artist": "Alexandre Honoré",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0579955-75f9-47a9-8b03-e287d120826a.jpg?1748706327"
     },
     "colorIdentityOverride": [
         "RED"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinEquipmentJobSelectScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinEquipmentJobSelectScenarioTest.kt
@@ -1,0 +1,213 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fin.cards.DarkKnightsGreatsword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Final Fantasy "Job select" Equipment cycle — three cards that all share the `jobSelect()` ETB
+ * (create a 1/1 colorless Hero token, then attach to it) but differ in their equipped-creature
+ * grants and equip cost:
+ *
+ *  - Dark Knight's Greatsword: +3/+0, Knight; "Chaosbringer — Equip—Pay 3 life. Activate only
+ *    once each turn." (non-mana equip cost + once-per-turn restriction).
+ *  - Dragoon's Lance: +1/+0, Knight; "During your turn, equipped creature has flying." (a
+ *    conditional static grant gated on the controller's turn).
+ *  - Red Mage's Rapier: Wizard; grants the equipped creature "Whenever you cast a noncreature
+ *    spell, this creature gets +2/+0 until end of turn."
+ */
+class FinEquipmentJobSelectScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Dark Knight's Greatsword") {
+            test("ETB makes a Hero token, grants +3/+0 and Knight to its bearer") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Dark Knight's Greatsword")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Dark Knight's Greatsword")
+                withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val hero = game.findPermanent("Hero Token")!!
+                val sword = game.findPermanent("Dark Knight's Greatsword")!!
+                withClue("Greatsword should be attached to the Hero token") {
+                    game.state.getEntity(sword)?.get<AttachedToComponent>()?.targetId shouldBe hero
+                }
+
+                val projected = stateProjector.project(game.state)
+                withClue("Equipped Hero is 1/1 + (+3/+0) = 4/1") {
+                    projected.getPower(hero) shouldBe 4
+                    projected.getToughness(hero) shouldBe 1
+                }
+                withClue("Equipped Hero is a Knight in addition to Hero") {
+                    projected.hasSubtype(hero, "Knight") shouldBe true
+                    projected.hasSubtype(hero, "Hero") shouldBe true
+                }
+            }
+
+            test("Chaosbringer equip costs 3 life and is usable only once each turn") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Dark Knight's Greatsword")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val sword = game.findPermanent("Dark Knight's Greatsword")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+                val equipId = DarkKnightsGreatsword.activatedAbilities.first().id
+
+                val lifeBefore = game.getLifeTotal(1)
+                val first = game.execute(
+                    ActivateAbility(game.player1Id, sword, equipId, targets = listOf(ChosenTarget.Permanent(bears)))
+                )
+                withClue("First equip should succeed: ${first.error}") { first.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Equip cost 3 life") { game.getLifeTotal(1) shouldBe lifeBefore - 3 }
+                withClue("Greatsword now equips Grizzly Bears") {
+                    game.state.getEntity(sword)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                }
+
+                // OncePerTurn: the equip ability is no longer offered, and re-activating fails.
+                withClue("Equip should not be offered a second time this turn") {
+                    game.getLegalActions(1).find {
+                        it.actionType == "ActivateAbility" &&
+                            (it.action as? ActivateAbility)?.sourceId == sword
+                    } shouldBe null
+                }
+                val second = game.execute(
+                    ActivateAbility(game.player1Id, sword, equipId, targets = listOf(ChosenTarget.Permanent(giant)))
+                )
+                withClue("Second equip same turn should be rejected") { second.error shouldNotBe null }
+                withClue("Still attached to Grizzly Bears, life unchanged after rejected equip") {
+                    game.state.getEntity(sword)?.get<AttachedToComponent>()?.targetId shouldBe bears
+                    game.getLifeTotal(1) shouldBe lifeBefore - 3
+                }
+            }
+        }
+
+        context("Dragoon's Lance") {
+            test("on its controller's turn the equipped Hero is a 2/1 flying Knight") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Dragoon's Lance")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Dragoon's Lance")
+                withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val hero = game.findPermanent("Hero Token")!!
+                val onTurn = stateProjector.project(game.state)
+                withClue("Equipped Hero is 1/1 + (+1/+0) = 2/1 Knight") {
+                    onTurn.getPower(hero) shouldBe 2
+                    onTurn.getToughness(hero) shouldBe 1
+                    onTurn.hasSubtype(hero, "Knight") shouldBe true
+                }
+                withClue("During its controller's turn the equipped Hero has flying") {
+                    onTurn.hasKeyword(hero, com.wingedsheep.sdk.core.Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("on the opponent's turn the equipped Hero keeps +1/+0 and Knight but loses flying") {
+                // Alice's Lance is already equipped to her Grizzly Bears; it is Bob's turn.
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Dragoon's Lance", "Grizzly Bears")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val offTurn = stateProjector.project(game.state)
+                withClue("Active player is Bob") { (game.state.activePlayerId == game.player2Id) shouldBe true }
+                withClue("Equipped creature keeps +1/+0 and Knight regardless of whose turn it is") {
+                    offTurn.getPower(bears) shouldBe 3 // Grizzly Bears 2/2 + 1/0
+                    offTurn.getToughness(bears) shouldBe 2
+                    offTurn.hasSubtype(bears, "Knight") shouldBe true
+                }
+                withClue("On the opponent's turn the equipped creature does NOT have flying") {
+                    offTurn.hasKeyword(bears, com.wingedsheep.sdk.core.Keyword.FLYING) shouldBe false
+                }
+            }
+        }
+
+        context("Red Mage's Rapier") {
+            test("equipped Hero is a Wizard and gets +2/+0 per noncreature spell its controller casts") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Red Mage's Rapier")
+                    .withCardInHand(1, "Shock")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Red Mage's Rapier")
+                withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val hero = game.findPermanent("Hero Token")!!
+                val before = stateProjector.project(game.state)
+                withClue("Equipped Hero is a Wizard, base 1/1 with no spell cast yet") {
+                    before.hasSubtype(hero, "Wizard") shouldBe true
+                    before.getPower(hero) shouldBe 1
+                    before.getToughness(hero) shouldBe 1
+                }
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val shock1 = game.castSpell(1, "Shock", giant)
+                withClue("First Shock should succeed: ${shock1.error}") { shock1.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val afterOne = stateProjector.project(game.state)
+                withClue("Casting one noncreature spell pumps the Hero to 3/1 (+2/+0)") {
+                    afterOne.getPower(hero) shouldBe 3
+                    afterOne.getToughness(hero) shouldBe 1
+                }
+
+                val shock2 = game.castSpell(1, "Shock", giant)
+                withClue("Second Shock should succeed: ${shock2.error}") { shock2.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val afterTwo = stateProjector.project(game.state)
+                withClue("A second noncreature spell stacks another +2/+0 → 5/1 this turn") {
+                    afterTwo.getPower(hero) shouldBe 5
+                    afterTwo.getToughness(hero) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements three Final Fantasy "Job select" Equipment, all composed from existing SDK primitives (no engine changes required):

- **Dark Knight's Greatsword** ({2}{B}) — Job select; equipped creature gets +3/+0 and is a Knight; "Chaosbringer — Equip—Pay 3 life. Activate only once each turn." (non-mana equip cost modeled as an equip-flagged sorcery-speed activated ability with `ActivationRestriction.OncePerTurn`).
- **Dragoon's Lance** ({1}{W}) — Job select; equipped creature gets +1/+0 and is a Knight; "During your turn, equipped creature has flying" via a `ConditionalStaticAbility` gated on `Conditions.IsYourTurn`. "Gae Bolg" is flavor on a standard Equip {4}.
- **Red Mage's Rapier** ({1}{R}) — Job select; equipped creature is a Wizard and has "Whenever you cast a noncreature spell, this creature gets +2/+0 until end of turn" via `GrantTriggeredAbility(YouCastNoncreature → ModifyStats(2,0,Self,EndOfTurn))`. Equip {3}.

## Testing
- New `FinEquipmentJobSelectScenarioTest` (rules-engine) — 5 cases, all passing: ETB Hero-token creation + stats/subtypes for each card, the pay-3-life once-per-turn equip (asserts life cost, attachment, and that a second equip the same turn is rejected), the on-turn/off-turn flying toggle for Dragoon's Lance, and the stacking +2/+0 pump per noncreature spell for Red Mage's Rapier.
- `CardDefinitionSnapshotTest` re-blessed (FIN golden) and `CardLintTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)