### PR TITLE
Add three Duskmourn cards (incl. linked-exile-owner player reference)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1660,6 +1660,14 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
   `PreventLifeGain` (`LifeGainEvent(player = EnchantedPlayer)`). Resolves to nothing if the source isn't
   an Aura attached to a player. (Grievous Wound.)
 - `Player.ControllerOf(desc)` / `Player.OwnerOf(desc)` — controller/owner of the first chosen target.
+- `Player.OwnersOfLinkedExile` — the **distinct owners** of the cards still in the effect source's
+  linked-exile pile (`LinkedExileComponent`, populated by `Effects.ExileUntilLeaves`). A *list*
+  reference: reach it only through `Effects.ForEachPlayer(Player.OwnersOfLinkedExile, …)`, typically
+  on a `LeavesBattlefield` trigger, to make "the exiled card's owner does X" act on the right
+  player(s). One iteration per distinct owner (a player owning several exiled cards acts once);
+  resolves to nothing — never "all players" — when the pile is empty. Unidentified Hovership ("the
+  exiled card's owner manifests dread", CR 701.62) = `ForEachPlayer(Player.OwnersOfLinkedExile,
+  Patterns.Library.manifestDread().effects)`.
 - `Player.ContextPlayer(i)` / `Player.Candidate` / `Player.Any` — positional target, CR 115
   candidate during target-restriction evaluation, and "a player" matching.
 - `EffectTarget.ContextProperty(key)` — value plumbed into `EffectContext` (damage amount, life gained, blight

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/references/Player.kt
@@ -184,6 +184,25 @@ sealed interface Player {
         override val description: String = "its owner"
     }
 
+    /**
+     * The distinct owners of the cards currently in the effect source's *linked-exile pile*
+     * (the source's [com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent],
+     * populated by [com.wingedsheep.sdk.dsl.Effects.ExileUntilLeaves]). Resolves to one entry
+     * per distinct owner of a still-exiled linked card — never falling back to "all players" —
+     * and to nothing when the pile is empty.
+     *
+     * Reach it through [com.wingedsheep.sdk.dsl.Effects.ForEachPlayer] on a leaves-the-battlefield
+     * trigger to make "the exiled card's owner does X" act on the right player(s). Per the
+     * Unidentified Hovership ruling (CR 701.62 manifest dread; DSK 37), when more than one card was
+     * exiled, *each player who owns one or more of them* acts once — hence distinct owners, not
+     * once per card. It is intentionally a list (per-player loop) reference, not a single-player one.
+     */
+    @SerialName("OwnersOfLinkedExile")
+    @Serializable
+    data object OwnersOfLinkedExile : Player {
+        override val description: String = "the exiled card's owner"
+    }
+
     // =============================================================================
     // Possessive Forms (for descriptions)
     // =============================================================================
@@ -207,5 +226,6 @@ sealed interface Player {
             EnchantedPlayer -> "enchanted player's"
             is ControllerOf -> "its controller's"
             is OwnerOf -> "its owner's"
+            OwnersOfLinkedExile -> "the exiled card's owner's"
         }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DerelictAtticWidowsWalk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DerelictAtticWidowsWalk.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Derelict Attic // Widow's Walk (DSK 93) — split-layout Room (CR 709.5).
+ *
+ * Derelict Attic {2}{B} — Enchantment — Room
+ *   When you unlock this door, you draw two cards and you lose 2 life.
+ *
+ * Widow's Walk {3}{B} — Enchantment — Room
+ *   Whenever a creature you control attacks alone, it gets +1/+0 and gains deathtouch
+ *   until end of turn.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ *
+ * Derelict Attic is a "when you unlock this door" trigger (CR 709.5h) — draw two, lose 2 life,
+ * both affecting the controller. Widow's Walk reuses the attacks-alone primitive
+ * [Triggers.attacks] with `AttackPredicate.Alone` and an ANY binding over creatures you control,
+ * buffing the lone attacker ("it" = [EffectTarget.TriggeringEntity]) with +1/+0 and deathtouch
+ * until end of turn.
+ */
+val DerelictAtticWidowsWalk = card("Derelict Attic // Widow's Walk") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "B"
+
+    face("Derelict Attic") {
+        manaCost = "{2}{B}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, you draw two cards and you lose 2 life."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Effects.Composite(
+                Effects.DrawCards(2),
+                Effects.LoseLife(2, EffectTarget.Controller),
+            )
+        }
+    }
+
+    face("Widow's Walk") {
+        manaCost = "{3}{B}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Whenever a creature you control attacks alone, it gets +1/+0 and gains " +
+            "deathtouch until end of turn."
+
+        triggeredAbility {
+            trigger = Triggers.attacks(
+                filter = GameObjectFilter.Creature.youControl(),
+                requires = setOf(AttackPredicate.Alone),
+                binding = TriggerBinding.ANY,
+            )
+            effect = Effects.Composite(
+                Effects.ModifyStats(1, 0, EffectTarget.TriggeringEntity),
+                Effects.GrantKeyword(Keyword.DEATHTOUCH, EffectTarget.TriggeringEntity),
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "93"
+        artist = "Marc Simonetti"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg?1726780598"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LakesideShack.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LakesideShack.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Lakeside Shack
+ * Land
+ *
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {G} or {U}.
+ */
+val LakesideShack = card("Lakeside Shack") {
+    typeLine = "Land"
+    colorIdentity = "GU"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {G} or {U}."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.APlayerLifeAtMost(13)
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "262"
+        artist = "Bartek Fedyczak"
+        flavorText = "They say that if you stay in the cabin until the mists reach it, something will slither from the water and knock at the door."
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a9367acd-393a-4966-ba60-af2ecd4e7596.jpg?1726286852"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnidentifiedHovership.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/UnidentifiedHovership.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Unidentified Hovership
+ * {1}{W}{W}
+ * Artifact — Vehicle
+ * 2/2
+ * Flying
+ * When this Vehicle enters, exile up to one target creature with toughness 5 or less.
+ * When this Vehicle leaves the battlefield, the exiled card's owner manifests dread.
+ * Crew 1
+ *
+ * The ETB exiles the target via [Effects.ExileUntilLeaves], which links it to this source's
+ * [com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent]. Unlike a typical
+ * "exile until ~ leaves" card, the exiled card is *not* returned — it stays exiled. The link
+ * exists only so the leaves-the-battlefield trigger can find the exiled card's owner.
+ *
+ * On leave, [Player.OwnersOfLinkedExile] resolves to the distinct owners of the still-exiled
+ * linked cards (CR ruling: "each player who owns one or more of the exiled cards manifests
+ * dread" — once per owner, nothing when the pile is empty), and each manifests dread (CR 701.62)
+ * via [Effects.ForEachPlayer] rebinding the shared [Patterns.Library.manifestDread] recipe to
+ * that player (same construction as Fear of Impostors).
+ */
+val UnidentifiedHovership = card("Unidentified Hovership") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Vehicle"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "When this Vehicle enters, exile up to one target creature with toughness 5 or less.\n" +
+        "When this Vehicle leaves the battlefield, the exiled card's owner manifests dread.\n" +
+        "Crew 1"
+
+    keywords(Keyword.FLYING)
+
+    // ETB: exile up to one target creature with toughness 5 or less, linked to this source.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "up to one target creature with toughness 5 or less",
+            TargetCreature(optional = true, filter = TargetFilter.Creature.toughnessAtMost(5))
+        )
+        effect = Effects.ExileUntilLeaves(creature)
+    }
+
+    // LTB: each owner of a card exiled with this Vehicle manifests dread.
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = Effects.ForEachPlayer(
+            players = Player.OwnersOfLinkedExile,
+            effects = Patterns.Library.manifestDread().effects,
+        )
+        description = "When this Vehicle leaves the battlefield, the exiled card's owner manifests dread."
+    }
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 1))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "37"
+        artist = "Jana Heidersdorf"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd23f168-9ad0-4b4e-bfff-ae004c163727.jpg?1726285993"
+
+        ruling("2024-09-20", "If Unidentified Hovership leaves the battlefield before its second ability resolves, the ability still exiles the target creature.")
+        ruling("2024-09-20", "If there's no exiled card when Unidentified Hovership's third ability resolves (most likely because its second ability hasn't resolved yet), the ability won't do anything.")
+        ruling("2024-09-20", "If Unidentified Hovership's second ability exiled more than one card (possibly because another effect caused it to trigger an additional time), each player who owns one or more of the exiled cards manifests dread.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -16201,6 +16201,142 @@
     ]
 }
 
+// Unidentified Hovership
+{
+    "name": "Unidentified Hovership",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Flying\nWhen this Vehicle enters, exile up to one target creature with toughness 5 or less.\nWhen this Vehicle leaves the battlefield, the exiled card's owner manifests dread.\nCrew 1",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ExileUntilLeaves",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target creature with toughness 5 or less"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature tou<=5"
+                    },
+                    "id": "up to one target creature with toughness 5 or less"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "OwnersOfLinkedExile"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeAs": "manifestDreadLooked"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "manifestDreadLooked",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "manifestDreadManifested",
+                                "storeRemainder": "manifestDreadGraveyard",
+                                "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                "remainderLabel": "Put into your graveyard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadManifested",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                },
+                                "faceDown": "MANIFEST"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "manifestDreadGraveyard",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                }
+                            },
+                            "EmitManifestedDreadEvent"
+                        ]
+                    }
+                },
+                "descriptionOverride": "When this Vehicle leaves the battlefield, the exiled card's owner manifests dread."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "RARE",
+        "artist": "Jana Heidersdorf",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd23f168-9ad0-4b4e-bfff-ae004c163727.jpg?1726285993",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "If Unidentified Hovership leaves the battlefield before its second ability resolves, the ability still exiles the target creature."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If there's no exiled card when Unidentified Hovership's third ability resolves (most likely because its second ability hasn't resolved yet), the ability won't do anything."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If Unidentified Hovership's second ability exiled more than one card (possibly because another effect caused it to trigger an additional time), each player who owns one or more of the exiled cards manifests dread."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Unnerving Grasp
 {
     "name": "Unnerving Grasp",

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -3363,6 +3363,102 @@
     ]
 }
 
+// Derelict Attic // Widow's Walk
+{
+    "name": "Derelict Attic // Widow's Walk",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, you draw two cards and you lose 2 life.\n//\nWhenever a creature you control attacks alone, it gets +1/+0 and gains deathtouch until end of turn.",
+    "metadata": {
+        "collectorNumber": "93",
+        "artist": "Marc Simonetti",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2cae24c1-53f1-4f3f-8795-b634c46a17c4.jpg?1726780598"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Derelict Attic",
+            "manaCost": "{2}{B}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, you draw two cards and you lose 2 life.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                {
+                                    "type": "LoseLife",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    },
+                                    "target": "Controller"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Widow's Walk",
+            "manaCost": "{3}{B}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Whenever a creature you control attacks alone, it gets +1/+0 and gains deathtouch until end of turn.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": {
+                            "type": "AttackEvent",
+                            "filter": "creature ctrl:you",
+                            "requires": [
+                                "AttacksAlone"
+                            ]
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    },
+                                    "target": "TriggeringEntity"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "DEATHTOUCH",
+                                    "target": "TriggeringEntity"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Dissection Tools
 {
     "name": "Dissection Tools",

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -9081,6 +9081,57 @@
     ]
 }
 
+// Lakeside Shack
+{
+    "name": "Lakeside Shack",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {G} or {U}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "262",
+        "artist": "Bartek Fedyczak",
+        "flavorText": "They say that if you stay in the cabin until the mists reach it, something will slither from the water and knock at the door.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a9367acd-393a-4966-ba60-af2ecd4e7596.jpg?1726286852"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Leyline of Hope
 {
     "name": "Leyline of Hope",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -920,6 +920,7 @@ class DynamicAmountEvaluator(
             is Player.AnOpponent, is Player.DefendingPlayer, is Player.EnchantedPlayer -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )
+            is Player.OwnersOfLinkedExile -> TargetResolutionUtils.linkedExileOwners(state, context)
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -139,8 +139,39 @@ object TargetResolutionUtils {
                 ?.let { state.getEntity(it)?.get<CardComponent>()?.ownerId }
             is Player.ControllerOf -> context.targets.firstOrNull()?.toEntityId()
                 ?.let { controllerOf(state, it) }
-            Player.Each, Player.EachOpponent, Player.ActivePlayerFirst -> null
+            // Multi-player / list-only references have no single resolution here.
+            // OwnersOfLinkedExile is resolved by ForEachExecutor.resolvePlayers (a player loop).
+            Player.Each, Player.EachOpponent, Player.ActivePlayerFirst,
+            Player.OwnersOfLinkedExile -> null
         }
+    }
+
+    /**
+     * Distinct owners of the cards still in the effect source's linked-exile pile
+     * ([com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent], populated by
+     * `Effects.ExileUntilLeaves`). Backs [Player.OwnersOfLinkedExile]. The component persists across
+     * the source's own zone change, so this resolves correctly from a leaves-the-battlefield
+     * trigger. Only cards still in an exile zone count (a token that ceased to exist, or a card that
+     * has since left exile, drops out); owners are deduplicated so a player owning several exiled
+     * cards is listed once. Empty — never "all players" — when nothing qualifies.
+     */
+    fun linkedExileOwners(state: GameState, context: EffectContext): List<EntityId> {
+        val sourceId = context.sourceId ?: return emptyList()
+        val linked = state.getEntity(sourceId)
+            ?.get<com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent>()
+            ?: return emptyList()
+        return linked.exiledIds
+            .filter { id ->
+                state.zones.any { (zone, cards) ->
+                    zone.zoneType == com.wingedsheep.sdk.core.Zone.EXILE && id in cards
+                }
+            }
+            .mapNotNull { id ->
+                val container = state.getEntity(id)
+                container?.get<com.wingedsheep.engine.state.components.identity.OwnerComponent>()?.playerId
+                    ?: container?.get<CardComponent>()?.ownerId
+            }
+            .distinct()
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/ForEachExecutor.kt
@@ -207,6 +207,11 @@ class ForEachExecutor(
             }
             Player.You -> listOf(context.controllerId)
             Player.EachOpponent -> state.getOpponents(context.controllerId)
+            // Distinct owners of the cards still in the source's linked-exile pile. Resolve to
+            // exactly those owners (empty when the pile is empty) — never the activePlayers
+            // fallback below, so "the exiled card's owner does X" does nothing when nothing was
+            // exiled (Unidentified Hovership ruling, DSK 37).
+            Player.OwnersOfLinkedExile -> TargetResolutionUtils.linkedExileOwners(state, context)
             Player.TargetOpponent, Player.TargetPlayer -> listOfNotNull(
                 TargetResolutionUtils.resolvePlayerRef(player, context, state)
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnidentifiedHovershipScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnidentifiedHovershipScenarioTest.kt
@@ -1,0 +1,133 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.UnidentifiedHovership
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Unidentified Hovership (DSK #37) — {1}{W}{W} Artifact — Vehicle, 2/2, Flying, Crew 1.
+ *
+ *   "When this Vehicle enters, exile up to one target creature with toughness 5 or less.
+ *    When this Vehicle leaves the battlefield, the exiled card's owner manifests dread."
+ *
+ * The interesting, newly-built behavior is the leaves-the-battlefield trigger acting on the
+ * *exiled card's owner* (often an opponent), not the Vehicle's controller — driven by the
+ * [com.wingedsheep.sdk.scripting.references.Player.OwnersOfLinkedExile] reference reading the
+ * source's linked-exile pile. These tests pin:
+ *  - the owner of the exiled creature (the opponent) manifests dread — not the Hovership's controller;
+ *  - the exiled card stays exiled (this card never returns it, unlike Fear of Abduction);
+ *  - with nothing exiled, the leaves trigger does nothing — and crucially does NOT fall back to
+ *    making every player manifest (the "won't do anything" ruling).
+ */
+class UnidentifiedHovershipScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + UnidentifiedHovership)
+        initMirrorMatch(deck = Deck.of("Plains" to 60), startingLife = 20)
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+    }
+
+    test("the exiled creature's owner — the opponent — manifests dread when the Vehicle leaves") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+
+        // The opponent controls a creature with toughness 5 or less (3/3) for the ETB to exile.
+        val courser = d.putPermanentOnBattlefield(opp, "Centaur Courser")
+
+        // Stack the opponent's top two cards so their manifest-dread pick is deterministic.
+        val oppLand = d.putCardOnTopOfLibrary(opp, "Plains")
+        val oppCreature = d.putCardOnTopOfLibrary(opp, "Grizzly Bears") // now the top card
+
+        // I cast the Hovership; its ETB pauses to choose the (up to one) creature to exile.
+        val hovInHand = d.putCardInHand(me, "Unidentified Hovership")
+        d.giveMana(me, Color.WHITE, 3)
+        d.castSpell(me, hovInHand).error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        d.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        d.submitTargetSelection(me, listOf(courser))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The opponent's creature is now exiled (owned by the opponent), Hovership is in play.
+        d.getExile(opp) shouldContain courser
+        val hov = d.findPermanent(me, "Unidentified Hovership")!!
+
+        // Destroy the Hovership with artifact removal to fire its leaves-the-battlefield trigger.
+        val disenchant = d.putCardInHand(me, "Disenchant")
+        d.giveMana(me, Color.WHITE, 2)
+        d.castSpellWithTargets(me, disenchant, listOf(ChosenTarget.Permanent(hov))).error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The leaves trigger makes the EXILED CARD'S OWNER (the opponent) manifest dread —
+        // the pick is presented to the opponent, over the opponent's own library cards.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        pick.playerId shouldBe opp
+        pick.options.toSet() shouldBe setOf(oppCreature, oppLand)
+        d.submitDecision(opp, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(oppCreature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The opponent's chosen card is a face-down 2/2 under the opponent's control; the other binned.
+        d.getPermanents(opp) shouldContain oppCreature
+        val manifested = d.state.getEntity(oppCreature)
+        manifested?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        manifested?.get<ManifestedComponent>() shouldBe ManifestedComponent
+        d.state.projectedState.getPower(oppCreature) shouldBe 2
+        d.getGraveyard(opp) shouldContain oppLand
+
+        // The exiled creature is NOT returned — it stays exiled (unlike Fear of Abduction).
+        d.getExile(opp) shouldContain courser
+        d.getPermanents(opp) shouldNotContain courser
+    }
+
+    test("with nothing exiled, the leaves trigger does nothing — no player manifests dread") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opp = d.getOpponent(me)
+
+        // The opponent has an eligible creature, but we DECLINE the "up to one" exile — so
+        // nothing is exiled and the linked-exile pile stays empty.
+        val courser = d.putPermanentOnBattlefield(opp, "Centaur Courser")
+        d.putCardOnTopOfLibrary(opp, "Grizzly Bears")
+
+        val hovInHand = d.putCardInHand(me, "Unidentified Hovership")
+        d.giveMana(me, Color.WHITE, 3)
+        d.castSpell(me, hovInHand).error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        // Decline the optional exile target (choose zero creatures).
+        d.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        d.submitTargetSelection(me, emptyList())
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        val hov = d.findPermanent(me, "Unidentified Hovership")!!
+        d.getExile(me).isEmpty() shouldBe true
+        d.getExile(opp).isEmpty() shouldBe true
+        // The declined creature is untouched on the battlefield.
+        d.getPermanents(opp) shouldContain courser
+
+        // Destroy the Hovership; its leaves trigger resolves with an empty linked-exile pile.
+        val disenchant = d.putCardInHand(me, "Disenchant")
+        d.giveMana(me, Color.WHITE, 2)
+        d.castSpellWithTargets(me, disenchant, listOf(ChosenTarget.Permanent(hov))).error shouldBe null
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // Nobody manifests dread: no decision is pending, and no manifested permanent exists.
+        (d.pendingDecision is SelectCardsDecision) shouldBe false
+        (d.getPermanents(me) + d.getPermanents(opp)).none {
+            d.state.getEntity(it)?.get<ManifestedComponent>() != null
+        } shouldBe true
+    }
+})


### PR DESCRIPTION
Three random Duskmourn: House of Horror cards from `/add-random-card`, plus one reusable engine building block the third card needed.

## Cards

- **Lakeside Shack** (DSK 262, common land) — completes the G/U member of the DSK "enters tapped unless a player has 13 or less life" dual-land cycle. Pure authoring; reuses the same `EntersTapped` + `APlayerLifeAtMost` replacement and twin mana abilities as its siblings.
- **Derelict Attic // Widow's Walk** (DSK 93, common Room) — split-layout Room. *Derelict Attic* `{2}{B}`: unlock → draw two, lose 2 life. *Widow's Walk* `{3}{B}`: whenever a creature you control attacks alone, it gets +1/+0 and gains deathtouch (composes `Triggers.attacks(Alone)` + `ModifyStats`/`GrantKeyword` on the triggering creature). No new engine work.
- **Unidentified Hovership** (DSK 37, rare Artifact — Vehicle) — 2/2, Flying, Crew 1. ETB exiles up to one target creature with toughness 5 or less; on leave, the exiled card's owner manifests dread. **This one needed a new engine capability** (below).

## New engine building block — `Player.OwnersOfLinkedExile`

A reusable `Player` reference resolving to the **distinct owners** of the cards in a source's linked-exile pile (`LinkedExileComponent`, populated by `Effects.ExileUntilLeaves`). Lets a leaves-the-battlefield trigger act on "the exiled card's owner" — which is often an opponent, not the source's controller.

- The "owner manifests dread" payoff is **pure composition** — `Effects.ForEachPlayer(Player.OwnersOfLinkedExile, Patterns.Library.manifestDread().effects)`, the same shape Fear of Impostors uses to make another player manifest dread. No new manifest/effect type.
- Resolution lives in one shared helper, `TargetResolutionUtils.linkedExileOwners`, consumed by both `ForEachExecutor.resolvePlayers` and `DynamicAmountEvaluator`. The `ForEachExecutor` branch deliberately does **not** fall through to the all-players fallback: an empty pile means nobody acts, matching the ruling *"If there's no exiled card … the ability won't do anything"* and *"each player who owns one or more of the exiled cards manifests dread"* (distinct owners).
- Updated the two exhaustive `when (player)` resolvers and `Player.possessive`; documented in `docs/card-sdk-language-reference.md`.

No client-facing surface (reuses the existing `SelectCardsDecision` flow); not an mtgish IR tag, so no coverage/emitter wiring.

## Tests

- `UnidentifiedHovershipScenarioTest` — (1) the exiled creature's **owner (the opponent)** manifests dread when the Vehicle leaves, and the exiled card stays exiled; (2) declined exile → empty pile → leaves trigger is a no-op (nobody manifests). Both PASS.
- Regression: `CardLintTest`, `CardDefinitionSnapshotTest` (DSK snapshot re-blessed), `FearOfImpostorsScenarioTest`, `FearOfAbductionScenarioTest` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)