### PR TITLE
Add five Duskmourn: House of Horror cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MolderingGymWeightRoom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MolderingGymWeightRoom.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Moldering Gym // Weight Room (DSK 190) — split-layout Room (CR 709.5).
+ *
+ * Moldering Gym {2}{G} — Enchantment — Room
+ *   When you unlock this door, search your library for a basic land card, put it onto the
+ *   battlefield tapped, then shuffle.
+ *
+ * Weight Room {5}{G} — Enchantment — Room
+ *   When you unlock this door, manifest dread, then put three +1/+1 counters on that creature.
+ *
+ * Weight Room reuses the shared [Patterns.Library.manifestDread] recipe with `markEntered = true`,
+ * then gathers the just-manifested creature via [CardSource.EnteredViaThisResolution] and adds the
+ * three counters — the same "manifest dread, then counters on those creatures" shape as
+ * Valgavoth's Onslaught. If the library is empty (or the manifested creature has already left the
+ * battlefield) the gather is empty and no counters land.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ */
+val MolderingGymWeightRoom = card("Moldering Gym // Weight Room") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "G"
+
+    face("Moldering Gym") {
+        manaCost = "{2}{G}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, search your library for a basic land card, put it onto the battlefield tapped, then shuffle."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.BasicLand,
+                destination = SearchDestination.BATTLEFIELD,
+                entersTapped = true
+            )
+        }
+    }
+
+    face("Weight Room") {
+        manaCost = "{5}{G}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, manifest dread, then put three +1/+1 counters on that creature."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Effects.Composite(
+                listOf(
+                    Patterns.Library.manifestDread(markEntered = true),
+                    GatherCardsEffect(
+                        source = CardSource.EnteredViaThisResolution,
+                        storeAs = "weightRoomManifested"
+                    ),
+                    Effects.AddCountersToCollection(
+                        collectionName = "weightRoomManifested",
+                        counterType = Counters.PLUS_ONE_PLUS_ONE,
+                        amount = DynamicAmount.Fixed(3)
+                    )
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "190"
+        artist = "Helge C. Balzer"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg?1726780702"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/NeglectedManor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/NeglectedManor.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Neglected Manor
+ * Land
+ *
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {W} or {B}.
+ */
+val NeglectedManor = card("Neglected Manor") {
+    typeLine = "Land"
+    colorIdentity = "WB"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {W} or {B}."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.APlayerLifeAtMost(13)
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "264"
+        artist = "Carlos Palma Cruchaga"
+        flavorText = "They say every family who resided there met a grisly end, and once in a while you'll hear their screams echoing through the moldering halls."
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11cf1531-8a3c-4e28-a114-d3a342b33bb6.jpg?1726286859"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PeculiarLighthouse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/PeculiarLighthouse.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Peculiar Lighthouse
+ * Land
+ *
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {U} or {R}.
+ */
+val PeculiarLighthouse = card("Peculiar Lighthouse") {
+    typeLine = "Land"
+    colorIdentity = "UR"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {U} or {R}."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.APlayerLifeAtMost(13)
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "265"
+        artist = "Raymond Bonilla"
+        flavorText = "They say its beckoning beacon leads not to safe harbor but into the arms of the drowned."
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a6e40c0-e70e-4353-a920-9851cfac71dd.jpg?1726286864"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RaucousCarnival.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/RaucousCarnival.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Raucous Carnival
+ * Land
+ *
+ * This land enters tapped unless a player has 13 or less life.
+ * {T}: Add {R} or {W}.
+ */
+val RaucousCarnival = card("Raucous Carnival") {
+    typeLine = "Land"
+    colorIdentity = "RW"
+    oracleText = "This land enters tapped unless a player has 13 or less life.\n{T}: Add {R} or {W}."
+
+    replacementEffect(
+        EntersTapped(
+            unlessCondition = Conditions.APlayerLifeAtMost(13)
+        )
+    )
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = AbilityCost.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "266"
+        artist = "Josu Solano"
+        flavorText = "They say that those who enter the amusement park never come back, and their disembodied laughter joins the others on the wind."
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/3604a211-9bf7-474e-bd78-32a862f4259c.jpg?1726286867"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TicketBoothTunnelOfHate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TicketBoothTunnelOfHate.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ticket Booth // Tunnel of Hate (DSK 158) — split-layout Room (CR 709.5).
+ *
+ * Ticket Booth {2}{R} — Enchantment — Room
+ *   When you unlock this door, manifest dread.
+ *
+ * Tunnel of Hate {4}{R}{R} — Enchantment — Room
+ *   Whenever you attack, target attacking creature gains double strike until end of turn.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ */
+val TicketBoothTunnelOfHate = card("Ticket Booth // Tunnel of Hate") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "R"
+
+    face("Ticket Booth") {
+        manaCost = "{2}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, manifest dread."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Patterns.Library.manifestDread()
+        }
+    }
+
+    face("Tunnel of Hate") {
+        manaCost = "{4}{R}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Whenever you attack, target attacking creature gains double strike until end of turn."
+
+        triggeredAbility {
+            trigger = Triggers.YouAttack
+            val creature = target("target attacking creature", Targets.AttackingCreature)
+            effect = Effects.GrantKeyword(Keyword.DOUBLE_STRIKE, creature)
+            description = "Whenever you attack, target attacking creature gains double strike until end of turn."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Marco Gorlei"
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg?1726780790"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -10185,6 +10185,158 @@
     ]
 }
 
+// Moldering Gym // Weight Room
+{
+    "name": "Moldering Gym // Weight Room",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n//\nWhen you unlock this door, manifest dread, then put three +1/+1 counters on that creature.",
+    "metadata": {
+        "collectorNumber": "190",
+        "artist": "Helge C. Balzer",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/245d5a61-c40c-4039-aea8-3ad61415b8f0.jpg?1726780702"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Moldering Gym",
+            "manaCost": "{2}{G}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, search your library for a basic land card, put it onto the battlefield tapped, then shuffle.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": "basicland"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield",
+                                        "placement": "Tapped"
+                                    }
+                                },
+                                "ShuffleLibrary"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Weight Room",
+            "manaCost": "{5}{G}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, manifest dread, then put three +1/+1 counters on that creature.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "TopOfLibrary",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 2
+                                                }
+                                            },
+                                            "storeAs": "manifestDreadLooked"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "manifestDreadLooked",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "manifestDreadManifested",
+                                            "storeRemainder": "manifestDreadGraveyard",
+                                            "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                            "remainderLabel": "Put into your graveyard"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "manifestDreadManifested",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Battlefield"
+                                            },
+                                            "faceDown": "MANIFEST",
+                                            "markEnteredViaSourceAbility": true
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "manifestDreadGraveyard",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            }
+                                        },
+                                        "EmitManifestedDreadEvent"
+                                    ]
+                                },
+                                {
+                                    "type": "GatherCards",
+                                    "source": "EnteredViaThisResolution",
+                                    "storeAs": "weightRoomManifested"
+                                },
+                                {
+                                    "type": "AddCountersToCollection",
+                                    "collectionName": "weightRoomManifested",
+                                    "counterType": "+1/+1",
+                                    "amount": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Monstrous Emergence
 {
     "name": "Monstrous Emergence",
@@ -10358,6 +10510,57 @@
     },
     "colorIdentityOverride": [
         "BLUE",
+        "BLACK"
+    ]
+}
+
+// Neglected Manor
+{
+    "name": "Neglected Manor",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {W} or {B}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "264",
+        "artist": "Carlos Palma Cruchaga",
+        "flavorText": "They say every family who resided there met a grisly end, and once in a while you'll hear their screams echoing through the moldering halls.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11cf1531-8a3c-4e28-a114-d3a342b33bb6.jpg?1726286859"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
         "BLACK"
     ]
 }
