### PR TITLE
Add five Duskmourn cards (Let's Play a Game, two Leylines, a Room)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GrandEntrywayElegantRotunda.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/GrandEntrywayElegantRotunda.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Grand Entryway // Elegant Rotunda (DSK 15) — split-layout Room (CR 709.5).
+ *
+ * Grand Entryway {1}{W} — Enchantment — Room
+ *   When you unlock this door, create a 1/1 white Glimmer enchantment creature token.
+ *
+ * Elegant Rotunda {2}{W} — Enchantment — Room
+ *   When you unlock this door, put a +1/+1 counter on each of up to two target creatures.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ *
+ * Both halves are "when you unlock this door" triggers ([Triggers.OnDoorUnlocked], CR 709.5h).
+ * Grand Entryway makes the same 1/1 white Glimmer enchantment-creature token as Tunnel Surveyor
+ * ([Effects.CreateToken] with `enchantmentToken = true`). Elegant Rotunda reuses the Byrke /
+ * Weftblade "each of up to two target creatures" shape — an optional `count = 2` [TargetCreature]
+ * fanned out with [ForEachTargetEffect] so each chosen creature gets one +1/+1 counter.
+ */
+val GrandEntrywayElegantRotunda = card("Grand Entryway // Elegant Rotunda") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "W"
+
+    face("Grand Entryway") {
+        manaCost = "{1}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, create a 1/1 white Glimmer enchantment creature token."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Glimmer"),
+                enchantmentToken = true,
+                imageUri = "https://cards.scryfall.io/normal/front/4/7/475c7449-2c95-4873-94de-68a5e06cdfb8.jpg?1754930946",
+            )
+        }
+    }
+
+    face("Elegant Rotunda") {
+        manaCost = "{2}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, put a +1/+1 counter on each of up to two target creatures."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            target("up to two target creatures", TargetCreature(count = 2, optional = true))
+            effect = ForEachTargetEffect(
+                listOf(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))
+            )
+            description = "When you unlock this door, put a +1/+1 counter on each of up to two target creatures."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Carlos Palma Cruchaga"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg?1726867775"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LetsPlayAGame.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LetsPlayAGame.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Let's Play a Game
+ * {3}{B}
+ * Sorcery
+ *
+ * Delirium — Choose one. If there are four or more card types among cards in your graveyard,
+ * choose one or more instead.
+ * • Creatures your opponents control get -1/-1 until end of turn.
+ * • Each opponent discards two cards.
+ * • Each opponent loses 3 life and you gain 3 life.
+ *
+ * Delirium gates the modal *choose count*, not a separate effect. The mandatory floor stays
+ * `minChooseCount = 1` ("choose one"); the cap is a cast-time [DynamicAmount.Conditional] that
+ * yields the full mode count (3 — "one or more") when delirium is active as the spell is cast,
+ * otherwise 1. Evaluated against the caster's graveyard at cast time by
+ * [com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler] — same machinery as Flame of
+ * Anor's "you may choose two instead."
+ */
+val LetsPlayAGame = card("Let's Play a Game") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Delirium — Choose one. If there are four or more card types among cards in your " +
+        "graveyard, choose one or more instead.\n" +
+        "• Creatures your opponents control get -1/-1 until end of turn.\n" +
+        "• Each opponent discards two cards.\n" +
+        "• Each opponent loses 3 life and you gain 3 life."
+
+    spell {
+        modal(
+            chooseCount = 1,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.Delirium(),
+                ifTrue = DynamicAmount.Fixed(3),
+                ifFalse = DynamicAmount.Fixed(1)
+            )
+        ) {
+            mode(
+                "Creatures your opponents control get -1/-1 until end of turn.",
+                Patterns.Group.modifyStatsForAll(-1, -1, Filters.Group.creaturesOpponentsControl, Duration.EndOfTurn)
+            )
+            mode(
+                "Each opponent discards two cards.",
+                Effects.EachOpponentDiscards(2)
+            )
+            mode(
+                "Each opponent loses 3 life and you gain 3 life.",
+                Effects.Composite(
+                    Effects.LoseLife(3, EffectTarget.PlayerRef(Player.EachOpponent)),
+                    Effects.GainLife(3)
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "105"
+        artist = "Riccardo Federici"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/645911b4-7728-4380-9097-e4139b986423.jpg?1726286240"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfMutation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfMutation.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.leyline
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantAlternativeCastingCost
+
+/**
+ * Leyline of Mutation (DSK #188)
+ * {2}{G}{G}  Enchantment
+ *
+ * If this card is in your opening hand, you may begin the game with it on the battlefield.
+ * You may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells you cast.
+ *
+ * The alternative cost is the Jodah, Archmage Eternal ability — [GrantAlternativeCastingCost]
+ * with the five-color cost. `leyline()` adds the "begin the game on the battlefield" opening-hand
+ * marker (CR 103.6). The card is mono-green by its own mana cost but has a five-color identity
+ * because of the {W}{U}{B}{R}{G} cost it references.
+ */
+val LeylineOfMutation = card("Leyline of Mutation") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Enchantment"
+    oracleText = "If this card is in your opening hand, you may begin the game with it on the battlefield.\n" +
+        "You may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells you cast."
+
+    leyline()
+
+    staticAbility {
+        ability = GrantAlternativeCastingCost(cost = "{W}{U}{B}{R}{G}")
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "188"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/2359b670-41f0-4ec7-8db9-3f87f7577bc3.jpg?1726286566"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfResonance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfResonance.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.leyline
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Leyline of Resonance (DSK #143)
+ * {2}{R}{R}  Enchantment
+ *
+ * If this card is in your opening hand, you may begin the game with it on the battlefield.
+ * Whenever you cast an instant or sorcery spell that targets only a single creature you control,
+ * copy that spell. You may choose new targets for the copy.
+ *
+ * "Targets only a single creature you control" is composed from two existing primitives rather
+ * than a bespoke predicate: the cast trigger requires [SpellCastPredicate.TargetsMatching] a
+ * creature you control (at least one chosen target is a creature you control), and
+ * [Conditions.TriggeringSpellHasSingleTarget] requires the spell have exactly one target — together
+ * that is "the spell's one and only target is a creature you control." The payoff is the standard
+ * [Effects.CopyTargetSpell] of the triggering spell ([EffectTarget.TriggeringEntity]), which already
+ * offers "you may choose new targets for the copy." `leyline()` adds the opening-hand marker
+ * (CR 103.6).
+ */
+val LeylineOfResonance = card("Leyline of Resonance") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "If this card is in your opening hand, you may begin the game with it on the battlefield.\n" +
+        "Whenever you cast an instant or sorcery spell that targets only a single creature you control, " +
+        "copy that spell. You may choose new targets for the copy."
+
+    leyline()
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.InstantOrSorcery,
+            requires = setOf(SpellCastPredicate.TargetsMatching(GameObjectFilter.Creature.youControl()))
+        )
+        triggerCondition = Conditions.TriggeringSpellHasSingleTarget
+        effect = Effects.CopyTargetSpell(target = EffectTarget.TriggeringEntity)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "143"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/92c5f0e3-345a-40a8-9cda-565a62156692.jpg?1731574465"
+
+        ruling("2024-09-20", "The copy will have the same targets (all the same creature you control) as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. The new targets must be legal.")
+        ruling("2024-09-20", "If the spell that's copied is modal, the copy will have the same mode or modes. You can't choose different ones.")
+        ruling("2024-09-20", "If the spell that's copied has an X whose value was determined as it was cast, the copy will have the same value of X.")
+        ruling("2024-09-20", "The copy is created on the stack, so it's not \"cast.\"")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -7213,6 +7213,89 @@
     ]
 }
 
+// Grand Entryway // Elegant Rotunda
+{
+    "name": "Grand Entryway // Elegant Rotunda",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, create a 1/1 white Glimmer enchantment creature token.\n//\nWhen you unlock this door, put a +1/+1 counter on each of up to two target creatures.",
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Carlos Palma Cruchaga",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/ef8a8ba7-f955-425d-9a16-816fc48a2a83.jpg?1726867775"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Grand Entryway",
+            "manaCost": "{1}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, create a 1/1 white Glimmer enchantment creature token.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "WHITE"
+                            ],
+                            "creatureTypes": [
+                                "Glimmer"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/4/7/475c7449-2c95-4873-94de-68a5e06cdfb8.jpg?1754930946",
+                            "enchantmentToken": true
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Elegant Rotunda",
+            "manaCost": "{2}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, put a +1/+1 counter on each of up to two target creatures.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "ForEach",
+                            "space": "IterationSpace.Targets",
+                            "body": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            }
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "count": 2,
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "up to two target creatures"
+                        },
+                        "descriptionOverride": "When you unlock this door, put a +1/+1 counter on each of up to two target creatures."
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Grasping Longneck
 {
     "name": "Grasping Longneck",
@@ -9309,6 +9392,149 @@
     ]
 }
 
