### PR TITLE
Add Quistis Trepe, Zell Dincht, and Snow Villiers to Final Fantasy (FIN)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/QuistisTrepe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/QuistisTrepe.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Quistis Trepe — Final Fantasy #66
+ * {2}{U} · Legendary Creature — Human Wizard · 2/2
+ *
+ * Blue Magic — When Quistis Trepe enters, you may cast target instant or sorcery card from a
+ * graveyard, and mana of any type can be spent to cast that spell. If that spell would be put
+ * into a graveyard, exile it instead.
+ *
+ * "Blue Magic" is an ability word (CR 207.2c) — flavor only, no rules meaning, so it adds no
+ * keyword. The card targets an instant/sorcery in *any* graveyard (yours or an opponent's),
+ * moves it to exile, then grants a may-play-from-exile permission with `withAnyManaType = true`
+ * (the "mana of any type can be spent" clause — you still pay the cost) and
+ * `exileAfterResolve = true` (the "if it would be put into a graveyard, exile it instead"
+ * rider). This mirrors Nita, Forum Conciliator's paid cast-from-exile, but as an ETB trigger
+ * targeting any graveyard rather than an activated ability limited to opponents'. The "you may"
+ * is honored by the cast itself being optional — the granted permission is never forced.
+ */
+val QuistisTrepe = card("Quistis Trepe") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 2
+    toughness = 2
+    oracleText = "Blue Magic — When Quistis Trepe enters, you may cast target instant or sorcery card " +
+        "from a graveyard, and mana of any type can be spent to cast that spell. If that spell would be " +
+        "put into a graveyard, exile it instead."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target = TargetObject(
+            filter = TargetFilter.InstantOrSorceryInGraveyard,
+        )
+        effect = Effects.Composite(
+            // Exile the targeted card from its graveyard.
+            Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE),
+            // Gather it into a named collection so the may-play grant can key off it.
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "borrowed"),
+            // "You may cast ... and mana of any type can be spent" + "if it would be put into a
+            // graveyard, exile it instead."
+            Effects.GrantMayPlayFromExile(
+                from = "borrowed",
+                expiry = MayPlayExpiry.EndOfTurn,
+                withAnyManaType = true,
+                exileAfterResolve = true,
+            ),
+        )
+        description = "Blue Magic — When Quistis Trepe enters, you may cast target instant or sorcery " +
+            "card from a graveyard, and mana of any type can be spent to cast that spell. If that spell " +
+            "would be put into a graveyard, exile it instead."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "66"
+        artist = "Touge369"
+        flavorText = "\"It's not like everyone can get by on their own, you know?\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61784cbd-92e9-43c7-a1a8-4004b1bf4dae.jpg?1748706001"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SnowVilliers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SnowVilliers.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CharacteristicValue
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Snow Villiers — Final Fantasy #33
+ * {2}{W} · Legendary Creature — Human Rebel Monk · * /3
+ *
+ * Vigilance
+ * Snow Villiers's power is equal to the number of creatures you control.
+ *
+ * Power is a characteristic-defining ability (printed *), recomputed continuously via
+ * [CharacteristicValue.dynamic] over the count of creatures you control (read through projected
+ * control). Snow himself is a creature you control, so he counts toward his own power. Toughness
+ * is the printed fixed value 3, so only `dynamicPower` is set.
+ */
+val SnowVilliers = card("Snow Villiers") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Rebel Monk"
+    dynamicPower = CharacteristicValue.dynamic(
+        DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Creature),
+    )
+    toughness = 3
+    oracleText = "Vigilance\nSnow Villiers's power is equal to the number of creatures you control."
+
+    keywords(Keyword.VIGILANCE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Fariba Khamseh"
+        flavorText = "\"All I can do is go forward. Keep fighting and surviving, until I find the answers I need.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/399bb699-e61d-4b41-b6e9-e594cbad6194.jpg?1748705880"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZellDincht.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZellDincht.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantAdditionalLandDrop
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Zell Dincht — Final Fantasy #170
+ * {2}{R} · Legendary Creature — Human Monk · 0/3
+ *
+ * You may play an additional land on each of your turns.
+ * Zell Dincht gets +1/+0 for each land you control.
+ * At the beginning of your end step, return a land you control to its owner's hand.
+ *
+ * - Extra land drop: [GrantAdditionalLandDrop] (cumulative with similar effects).
+ * - The +1/+0 buff is a continuous self-buff whose power bonus is the number of lands you control,
+ *   read through projected control via [GrantDynamicStatsEffect]. Not "other" lands — Zell isn't a
+ *   land, so every land you control counts.
+ * - The end-step bounce is a forced (non-"may") triggered ability targeting a land you control; you
+ *   choose which when it's put on the stack and return it to its owner's hand on resolution.
+ */
+val ZellDincht = card("Zell Dincht") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Monk"
+    power = 0
+    toughness = 3
+    oracleText = "You may play an additional land on each of your turns.\n" +
+        "Zell Dincht gets +1/+0 for each land you control.\n" +
+        "At the beginning of your end step, return a land you control to its owner's hand."
+
+    // You may play an additional land on each of your turns.
+    staticAbility {
+        ability = GrantAdditionalLandDrop(count = 1)
+    }
+
+    // Zell Dincht gets +1/+0 for each land you control.
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmount.AggregateBattlefield(Player.You, GameObjectFilter.Land),
+            toughnessBonus = DynamicAmount.Fixed(0),
+        )
+    }
+
+    // At the beginning of your end step, return a land you control to its owner's hand.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        target = TargetObject(
+            filter = TargetFilter(GameObjectFilter.Land.youControl()),
+        )
+        effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0))
+        description = "At the beginning of your end step, return a land you control to its owner's hand."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "170"
+        artist = "Kevin Sidharta"
+        flavorText = "\"My weapons are these fists of mine!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/135d6b27-9168-4513-9d7d-56edae048857.jpg?1748706397"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -7838,6 +7838,71 @@
     ]
 }
 
