### PR TITLE
Add five Final Fantasy cards (Scorpion Sentinel, Matoya, Deadly Embrace, Xande, Relm's Sketching)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DeadlyEmbrace.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DeadlyEmbrace.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Deadly Embrace
+ * {3}{B}{B}
+ * Sorcery
+ * Destroy target creature an opponent controls. Then draw a card for each creature that
+ * died this turn.
+ *
+ * The destroy resolves first, so the creature it kills has already died this turn by the time
+ * the draw counts — it is included in the count (per the Scryfall ruling). "Each creature that
+ * died this turn" is controller-agnostic, so the count sums [Player.Each]: the number of
+ * creatures that died under any player's control this turn.
+ */
+val DeadlyEmbrace = card("Deadly Embrace") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature an opponent controls. Then draw a card for each creature that died this turn."
+
+    spell {
+        val creature = target("target creature an opponent controls", Targets.CreatureOpponentControls)
+        effect = Effects.Destroy(creature) then
+            Effects.DrawCards(DynamicAmounts.creaturesDiedThisTurn(Player.Each))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "557"
+        artist = "Lius Lasahido"
+        flavorText = "\"Come, little lamb... to the slaughter with you!\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a11cb85c-85dd-435c-8303-4d0d18bdb1e9.jpg?1748707601"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MatoyaArchonElder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MatoyaArchonElder.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Matoya, Archon Elder
+ * {2}{U}
+ * Legendary Creature — Human Warlock
+ * 1/4
+ * Whenever you scry or surveil, draw a card. (Draw after you scry or surveil.)
+ *
+ * Uses the unified [Triggers.WheneverYouScryOrSurveil] trigger so a single scry or surveil
+ * event fires the ability once (the engine collapses simultaneous scry+surveil into one event).
+ */
+val MatoyaArchonElder = card("Matoya, Archon Elder") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 1
+    toughness = 4
+    oracleText = "Whenever you scry or surveil, draw a card. (Draw after you scry or surveil.)"
+
+    triggeredAbility {
+        trigger = Triggers.WheneverYouScryOrSurveil
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "62"
+        artist = "Luisa J. Preissler"
+        flavorText = "\"Don't you know it's rude to enter without knocking? Hmph, the youth of today...\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/d/1dd61cf6-2fb5-4cff-ab00-7677ac85774c.jpg?1748705987"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RelmsSketching.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RelmsSketching.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Relm's Sketching
+ * {2}{U}{U}
+ * Sorcery
+ * Create a token that's a copy of target artifact, creature, or land.
+ *
+ * Targets any one artifact, creature, or land permanent (the union filter), then makes a token
+ * copy of it via [Effects.CreateTokenCopyOfTarget], which copies that permanent's copiable
+ * characteristics (Rule 707.2) for whichever permanent type was chosen.
+ */
+val RelmsSketching = card("Relm's Sketching") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Create a token that's a copy of target artifact, creature, or land."
+
+    spell {
+        val permanent = target(
+            "target artifact, creature, or land",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact or GameObjectFilter.Creature or GameObjectFilter.Land
+                )
+            )
+        )
+        effect = Effects.CreateTokenCopyOfTarget(target = permanent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "67"
+        artist = "Smirtouille"
+        flavorText = "In her pictures she captures everything: forests, water, light . . . the very essence of the things she paints."
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6aedac12-3714-4a81-bd4d-1d2555c66f78.jpg?1748706008"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ScorpionSentinel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ScorpionSentinel.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Scorpion Sentinel
+ * {1}{U}
+ * Artifact Creature — Robot Scorpion
+ * 1/4
+ * As long as you control seven or more lands, this creature gets +3/+0.
+ */
+val ScorpionSentinel = card("Scorpion Sentinel") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Robot Scorpion"
+    power = 1
+    toughness = 4
+    oracleText = "As long as you control seven or more lands, this creature gets +3/+0."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 3, toughnessBonus = 0, filter = GroupFilter.source()),
+            condition = Conditions.ControlLandsAtLeast(7)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "HAISIRO"
+        flavorText = "\"Barret, be careful! Attack while its tail's up, it's gonna counterattack with its laser.\"\n—Cloud Strife"
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/08ab5220-e5c1-472e-8217-97fd60e1773c.jpg?1748706024"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/XandeDarkMage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/XandeDarkMage.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Xande, Dark Mage
+ * {2}{U}{B}
+ * Legendary Creature — Human Wizard
+ * 3/3
+ * Menace
+ * Xande gets +1/+1 for each noncreature, nonland card in your graveyard.
+ *
+ * The buff is a continuously-recomputed dynamic stat modifier scoped to the source, counting
+ * the noncreature, nonland cards in the controller's graveyard.
+ */
+val XandeDarkMage = card("Xande, Dark Mage") {
+    manaCost = "{2}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 3
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Xande gets +1/+1 for each noncreature, nonland card in your graveyard."
+
+    keywords(Keyword.MENACE)
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.source(),
+            powerBonus = DynamicAmounts.zone(
+                Player.You,
+                Zone.GRAVEYARD,
+                GameObjectFilter.Noncreature and GameObjectFilter.Nonland
+            ).count(),
+            toughnessBonus = DynamicAmounts.zone(
+                Player.You,
+                Zone.GRAVEYARD,
+                GameObjectFilter.Noncreature and GameObjectFilter.Nonland
+            ).count()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "561"
+        artist = "Joseph Weston"
+        flavorText = "\"But your struggle was all for naught. Don't you see how close the darkness has drawn?\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/c/1caed9a8-b73b-470e-b9d8-8c3b7cac3eee.jpg?1748707603"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -3394,6 +3394,57 @@
     ]
 }
 
+// Deadly Embrace
+{
+    "name": "Deadly Embrace",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature an opponent controls. Then draw a card for each creature that died this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "TurnTracking",
+                        "player": "Each",
+                        "tracker": "CREATURES_DIED"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:opponent"
+                },
+                "id": "target creature an opponent controls"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "557",
+        "rarity": "RARE",
+        "artist": "Lius Lasahido",
+        "flavorText": "\"Come, little lamb... to the slaughter with you!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a11cb85c-85dd-435c-8303-4d0d18bdb1e9.jpg?1748707601"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Delivery Moogle
 {
     "name": "Delivery Moogle",
@@ -6944,6 +6995,44 @@
     ]
 }
 
