### PR TITLE
Add 5 Duskmourn Room cards (DSK)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GlassworksShatteredYard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GlassworksShatteredYard.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Glassworks // Shattered Yard (DSK 137) — split-layout Room (CR 709.5).
+ *
+ * Glassworks {2}{R} — Enchantment — Room
+ *   When you unlock this door, this Room deals 4 damage to target creature an opponent controls.
+ *
+ * Shattered Yard {4}{R} — Enchantment — Room
+ *   At the beginning of your end step, this Room deals 1 damage to each opponent.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e). Both
+ * doors use the Room itself as the damage source (the default when no explicit `damageSource`
+ * is given to [Effects.DealDamage]).
+ */
+val GlassworksShatteredYard = card("Glassworks // Shattered Yard") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "R"
+
+    face("Glassworks") {
+        manaCost = "{2}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, this Room deals 4 damage to target creature an opponent controls."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            target = Targets.CreatureOpponentControls
+            effect = Effects.DealDamage(4, EffectTarget.ContextTarget(0))
+            description = "When you unlock this door, this Room deals 4 damage to target creature an opponent controls."
+        }
+    }
+
+    face("Shattered Yard") {
+        manaCost = "{4}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "At the beginning of your end step, this Room deals 1 damage to each opponent."
+
+        triggeredAbility {
+            trigger = Triggers.YourEndStep
+            effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+            description = "At the beginning of your end step, this Room deals 1 damage to each opponent."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "137"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg?1726780646"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MeatLockerDrownedDiner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MeatLockerDrownedDiner.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Meat Locker // Drowned Diner (DSK 65) — split-layout Room (CR 709.5).
+ *
+ * Meat Locker {2}{U} — Enchantment — Room
+ *   When you unlock this door, tap up to one target creature and put two stun counters on it.
+ *
+ * Drowned Diner {3}{U}{U} — Enchantment — Room
+ *   When you unlock this door, draw three cards, then discard a card.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ */
+val MeatLockerDrownedDiner = card("Meat Locker // Drowned Diner") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "U"
+
+    face("Meat Locker") {
+        manaCost = "{2}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, tap up to one target creature and put two stun counters on it."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            val t = target("up to one target creature", Targets.UpToCreatures(1))
+            effect = Effects.Tap(t).then(Effects.AddCounters("STUN", 2, t))
+            description = "When you unlock this door, tap up to one target creature and put two stun counters on it."
+        }
+    }
+
+    face("Drowned Diner") {
+        manaCost = "{3}{U}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, draw three cards, then discard a card."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Patterns.Hand.loot(draw = 3, discard = 1)
+            description = "When you unlock this door, draw three cards, then discard a card."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "65"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg?1726780679"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PaintersStudioDefacedGallery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PaintersStudioDefacedGallery.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Painter's Studio // Defaced Gallery (DSK 147) — split-layout Room (CR 709.5).
+ *
+ * Painter's Studio {2}{R} — Enchantment — Room
+ *   When you unlock this door, exile the top two cards of your library. You may play them until
+ *   the end of your next turn.
+ *
+ * Defaced Gallery {1}{R} — Enchantment — Room
+ *   Whenever you attack, attacking creatures you control get +1/+0 until end of turn.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e). The
+ * Painter's Studio door-unlock impulse uses [MayPlayExpiry.UntilEndOfNextTurn] for the
+ * "until the end of your next turn" play window.
+ */
+val PaintersStudioDefacedGallery = card("Painter's Studio // Defaced Gallery") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "R"
+
+    face("Painter's Studio") {
+        manaCost = "{2}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, exile the top two cards of your library. You may " +
+            "play them until the end of your next turn."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Patterns.Exile.impulse(count = 2, expiry = MayPlayExpiry.UntilEndOfNextTurn)
+            description = "When you unlock this door, exile the top two cards of your library. You " +
+                "may play them until the end of your next turn."
+        }
+    }
+
+    face("Defaced Gallery") {
+        manaCost = "{1}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Whenever you attack, attacking creatures you control get +1/+0 until end of turn."
+
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            effect = Patterns.Group.modifyStatsForAll(
+                power = 1,
+                toughness = 0,
+                filter = GroupFilter.AllCreaturesYouControl.attacking(),
+                duration = Duration.EndOfTurn
+            )
+            description = "Whenever you attack, attacking creatures you control get +1/+0 until end of turn."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "147"
+        artist = "Marc Simonetti"
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg?1726780710"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RestrictedOfficeLectureHall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RestrictedOfficeLectureHall.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Restricted Office // Lecture Hall (DSK 227) — split-layout Room (CR 709.5).
+ *
+ * Restricted Office {2}{W}{W} — Enchantment — Room
+ *   When you unlock this door, destroy all creatures with power 3 or greater.
+ *
+ * Lecture Hall {5}{U}{U} — Enchantment — Room
+ *   Other permanents you control have hexproof.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e). The
+ * Lecture Hall lord uses a battlefield-scoped [GrantKeyword] excluding the source itself, so the
+ * Room doesn't give itself hexproof.
+ */
+val RestrictedOfficeLectureHall = card("Restricted Office // Lecture Hall") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "WU"
+
+    face("Restricted Office") {
+        manaCost = "{2}{W}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, destroy all creatures with power 3 or greater."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Effects.DestroyAll(GameObjectFilter.Creature.powerAtLeast(3))
+            description = "When you unlock this door, destroy all creatures with power 3 or greater."
+        }
+    }
+
+    face("Lecture Hall") {
+        manaCost = "{5}{U}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Other permanents you control have hexproof."
+
+        staticAbility {
+            ability = GrantKeyword(
+                Keyword.HEXPROOF,
+                GroupFilter.AllPermanentsYouControl.other()
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "227"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg?1726867717"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SurgicalSuiteHospitalRoom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SurgicalSuiteHospitalRoom.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Surgical Suite // Hospital Room (DSK 34) — split-layout Room (CR 709.5).
+ *
+ * Surgical Suite {1}{W} — Enchantment — Room
+ *   When you unlock this door, return target creature card with mana value 3 or less from your
+ *   graveyard to the battlefield.
+ *
+ * Hospital Room {3}{W} — Enchantment — Room
+ *   Whenever you attack, put a +1/+1 counter on target attacking creature.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ */
+val SurgicalSuiteHospitalRoom = card("Surgical Suite // Hospital Room") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "W"
+
+    face("Surgical Suite") {
+        manaCost = "{1}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, return target creature card with mana value 3 or " +
+            "less from your graveyard to the battlefield."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            val t = target(
+                "target creature card with mana value 3 or less",
+                TargetObject(filter = TargetFilter.CreatureInYourGraveyard.manaValueAtMost(3))
+            )
+            effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+            description = "When you unlock this door, return target creature card with mana value " +
+                "3 or less from your graveyard to the battlefield."
+        }
+    }
+
+    face("Hospital Room") {
+        manaCost = "{3}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Whenever you attack, put a +1/+1 counter on target attacking creature."
+
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            val attacker = target("target attacking creature", Targets.AttackingCreature)
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, attacker)
+            description = "Whenever you attack, put a +1/+1 counter on target attacking creature."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "34"
+        artist = "Titus Lunter"
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg?1726780782"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -6813,6 +6813,87 @@
     ]
 }
 