+// Quistis Trepe
+{
+    "name": "Quistis Trepe",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Blue Magic — When Quistis Trepe enters, you may cast target instant or sorcery card from a graveyard, and mana of any type can be spent to cast that spell. If that spell would be put into a graveyard, exile it instead.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "borrowed"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "borrowed",
+                            "withAnyManaType": true,
+                            "exileAfterResolve": true
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "instant|sorcery",
+                        "zone": "Graveyard"
+                    }
+                },
+                "descriptionOverride": "Blue Magic — When Quistis Trepe enters, you may cast target instant or sorcery card from a graveyard, and mana of any type can be spent to cast that spell. If that spell would be put into a graveyard, exile it instead."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "UNCOMMON",
+        "artist": "Touge369",
+        "flavorText": "\"It's not like everyone can get by on their own, you know?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61784cbd-92e9-43c7-a1a8-4004b1bf4dae.jpg?1748706001"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Rabanastre, Royal City
 {
     "name": "Rabanastre, Royal City",
@@ -9386,6 +9451,38 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Snow Villiers
+{
+    "name": "Snow Villiers",
+    "manaCost": "{2}{W}",
+    "typeLine": "Legendary Creature — Human Rebel Monk",
+    "oracleText": "Vigilance\nSnow Villiers's power is equal to the number of creatures you control.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            }
+        },
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Fariba Khamseh",
+        "flavorText": "\"All I can do is go forward. Keep fighting and surviving, until I find the answers I need.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/399bb699-e61d-4b41-b6e9-e594cbad6194.jpg?1748705880"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -12611,5 +12708,73 @@
                 }
             }
         }