+// Matoya, Archon Elder
+{
+    "name": "Matoya, Archon Elder",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Whenever you scry or surveil, draw a card. (Draw after you scry or surveil.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "ScriedOrSurveiledEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "RARE",
+        "artist": "Luisa J. Preissler",
+        "flavorText": "\"Don't you know it's rude to enter without knocking? Hmph, the youth of today...\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/d/1dd61cf6-2fb5-4cff-ab00-7677ac85774c.jpg?1748705987"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Memories Returning
 {
     "name": "Memories Returning",
@@ -8371,6 +8460,42 @@
     ]
 }
 
+// Relm's Sketching
+{
+    "name": "Relm's Sketching",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a token that's a copy of target artifact, creature, or land.",
+    "script": {
+        "spellEffect": {
+            "type": "CreateTokenCopyOfTarget",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target artifact, creature, or land"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|creature|land"
+                },
+                "id": "target artifact, creature, or land"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "rarity": "UNCOMMON",
+        "artist": "Smirtouille",
+        "flavorText": "In her pictures she captures everything: forests, water, light . . . the very essence of the things she paints.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6aedac12-3714-4a81-bd4d-1d2555c66f78.jpg?1748706008"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Resentful Revelation
 {
     "name": "Resentful Revelation",
@@ -9366,6 +9491,56 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Scorpion Sentinel
+{
+    "name": "Scorpion Sentinel",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact Creature — Robot Scorpion",
+    "oracleText": "As long as you control seven or more lands, this creature gets +3/+0.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 3,
+                    "toughnessBonus": 0,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "land"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "HAISIRO",
+        "flavorText": "\"Barret, be careful! Attack while its tail's up, it's gonna counterattack with its laser.\"\n—Cloud Strife",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/08ab5220-e5c1-472e-8217-97fd60e1773c.jpg?1748706024"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -12971,6 +13146,55 @@
         "imageUri": "https://cards.scryfall.io/normal/front/7/0/70d9ab99-ec8a-402e-ba1d-ffa6c4c84a3f.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Xande, Dark Mage
+{
+    "name": "Xande, Dark Mage",
+    "manaCost": "{2}{U}{B}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nXande gets +1/+1 for each noncreature, nonland card in your graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "Self"
+                },
+                "powerBonus": {
+                    "type": "AggregateZone",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": "noncreature nonland"
+                },
+                "toughnessBonus": {
+                    "type": "AggregateZone",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": "noncreature nonland"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "561",
+        "rarity": "RARE",
+        "artist": "Joseph Weston",
+        "flavorText": "\"But your struggle was all for naught. Don't you see how close the darkness has drawn?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/c/1caed9a8-b73b-470e-b9d8-8c3b7cac3eee.jpg?1748707603"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
 }
 
 // Y'shtola Rhul

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinBatchSentinelMatoyaXandeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinBatchSentinelMatoyaXandeScenarioTest.kt
@@ -1,0 +1,183 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.DeadlyEmbrace
+import com.wingedsheep.mtg.sets.definitions.fin.cards.MatoyaArchonElder
+import com.wingedsheep.mtg.sets.definitions.fin.cards.RelmsSketching
+import com.wingedsheep.mtg.sets.definitions.fin.cards.ScorpionSentinel
+import com.wingedsheep.mtg.sets.definitions.fin.cards.XandeDarkMage
+import com.wingedsheep.mtg.sets.definitions.inv.cards.Opt
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario coverage for the FIN batch:
+ *  - Scorpion Sentinel — conditional +3/+0 at seven lands (projected stats).
+ *  - Xande, Dark Mage — dynamic +1/+1 per noncreature, nonland card in graveyard.
+ *  - Matoya, Archon Elder — scry/surveil triggers an extra draw.
+ *  - Deadly Embrace — destroy + draw "for each creature that died this turn", with the
+ *    just-destroyed creature counted (resolution timing).
+ *  - Relm's Sketching — token copy of a target permanent.
+ */
+class FinBatchSentinelMatoyaXandeScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(vararg cards: CardDefinition): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        cards.forEach { driver.registerCard(it) }
+        return driver
+    }
+
+    // Resolve the whole stack (auto-resolving scry/library-order decisions) without advancing
+    // past the current step, so end-of-turn cleanup never perturbs hand counts.
+    fun GameTestDriver.resolveStackFully() {
+        var guard = 0
+        while ((stackSize > 0 || state.pendingDecision != null) && guard++ < 40) {
+            if (state.pendingDecision != null) {
+                autoResolveDecision()
+            } else {
+                passPriority(state.priorityPlayerId ?: player1)
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Scorpion Sentinel
+    // ---------------------------------------------------------------------------------------------
+
+    test("Scorpion Sentinel gets +3/+0 only while you control seven or more lands") {
+        val driver = createDriver(ScorpionSentinel)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        val active = driver.activePlayer!!
+
+        val sentinel = driver.putCreatureOnBattlefield(active, "Scorpion Sentinel")
+
+        // Six lands: base 1/4.
+        repeat(6) { driver.putLandOnBattlefield(active, "Island") }
+        projector.getProjectedPower(driver.state, sentinel) shouldBe 1
+        projector.getProjectedToughness(driver.state, sentinel) shouldBe 4
+
+        // Seventh land: +3/+0 → 4/4.
+        driver.putLandOnBattlefield(active, "Island")
+        projector.getProjectedPower(driver.state, sentinel) shouldBe 4
+        projector.getProjectedToughness(driver.state, sentinel) shouldBe 4
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Xande, Dark Mage
+    // ---------------------------------------------------------------------------------------------
+
+    test("Xande gets +1/+1 for each noncreature, nonland card in your graveyard") {
+        val driver = createDriver(XandeDarkMage)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        val active = driver.activePlayer!!
+
+        val xande = driver.putCreatureOnBattlefield(active, "Xande, Dark Mage")
+
+        // Empty graveyard: base 3/3.
+        projector.getProjectedPower(driver.state, xande) shouldBe 3
+        projector.getProjectedToughness(driver.state, xande) shouldBe 3
+
+        // An instant (noncreature, nonland) counts: 4/4.
+        driver.putCardInGraveyard(active, "Lightning Bolt")
+        projector.getProjectedPower(driver.state, xande) shouldBe 4
+        projector.getProjectedToughness(driver.state, xande) shouldBe 4
+
+        // A creature card does NOT count.
+        driver.putCardInGraveyard(active, "Centaur Courser")
+        projector.getProjectedPower(driver.state, xande) shouldBe 4
+
+        // A land card does NOT count.
+        driver.putCardInGraveyard(active, "Swamp")
+        projector.getProjectedPower(driver.state, xande) shouldBe 4
+
+        // A second instant counts: 5/5.
+        driver.putCardInGraveyard(active, "Doom Blade")
+        projector.getProjectedPower(driver.state, xande) shouldBe 5
+        projector.getProjectedToughness(driver.state, xande) shouldBe 5
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Matoya, Archon Elder
+    // ---------------------------------------------------------------------------------------------
+
+    test("Matoya draws a card whenever you scry") {
+        val driver = createDriver(MatoyaArchonElder, Opt)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(active, "Matoya, Archon Elder")
+        val opt = driver.putCardInHand(active, "Opt")
+        driver.giveMana(active, Color.BLUE, 1)
+
+        val handBefore = driver.getHandSize(active) // includes Opt
+
+        driver.castSpell(active, opt)
+        driver.resolveStackFully()
+
+        // Opt: −1 (cast) +1 (its own draw) +1 (Matoya's scry-triggered draw) = handBefore + 1.
+        driver.getHandSize(active) shouldBe handBefore + 1
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Deadly Embrace
+    // ---------------------------------------------------------------------------------------------
+
+    test("Deadly Embrace destroys the creature and draws for it (counted as died this turn)") {
+        val driver = createDriver(DeadlyEmbrace)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        val spell = driver.putCardInHand(active, "Deadly Embrace")
+        driver.giveMana(active, Color.BLACK, 5) // {3}{B}{B}
+
+        val handBefore = driver.getHandSize(active) // includes Deadly Embrace
+
+        driver.castSpell(active, spell, listOf(victim))
+        driver.resolveStackFully()
+
+        // The creature is destroyed and counts as having died this turn → draw exactly 1.
+        // Hand: handBefore −1 (spell cast) +1 (draw) = handBefore. Drawing 0 (wrong timing)
+        // would leave handBefore − 1.
+        driver.state.getBattlefield().contains(victim) shouldBe false
+        driver.getHandSize(active) shouldBe handBefore
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Relm's Sketching
+    // ---------------------------------------------------------------------------------------------
+
+    test("Relm's Sketching creates a token copy of the targeted creature") {
+        val driver = createDriver(RelmsSketching)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+
+        val original = driver.putCreatureOnBattlefield(active, "Centaur Courser")
+        val spell = driver.putCardInHand(active, "Relm's Sketching")
+        driver.giveMana(active, Color.BLUE, 4) // {2}{U}{U}
+
+        driver.castSpell(active, spell, listOf(original))
+        driver.resolveStackFully()
+
+        val coursers = driver.state.getBattlefield()
+            .filter { driver.getCardName(it) == "Centaur Courser" }
+        coursers.size shouldBe 2
+
+        val token = coursers.first { it != original }
+        driver.state.getEntity(token)!!.has<TokenComponent>() shouldBe true
+    }
+})


### PR DESCRIPTION
Implements a handful of unimplemented **Final Fantasy (FIN)** cards, chosen to compose cleanly from existing SDK primitives (no engine/SDK changes).

## Cards

| Card | Cost | Type | How it's modeled |
|------|------|------|------------------|
| **Scorpion Sentinel** | {1}{U} | Artifact Creature 1/4 | `ConditionalStaticAbility(ModifyStats(+3/+0), Conditions.ControlLandsAtLeast(7))` |
| **Matoya, Archon Elder** | {2}{U} | Legendary Creature 1/4 | `Triggers.WheneverYouScryOrSurveil → DrawCards(1)` |
| **Deadly Embrace** | {3}{B}{B} | Sorcery | `Destroy(target opp creature) then DrawCards(creaturesDiedThisTurn(Player.Each))` |
| **Xande, Dark Mage** | {2}{U}{B} | Legendary Creature 3/3 | Menace + `GrantDynamicStatsEffect` scaling on noncreature/nonland cards in graveyard |
| **Relm's Sketching** | {2}{U}{U} | Sorcery | `CreateTokenCopyOfTarget` over an artifact/creature/land union target |

## Rules notes
- **Deadly Embrace** destroys the creature *first*, so it is counted among "creatures that died this turn" (per the Scryfall ruling). `Player.Each` sums the per-player `CREATURES_DIED` tracker, i.e. all creatures regardless of controller.
- **Xande** counts only noncreature, nonland cards (`GameObjectFilter.Noncreature and GameObjectFilter.Nonland`); verified that creature and land cards in the graveyard don't contribute.

## Tests
- `FinBatchSentinelMatoyaXandeScenarioTest` covers all five: projected conditional/dynamic stats, scry-triggered draw, death-count timing, and the token copy.
- Re-blessed the FIN card snapshot (only the five new cards added; no other card moved).
- `just build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)