+// Glassworks // Shattered Yard
+{
+    "name": "Glassworks // Shattered Yard",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, this Room deals 4 damage to target creature an opponent controls.\n//\nAt the beginning of your end step, this Room deals 1 damage to each opponent.",
+    "metadata": {
+        "collectorNumber": "137",
+        "artist": "Sergey Glushakov",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/e/fe32f667-8d9f-4414-913e-256cbc2fbc45.jpg?1726780646"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Glassworks",
+            "manaCost": "{2}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, this Room deals 4 damage to target creature an opponent controls.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        },
+                        "descriptionOverride": "When you unlock this door, this Room deals 4 damage to target creature an opponent controls."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Shattered Yard",
+            "manaCost": "{4}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "At the beginning of your end step, this Room deals 1 damage to each opponent.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": {
+                            "type": "StepEvent",
+                            "step": "END"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            }
+                        },
+                        "descriptionOverride": "At the beginning of your end step, this Room deals 1 damage to each opponent."
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Glimmer Seeker
 {
     "name": "Glimmer Seeker",
@@ -9670,6 +9751,131 @@
     }
 }
 
+// Meat Locker // Drowned Diner
+{
+    "name": "Meat Locker // Drowned Diner",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, tap up to one target creature and put two stun counters on it.\n//\nWhen you unlock this door, draw three cards, then discard a card.",
+    "metadata": {
+        "collectorNumber": "65",
+        "artist": "Sergey Glushakov",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3c773f0-9e65-48de-a362-a9a943198693.jpg?1726780679"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Meat Locker",
+            "manaCost": "{2}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, tap up to one target creature and put two stun counters on it.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "up to one target creature"
+                                    }
+                                },
+                                {
+                                    "type": "AddCounters",
+                                    "counterType": "STUN",
+                                    "count": 2,
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "up to one target creature"
+                                    }
+                                }
+                            ]
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "up to one target creature"
+                        },
+                        "descriptionOverride": "When you unlock this door, tap up to one target creature and put two stun counters on it."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Drowned Diner",
+            "manaCost": "{3}{U}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, draw three cards, then discard a card.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                },
+                                {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded",
+                                            "prompt": "Choose 1 card to discard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "descriptionOverride": "When you unlock this door, draw three cards, then discard a card."
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Meathook Massacre II
 {
     "name": "Meathook Massacre II",
@@ -11629,6 +11835,111 @@
     ]
 }
 