@@ -12274,6 +12477,57 @@
     ]
 }
 
+// Peculiar Lighthouse
+{
+    "name": "Peculiar Lighthouse",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {U} or {R}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "265",
+        "artist": "Raymond Bonilla",
+        "flavorText": "They say its beckoning beacon leads not to safe harbor but into the arms of the drowned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a6e40c0-e70e-4353-a920-9851cfac71dd.jpg?1726286864"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Peer Past the Veil
 {
     "name": "Peer Past the Veil",
@@ -12668,6 +12922,57 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Raucous Carnival
+{
+    "name": "Raucous Carnival",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "This land enters tapped unless a player has 13 or less life.\n{T}: Add {R} or {W}.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersTapped",
+                "unlessCondition": {
+                    "type": "APlayerLifeAtMost",
+                    "threshold": 13
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "artist": "Josu Solano",
+        "flavorText": "They say that those who enter the amusement park never come back, and their disembodied laughter joins the others on the wind.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/3604a211-9bf7-474e-bd78-32a862f4259c.jpg?1726286867"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 
@@ -15717,6 +16022,119 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Ticket Booth // Tunnel of Hate
+{
+    "name": "Ticket Booth // Tunnel of Hate",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, manifest dread.\n//\nWhenever you attack, target attacking creature gains double strike until end of turn.",
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Marco Gorlei",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/058ffe36-ed2d-4b67-83cd-162db8383a32.jpg?1726780790"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Ticket Booth",
+            "manaCost": "{2}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, manifest dread.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeAs": "manifestDreadLooked"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "manifestDreadLooked",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "manifestDreadManifested",
+                                    "storeRemainder": "manifestDreadGraveyard",
+                                    "selectedLabel": "Manifest (put onto the battlefield face down)",
+                                    "remainderLabel": "Put into your graveyard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadManifested",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Battlefield"
+                                    },
+                                    "faceDown": "MANIFEST"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "manifestDreadGraveyard",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                },
+                                "EmitManifestedDreadEvent"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Tunnel of Hate",
+            "manaCost": "{4}{R}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Whenever you attack, target attacking creature gains double strike until end of turn.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "YouAttackEvent",
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "GrantKeyword",
+                            "keyword": "DOUBLE_STRIKE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target attacking creature"
+                            }
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature attacking"
+                            },
+                            "id": "target attacking creature"
+                        },
+                        "descriptionOverride": "Whenever you attack, target attacking creature gains double strike until end of turn."
+                    }
+                ]
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MolderingGymWeightRoomTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MolderingGymWeightRoomTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.MolderingGymWeightRoom
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Moldering Gym // Weight Room (DSK 190) — split-layout Room (CR 709.5).
+ *
+ * Moldering Gym {2}{G} — "When you unlock this door, search your library for a basic land card,
+ *                         put it onto the battlefield tapped, then shuffle."
+ * Weight Room {5}{G}   — "When you unlock this door, manifest dread, then put three +1/+1 counters
+ *                         on that creature."
+ */
+class MolderingGymWeightRoomTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(MolderingGymWeightRoom)
+        d.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("casting Moldering Gym fetches a basic land onto the battlefield tapped") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val landsBefore = d.getLands(p1).size
+
+        val roomId = d.putCardInHand(p1, MolderingGymWeightRoom.name)
+        d.giveMana(p1, Color.GREEN, 1)
+        d.giveColorlessMana(p1, 2)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+
+        // Resolve the Room, then its unlock trigger, until the library search pauses.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe setOf(RoomFaceId("Moldering Gym"))
+
+        // Search pauses to pick a basic land from the library.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val forest = pick.options.first()
+        d.submitDecision(p1, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(forest)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The fetched land is on the battlefield, tapped.
+        d.getLands(p1).size shouldBe landsBefore + 1
+        d.getLands(p1) shouldContain forest
+        d.isTapped(forest) shouldBe true
+    }
+
+    test("casting Weight Room manifests dread and puts three +1/+1 counters on that creature") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top two of library for manifest dread.
+        d.putCardOnTopOfLibrary(p1, "Forest")
+        val creature = d.putCardOnTopOfLibrary(p1, "Grizzly Bears")
+
+        val roomId = d.putCardInHand(p1, MolderingGymWeightRoom.name)
+        d.giveMana(p1, Color.GREEN, 1)
+        d.giveColorlessMana(p1, 5)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe setOf(RoomFaceId("Weight Room"))
+
+        // Manifest dread pauses to choose which card to manifest.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(p1, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The manifested creature is a face-down 2/2 with three +1/+1 counters → 5/5.
+        d.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        d.state.getEntity(creature)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 3
+        StateProjector().getProjectedPower(d.state, creature) shouldBe 5
+        StateProjector().getProjectedToughness(d.state, creature) shouldBe 5
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TicketBoothTunnelOfHateTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TicketBoothTunnelOfHateTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.FaceDownComponent
+import com.wingedsheep.engine.state.components.identity.ManifestedComponent
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.TicketBoothTunnelOfHate
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Ticket Booth // Tunnel of Hate (DSK 158) — split-layout Room (CR 709.5).
+ *
+ * Ticket Booth {2}{R}   — "When you unlock this door, manifest dread." Casting the half enters it
+ *                          unlocked, firing the trigger (the shared manifest-dread recipe).
+ * Tunnel of Hate {4}{R}{R} — "Whenever you attack, target attacking creature gains double strike
+ *                          until end of turn."
+ */
+class TicketBoothTunnelOfHateTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(TicketBoothTunnelOfHate)
+        d.initMirrorMatch(
+            deck = Deck.of("Mountain" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("casting Ticket Booth unlocks its door and manifests dread") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Top two of library for manifest dread: a creature to manifest, a land to bin.
+        d.putCardOnTopOfLibrary(p1, "Mountain")
+        val creature = d.putCardOnTopOfLibrary(p1, "Grizzly Bears")
+
+        val roomId = d.putCardInHand(p1, TicketBoothTunnelOfHate.name)
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 2)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+
+        // Resolve the Room onto the battlefield, then the unlock trigger, until manifest pauses.
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe setOf(RoomFaceId("Ticket Booth"))
+
+        // Manifest dread pauses to choose which of the looked-at two to manifest.
+        val pick = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        d.submitDecision(p1, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(creature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The chosen card is now a face-down 2/2 manifested creature.
+        d.state.getEntity(creature)?.get<FaceDownComponent>() shouldBe FaceDownComponent
+        d.state.getEntity(creature)?.get<ManifestedComponent>() shouldBe ManifestedComponent
+    }
+
+    test("Tunnel of Hate gives a target attacking creature double strike when you attack") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast Tunnel of Hate ({4}{R}{R}, face 1).
+        val roomId = d.putCardInHand(p1, TicketBoothTunnelOfHate.name)
+        d.giveMana(p1, Color.RED, 2)
+        d.giveColorlessMana(p1, 4)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+        d.bothPass()
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe setOf(RoomFaceId("Tunnel of Hate"))
+
+        // An attacker is ready.
+        val attacker = d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        d.removeSummoningSickness(attacker)
+        d.state.projectedState.hasKeyword(attacker, Keyword.DOUBLE_STRIKE) shouldBe false
+
+        // Declaring attackers fires "Whenever you attack"; the trigger targets the attacker.
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(p1, listOf(attacker), p2)
+        d.submitTargetSelection(p1, listOf(attacker))
+        d.bothPass()
+
+        // The attacker now has double strike for the turn.
+        d.state.projectedState.hasKeyword(attacker, Keyword.DOUBLE_STRIKE) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements a handful of missing **Duskmourn: House of Horror (DSK)** cards. All five are pure composition over existing SDK building blocks — no new effects/triggers/conditions were needed.

## Cards

### Lands — the "13 or less life" dual cycle
- **Neglected Manor** (W/B)
- **Raucous Carnival** (R/W)
- **Peculiar Lighthouse** (U/R)

`This land enters tapped unless a player has 13 or less life. {T}: Add {X} or {Y}.` — copies of the already-implemented cycle members Lakeside Shack and Razortrap Gorge (`EntersTapped(unlessCondition = Conditions.APlayerLifeAtMost(13))`).

### Rooms (split-layout, CR 709.5)
- **Ticket Booth // Tunnel of Hate**
  - *Ticket Booth* {2}{R}: "When you unlock this door, manifest dread." — shared `Patterns.Library.manifestDread()` recipe.
  - *Tunnel of Hate* {4}{R}{R}: "Whenever you attack, target attacking creature gains double strike until end of turn." — `Triggers.YouAttack` + `Effects.GrantKeyword(DOUBLE_STRIKE, target)`.
- **Moldering Gym // Weight Room**
  - *Moldering Gym* {2}{G}: "search your library for a basic land card, put it onto the battlefield tapped, then shuffle." — `Patterns.Library.searchLibrary(BasicLand, BATTLEFIELD, entersTapped = true)`.
  - *Weight Room* {5}{G}: "manifest dread, then put three +1/+1 counters on that creature." — manifest dread (`markEntered = true`) → gather via `EnteredViaThisResolution` → `AddCountersToCollection` (the Valgavoth's Onslaught shape).

## Tests
- New scenario tests `TicketBoothTunnelOfHateTest` and `MolderingGymWeightRoomTest` cover both faces of each Room (unlock-trigger manifest, double-strike-on-attack, basic-land fetch tapped, manifest-then-counters → 5/5).
- `CardDefinitionSnapshotTest` re-blessed (additive: +418 lines, only the five new cards).
- DSK coverage: 249 → 254 / 276 (90% → 92%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)