+// Let's Play a Game
+{
+    "name": "Let's Play a Game",
+    "manaCost": "{3}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Delirium — Choose one. If there are four or more card types among cards in your graveyard, choose one or more instead.\n• Creatures your opponents control get -1/-1 until end of turn.\n• Each opponent discards two cards.\n• Each opponent loses 3 life and you gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": -1
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures your opponents control get -1/-1 until end of turn."
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Players",
+                            "players": "EachOpponent"
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "discarded"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    },
+                    "description": "Each opponent discards two cards."
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Each opponent loses 3 life and you gain 3 life."
+                }
+            ],
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "aggregation": "DISTINCT_TYPES"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 3
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "UNCOMMON",
+        "artist": "Riccardo Federici",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/645911b4-7728-4380-9097-e4139b986423.jpg?1726286240"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Leyline of Hope
 {
     "name": "Leyline of Hope",
@@ -9365,6 +9591,105 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Leyline of Mutation
+{
+    "name": "Leyline of Mutation",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nYou may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells you cast.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantAlternativeCastingCost",
+                "cost": "{W}{U}{B}{R}{G}"
+            }
+        ],
+        "mayStartOnBattlefield": true
+    },
+    "metadata": {
+        "collectorNumber": "188",
+        "rarity": "RARE",
+        "artist": "Sergey Glushakov",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/2359b670-41f0-4ec7-8db9-3f87f7577bc3.jpg?1726286566"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Leyline of Resonance
+{
+    "name": "Leyline of Resonance",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nWhenever you cast an instant or sorcery spell that targets only a single creature you control, copy that spell. You may choose new targets for the copy.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            }
+                        ]
+                    },
+                    "requires": [
+                        {
+                            "type": "SpellTargetsMatching",
+                            "filter": "creature ctrl:you"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CopyTargetSpell",
+                    "target": "TriggeringEntity"
+                },
+                "triggerCondition": "TriggeringSpellHasSingleTarget"
+            }
+        ],
+        "mayStartOnBattlefield": true
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "RARE",
+        "artist": "Sergey Glushakov",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/92c5f0e3-345a-40a8-9cda-565a62156692.jpg?1731574465",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "The copy will have the same targets (all the same creature you control) as the spell it's copying unless you choose new ones. You may change any number of the targets, including all of them or none of them. The new targets must be legal."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If the spell that's copied is modal, the copy will have the same mode or modes. You can't choose different ones."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If the spell that's copied has an X whose value was determined as it was cast, the copy will have the same value of X."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "The copy is created on the stack, so it's not \"cast.\""
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfResonanceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfResonanceScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.stack.TriggeredAbilityOnStackComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.LeylineOfResonance
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.CopyTargetSpellEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Leyline of Resonance {2}{R}{R} — Enchantment.
+ * "Whenever you cast an instant or sorcery spell that targets only a single creature you control,
+ *  copy that spell. You may choose new targets for the copy."
+ *
+ * "Targets only a single creature you control" is composed from two existing primitives:
+ * `SpellCastPredicate.TargetsMatching(Creature.youControl())` (at least one chosen target is a
+ * creature you control) plus `Conditions.TriggeringSpellHasSingleTarget` (exactly one target) —
+ * together meaning the spell's one and only target is a creature you control.
+ *
+ * These tests pin that composition by checking whether the copy trigger
+ * ([CopyTargetSpellEffect]) lands on the stack on cast. Lightning Bolt is the probe: an
+ * instant with a single "any target" requirement, so retargeting it across creature-you-control,
+ * creature-you-don't-control, and a player exercises every arm of the filter.
+ */
+class LeylineOfResonanceScenarioTest : FunSpec({
+
+    fun copyTriggers(driver: GameTestDriver) =
+        driver.state.stack.mapNotNull {
+            driver.state.getEntity(it)?.get<TriggeredAbilityOnStackComponent>()
+        }.filter { it.effect is CopyTargetSpellEffect }
+
+    fun setup(): Triple<GameTestDriver, com.wingedsheep.sdk.model.EntityId, com.wingedsheep.sdk.model.EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LeylineOfResonance))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.putPermanentOnBattlefield(you, "Leyline of Resonance")
+        return Triple(driver, you, opponent)
+    }
+
+    test("fires when you cast an instant targeting a single creature you control") {
+        val (driver, you, _) = setup()
+        val myCreature = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Permanent(myCreature))).error shouldBe null
+
+        copyTriggers(driver).size shouldBe 1
+    }
+
+    test("does NOT fire when the spell targets a creature you don't control") {
+        val (driver, you, opponent) = setup()
+        val theirCreature = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Permanent(theirCreature))).error shouldBe null
+
+        copyTriggers(driver).size shouldBe 0
+    }
+
+    test("does NOT fire when the spell targets a player rather than a creature") {
+        val (driver, you, opponent) = setup()
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Player(opponent))).error shouldBe null
+
+        copyTriggers(driver).size shouldBe 0
+    }
+})