+// Painter's Studio // Defaced Gallery
+{
+    "name": "Painter's Studio // Defaced Gallery",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, exile the top two cards of your library. You may play them until the end of your next turn.\n//\nWhenever you attack, attacking creatures you control get +1/+0 until end of turn.",
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "UNCOMMON",
+        "artist": "Marc Simonetti",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e96901eb-5b57-43f4-a7b1-ae3b809bc36e.jpg?1726780710"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Painter's Studio",
+            "manaCost": "{2}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, exile the top two cards of your library. You may play them until the end of your next turn.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeAs": "impulseExiled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "impulseExiled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    }
+                                },
+                                {
+                                    "type": "GrantMayPlayFromExile",
+                                    "from": "impulseExiled",
+                                    "expiry": {
+                                        "type": "UntilControllerStep",
+                                        "step": "CLEANUP",
+                                        "includeCurrentTurn": false
+                                    }
+                                }
+                            ]
+                        },
+                        "descriptionOverride": "When you unlock this door, exile the top two cards of your library. You may play them until the end of your next turn."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Defaced Gallery",
+            "manaCost": "{1}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Whenever you attack, attacking creatures you control get +1/+0 until end of turn.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "YouAttackEvent",
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature attacking ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        "descriptionOverride": "Whenever you attack, attacking creatures you control get +1/+0 until end of turn."
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Paranormal Analyst
 {
     "name": "Paranormal Analyst",
@@ -12467,6 +12778,82 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Restricted Office // Lecture Hall
+{
+    "name": "Restricted Office // Lecture Hall",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, destroy all creatures with power 3 or greater.\n//\nOther permanents you control have hexproof.",
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "RARE",
+        "artist": "Antonio José Manzanedo",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac794b2f-b5ea-449d-bb0b-4f0e6cc145ef.jpg?1726867717"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Restricted Office",
+            "manaCost": "{2}{W}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, destroy all creatures with power 3 or greater.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "BattlefieldMatching",
+                                        "filter": "creature pow>=3"
+                                    },
+                                    "storeAs": "destroyAll_gathered"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "destroyAll_gathered",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Destroy"
+                                }
+                            ]
+                        },
+                        "descriptionOverride": "When you unlock this door, destroy all creatures with power 3 or greater."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Lecture Hall",
+            "manaCost": "{5}{U}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Other permanents you control have hexproof.",
+            "script": {
+                "staticAbilities": [
+                    {
+                        "type": "GrantKeyword",
+                        "keyword": "HEXPROOF",
+                        "filter": {
+                            "baseFilter": "permanent ctrl:you",
+                            "excludeSelf": true
+                        }
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -14653,6 +15040,90 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Surgical Suite // Hospital Room
+{
+    "name": "Surgical Suite // Hospital Room",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, return target creature card with mana value 3 or less from your graveyard to the battlefield.\n//\nWhenever you attack, put a +1/+1 counter on target attacking creature.",
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "UNCOMMON",
+        "artist": "Titus Lunter",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96b2dc14-4477-4444-a9eb-4fa4c02dfbde.jpg?1726780782"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Surgical Suite",
+            "manaCost": "{1}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, return target creature card with mana value 3 or less from your graveyard to the battlefield.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card with mana value 3 or less"
+                            },
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature mv<=3 own:you",
+                                "zone": "Graveyard"
+                            },
+                            "id": "target creature card with mana value 3 or less"
+                        },
+                        "descriptionOverride": "When you unlock this door, return target creature card with mana value 3 or less from your graveyard to the battlefield."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Hospital Room",
+            "manaCost": "{3}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Whenever you attack, put a +1/+1 counter on target attacking creature.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "YouAttackEvent",
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target attacking creature"
+                            }
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature attacking"
+                            },
+                            "id": "target attacking creature"
+                        },
+                        "descriptionOverride": "Whenever you attack, put a +1/+1 counter on target attacking creature."
+                    }
+                ]
+            }
+        }
     ]
 }
 


