### PR TITLE
Add The Fire Crystal and The Wind Crystal to Final Fantasy (FIN)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheFireCrystal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheFireCrystal.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * The Fire Crystal
+ * {2}{R}{R}
+ * Legendary Artifact
+ *
+ * Red spells you cast cost {1} less to cast.
+ * Creatures you control have haste.
+ * {4}{R}{R}, {T}: Create a token that's a copy of target creature you control.
+ *   Sacrifice it at the beginning of the next end step.
+ *
+ * Notes:
+ *  - The cost reduction reduces only generic mana in the total cost of red spells you cast
+ *    (Scryfall ruling 2025-06-06); modeled with [CostModification.ReduceGeneric].
+ *  - The token copy + "sacrifice at the beginning of the next end step" is the
+ *    [Effects.CreateTokenCopyOfTarget] effect with `sacrificeAtStep = Step.END`, which creates
+ *    the delayed sacrifice trigger automatically (the next end step, not gated to yours).
+ */
+val TheFireCrystal = card("The Fire Crystal") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Artifact"
+    oracleText = "Red spells you cast cost {1} less to cast.\n" +
+        "Creatures you control have haste.\n" +
+        "{4}{R}{R}, {T}: Create a token that's a copy of target creature you control. " +
+        "Sacrifice it at the beginning of the next end step."
+
+    // Red spells you cast cost {1} less to cast.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.RED)),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    // Creatures you control have haste.
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+        )
+    }
+
+    // {4}{R}{R}, {T}: Create a token that's a copy of target creature you control.
+    // Sacrifice it at the beginning of the next end step.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{R}{R}"), Costs.Tap)
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.CreateTokenCopyOfTarget(
+            target = creature,
+            sacrificeAtStep = Step.END,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "135"
+        artist = "Pablo Mendoza"
+        flavorText = "\"Warriors of Light...Only you can restore hope to the world, for yours is " +
+            "the light that can balance out the darkness...\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea430b17-2014-4b8e-b53f-43bcfc06f7cd.jpg?1748706272"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheWindCrystal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheWindCrystal.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyLifeGain
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * The Wind Crystal
+ * {2}{W}{W}
+ * Legendary Artifact
+ *
+ * White spells you cast cost {1} less to cast.
+ * If you would gain life, you gain twice that much life instead.
+ * {4}{W}{W}, {T}: Creatures you control gain flying and lifelink until end of turn.
+ *
+ * Notes:
+ *  - The cost reduction reduces only generic mana in the total cost of white spells you cast
+ *    (Scryfall ruling 2025-06-06); modeled with [CostModification.ReduceGeneric].
+ *  - "You gain twice that much life instead" is [ModifyLifeGain] with `multiplier = 2`, scoped
+ *    to life gained by you ([Player.You]). Two copies multiply by four, three by eight, etc.,
+ *    because each is a separate replacement applied in turn (Scryfall ruling 2025-06-06).
+ *  - The activated ability grants flying and lifelink to creatures you control (a group, not a
+ *    target) until end of turn.
+ */
+val TheWindCrystal = card("The Wind Crystal") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Artifact"
+    oracleText = "White spells you cast cost {1} less to cast.\n" +
+        "If you would gain life, you gain twice that much life instead.\n" +
+        "{4}{W}{W}, {T}: Creatures you control gain flying and lifelink until end of turn."
+
+    // White spells you cast cost {1} less to cast.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.WHITE)),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    // If you would gain life, you gain twice that much life instead.
+    replacementEffect(
+        ModifyLifeGain(
+            multiplier = 2,
+            appliesTo = EventPattern.LifeGainEvent(player = Player.You),
+        )
+    )
+
+    // {4}{W}{W}, {T}: Creatures you control gain flying and lifelink until end of turn.
+    // Grant per-creature via ForEachInGroup so each creature you control receives a floating
+    // keyword effect (a GroupRef target on GrantKeyword is not expanded per-permanent).
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{W}{W}"), Costs.Tap)
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            Effects.Composite(
+                Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self),
+                Effects.GrantKeyword(Keyword.LIFELINK, EffectTarget.Self),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "43"
+        artist = "Pablo Mendoza"
+        flavorText = "\"I give unto you the last of my light, and with it, the last hope of a fading world.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19bd0885-baaa-40f2-9c59-b1ea53807540.jpg?1748705917"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -10734,6 +10734,159 @@
     ]
 }
 