+    ]
+}
+
+// Zell Dincht
+{
+    "name": "Zell Dincht",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Human Monk",
+    "oracleText": "You may play an additional land on each of your turns.\nZell Dincht gets +1/+0 for each land you control.\nAt the beginning of your end step, return a land you control to its owner's hand.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land ctrl:you"
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, return a land you control to its owner's hand."
+            }
+        ],
+        "staticAbilities": [
+            "GrantAdditionalLandDrop",
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land"
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "RARE",
+        "artist": "Kevin Sidharta",
+        "flavorText": "\"My weapons are these fists of mine!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/135d6b27-9168-4513-9d7d-56edae048857.jpg?1748706397"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuistisTrepeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuistisTrepeScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.QuistisTrepe
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Quistis Trepe (FIN) — {2}{U} Legendary Creature — Human Wizard 2/2.
+ *
+ *  "Blue Magic — When Quistis Trepe enters, you may cast target instant or sorcery card from a
+ *   graveyard, and mana of any type can be spent to cast that spell. If that spell would be put
+ *   into a graveyard, exile it instead."
+ *
+ * Exercises the ETB borrow-and-cast: Quistis targets an instant in a graveyard, exiles it, and
+ * grants a may-play permission with `withAnyManaType` so it can be paid with off-color mana, plus
+ * `exileAfterResolve` so the cast spell ends up in exile rather than the graveyard.
+ */
+class QuistisTrepeScenarioTest : FunSpec({
+
+    // An off-color instant ({R}) the opponent owns. Casting it from a {U}-only board with white/blue
+    // mana proves "mana of any type can be spent".
+    val borrowedInstant = card("Quistis Test Spark") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        oracleText = "Quistis Test Spark deals 2 damage to any target."
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(QuistisTrepe)
+        driver.registerCard(borrowedInstant)
+        driver.initMirrorMatch(Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("ETB grants a may-play permission for an instant in a graveyard with any-mana + exile-after-resolve") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opponent = driver.player2
+
+        // The instant sits in the opponent's graveyard — "from a graveyard" reaches any graveyard.
+        val instant = driver.putCardInGraveyard(opponent, "Quistis Test Spark")
+
+        // Cast Quistis from hand so her "When ~ enters" trigger genuinely fires (a direct
+        // putCreatureOnBattlefield would skip the enters event).
+        val quistis = driver.putCardInHand(me, "Quistis Trepe")
+        repeat(3) { driver.putLandOnBattlefield(me, "Island") } // {2}{U}
+        driver.castSpell(me, quistis, emptyList())
+
+        // Resolve the cast + the ETB trigger, targeting the instant when prompted.
+        run {
+            repeat(40) {
+                if (driver.state.mayPlayPermissions.any { instant in it.cardIds }) return@run
+                when (val pending = driver.pendingDecision) {
+                    is ChooseTargetsDecision -> driver.submitTargetSelection(pending.playerId, listOf(instant))
+                    null -> driver.bothPass()
+                    else -> driver.autoResolveDecision()
+                }
+            }
+        }
+
+        // The instant left the opponent's graveyard for exile and is castable by me with any mana.
+        driver.getGraveyard(opponent).contains(instant) shouldBe false
+        val perm = driver.state.mayPlayPermissions.single { instant in it.cardIds }
+        withClue("Permission allows spending mana of any type") {
+            perm.withAnyManaType shouldBe true
+        }
+
+        // Cast the borrowed instant with blue mana (off-color), targeting the opponent.
+        repeat(2) { driver.putLandOnBattlefield(me, "Island") }
+        driver.castSpell(me, instant, listOf(opponent))
+        run {
+            repeat(25) {
+                if (driver.state.getZone(opponent, Zone.EXILE).contains(instant)) return@run
+                if (driver.pendingDecision != null) driver.autoResolveDecision() else driver.bothPass()
+            }
+        }
+
+        withClue("After resolving, the borrowed spell is exiled, not in the owner's graveyard") {
+            driver.state.getZone(opponent, Zone.EXILE).contains(instant).shouldBeTrue()
+            driver.getGraveyard(opponent).contains(instant) shouldBe false
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SnowVilliersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SnowVilliersScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Snow Villiers (FIN) — {2}{W} Legendary Creature — Human Rebel Monk * /3.
+ *
+ *  "Vigilance
+ *   Snow Villiers's power is equal to the number of creatures you control."
+ *
+ * Verifies the characteristic-defining power (recomputes with the number of creatures you control,
+ * counting Snow himself), the fixed toughness of 3, and vigilance.
+ */
+class SnowVilliersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Snow Villiers CDA power") {
+
+            test("power equals the number of creatures you control (Snow counts himself)") {
+                val alone = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Snow Villiers", summoningSickness = false)
+                    .build()
+
+                val snowAlone = alone.findPermanent("Snow Villiers")!!
+                withClue("Alone, Snow is the only creature you control → power 1, toughness 3") {
+                    alone.state.projectedState.getPower(snowAlone) shouldBe 1
+                    alone.state.projectedState.getToughness(snowAlone) shouldBe 3
+                }
+
+                val withFriends = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Snow Villiers", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Savannah Lions", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    // An opponent's creature must NOT count.
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .build()
+
+                val snow = withFriends.findPermanent("Snow Villiers")!!
+                withClue("Three creatures you control (Snow + two) → power 3; opponent's creature ignored") {
+                    withFriends.state.projectedState.getPower(snow) shouldBe 3
+                    withFriends.state.projectedState.getToughness(snow) shouldBe 3
+                }
+            }
+
+            test("has vigilance") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Snow Villiers", summoningSickness = false)
+                    .build()
+
+                val snow = game.findPermanent("Snow Villiers")!!
+                game.state.projectedState.hasKeyword(snow, Keyword.VIGILANCE) shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZellDinchtScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZellDinchtScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.player.LandDropsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.ZellDincht
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Zell Dincht (FIN) — {2}{R} Legendary Creature — Human Monk 0/3.
+ *
+ *  "You may play an additional land on each of your turns.
+ *   Zell Dincht gets +1/+0 for each land you control.
+ *   At the beginning of your end step, return a land you control to its owner's hand."
+ *
+ * Covers the +1/+0-per-land continuous self-buff, the extra land drop, and the forced end-step
+ * land bounce.
+ */
+class ZellDinchtScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ZellDincht)
+        driver.initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("gets +1/+0 for each land you control") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        val zell = driver.putCreatureOnBattlefield(me, "Zell Dincht")
+
+        withClue("No lands → base 0/3") {
+            driver.state.projectedState.getPower(zell) shouldBe 0
+            driver.state.projectedState.getToughness(zell) shouldBe 3
+        }
+
+        repeat(3) { driver.putLandOnBattlefield(me, "Mountain") }
+        // An opponent's land must NOT count toward Zell's power.
+        driver.putLandOnBattlefield(driver.player2, "Mountain")
+
+        withClue("Three lands you control → +3/+0 = 3/3") {
+            driver.state.projectedState.getPower(zell) shouldBe 3
+            driver.state.projectedState.getToughness(zell) shouldBe 3
+        }
+    }
+
+    test("lets you play an additional land each turn") {
+        val driver = newDriver()
+        val me = driver.player1
+        driver.putCreatureOnBattlefield(me, "Zell Dincht")
+
+        val land1 = driver.putCardInHand(me, "Mountain")
+        driver.playLand(me, land1).isSuccess shouldBe true
+        driver.state.getEntity(me)?.get<LandDropsComponent>()?.remaining shouldBe 0
+
+        // The static bonus grants one more land play this turn.
+        val land2 = driver.putCardInHand(me, "Mountain")
+        driver.playLand(me, land2).isSuccess shouldBe true
+
+        // Now the extra drop is consumed; a third land play is illegal.
+        val land3 = driver.putCardInHand(me, "Mountain")
+        driver.submitExpectFailure(com.wingedsheep.engine.core.PlayLand(me, land3)).isSuccess shouldBe false
+    }
+
+    test("returns a land you control to its owner's hand at your end step") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        driver.putCreatureOnBattlefield(me, "Zell Dincht")
+        val land = driver.putLandOnBattlefield(me, "Mountain")
+        val handBefore = driver.getHandSize(me)
+
+        // Advance to the end step; the trigger goes on the stack and asks which land to return.
+        driver.passPriorityUntil(Step.END)
+        repeat(20) {
+            if (!driver.state.getZone(me, Zone.BATTLEFIELD).contains(land)) return@repeat
+            when (val pending = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(pending.playerId, listOf(land))
+                null -> {
+                    if (driver.state.stack.isEmpty()) return@repeat
+                    driver.bothPass()
+                }
+                else -> driver.autoResolveDecision()
+            }
+        }
+
+        withClue("The chosen land left the battlefield for its owner's hand") {
+            driver.state.getZone(me, Zone.BATTLEFIELD).contains(land) shouldBe false
+            driver.state.getZone(me, Zone.HAND).contains(land) shouldBe true
+            driver.getHandSize(me) shouldBe handBefore + 1
+        }
+    }
+})