### PR DESCRIPTION
## Summary

Implements a handful of the remaining missing **Duskmourn: House of Horror** cards. Every card is **pure authoring over existing SDK primitives** — no engine, SDK, or client changes — so the only non-card file touched is the DSK card snapshot (additive re-bless). DSK coverage goes 254 → 258 of 276.

| Card | Mechanic | Reused from |
|------|----------|-------------|
| **Let's Play a Game** `{3}{B}` | Delirium-gated modal sorcery — "choose one; if delirium, choose one or more instead" | Flame of Anor cast-time `dynamicChooseCount` (`Conditional` on `Conditions.Delirium()`) |
| **Leyline of Mutation** `{2}{G}{G}` | `leyline()` + `GrantAlternativeCastingCost("{W}{U}{B}{R}{G}")` | Jodah, Archmage Eternal |
| **Leyline of Resonance** `{2}{R}{R}` | Cast trigger filtered to "targets only a single creature you control" → copy that spell | `SpellCastPredicate.TargetsMatching` + `Conditions.TriggeringSpellHasSingleTarget` + `Effects.CopyTargetSpell` |
| **Grand Entryway // Elegant Rotunda** `{1}{W}` // `{2}{W}` | Split Room; both halves are `Triggers.OnDoorUnlocked` — Glimmer token / +1/+1 on up to two target creatures | Tunnel Surveyor (token), Byrke (up-to-two-target counters), Funeral Room (Room layout) |

### "Targets only a single creature you control"

Leyline of Resonance's filter is composed from two existing primitives rather than a bespoke predicate: `TargetsMatching(Creature.youControl())` (≥1 chosen target is a creature you control) **and** `TriggeringSpellHasSingleTarget` (exactly one target) ⇒ the spell's one and only target is a creature you control.

## Testing

- `LeylineOfResonanceScenarioTest` (new) — pins the filter composition: fires when bolting your own creature; does **not** fire on an opponent's creature or on a player. ✅
- `just build` + full `:mtg-sets:test` (snapshot + `CardLintTest`) green. ✅
- Snapshot diff is additive-only (the four new cards, nothing else moved). ✅
- `check-card-printing` confirms all four are canonical in their earliest printing (DSK). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)