### PR TITLE
Add five Final Fantasy cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DarkConfidantReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DarkConfidantReprint.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dark Confidant reprint in FIN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * the Ravnica: City of Guilds (`rav`) `cards/` package — the earliest real printing. This
+ * file contributes only the FIN-specific presentation row — set, collector number, art —
+ * picked up automatically by `CardDiscovery.findPrintingsIn` and surfaced via the set's
+ * `printings`.
+ */
+val DarkConfidantReprint = Printing(
+    oracleId = "2068185c-1b50-47d0-aa3f-bf505d199428",
+    name = "Dark Confidant",
+    setCode = "FIN",
+    collectorNumber = "94",
+    scryfallId = "2520ab23-a068-4462-b261-2754409b4108",
+    artist = "Immanuela Crovius",
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/2520ab23-a068-4462-b261-2754409b4108.jpg?1748706117",
+    releaseDate = "2025-06-13",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LaughingMad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LaughingMad.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Laughing Mad
+ * {2}{R}
+ * Instant
+ * As an additional cost to cast this spell, discard a card.
+ * Draw two cards.
+ * Flashback {3}{R} (You may cast this card from your graveyard for its flashback cost and
+ * any additional costs. Then exile it.)
+ *
+ * The discard additional cost applies on every cast, including the flashback cast — the
+ * engine evaluates `additionalCost` as part of the spell's casting requirements regardless
+ * of which zone it is cast from.
+ */
+val LaughingMad = card("Laughing Mad") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, discard a card.\nDraw two cards.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)"
+
+    additionalCost(Costs.additional.DiscardCards())
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    keywordAbility(KeywordAbility.flashback("{3}{R}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "143"
+        artist = "RARE ENGINE"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd5b9daf-6325-4eb4-a069-4a8cc7807884.jpg?1748706298"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PrishesWanderings.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PrishesWanderings.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Prishe's Wanderings
+ * {2}{G}
+ * Instant
+ * Search your library for a basic land card or Town card, put it onto the battlefield
+ * tapped, then shuffle. When you search your library this way, put a +1/+1 counter on
+ * target creature you control.
+ *
+ * Resolving the spell always performs the search, so the reflexive "when you search …"
+ * counter is modeled as a straight follow-up effect on the spell's target creature. The
+ * spell requires a legal target creature you control to be cast.
+ */
+val PrishesWanderings = card("Prishe's Wanderings") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Search your library for a basic land card or Town card, put it onto the battlefield tapped, then shuffle. When you search your library this way, put a +1/+1 counter on target creature you control."
+
+    val basicOrTown = GameObjectFilter.BasicLand or GameObjectFilter.Land.withSubtype("Town")
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            listOf(
+                Patterns.Library.searchLibrary(
+                    filter = basicOrTown,
+                    count = 1,
+                    destination = SearchDestination.BATTLEFIELD,
+                    entersTapped = true
+                ),
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "193"
+        artist = "Daniel Correia"
+        flavorText = "\"There's only one reason. They smell an adventure! C'mon! We've got no time to lose!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/6/d6e1dee0-e2cd-4899-a3ea-7d0df717c9ab.jpg?1748706482"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ReachTheHorizon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ReachTheHorizon.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SelectionRestriction
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Reach the Horizon
+ * {3}{G}
+ * Sorcery
+ * Search your library for up to two basic land cards and/or Town cards with different
+ * names, put them onto the battlefield tapped, then shuffle.
+ *
+ * Atomic pipeline: gather library basics/Towns → ChooseUpTo(2) with OnePerCardName
+ * ("different names") → MoveCollection onto the battlefield tapped → shuffle. "Up to two"
+ * means you may find fewer (or none).
+ */
+val ReachTheHorizon = card("Reach the Horizon") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for up to two basic land cards and/or Town cards with different names, put them onto the battlefield tapped, then shuffle."
+
+    val basicOrTown = GameObjectFilter.BasicLand or GameObjectFilter.Land.withSubtype("Town")
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.LIBRARY, Player.You, basicOrTown),
+                    storeAs = "searchable"
+                ),
+                SelectFromCollectionEffect(
+                    from = "searchable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(2)),
+                    storeSelected = "found",
+                    restrictions = listOf(SelectionRestriction.OnePerCardName),
+                    prompt = "Search for up to two basic land or Town cards with different names"
+                ),
+                MoveCollectionEffect(
+                    from = "found",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped)
+                ),
+                ShuffleLibraryEffect()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "195"
+        artist = "ikeda_cpt"
+        flavorText = "\"Guess this is goodbye, City of Mako.\"\n—Tifa Lockhart"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c25960e0-5779-4e20-89f3-03950ad9d91c.jpg?1748706490"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RufusShinra.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RufusShinra.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Rufus Shinra
+ * {1}{W}{B}
+ * Legendary Creature — Human Noble
+ * 2/4
+ * Whenever Rufus Shinra attacks, if you don't control a creature named Darkstar, create
+ * Darkstar, a legendary 2/2 white and black Dog creature token.
+ *
+ * The "if you don't control …" clause is an intervening-if condition (CR 603.4): the
+ * trigger only fires — and only resolves — while no Darkstar is on your battlefield.
+ */
+val RufusShinra = card("Rufus Shinra") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Human Noble"
+    power = 2
+    toughness = 4
+    oracleText = "Whenever Rufus Shinra attacks, if you don't control a creature named Darkstar, create Darkstar, a legendary 2/2 white and black Dog creature token."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.YouControl(
+            GameObjectFilter.Creature.named("Darkstar"),
+            negate = true
+        )
+        effect = CreateTokenEffect(
+            count = 1,
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE, Color.BLACK),
+            creatureTypes = setOf("Dog"),
+            name = "Darkstar",
+            legendary = true,
+            imageUri = "https://cards.scryfall.io/normal/front/1/9/19faca08-0eef-4da4-ab6f-c3aed63ac77b.jpg?1748704096"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "238"
+        artist = "Ittoku"
+        flavorText = "\"I'll control the world with fear. It takes too much to do it like my old man.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5fff00b-c9a0-4e90-abc0-349f8716c885.jpg?1748706668"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DarkConfidant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/DarkConfidant.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dark Confidant
+ * {1}{B}
+ * Creature — Human Wizard
+ * 2/1
+ *
+ * At the beginning of your upkeep, reveal the top card of your library and put
+ * that card into your hand. You lose life equal to its mana value.
+ *
+ * Canonical printing lives here (Ravnica: City of Guilds, 2005 — earliest real
+ * expansion). Later printings (e.g. Final Fantasy) contribute only a `Printing` row.
+ */
+val DarkConfidant = card("Dark Confidant") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1), Player.You),
+                    storeAs = "revealed"
+                ),
+                MoveCollectionEffect(
+                    from = "revealed",
+                    destination = CardDestination.ToZone(Zone.HAND, Player.You),
+                    revealed = true
+                ),
+                LoseLifeEffect(
+                    DynamicAmount.StoredCardManaValue("revealed"),
+                    EffectTarget.Controller
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "81"
+        artist = "Ron Spears"
+        flavorText = "Greatness, at any cost."
+        imageUri = "https://cards.scryfall.io/normal/front/9/4/94f7a441-bf2d-46fb-a7b6-9bd6137f86d9.jpg?1598914714"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -6378,6 +6378,46 @@
     ]
 }
 