+// The Fire Crystal
+{
+    "name": "The Fire Crystal",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Red spells you cast cost {1} less to cast.\nCreatures you control have haste.\n{4}{R}{R}, {T}: Create a token that's a copy of target creature you control. Sacrifice it at the beginning of the next end step.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}{R}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateTokenCopyOfTarget",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    },
+                    "sacrificeAtStep": "END"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "red"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "rarity": "RARE",
+        "artist": "Pablo Mendoza",
+        "flavorText": "\"Warriors of Light...Only you can restore hope to the world, for yours is the light that can balance out the darkness...\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea430b17-2014-4b8e-b53f-43bcfc06f7cd.jpg?1748706272"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// The Wind Crystal
+{
+    "name": "The Wind Crystal",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "White spells you cast cost {1} less to cast.\nIf you would gain life, you gain twice that much life instead.\n{4}{W}{W}, {T}: Creatures you control gain flying and lifelink until end of turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{W}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "FLYING",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "LIFELINK",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "white"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ],
+        "replacementEffects": [
+            "ModifyLifeGain"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "rarity": "RARE",
+        "artist": "Pablo Mendoza",
+        "flavorText": "\"I give unto you the last of my light, and with it, the last hope of a fading world.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19bd0885-baaa-40f2-9c59-b1ea53807540.jpg?1748705917"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Thief's Knife
 {
     "name": "Thief's Knife",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheFireCrystalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheFireCrystalScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Fire Crystal (FIN #135).
+ *
+ * {2}{R}{R} Legendary Artifact
+ *  - Red spells you cast cost {1} less to cast.
+ *  - Creatures you control have haste.
+ *  - {4}{R}{R}, {T}: Create a token that's a copy of target creature you control. Sacrifice it at
+ *    the beginning of the next end step.
+ *
+ * These tests cover the haste-granting static and the token-copy activated ability with its
+ * delayed end-step sacrifice. The {1}-less cost reduction reuses the existing ModifySpellCost
+ * primitive (covered by the Invasion leech cards) so it isn't re-exercised here.
+ */
+class TheFireCrystalScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Fire Crystal") {
+
+            test("grants haste to a creature you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Fire Crystal")
+                    // Summoning-sick on purpose: only the crystal's haste static should matter.
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("Grizzly Bears gains haste from The Fire Crystal") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("{4}{R}{R}, {T}: makes a token copy that is sacrificed at the next end step") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Fire Crystal", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 6) // pays {4}{R}{R}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crystal = game.findPermanent("The Fire Crystal")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.getCard("The Fire Crystal")!!
+                    .script.activatedAbilities[0].id
+
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crystal,
+                        abilityId = abilityId,
+                        targets = listOf(entityIdToChosenTarget(game.state, bears)),
+                    )
+                )
+                withClue("Activating The Fire Crystal should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                if (game.getPendingDecision() is com.wingedsheep.engine.core.SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("A token copy of Grizzly Bears is created (2 Grizzly Bears now)") {
+                    game.findAllPermanents("Grizzly Bears").size shouldBe 2
+                }
+
+                // The delayed trigger sacrifices the token at the beginning of the next end step.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("The token copy is sacrificed at the next end step; only the original remains") {
+                    game.findAllPermanents("Grizzly Bears").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheWindCrystalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheWindCrystalScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Wind Crystal (FIN #43).
+ *
+ * {2}{W}{W} Legendary Artifact
+ *  - White spells you cast cost {1} less to cast.
+ *  - If you would gain life, you gain twice that much life instead.
+ *  - {4}{W}{W}, {T}: Creatures you control gain flying and lifelink until end of turn.
+ *
+ * Covers the life-gain doubling replacement and the group flying+lifelink grant. The {1}-less
+ * cost reduction reuses the existing ModifySpellCost primitive so it isn't re-exercised here.
+ */
+class TheWindCrystalScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Wind Crystal") {
+
+            test("doubles life you gain (Reviving Dose gains 6 instead of 3)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Wind Crystal")
+                    .withCardInHand(1, "Reviving Dose")
+                    .withLandsOnBattlefield(1, "Plains", 3) // pays {1}{W}
+                    .withLifeTotal(1, 20)
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(2, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Reviving Dose").error shouldBe null
+                game.resolveStack()
+
+                withClue("Reviving Dose gains 3, doubled to 6 by The Wind Crystal") {
+                    game.getLifeTotal(1) shouldBe 26 // 20 + (3 * 2)
+                }
+            }
+
+            test("{4}{W}{W}, {T}: creatures you control gain flying and lifelink") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Wind Crystal", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 6) // pays {4}{W}{W}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crystal = game.findPermanent("The Wind Crystal")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.getCard("The Wind Crystal")!!
+                    .script.activatedAbilities[0].id
+
+                withClue("Grizzly Bears has neither keyword before activation") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.FLYING) shouldBe false
+                    game.state.projectedState.hasKeyword(bears, Keyword.LIFELINK) shouldBe false
+                }
+
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crystal,
+                        abilityId = abilityId,
+                    )
+                )
+                withClue("Activating The Wind Crystal should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                if (game.getPendingDecision() is com.wingedsheep.engine.core.SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears gains flying and lifelink until end of turn") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.FLYING) shouldBe true
+                    game.state.projectedState.hasKeyword(bears, Keyword.LIFELINK) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements two of the three FIN crystal artifacts, built entirely from existing SDK primitives. Each has a passing rules-engine scenario test.

## Cards implemented

- **The Fire Crystal** (FIN #135) — `{2}{R}{R}` Legendary Artifact
  - Red spells you cast cost `{1}` less (generic reduction per the 2025-06-06 ruling).
  - Creatures you control have haste (`GrantKeyword` static lord).
  - `{4}{R}{R}, {T}`: create a token copy of target creature you control, sacrificed at the next end step (`CreateTokenCopyOfTarget` with `sacrificeAtStep = Step.END`).
- **The Wind Crystal** (FIN #43) — `{2}{W}{W}` Legendary Artifact
  - White spells you cast cost `{1}` less.
  - If you would gain life, you gain twice that much instead (`ModifyLifeGain` multiplier 2, scoped to you).
  - `{4}{W}{W}, {T}`: creatures you control gain flying and lifelink until end of turn (`ForEachInGroup` + `GrantKeyword`).

## Not implemented (deferred)

- **The Water Crystal** — intentionally skipped. Its "if an opponent would mill one or more cards, they mill that many cards plus four instead" requires a mill-amount replacement effect that does not exist: there is no `MillEvent` or `ModifyMillAmount` replacement, and the mill pipeline (gather + move) has no interception point. Implementing it faithfully is add-feature work (new event + replacement + dispatcher + mill-pipeline refactor), not single-card authoring. The gap is already tracked in `backlog/fin-engine-gaps.md`.

## Tests

`TheFireCrystalScenarioTest` and `TheWindCrystalScenarioTest` (4 tests, all green) cover the haste lord, token-copy + delayed end-step sacrifice, life-gain doubling, and the flying/lifelink group grant. The FIN card snapshot golden was re-blessed (additions only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)