### PR DESCRIPTION
Implements five split-layout **Room** cards for Duskmourn: House of Horror, taking the set from 241 → 246 of 276 implemented (89%). Each card composes existing SDK primitives — **no new engine features**, so no new scenario tests are required (the door-unlock trigger, damage, reanimation, board wipe, hexproof grant, stun counters, loot, impulse, and attack buffs are all exercised by existing cards).

## Cards

| Card | Front door (on unlock / static) | Back door |
|------|--------------------------------|-----------|
| **Glassworks // Shattered Yard** (137, C) | 4 damage to target creature an opponent controls | end step: 1 damage to each opponent |
| **Surgical Suite // Hospital Room** (34, U) | reanimate a creature card with MV ≤ 3 from your graveyard | attack: +1/+1 counter on target attacker |
| **Restricted Office // Lecture Hall** (227, R) | destroy all creatures with power 3+ | static: other permanents you control have hexproof |
| **Meat Locker // Drowned Diner** (65, C) | tap up to one target creature + 2 stun counters | unlock: draw three, then discard one |
| **Painter's Studio // Defaced Gallery** (147, U) | exile top two, play until end of your next turn | attack: attacking creatures you control get +1/+0 |

## Implementation notes
- All five follow the existing DSK split-Room template (`BottomlessPoolLockerRoom`, `RoaringFurnaceSteamingSauna`): `CardLayout.SPLIT`, one `face(...)` per door, `Triggers.OnDoorUnlocked` for unlock triggers. The Room itself is the damage source (default for `Effects.DealDamage`).
- Surgical Suite uses `TargetFilter.CreatureInYourGraveyard.manaValueAtMost(3)` — note the generated `Unearth` card silently drops this MV restriction; this implementation keeps it.
- Lecture Hall grants hexproof via `GrantKeyword(HEXPROOF, GroupFilter.AllPermanentsYouControl.other())` so the Room doesn't grant itself hexproof.
- Drowned Diner uses `Patterns.Hand.loot(draw = 3, discard = 1)`; Painter's Studio uses `Patterns.Exile.impulse(count = 2, expiry = MayPlayExpiry.UntilEndOfNextTurn)`.

## Testing
- `just` (lock-serialized) `:mtg-sets:test` — green (CardLintTest, CardDefinitionSnapshotTest match, JSON round-trip).
- Re-blessed the DSK snapshot golden; diff adds only these five cards.
- All metadata (collector number, artist, rarity, image URI) pulled from the DSK Scryfall printing; image URLs verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)