+// Laughing Mad
+{
+    "name": "Laughing Mad",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, discard a card.\nDraw two cards.\nFlashback {3}{R} (You may cast this card from your graveyard for its flashback cost and any additional costs. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{3}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "143",
+        "artist": "RARE ENGINE",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd5b9daf-6325-4eb4-a069-4a8cc7807884.jpg?1748706298"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Lindblum, Industrial Regency
 {
     "name": "Lindblum, Industrial Regency",
@@ -8034,6 +8074,103 @@
     ]
 }
 
+// Prishe's Wanderings
+{
+    "name": "Prishe's Wanderings",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Search your library for a basic land card or Town card, put it onto the battlefield tapped, then shuffle. When you search your library this way, put a +1/+1 counter on target creature you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": {
+                                    "cardPredicates": [
+                                        {
+                                            "type": "Or",
+                                            "predicates": [
+                                                "IsBasicLand",
+                                                {
+                                                    "type": "And",
+                                                    "predicates": [
+                                                        "IsLand",
+                                                        {
+                                                            "type": "HasSubtype",
+                                                            "subtype": "Town"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        "ShuffleLibrary"
+                    ]
+                },
+                {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "193",
+        "artist": "Daniel Correia",
+        "flavorText": "\"There's only one reason. They smell an adventure! C'mon! We've got no time to lose!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/6/d6e1dee0-e2cd-4899-a3ea-7d0df717c9ab.jpg?1748706482"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Prompto Argentum
 {
     "name": "Prompto Argentum",
@@ -8581,6 +8718,85 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Reach the Horizon
+{
+    "name": "Reach the Horizon",
+    "manaCost": "{3}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for up to two basic land cards and/or Town cards with different names, put them onto the battlefield tapped, then shuffle.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": {
+                            "cardPredicates": [
+                                {
+                                    "type": "Or",
+                                    "predicates": [
+                                        "IsBasicLand",
+                                        {
+                                            "type": "And",
+                                            "predicates": [
+                                                "IsLand",
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Town"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeSelected": "found",
+                    "prompt": "Search for up to two basic land or Town cards with different names",
+                    "restrictions": [
+                        "OnePerCardName"
+                    ]
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "found",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                },
+                "ShuffleLibrary"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "195",
+        "rarity": "UNCOMMON",
+        "artist": "ikeda_cpt",
+        "flavorText": "\"Guess this is goodbye, City of Mako.\"\n—Tifa Lockhart",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c25960e0-5779-4e20-89f3-03950ad9d91c.jpg?1748706490"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -9258,6 +9474,59 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Rufus Shinra
+{
+    "name": "Rufus Shinra",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Legendary Creature — Human Noble",
+    "oracleText": "Whenever Rufus Shinra attacks, if you don't control a creature named Darkstar, create Darkstar, a legendary 2/2 white and black Dog creature token.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE",
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Dog"
+                    ],
+                    "name": "Darkstar",
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/9/19faca08-0eef-4da4-ab6f-c3aed63ac77b.jpg?1748704096",
+                    "legendary": true
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature name:Darkstar",
+                    "negate": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "UNCOMMON",
+        "artist": "Ittoku",
+        "flavorText": "\"I'll control the world with fear. It takes too much to do it like my old man.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5fff00b-c9a0-4e90-abc0-349f8716c885.jpg?1748706668"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -868,6 +868,73 @@
     "colorIdentityOverride": []
 }
 
+// Dark Confidant
+{
+    "name": "Dark Confidant",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "revealed"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "revealed",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "StoredCardManaValue",
+                                "collectionName": "revealed"
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "81",
+        "rarity": "RARE",
+        "artist": "Ron Spears",
+        "flavorText": "Greatness, at any cost.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/4/94f7a441-bf2d-46fb-a7b6-9bd6137f86d9.jpg?1598914714"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dimir Cutpurse
 {
     "name": "Dimir Cutpurse",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DarkConfidantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DarkConfidantScenarioTest.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Dark Confidant (canonical printing in Ravnica: City of Guilds,
+ * reprinted in Final Fantasy).
+ *
+ * Dark Confidant — {1}{B} Creature — Human Wizard 2/1.
+ *   "At the beginning of your upkeep, reveal the top card of your library and put that
+ *    card into your hand. You lose life equal to its mana value."
+ */
+class DarkConfidantScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("upkeep moves the top card to hand and loses life equal to its mana value") {
+            val game = scenario()
+                .withPlayers()
+                .withActivePlayer(1)
+                .inPhase(Phase.BEGINNING, Step.UNTAP)
+                .withCardOnBattlefield(1, "Dark Confidant")
+                .withCardInLibrary(1, "Laughing Mad") // mana value 3 ({2}{R})
+                .build()
+
+            game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+            game.resolveStack()
+
+            withClue("the revealed top card is now in hand") {
+                game.isInHand(1, "Laughing Mad") shouldBe true
+            }
+            withClue("controller loses life equal to the revealed card's mana value (3)") {
+                game.getLifeTotal(1) shouldBe 17
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LaughingMadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LaughingMadScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Laughing Mad (FIN #143).
+ *
+ * Laughing Mad — {2}{R} Instant.
+ *   "As an additional cost to cast this spell, discard a card.
+ *    Draw two cards.
+ *    Flashback {3}{R}"
+ */
+class LaughingMadScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("discards a card as an additional cost and draws two cards") {
+            val game = scenario()
+                .withPlayers()
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withCardInHand(1, "Laughing Mad")
+                .withCardInHand(1, "Forest") // the card to discard
+                .withLandsOnBattlefield(1, "Mountain", 3)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Island")
+                .build()
+
+            val laughingMad = game.findCardsInHand(1, "Laughing Mad").first()
+            val discard = game.findCardsInHand(1, "Forest").first()
+
+            game.execute(
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = laughingMad,
+                    targets = emptyList(),
+                    additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(discard))
+                )
+            ).error shouldBe null
+
+            withClue("the discarded card is in the graveyard") {
+                game.isInGraveyard(1, "Forest") shouldBe true
+            }
+
+            game.resolveStack()
+
+            withClue("two cards were drawn") {
+                game.isInHand(1, "Plains") shouldBe true
+                game.isInHand(1, "Island") shouldBe true
+            }
+        }
+
+        test("can be cast from the graveyard with flashback, then is exiled") {
+            val game = scenario()
+                .withPlayers()
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withCardInGraveyard(1, "Laughing Mad")
+                .withCardInHand(1, "Forest") // discarded for the additional cost
+                .withLandsOnBattlefield(1, "Mountain", 4)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Island")
+                .build()
+
+            val laughingMad = game.findCardsInGraveyard(1, "Laughing Mad").first()
+            val discard = game.findCardsInHand(1, "Forest").first()
+
+            game.execute(
+                // Casting from the graveyard auto-applies the flashback alternative cost; the
+                // discard additional cost still applies ("its flashback cost and any additional costs").
+                CastSpell(
+                    playerId = game.player1Id,
+                    cardId = laughingMad,
+                    targets = emptyList(),
+                    additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(discard))
+                )
+            ).error shouldBe null
+
+            game.resolveStack()
+
+            withClue("flashback exiles the card after it resolves") {
+                game.isInExile(1, "Laughing Mad") shouldBe true
+                game.isInGraveyard(1, "Laughing Mad") shouldBe false
+            }
+            withClue("two cards were drawn from the flashback cast") {
+                game.isInHand(1, "Plains") shouldBe true
+                game.isInHand(1, "Island") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrishesWanderingsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PrishesWanderingsScenarioTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Prishe's Wanderings (FIN #193).
+ *
+ * Prishe's Wanderings — {2}{G} Instant.
+ *   "Search your library for a basic land card or Town card, put it onto the battlefield
+ *    tapped, then shuffle. When you search your library this way, put a +1/+1 counter on
+ *    target creature you control."
+ */
+class PrishesWanderingsScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("fetches a basic land and puts a +1/+1 counter on the targeted creature") {
+            val game = scenario()
+                .withPlayers()
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withCardInHand(1, "Prishe's Wanderings")
+                .withCardOnBattlefield(1, "Rufus Shinra") // a creature you control (2/4)
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            val rufus = game.findPermanent("Rufus Shinra")!!
+            game.castSpell(1, "Prishe's Wanderings", targetId = rufus).error shouldBe null
+            game.resolveStack() // pauses at the land search
+
+            if (game.hasPendingDecision()) {
+                game.selectCards(game.findCardsInLibrary(1, "Plains")).error shouldBe null
+                game.resolveStack()
+            }
+
+            withClue("the fetched land entered the battlefield") {
+                game.isOnBattlefield("Plains") shouldBe true
+            }
+            withClue("the targeted creature has a +1/+1 counter") {
+                val counters = game.state.getEntity(rufus)
+                    ?.get<CountersComponent>()
+                    ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                counters shouldBe 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReachTheHorizonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReachTheHorizonScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Reach the Horizon (FIN #195).
+ *
+ * Reach the Horizon — {3}{G} Sorcery.
+ *   "Search your library for up to two basic land cards and/or Town cards with different
+ *    names, put them onto the battlefield tapped, then shuffle."
+ */
+class ReachTheHorizonScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("fetches two different-named basic/Town lands onto the battlefield tapped") {
+            val game = scenario()
+                .withPlayers()
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withCardInHand(1, "Reach the Horizon")
+                .withLandsOnBattlefield(1, "Forest", 4)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Island")
+                .build()
+
+            game.castSpell(1, "Reach the Horizon").error shouldBe null
+            game.resolveStack() // pauses at the search selection
+
+            val plains = game.findCardsInLibrary(1, "Plains")
+            val island = game.findCardsInLibrary(1, "Island")
+            withClue("the search decision is offered") { game.hasPendingDecision() shouldBe true }
+            game.selectCards(plains + island).error shouldBe null
+            game.resolveStack()
+
+            withClue("both fetched lands are on the battlefield") {
+                game.isOnBattlefield("Plains") shouldBe true
+                game.isOnBattlefield("Island") shouldBe true
+            }
+            withClue("the fetched Plains entered tapped") {
+                val plainsId = game.findPermanent("Plains")!!
+                game.state.getEntity(plainsId)?.get<TappedComponent>() shouldNotBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RufusShinraScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RufusShinraScenarioTest.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Rufus Shinra (FIN #238).
+ *
+ * Rufus Shinra — {1}{W}{B} Legendary Creature — Human Noble 2/4.
+ *   "Whenever Rufus Shinra attacks, if you don't control a creature named Darkstar, create
+ *    Darkstar, a legendary 2/2 white and black Dog creature token."
+ */
+class RufusShinraScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("attacking creates a single Darkstar token when none is controlled") {
+            val game = scenario()
+                .withPlayers()
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withCardOnBattlefield(1, "Rufus Shinra", summoningSickness = false)
+                .build()
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Rufus Shinra" to 2)).error shouldBe null
+            game.resolveStack()
+
+            withClue("a Darkstar token was created") {
+                game.isOnBattlefield("Darkstar") shouldBe true
+            }
+            withClue("exactly one Darkstar exists (the intervening-if guards against duplicates)") {
+                game.findAllPermanents("Darkstar").size shouldBe 1
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of cards from the Final Fantasy (FIN) set, all built by **composing existing SDK primitives** — no new engine effects, keywords, triggers, or conditions.

## Cards

| Card | Type | Mechanic |
|------|------|----------|
| **Dark Confidant** | {1}{B} Creature 2/1 | Upkeep: reveal top → hand, lose life = its mana value |
| **Reach the Horizon** | {3}{G} Sorcery | Search up to two different-named basic/Town lands, onto battlefield tapped |
| **Laughing Mad** | {2}{R} Instant | Additional-cost discard, draw two, Flashback {3}{R} |
| **Rufus Shinra** | {1}{W}{B} Legendary 2/4 | Attack trigger (intervening-if you don't control a Darkstar) → create the legendary Darkstar token |
| **Prishe's Wanderings** | {2}{G} Instant | Search a basic/Town land tapped, +1/+1 counter on target creature you control |

## Notes

- **Dark Confidant is a reprint.** Per the project's reprint rule, its canonical `CardDefinition` lives in its earliest real printing — **Ravnica: City of Guilds** (`rav`) — and FIN gets only a `Printing` row. `just check-card-printing "Dark Confidant"` passes.
- **Reach the Horizon** uses the `OnePerCardName` selection restriction for "different names" and the basic-land `or` Town-subtype filter (same shape as Omenpath Journey).
- **Rufus Shinra** uses `Conditions.YouControl(..., negate = true)` as the trigger's intervening-if so a redundant Darkstar is never created.
- Originally scoped *Light of Judgment* into this batch, but its "destroy up to one Equipment attached to that creature" has no faithful composition path (it needs a new gather-attachments-of-target engine primitive — `add-feature` territory), so it was swapped for *Reach the Horizon* to keep this a clean, composition-only cards PR.

## Testing

- A rules-engine scenario test per card (6 tests incl. Laughing Mad flashback-from-graveyard). All pass.
- `CardLintTest` passes.
- Card snapshot goldens for **FIN** and **RAV** re-blessed — the diff adds only the new cards; no other card moved.
- Full main + test compilation across all modules succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)