### PR TITLE
Add five Final Fantasy cards (Rinoa, Sazh, Shambling Cie'th, Giott, Stiltzkin)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1151,6 +1151,13 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     accepts any recipient. Mishra's War Machine: "deals 3 damage to you unless you discard a card. If
     it deals damage to you this way, tap it" → `IfYouDoEffect(PayOrSuffer(discard, DealDamage(3,
     Controller, source=Self)), Tap(Self), successCriterion = DamageDealt(Controller))`.
+    `SuccessCriterion.ControlChanged` gates on whether the action **actually changed control** of a
+    permanent (a `ControlChangedEvent` whose old and new controllers differ) — a control change that
+    never happened (the targeted permanent left the battlefield / is no longer controlled by the donor
+    at resolution) emits no such event and counts as "didn't happen". Stiltzkin, Moogle Merchant:
+    "{2}, {T}: Target opponent gains control of another target permanent you control. If they do, you
+    draw a card" → `IfYouDoEffect(GiveControlToTargetPlayer(permanent, opponent), DrawCards(1),
+    successCriterion = ControlChanged)`.
     `CollectionNonEmpty` gates on the action's actual pipeline collection
     (`storedCollections[name].size >= min` after the action runs) — the collections propagate onto
     the gate frame via `exposeCollectionsToNextFrame`, in both the synchronous and the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -428,6 +428,23 @@ sealed interface SuccessCriterion {
     data class DamageDealt(
         val recipient: DamageRecipient = DamageRecipient.Controller
     ) : SuccessCriterion
+
+    /**
+     * Action succeeded iff the gated action actually *changed control* of a permanent — at least one
+     * permanent moved from one controller to a different controller during the action (a
+     * `ControlChangedEvent` whose old and new controllers differ). Use for "[a player] gains control
+     * of [a permanent]. If they do, …" riders where the control change can silently fail to happen —
+     * e.g. the donated permanent has already left the battlefield (or is no longer controlled by the
+     * intended donor) by the time the ability resolves, so no control actually moves and the rider
+     * must not fire.
+     *
+     * Stiltzkin, Moogle Merchant: "{2}, {T}: Target opponent gains control of another target
+     * permanent you control. If they do, you draw a card." The control change is not a zone move, so
+     * `Auto` can't infer it; this criterion gates the draw on the control actually moving.
+     */
+    @SerialName("SuccessCriterion.ControlChanged")
+    @Serializable
+    data object ControlChanged : SuccessCriterion
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GiottKingOfTheDwarves.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GiottKingOfTheDwarves.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Giott, King of the Dwarves
+ * {R}{W}
+ * Legendary Creature — Dwarf Noble
+ * 1/1
+ * Double strike
+ * Whenever Giott or another Dwarf you control enters and whenever an Equipment you control enters,
+ * you may discard a card. If you do, draw a card.
+ *
+ * The printed ability triggers on two distinct events ("whenever X and whenever Y"); modeled as two
+ * triggered abilities sharing the same rummage payoff. The Dwarf trigger uses [TriggerBinding.ANY]
+ * with a "Dwarf you control" filter so it also fires when Giott itself enters.
+ */
+val GiottKingOfTheDwarves = card("Giott, King of the Dwarves") {
+    manaCost = "{R}{W}"
+    colorIdentity = "WR"
+    typeLine = "Legendary Creature — Dwarf Noble"
+    oracleText = "Double strike\nWhenever Giott or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype("Dwarf").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = MayEffect(
+            effect = IfYouDoEffect(
+                action = Patterns.Hand.discardCards(1),
+                ifYouDo = Effects.DrawCards(1),
+            ),
+            descriptionOverride = "You may discard a card. If you do, draw a card.",
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.withSubtype("Equipment").youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = MayEffect(
+            effect = IfYouDoEffect(
+                action = Patterns.Hand.discardCards(1),
+                ifYouDo = Effects.DrawCards(1),
+            ),
+            descriptionOverride = "You may discard a card. If you do, draw a card.",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "223"
+        artist = "Ben Wootten"
+        flavorText = "\"We will fight along with you for the planet, our home!\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6a7784de-a10d-4ce6-98a5-aaf3e85773b6.jpg?1748706604"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RinoaHeartilly.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RinoaHeartilly.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Rinoa Heartilly
+ * {3}{G}{W}
+ * Legendary Creature — Human Rebel Warlock
+ * 4/4
+ * When Rinoa Heartilly enters, create Angelo, a legendary 1/1 green and white Dog creature token.
+ * Angelo Cannon — Whenever Rinoa Heartilly attacks, another target creature you control gets +1/+1
+ * until end of turn for each creature you control.
+ */
+val RinoaHeartilly = card("Rinoa Heartilly") {
+    manaCost = "{3}{G}{W}"
+    colorIdentity = "WG"
+    typeLine = "Legendary Creature — Human Rebel Warlock"
+    oracleText = "When Rinoa Heartilly enters, create Angelo, a legendary 1/1 green and white Dog creature token.\nAngelo Cannon — Whenever Rinoa Heartilly attacks, another target creature you control gets +1/+1 until end of turn for each creature you control."
+    power = 4
+    toughness = 4
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            count = 1,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN, Color.WHITE),
+            creatureTypes = setOf("Dog"),
+            name = "Angelo",
+            legendary = true,
+            imageUri = "https://cards.scryfall.io/normal/front/5/4/54347961-0a41-4f62-b47e-2afa0ca07b21.jpg?1748704090"
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val t = target("target", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
+        effect = Effects.ModifyStats(
+            power = DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature),
+            toughness = DynamicAmount.Count(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Creature),
+            target = t
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Francesca Resta"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/ba79d293-bf42-48b6-a868-5249f4beeb76.jpg?1748706666"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SazhKatzroy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SazhKatzroy.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sazh Katzroy
+ * {3}{G}
+ * Legendary Creature — Human Pilot
+ * 3/3
+ * When Sazh Katzroy enters, you may search your library for a Bird or basic land card, reveal it,
+ * put it into your hand, then shuffle.
+ * Whenever Sazh Katzroy attacks, put a +1/+1 counter on target creature, then double the number of
+ * +1/+1 counters on that creature.
+ */
+val SazhKatzroy = card("Sazh Katzroy") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Pilot"
+    oracleText = "When Sazh Katzroy enters, you may search your library for a Bird or basic land card, reveal it, put it into your hand, then shuffle.\nWhenever Sazh Katzroy attacks, put a +1/+1 counter on target creature, then double the number of +1/+1 counters on that creature."
+    power = 3
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter(
+                    cardPredicates = listOf(
+                        CardPredicate.Or(
+                            listOf(
+                                CardPredicate.HasSubtype(Subtype("Bird")),
+                                CardPredicate.IsBasicLand
+                            )
+                        )
+                    )
+                ),
+                count = 1,
+                destination = SearchDestination.HAND,
+                reveal = true
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 1, target = t),
+            Effects.DoubleCounters(Counters.PLUS_ONE_PLUS_ONE, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "199"
+        artist = "Colin Boyer"
+        flavorText = "\"Chocobo, we just can't catch a break, can we?\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1e2a3566-1390-457e-8077-d776a8671319.jpg?1748706504"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ShamblingCieth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ShamblingCieth.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Shambling Cie'th
+ * {2}{B}
+ * Creature — Mutant Horror
+ * 3/3
+ * This creature enters tapped.
+ * Whenever you cast a noncreature spell, you may pay {B}. If you do, return this card from your
+ * graveyard to your hand.
+ *
+ * The recursion ability functions from the graveyard via `triggerZone = Zone.GRAVEYARD`
+ * (MayPayMana), the same shape as Invasion's Pyre Zombie.
+ */
+val ShamblingCieth = card("Shambling Cie'th") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Mutant Horror"
+    oracleText = "This creature enters tapped.\nWhenever you cast a noncreature spell, you may pay {B}. If you do, return this card from your graveyard to your hand."
+    power = 3
+    toughness = 3
+
+    replacementEffect(EntersTapped())
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Noncreature)
+        triggerZone = Zone.GRAVEYARD
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{B}"),
+            effect = Effects.ReturnToHand(EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "117"
+        artist = "Nottsuo"
+        flavorText = "Cie'th are damned to wander the world unliving and undying, until their corrupted flesh at last can move no more."
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f02ce338-4fe2-44b0-a896-3ed7e6c874a3.jpg?1748706199"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/StiltzkinMoogleMerchant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/StiltzkinMoogleMerchant.kt
@@ -7,6 +7,8 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetOpponent
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
@@ -20,11 +22,10 @@ import com.wingedsheep.sdk.scripting.targets.TargetPermanent
  * {2}, {T}: Target opponent gains control of another target permanent you control. If they do, you
  * draw a card.
  *
- * The donation always succeeds when both targets are still legal at resolution, so the "if they do"
- * rider is modeled as a sequenced draw. The only case the printed text would withhold the draw is the
- * rare one where the donated permanent has left the battlefield (or you've lost control of it) before
- * resolution while the opponent target stays legal; the engine has no control-change success
- * criterion to gate on, so the draw still happens in that narrow corner.
+ * The "if they do" rider is gated on the control change actually happening via
+ * [SuccessCriterion.ControlChanged]: you draw only when a permanent really moves controller. If the
+ * donated permanent has left the battlefield (or you've lost control of it) before resolution while
+ * the opponent target stays legal, no control moves and the draw is withheld, per the printed text.
  */
 val StiltzkinMoogleMerchant = card("Stiltzkin, Moogle Merchant") {
     manaCost = "{W}"
@@ -45,12 +46,13 @@ val StiltzkinMoogleMerchant = card("Stiltzkin, Moogle Merchant") {
                 filter = TargetFilter(GameObjectFilter.Permanent.youControl(), excludeSelf = true),
             ),
         )
-        effect = Effects.Composite(
-            GiveControlToTargetPlayerEffect(
+        effect = IfYouDoEffect(
+            action = GiveControlToTargetPlayerEffect(
                 permanent = permanent,
                 newController = opponent,
             ),
-            Effects.DrawCards(1),
+            ifYouDo = Effects.DrawCards(1),
+            successCriterion = SuccessCriterion.ControlChanged,
         )
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/StiltzkinMoogleMerchant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/StiltzkinMoogleMerchant.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Stiltzkin, Moogle Merchant
+ * {W}
+ * Legendary Creature — Moogle
+ * 1/2
+ * Lifelink
+ * {2}, {T}: Target opponent gains control of another target permanent you control. If they do, you
+ * draw a card.
+ *
+ * The donation always succeeds when both targets are still legal at resolution, so the "if they do"
+ * rider is modeled as a sequenced draw. The only case the printed text would withhold the draw is the
+ * rare one where the donated permanent has left the battlefield (or you've lost control of it) before
+ * resolution while the opponent target stays legal; the engine has no control-change success
+ * criterion to gate on, so the draw still happens in that narrow corner.
+ */
+val StiltzkinMoogleMerchant = card("Stiltzkin, Moogle Merchant") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Moogle"
+    oracleText = "Lifelink\n{2}, {T}: Target opponent gains control of another target permanent you control. If they do, you draw a card."
+    power = 1
+    toughness = 2
+
+    keywords(Keyword.LIFELINK)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val opponent = target("target opponent", TargetOpponent())
+        val permanent = target(
+            "another target permanent you control",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.Permanent.youControl(), excludeSelf = true),
+            ),
+        )
+        effect = Effects.Composite(
+            GiveControlToTargetPlayerEffect(
+                permanent = permanent,
+                newController = opponent,
+            ),
+            Effects.DrawCards(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "34"
+        artist = "Hendry Iwanaga"
+        flavorText = "\"How about a three-piece combo of Hi-Potion, Ether, and Phoenix Pinion for 444 Gil?\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06a972a4-0c1b-4f12-a5a5-fdea47c4cd35.jpg?1748705882"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -10631,9 +10631,10 @@
                     ]
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
                             "type": "GiveControlToTargetPlayer",
                             "permanent": {
                                 "type": "BoundVariable",
@@ -10644,14 +10645,15 @@
                                 "name": "target opponent"
                             }
                         },
-                        {
-                            "type": "DrawCards",
-                            "count": {
-                                "type": "Fixed",
-                                "amount": 1
-                            }
+                        "successCriterion": "SuccessCriterion.ControlChanged"
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
                         }
-                    ]
+                    }
                 },
                 "targetRequirements": [
                     {

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -4492,6 +4492,160 @@
     ]
 }
 
+// Giott, King of the Dwarves
+{
+    "name": "Giott, King of the Dwarves",
+    "manaCost": "{R}{W}",
+    "typeLine": "Legendary Creature — Dwarf Noble",
+    "oracleText": "Double strike\nWhenever Giott or another Dwarf you control enters and whenever an Equipment you control enters, you may discard a card. If you do, draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Dwarf ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    },
+                    "descriptionOverride": "You may discard a card. If you do, draw a card."
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact Equipment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    },
+                    "descriptionOverride": "You may discard a card. If you do, draw a card."
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "UNCOMMON",
+        "artist": "Ben Wootten",
+        "flavorText": "\"We will fight along with you for the planet, our home!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6a7784de-a10d-4ce6-98a5-aaf3e85773b6.jpg?1748706604"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "RED"
+    ]
+}
+
 // Gladiolus Amicitia
 {
     "name": "Gladiolus Amicitia",
@@ -8875,6 +9029,85 @@
     "colorIdentityOverride": []
 }
 
+// Rinoa Heartilly
+{
+    "name": "Rinoa Heartilly",
+    "manaCost": "{3}{G}{W}",
+    "typeLine": "Legendary Creature — Human Rebel Warlock",
+    "oracleText": "When Rinoa Heartilly enters, create Angelo, a legendary 1/1 green and white Dog creature token.\nAngelo Cannon — Whenever Rinoa Heartilly attacks, another target creature you control gets +1/+1 until end of turn for each creature you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Dog"
+                    ],
+                    "name": "Angelo",
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/4/54347961-0a41-4f62-b47e-2afa0ca07b21.jpg?1748704090",
+                    "legendary": true
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "creature"
+                    },
+                    "toughnessModifier": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "creature"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Francesca Resta",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/ba79d293-bf42-48b6-a868-5249f4beeb76.jpg?1748706666"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "GREEN"
+    ]
+}
+
 // Rook Turret
 {
     "name": "Rook Turret",
@@ -9544,6 +9777,111 @@
     ]
 }
 
+// Sazh Katzroy
+{
+    "name": "Sazh Katzroy",
+    "manaCost": "{3}{G}",
+    "typeLine": "Legendary Creature — Human Pilot",
+    "oracleText": "When Sazh Katzroy enters, you may search your library for a Bird or basic land card, reveal it, put it into your hand, then shuffle.\nWhenever Sazh Katzroy attacks, put a +1/+1 counter on target creature, then double the number of +1/+1 counters on that creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "Bird|basicland"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Hand"
+                                },
+                                "revealed": true
+                            },
+                            "ShuffleLibrary"
+                        ]
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "DoubleCounters",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "rarity": "RARE",
+        "artist": "Colin Boyer",
+        "flavorText": "\"Chocobo, we just can't catch a break, can we?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1e2a3566-1390-457e-8077-d776a8671319.jpg?1748706504"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Sazh's Chocobo
 {
     "name": "Sazh's Chocobo",
@@ -9749,6 +10087,63 @@
         "artist": "Joshua Raphael",
         "flavorText": "\"Fate is not to be taken lightly, Cloud.\"",
         "imageUri": "https://cards.scryfall.io/normal/front/c/f/cf7df82f-937a-443f-813f-2bcc6944c5c0.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Shambling Cie'th
+{
+    "name": "Shambling Cie'th",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Mutant Horror",
+    "oracleText": "This creature enters tapped.\nWhenever you cast a noncreature spell, you may pay {B}. If you do, return this card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{B}"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand"
+                    }
+                },
+                "activeZone": "Graveyard"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "UNCOMMON",
+        "artist": "Nottsuo",
+        "flavorText": "Cie'th are damned to wander the world unliving and undying, until their corrupted flesh at last can move no more.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f02ce338-4fe2-44b0-a896-3ed7e6c874a3.jpg?1748706199"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -10203,6 +10598,88 @@
         "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc7d1912-7e27-49ef-bd98-375d975a42b0.jpg?1748706861"
     },
     "colorIdentityOverride": []
+}
+
+// Stiltzkin, Moogle Merchant
+{
+    "name": "Stiltzkin, Moogle Merchant",
+    "manaCost": "{W}",
+    "typeLine": "Legendary Creature — Moogle",
+    "oracleText": "Lifelink\n{2}, {T}: Target opponent gains control of another target permanent you control. If they do, you draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GiveControlToTargetPlayer",
+                            "permanent": {
+                                "type": "BoundVariable",
+                                "name": "another target permanent you control"
+                            },
+                            "newController": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponent",
+                        "id": "target opponent"
+                    },
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "another target permanent you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "34",
+        "rarity": "RARE",
+        "artist": "Hendry Iwanaga",
+        "flavorText": "\"How about a three-piece combo of Hi-Potion, Ether, and Phoenix Pinion for 444 Gil?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06a972a4-0c1b-4f12-a5a5-fdea47c4cd35.jpg?1748705882"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Stolen Uniform

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/GatedEffectExecutor.kt
@@ -575,7 +575,22 @@ class GatedEffectExecutor(
             is SuccessCriterion.CollectionNonEmpty ->
                 (effectContext.pipeline.storedCollections[criterion.name]?.size ?: 0) >= criterion.min
             is SuccessCriterion.DamageDealt -> evaluateDamageDealt(criterion, effectContext, priorEvents)
+            is SuccessCriterion.ControlChanged -> evaluateControlChanged(priorEvents)
         }
+
+        /**
+         * Did the gated action actually change control of a permanent? Scans the action's events for
+         * a [ControlChangedEvent] whose old and new controllers differ. The events scanned are only
+         * the gated action's own (the executor passes the action result's events), so a bare presence
+         * check is correctly scoped to this ability; the old/new comparison rejects the no-op case
+         * where the control-change effect ran against a permanent already controlled by the intended
+         * new controller, and a control change that never happened (illegal/missing permanent target
+         * at resolution) emits no such event at all.
+         */
+        private fun evaluateControlChanged(priorEvents: List<GameEvent>): Boolean =
+            priorEvents.any { event ->
+                event is ControlChangedEvent && event.oldControllerId != event.newControllerId
+            }
 
         /**
          * Did the gated action actually deal damage from this ability's source? Scans the action's

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2051,6 +2051,16 @@ class StackResolver(
         val sourceCard = state.getEntity(abilityComponent.sourceId)?.get<CardComponent>()
         val sourceColors = sourceCard?.colors ?: emptySet()
         val sourceSubtypes = sourceCard?.typeLine?.subtypes?.map { it.value }?.toSet() ?: emptySet()
+        val activatedReqs = targetsComponent?.targetRequirements ?: emptyList()
+        // Resolution-time legality (CR 608.2b): drop individually-illegal targets, not just the
+        // all-invalid fizzle. `activatedTargets` is the compacted list every executor reads as
+        // `context.targets`; `alignedActivatedTargets` keeps a `null` in each dropped slot so a
+        // sub-effect referencing a now-illegal target through its [EffectTarget.BoundVariable]
+        // resolves to `null` and fizzles (mirrors resolveSpell) instead of silently consuming a
+        // still-legal later target whose position shifted forward in the compacted list — e.g.
+        // Stiltzkin's "If they do, you draw" when the donated permanent left in response.
+        val activatedTargets: List<ChosenTarget>
+        val alignedActivatedTargets: List<ChosenTarget?>
         if (targetsComponent != null && targetsComponent.targets.isNotEmpty()) {
             val validTargets = validateTargets(
                 state, targetsComponent.targets, sourceColors, sourceSubtypes,
@@ -2071,23 +2081,27 @@ class StackResolver(
                     )
                 )
             }
+            activatedTargets = validTargets
+            alignedActivatedTargets = buildAlignedValidated(targetsComponent.targets, validTargets)
+        } else {
+            activatedTargets = targetsComponent?.targets ?: emptyList()
+            alignedActivatedTargets = activatedTargets
         }
 
         // Execute the effect
-        val activatedTargets = targetsComponent?.targets ?: emptyList()
-        val activatedReqs = targetsComponent?.targetRequirements ?: emptyList()
         val context = EffectContext(
             sourceId = abilityComponent.sourceId,
             controllerId = abilityComponent.controllerId,
             abilityIdentity = abilityComponent.abilityIdentity,
             targets = activatedTargets,
+            alignedTargets = alignedActivatedTargets,
             sacrificedPermanents = abilityComponent.sacrificedPermanents,
             xValue = abilityComponent.xValue,
             tappedPermanents = abilityComponent.tappedPermanents,
             tappedPermanentSnapshots = abilityComponent.tappedPermanentSnapshots,
             lastKnownSourceCounters = abilityComponent.lastKnownSourceCounters,
             lastKnownSourceSnapshot = abilityComponent.lastKnownSourceSnapshot,
-            pipeline = PipelineState(namedTargets = EffectContext.buildNamedTargets(activatedReqs, activatedTargets))
+            pipeline = PipelineState(namedTargets = EffectContext.buildNamedTargets(activatedReqs, alignedActivatedTargets))
         )
 
         val effectResult = effectHandler.execute(state, abilityComponent.effect, context)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StiltzkinMoogleMerchantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StiltzkinMoogleMerchantScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.StiltzkinMoogleMerchant
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Stiltzkin, Moogle Merchant (FIN #34) — {W} Legendary Creature — Moogle.
+ *
+ * "Lifelink
+ *  {2}, {T}: Target opponent gains control of another target permanent you control. If they do,
+ *  you draw a card."
+ *
+ * The "if they do" rider is gated on the control change actually happening
+ * (`SuccessCriterion.ControlChanged`):
+ *  - Happy path: a legal donated permanent moves to the opponent, so you draw.
+ *  - Edge case: the donated permanent leaves the battlefield in response (so no control moves at
+ *    resolution) while the opponent target stays legal — you must NOT draw.
+ */
+class StiltzkinMoogleMerchantScenarioTest : FunSpec({
+
+    val donateAbilityId = StiltzkinMoogleMerchant.activatedAbilities.first().id
+    val projector = StateProjector()
+
+    test("opponent gains control of the donated permanent and you draw") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(StiltzkinMoogleMerchant))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val stiltzkin = driver.putCreatureOnBattlefield(player, "Stiltzkin, Moogle Merchant")
+        driver.removeSummoningSickness(stiltzkin)
+        val mountain = driver.putLandOnBattlefield(player, "Mountain")
+        driver.giveMana(player, Color.WHITE, 2)
+
+        val handBefore = driver.getHandSize(player)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = stiltzkin,
+                abilityId = donateAbilityId,
+                targets = listOf(ChosenTarget.Player(opponent), ChosenTarget.Permanent(mountain)),
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve the ability
+
+        // The opponent now controls the donated Mountain...
+        projector.project(driver.state).getController(mountain) shouldBe opponent
+        // ...and the control change happened, so you drew a card.
+        driver.getHandSize(player) shouldBe handBefore + 1
+    }
+
+    test("no draw when the donated permanent leaves the battlefield before resolution") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(StiltzkinMoogleMerchant))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val stiltzkin = driver.putCreatureOnBattlefield(player, "Stiltzkin, Moogle Merchant")
+        driver.removeSummoningSickness(stiltzkin)
+        val mountain = driver.putLandOnBattlefield(player, "Mountain")
+        driver.giveMana(player, Color.WHITE, 2)
+
+        driver.submit(
+            ActivateAbility(
+                playerId = player,
+                sourceId = stiltzkin,
+                abilityId = donateAbilityId,
+                targets = listOf(ChosenTarget.Player(opponent), ChosenTarget.Permanent(mountain)),
+            )
+        ).isSuccess shouldBe true
+
+        // In response, the donated permanent leaves the battlefield: at resolution the control
+        // change can't happen even though the opponent target is still legal.
+        driver.moveToGraveyard(mountain)
+        val handBefore = driver.getHandSize(player)
+
+        driver.bothPass() // resolve the ability
+
+        // No control change occurred, so the "if they do" draw is withheld.
+        driver.getHandSize(player) shouldBe handBefore
+        // The Mountain is in the graveyard, controlled by no one on the battlefield.
+        driver.findPermanent(opponent, "Mountain") shouldBe null
+    }
+})


### PR DESCRIPTION
## Summary

Implements a handful of missing **Final Fantasy (FIN)** cards. Four are content-only (composed from existing SDK primitives); **Stiltzkin** additionally adds a small, general engine capability so its "if they do" rider is rules-faithful.

| Card | What it does | Reused pattern |
|------|--------------|----------------|
| **Rinoa Heartilly** `{3}{G}{W}` | ETB creates the legendary Angelo Dog token; on attack, another target creature you control gets +1/+1 until EOT *for each creature you control* | `CreateTokenEffect` + `Effects.ModifyStats(DynamicAmount.Count(...))`, like Gladiolus Amicitia |
| **Sazh Katzroy** `{3}{G}` | ETB may search for a **Bird or basic land**; on attack, add a +1/+1 counter then double counters on target | `MayEffect(searchLibrary)` with a `CardPredicate.Or` filter + `Effects.DoubleCounters` |
| **Shambling Cie'th** `{2}{B}` | Enters tapped; whenever you cast a noncreature spell, may pay `{B}` to return it from your graveyard to hand | `EntersTapped` + graveyard-active trigger (`triggerZone = GRAVEYARD`) + `MayPayManaEffect`, same shape as Pyre Zombie |
| **Giott, King of the Dwarves** `{R}{W}` | Double strike; Dwarf-enters and Equipment-enters each offer a rummage (may discard, if you do draw) | two `entersBattlefield` triggers + `MayEffect(IfYouDoEffect(...))`, like Whiskerquill Scribe |
| **Stiltzkin, Moogle Merchant** `{W}` | Lifelink; `{2},{T}`: target opponent gains control of another target permanent you control, then **if they do** you draw | `GiveControlToTargetPlayerEffect` + dual targets + new `SuccessCriterion.ControlChanged` |

## Stiltzkin: faithful "if they do" gate (+ an engine fix)

The draw is gated on the control change **actually happening**, via a new event-based criterion:

- **`SuccessCriterion.ControlChanged`** (SDK) — a `Gate.DoAction` succeeds iff the gated action emitted a `ControlChangedEvent` whose old and new controllers differ. Mirrors the existing `DamageDealt` criterion. Stiltzkin: `IfYouDoEffect(GiveControlToTargetPlayer(permanent, opponent), DrawCards(1), successCriterion = ControlChanged)`.
- **Engine fix — CR 608.2b for activated abilities.** `resolveActivatedAbility` validated targets only to detect the *all-invalid* fizzle, then built the effect context from the **raw** chosen targets. An individually-illegal target (e.g. the donated permanent removed in response) was still handed to `buildNamedTargets`, so the effect resolved against it. It now uses the compacted valid list for `context.targets` and the position-aligned (null-padded) list for `buildNamedTargets`/`alignedTargets` — exactly like `resolveSpell`. A sub-effect referencing a now-illegal target via its `BoundVariable` resolves to `null` and fizzles, instead of silently consuming it (or a shifted later target). This benefits every multi-target activated ability, not just Stiltzkin.

Other fidelity note: **Sazh** — the mtgish auto-draft dropped the *"or basic land"* clause; the filter here is an explicit `Bird OR basic land` disjunction.

## Testing
- `just test` — full suite green (engine + server + sets), confirming the activated-ability target-validation change is regression-free.
- **`StiltzkinMoogleMerchantScenarioTest`** — happy path (control moves → you draw) **and** the edge case (donated permanent removed in response → no control change → no draw).
- `CardDefinitionSnapshotTest` re-blessed: `FIN.json` additions are the five new cards (and the Angelo token); Stiltzkin's tree updated for the gated draw.
- SDK reference (`card-sdk-language-reference.md`) updated for the new criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)