### PR TITLE
Add three Duskmourn Room cards (Dollmaker's Shop, Smoky Lounge, Dazzling Theater)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DazzlingTheaterPropRoom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DazzlingTheaterPropRoom.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeywordToOwnSpells
+import com.wingedsheep.sdk.scripting.UntapFilteredDuringOtherUntapSteps
+
+/**
+ * Dazzling Theater // Prop Room (DSK 3) — split-layout Room (CR 709.5).
+ *
+ * Dazzling Theater {3}{W} — Enchantment — Room
+ *   Creature spells you cast have convoke.
+ *
+ * Prop Room {2}{W} — Enchantment — Room
+ *   Untap each creature you control during each other player's untap step.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e). Each face's
+ * static ability only functions while that door is unlocked.
+ *
+ * Both halves reuse existing group statics: Dazzling Theater is [GrantKeywordToOwnSpells] with
+ * CONVOKE over the controller's creature spells (the same "Creature spells you cast have convoke"
+ * shape as Eirdu, Carrier of Dawn), and Prop Room is [UntapFilteredDuringOtherUntapSteps] over
+ * creatures (the Seedborn-Muse family, filtered to creatures, cf. Ivorytusk Fortress).
+ */
+val DazzlingTheaterPropRoom = card("Dazzling Theater // Prop Room") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "W"
+
+    face("Dazzling Theater") {
+        manaCost = "{3}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Creature spells you cast have convoke. (Your creatures can help cast those " +
+            "spells. Each creature you tap while casting a creature spell pays for {1} or one mana " +
+            "of that creature's color.)"
+
+        staticAbility {
+            ability = GrantKeywordToOwnSpells(
+                keyword = Keyword.CONVOKE,
+                spellFilter = Filters.Creature,
+            )
+        }
+    }
+
+    face("Prop Room") {
+        manaCost = "{2}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Untap each creature you control during each other player's untap step."
+
+        staticAbility {
+            ability = UntapFilteredDuringOtherUntapSteps(filter = Filters.Creature)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "3"
+        artist = "Henry Peters"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg?1770639004"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DollmakersShopPorcelainGallery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/DollmakersShopPorcelainGallery.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessDynamicStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Dollmaker's Shop // Porcelain Gallery (DSK 4) — split-layout Room (CR 709.5).
+ *
+ * Dollmaker's Shop {1}{W} — Enchantment — Room
+ *   Whenever one or more non-Toy creatures you control attack a player, create a 1/1 white Toy
+ *   artifact creature token.
+ *
+ * Porcelain Gallery {4}{W}{W} — Enchantment — Room
+ *   Creatures you control have base power and toughness each equal to the number of creatures you
+ *   control.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e). Each face's
+ * ability only functions while that door is unlocked — the engine gates a Room face's
+ * triggered/static abilities on its door state, so the Dollmaker's Shop attack trigger and the
+ * Porcelain Gallery lord both go live only once their door is open (cf. Painter's Studio //
+ * Defaced Gallery, Restricted Office // Lecture Hall).
+ *
+ * Porcelain Gallery is a Layer 7b base-P/T set ([SetBasePowerToughnessDynamicStatic]) over every
+ * creature you control, with the same single count — creatures you control — feeding both power and
+ * toughness (the count is recomputed continuously, so it grows as you add creatures and includes
+ * the affected creatures themselves and any tokens). Cf. Titania's Song for the group base-P/T set.
+ */
+val DollmakersShopPorcelainGallery = card("Dollmaker's Shop // Porcelain Gallery") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "W"
+
+    face("Dollmaker's Shop") {
+        manaCost = "{1}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Whenever one or more non-Toy creatures you control attack a player, create a " +
+            "1/1 white Toy artifact creature token."
+
+        triggeredAbility {
+            trigger = Triggers.YouAttackWithFilter(
+                GameObjectFilter.Creature.youControl().notSubtype(Subtype("Toy"))
+            )
+            effect = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Toy"),
+                artifactToken = true,
+                imageUri = "https://cards.scryfall.io/normal/front/5/e/5e6d479d-c30d-4048-b250-5233358a174c.jpg?1726236536",
+            )
+            description = "Whenever one or more non-Toy creatures you control attack a player, " +
+                "create a 1/1 white Toy artifact creature token."
+        }
+    }
+
+    face("Porcelain Gallery") {
+        manaCost = "{4}{W}{W}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Creatures you control have base power and toughness each equal to the number " +
+            "of creatures you control."
+
+        staticAbility {
+            ability = SetBasePowerToughnessDynamicStatic(
+                power = DynamicAmounts.creaturesYouControl(),
+                toughness = DynamicAmounts.creaturesYouControl(),
+                filter = GroupFilter.AllCreaturesYouControl,
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "4"
+        artist = "Chris Cold"
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg?1726867800"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SmokyLoungeMistySalon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/SmokyLoungeMistySalon.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Smoky Lounge // Misty Salon (DSK 235) — split-layout Room (CR 709.5).
+ *
+ * Smoky Lounge {2}{R} — Enchantment — Room
+ *   At the beginning of your first main phase, add {R}{R}. Spend this mana only to cast Room spells
+ *   and unlock doors.
+ *
+ * Misty Salon {3}{U} — Enchantment — Room
+ *   When you unlock this door, create an X/X blue Spirit creature token with flying, where X is the
+ *   number of unlocked doors among Rooms you control.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e). Each face's
+ * ability only functions while that door is unlocked.
+ *
+ * Smoky Lounge's restricted ritual is the existing [Effects.AddMana] with a
+ * [ManaRestriction.AnyOf] over "cast a Room spell" ([ManaRestriction.SubtypeSpellsOnly]) and
+ * "unlock a door" ([ManaRestriction.UnlockDoorOnly]) — the two ways the printed text lets you
+ * spend it. Misty Salon's token uses [Effects.CreateDynamicToken] with
+ * [DynamicAmounts.unlockedDoors] feeding both power and toughness; X is recomputed at resolution,
+ * so the Misty Salon door that triggered (now unlocked) is itself counted (CR 709.5).
+ */
+val SmokyLoungeMistySalon = card("Smoky Lounge // Misty Salon") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "UR"
+
+    face("Smoky Lounge") {
+        manaCost = "{2}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "At the beginning of your first main phase, add {R}{R}. Spend this mana only " +
+            "to cast Room spells and unlock doors."
+
+        triggeredAbility {
+            trigger = Triggers.FirstMainPhase
+            effect = Effects.AddMana(
+                color = Color.RED,
+                amount = 2,
+                restriction = ManaRestriction.AnyOf(
+                    listOf(
+                        ManaRestriction.SubtypeSpellsOnly(setOf("Room")),
+                        ManaRestriction.UnlockDoorOnly,
+                    )
+                ),
+            )
+            description = "At the beginning of your first main phase, add {R}{R}. Spend this mana " +
+                "only to cast Room spells and unlock doors."
+        }
+    }
+
+    face("Misty Salon") {
+        manaCost = "{3}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, create an X/X blue Spirit creature token with " +
+            "flying, where X is the number of unlocked doors among Rooms you control."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Effects.CreateDynamicToken(
+                dynamicPower = DynamicAmounts.unlockedDoors(),
+                dynamicToughness = DynamicAmounts.unlockedDoors(),
+                colors = setOf(Color.BLUE),
+                creatureTypes = setOf("Spirit"),
+                keywords = setOf(Keyword.FLYING),
+                imageUri = "https://cards.scryfall.io/normal/front/9/0/90f6d606-55ca-4431-ae61-5d4f05259403.jpg?1726236595",
+            )
+            description = "When you unlock this door, create an X/X blue Spirit creature token " +
+                "with flying, where X is the number of unlocked doors among Rooms you control."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "235"
+        artist = "Marco Gorlei"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg?1726780766"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -3086,6 +3086,54 @@
     ]
 }
 
+// Dazzling Theater // Prop Room
+{
+    "name": "Dazzling Theater // Prop Room",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "Creature spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting a creature spell pays for {1} or one mana of that creature's color.)\n//\nUntap each creature you control during each other player's untap step.",
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "RARE",
+        "artist": "Henry Peters",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8e2fae80-60af-44cf-95b4-177837435d1a.jpg?1770639004"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Dazzling Theater",
+            "manaCost": "{3}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Creature spells you cast have convoke. (Your creatures can help cast those spells. Each creature you tap while casting a creature spell pays for {1} or one mana of that creature's color.)",
+            "script": {
+                "staticAbilities": [
+                    {
+                        "type": "GrantKeywordToOwnSpells",
+                        "keyword": "CONVOKE"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Prop Room",
+            "manaCost": "{2}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Untap each creature you control during each other player's untap step.",
+            "script": {
+                "staticAbilities": [
+                    {
+                        "type": "UntapFilteredDuringOtherUntapSteps",
+                        "filter": "creature"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Defiant Survivor
 {
     "name": "Defiant Survivor",
@@ -3785,6 +3833,93 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Dollmaker's Shop // Porcelain Gallery
+{
+    "name": "Dollmaker's Shop // Porcelain Gallery",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "Whenever one or more non-Toy creatures you control attack a player, create a 1/1 white Toy artifact creature token.\n//\nCreatures you control have base power and toughness each equal to the number of creatures you control.",
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "MYTHIC",
+        "artist": "Chris Cold",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5ee6651-9946-4bae-b21e-6cf28fa77b13.jpg?1726867800"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Dollmaker's Shop",
+            "manaCost": "{1}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Whenever one or more non-Toy creatures you control attack a player, create a 1/1 white Toy artifact creature token.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": {
+                            "type": "YouAttackEvent",
+                            "attackerFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotSubtype",
+                                        "subtype": "Toy"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [
+                                "WHITE"
+                            ],
+                            "creatureTypes": [
+                                "Toy"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e6d479d-c30d-4048-b250-5233358a174c.jpg?1726236536",
+                            "artifactToken": true
+                        },
+                        "descriptionOverride": "Whenever one or more non-Toy creatures you control attack a player, create a 1/1 white Toy artifact creature token."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Porcelain Gallery",
+            "manaCost": "{4}{W}{W}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Creatures you control have base power and toughness each equal to the number of creatures you control.",
+            "script": {
+                "staticAbilities": [
+                    {
+                        "type": "SetBasePowerToughnessDynamicStatic",
+                        "power": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "creature"
+                        },
+                        "toughness": {
+                            "type": "AggregateBattlefield",
+                            "player": "You",
+                            "filter": "creature"
+                        },
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -15231,6 +15366,98 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Smoky Lounge // Misty Salon
+{
+    "name": "Smoky Lounge // Misty Salon",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "At the beginning of your first main phase, add {R}{R}. Spend this mana only to cast Room spells and unlock doors.\n//\nWhen you unlock this door, create an X/X blue Spirit creature token with flying, where X is the number of unlocked doors among Rooms you control.",
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "UNCOMMON",
+        "artist": "Marco Gorlei",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/4700987d-fc55-44eb-bc9f-0e0316ca65e2.jpg?1726780766"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Smoky Lounge",
+            "manaCost": "{2}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "At the beginning of your first main phase, add {R}{R}. Spend this mana only to cast Room spells and unlock doors.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": {
+                            "type": "StepEvent",
+                            "step": "PRECOMBAT_MAIN"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "AddMana",
+                            "color": "RED",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "restriction": {
+                                "type": "AnyOf",
+                                "restrictions": [
+                                    {
+                                        "type": "SubtypeSpellsOnly",
+                                        "subtypes": [
+                                            "Room"
+                                        ]
+                                    },
+                                    "UnlockDoorOnly"
+                                ]
+                            }
+                        },
+                        "descriptionOverride": "At the beginning of your first main phase, add {R}{R}. Spend this mana only to cast Room spells and unlock doors."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Misty Salon",
+            "manaCost": "{3}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, create an X/X blue Spirit creature token with flying, where X is the number of unlocked doors among Rooms you control.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "CreateToken",
+                            "power": 0,
+                            "toughness": 0,
+                            "colors": [
+                                "BLUE"
+                            ],
+                            "creatureTypes": [
+                                "Spirit"
+                            ],
+                            "keywords": [
+                                "FLYING"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/9/0/90f6d606-55ca-4431-ae61-5d4f05259403.jpg?1726236595",
+                            "dynamicPower": "UnlockedDoors",
+                            "dynamicToughness": "UnlockedDoors"
+                        },
+                        "descriptionOverride": "When you unlock this door, create an X/X blue Spirit creature token with flying, where X is the number of unlocked doors among Rooms you control."
+                    }
+                ]
+            }
+        }
     ]
 }
 


### PR DESCRIPTION
Implements three split-layout **Room** cards from *Duskmourn: House of Horror* (DSK 95% → was 18 missing, now 15). Each composes **only existing SDK primitives** — no new engine mechanics, no SDK/engine changes, purely additive card data.

## Cards

### Dollmaker's Shop // Porcelain Gallery (DSK 4, mythic)
- **Dollmaker's Shop** — `Triggers.YouAttackWithFilter` over non-Toy creatures you control (`GameObjectFilter.Creature.notSubtype("Toy")`), creating a 1/1 white **Toy** *artifact* creature token (`Effects.CreateToken(artifactToken = true)`).
- **Porcelain Gallery** — `SetBasePowerToughnessDynamicStatic` over `GroupFilter.AllCreaturesYouControl`, base P/T each = `DynamicAmounts.creaturesYouControl()` (same group base-P/T shape as Titania's Song).

### Smoky Lounge // Misty Salon (DSK 235, uncommon)
- **Smoky Lounge** — first-main-phase ritual: `Effects.AddMana({R}{R})` with `ManaRestriction.AnyOf(SubtypeSpellsOnly("Room"), UnlockDoorOnly)`.
- **Misty Salon** — on-unlock `Effects.CreateDynamicToken` X/X blue **Spirit** with flying, X = `DynamicAmounts.unlockedDoors()` (the door that just unlocked is counted).

### Dazzling Theater // Prop Room (DSK 3, rare)
- **Dazzling Theater** — `GrantKeywordToOwnSpells(CONVOKE)` over creature spells (same shape as Eirdu, Carrier of Dawn).
- **Prop Room** — `UntapFilteredDuringOtherUntapSteps(Filters.Creature)` (Seedborn Muse family, filtered to creatures, cf. Ivorytusk Fortress).

Each face's ability is automatically gated on its door being unlocked by the engine's existing Room machinery (cf. Painter's Studio // Defaced Gallery, Restricted Office // Lecture Hall).

## Testing
- `just build` — full project compiles, all module tests pass.
- `CardLintTest` (dataflow/target/slot) — pass.
- `CardDefinitionSnapshotTest` golden re-blessed: **227 insertions, 0 deletions** — only the three new cards added, no other card's tree changed.
- Canonical placement verified via `just check-card-printing` (DSK is each card's earliest real printing).
- No new effects/triggers/conditions introduced, so no new scenario tests required (Step 5); every primitive is already proven by its origin card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)