### PR DESCRIPTION
Implements three FIN-exclusive legendary creatures, each reusing existing SDK primitives (no new engine features) and each verified by a passing scenario test.

## Cards

- **Quistis Trepe** — {2}{U} Legendary Creature — Human Wizard 2/2. "Blue Magic — When Quistis Trepe enters, you may cast target instant or sorcery card from a graveyard, and mana of any type can be spent to cast that spell. If that spell would be put into a graveyard, exile it instead." Modeled as an enters trigger that targets an instant/sorcery in any graveyard, moves it to exile, and grants a may-play-from-exile permission with `withAnyManaType` + `exileAfterResolve` (the same paid cast-from-exile shape as Nita, Forum Conciliator, but as an ETB over any graveyard rather than an activated ability limited to opponents').
- **Zell Dincht** — {2}{R} Legendary Creature — Human Monk 0/3. Extra land drop (`GrantAdditionalLandDrop`), a +1/+0-per-land dynamic self-buff (`GrantDynamicStatsEffect`), and a forced end-step bounce of a chosen land you control.
- **Snow Villiers** — {2}{W} Legendary Creature — Human Rebel Monk */3. Vigilance plus a characteristic-defining power equal to the number of creatures you control (`dynamicPower`), with a fixed toughness of 3.

## Testing

- `QuistisTrepeScenarioTest`, `ZellDinchtScenarioTest`, `SnowVilliersScenarioTest` — all passing in `rules-engine`.
- `CardDefinitionSnapshotTest` FIN golden re-blessed (only the three new cards added).
- `check-card-printing` confirms FIN is the canonical (earliest real) printing for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)