### PR TITLE
Add five Final Fantasy cards (Excalibur II, Ultros, Weapons Vendor, From Father to Son, Diamond Weapon)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DiamondWeapon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DiamondWeapon.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+
+/**
+ * Diamond Weapon
+ * {7}{G}{G}
+ * Legendary Artifact Creature — Elemental
+ * 8/8
+ * This spell costs {1} less to cast for each permanent card in your graveyard.
+ * Reach
+ * Immune — Prevent all combat damage that would be dealt to Diamond Weapon.
+ *
+ * Three existing primitives, no new mechanic:
+ *   - A self-cast [ModifySpellCost] reducing generic by [CostReductionSource]
+ *     `CardsInGraveyardMatchingFilter(Permanent)` — "{1} less for each permanent card in your
+ *     graveyard" (CR 601.2f cost reduction).
+ *   - [Keyword.REACH].
+ *   - A continuous [PreventDamage] replacement (CR 615) scoped to combat damage
+ *     ([DamageType.Combat]) dealt to itself ([RecipientFilter.Self]). Per Scryfall ruling this
+ *     prevention isn't considered while a trampling attacker it blocks assigns lethal damage
+ *     (CR 510.1c handles that at assignment time, before the replacement applies).
+ */
+val DiamondWeapon = card("Diamond Weapon") {
+    manaCost = "{7}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Artifact Creature — Elemental"
+    power = 8
+    toughness = 8
+    oracleText = "This spell costs {1} less to cast for each permanent card in your graveyard.\n" +
+        "Reach\n" +
+        "Immune — Prevent all combat damage that would be dealt to Diamond Weapon."
+
+    keywords(Keyword.REACH)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.CardsInGraveyardMatchingFilter(GameObjectFilter.Permanent)
+            )
+        )
+    }
+
+    replacementEffect(
+        PreventDamage(
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.Self,
+                damageType = DamageType.Combat
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "183"
+        artist = "Esuthio"
+        flavorText = "A tutelary creature said only to appear when the planet is in grave danger."
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6ce7f494-2a19-4b11-94d4-fc5e5a7068bd.jpg?1748706442"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ExcaliburII.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ExcaliburII.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Excalibur II
+ * {1}
+ * Legendary Artifact — Equipment
+ * Whenever you gain life, put a charge counter on Excalibur II.
+ * Equipped creature gets +1/+1 for each charge counter on Excalibur II.
+ * Equip {3}
+ *
+ * Composed from existing primitives — the Withering Hex shape (an attachment whose grant
+ * scales with counters on the attachment itself), inverted to a positive buff:
+ *   - A [Triggers.YouGainLife] trigger adds a charge counter to the Equipment
+ *     ([EffectTarget.Self]). Per Scryfall rulings, each life-gaining *event* triggers this
+ *     once regardless of how much life it represents, which is exactly how YouGainLife fires.
+ *   - A [GrantDynamicStatsEffect] (Layer 7c bonus) on [GroupFilter.attachedCreature] reads
+ *     the live charge-counter count off the source via
+ *     [EntityReference.Source] + [EntityNumericProperty.CounterCount], so the bonus tracks
+ *     the counter total continuously.
+ */
+val ExcaliburII = card("Excalibur II") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Whenever you gain life, put a charge counter on Excalibur II.\n" +
+        "Equipped creature gets +1/+1 for each charge counter on Excalibur II.\n" +
+        "Equip {3}"
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = AddCountersEffect(Counters.CHARGE, 1, EffectTarget.Self)
+    }
+
+    staticAbility {
+        val chargeCounters = DynamicAmount.EntityProperty(
+            EntityReference.Source,
+            EntityNumericProperty.CounterCount(CounterTypeFilter.Named(Counters.CHARGE))
+        )
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = chargeCounters,
+            toughnessBonus = chargeCounters
+        )
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "257"
+        artist = "Russell Dongjun Lu"
+        flavorText = "The ultimate sword, used by a legendary king. It was forged in another world."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d42e5fed-67ac-46d7-a5d4-78f661f3e8b4.jpg?1748706751"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FromFatherToSon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FromFatherToSon.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasCastFromZone
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * From Father to Son
+ * {1}{W}
+ * Sorcery
+ * Search your library for a Vehicle card, reveal it, and put it into your hand. If this spell
+ *   was cast from a graveyard, put that card onto the battlefield instead. Then shuffle.
+ * Flashback {4}{W}{W}{W}
+ *
+ * A Gather → Select → Move tutor whose *destination* is chosen at resolution by where the spell
+ * was cast from. The only flashback-legal way to cast this from the graveyard is its own
+ * flashback cost, so [WasCastFromZone] (GRAVEYARD) cleanly distinguishes the two printed
+ * destinations: the found card goes to the battlefield on a graveyard cast, otherwise to hand.
+ * Both branches reveal the card (the move's `revealed` flag) and the shuffle happens after,
+ * matching "Then shuffle." "Search for ... a card" is a may-find tutor, so the selection is
+ * [SelectionMode.ChooseUpTo] 1 (you may fail to find).
+ */
+val FromFatherToSon = card("From Father to Son") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Search your library for a Vehicle card, reveal it, and put it into your hand. " +
+        "If this spell was cast from a graveyard, put that card onto the battlefield instead. Then shuffle.\n" +
+        "Flashback {4}{W}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    zone = Zone.LIBRARY,
+                    player = Player.You,
+                    filter = GameObjectFilter.Artifact.withSubtype(Subtype.VEHICLE)
+                ),
+                storeAs = "searchable"
+            ),
+            SelectFromCollectionEffect(
+                from = "searchable",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "found",
+                prompt = "Search for a Vehicle card",
+                selectedLabel = "Reveal it",
+            ),
+            ConditionalEffect(
+                condition = WasCastFromZone(Zone.GRAVEYARD),
+                effect = MoveCollectionEffect(
+                    from = "found",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+                    revealed = true
+                ),
+                elseEffect = MoveCollectionEffect(
+                    from = "found",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                )
+            ),
+            ShuffleLibraryEffect()
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{4}{W}{W}{W}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "20"
+        artist = "Jeremy Chong"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c730a3b-334e-466b-bb9b-4b41fce2af6d.jpg?1748705832"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/UltrosObnoxiousOctopus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/UltrosObnoxiousOctopus.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ultros, Obnoxious Octopus
+ * {1}{U}
+ * Legendary Creature — Octopus
+ * 2/1
+ * Whenever you cast a noncreature spell, if at least four mana was spent to cast it, tap
+ *   target creature an opponent controls and put a stun counter on it.
+ * Whenever you cast a noncreature spell, if at least eight mana was spent to cast it, put
+ *   eight +1/+1 counters on Ultros.
+ *
+ * Two independent cast triggers, each an intervening-"if" on the mana actually paid for the
+ * triggering spell ([Conditions.TriggeringSpellManaSpentAtLeast] — same primitive as Sahagin,
+ * so an {X} spell paying the threshold qualifies while a lower-cost spell with a high mana
+ * value does not). Both can fire off one eight-mana spell. Per Scryfall ruling, each ability
+ * resolves before the triggering spell, and still resolves even if that spell is countered.
+ *   - ≥4: tap [Targets.CreatureOpponentControls] and add a stun counter (CR 122 / 701 stun).
+ *   - ≥8: add eight +1/+1 counters to Ultros ([EffectTarget.Self]); non-targeting.
+ */
+val UltrosObnoxiousOctopus = card("Ultros, Obnoxious Octopus") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Octopus"
+    power = 2
+    toughness = 1
+    oracleText = "Whenever you cast a noncreature spell, if at least four mana was spent to cast it, " +
+        "tap target creature an opponent controls and put a stun counter on it. (If a permanent with " +
+        "a stun counter would become untapped, remove one from it instead.)\n" +
+        "Whenever you cast a noncreature spell, if at least eight mana was spent to cast it, put eight " +
+        "+1/+1 counters on Ultros."
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        triggerCondition = Conditions.TriggeringSpellManaSpentAtLeast(4)
+        val t = target("target", Targets.CreatureOpponentControls)
+        effect = Effects.Composite(
+            Effects.Tap(t),
+            Effects.AddCounters(Counters.STUN, 1, t),
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        triggerCondition = Conditions.TriggeringSpellManaSpentAtLeast(8)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 8, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Domenico Cava"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14379198-9a0a-4853-9d51-fb074a24b1c0.jpg?1748706073"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/WeaponsVendor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/WeaponsVendor.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Weapons Vendor
+ * {3}{W}
+ * Creature — Human Artificer
+ * 2/2
+ * When this creature enters, draw a card.
+ * At the beginning of combat on your turn, if you control an Equipment, you may pay {1}. When
+ *   you do, attach target Equipment you control to target creature you control.
+ *
+ * The combat ability is the Spellbook Vendor shape: an intervening-"if" gates the trigger on
+ * controlling an Equipment, then [MayPayManaEffect] models the optional {1} payment whose
+ * "when you do" reflexive ability chooses its targets as it goes on the stack (Scryfall
+ * ruling). The reflexive payoff reuses [Effects.AttachTargetEquipmentToCreature], moving the
+ * chosen Equipment onto the chosen creature.
+ */
+val WeaponsVendor = card("Weapons Vendor") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Artificer"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, draw a card.\n" +
+        "At the beginning of combat on your turn, if you control an Equipment, you may pay {1}. " +
+        "When you do, attach target Equipment you control to target creature you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.YouControl(
+            GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT)
+        )
+        val equipment = target(
+            "target Equipment you control",
+            TargetPermanent(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).youControl()
+                )
+            )
+        )
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.AttachTargetEquipmentToCreature(equipment, creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "40"
+        artist = "Mushk Rizvi"
+        flavorText = "\"Man in your line of work needs weapons, no? Why not try that one on for size?\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9e6b374-3e44-4df7-b0a3-4ef98dc08267.jpg?1748705905"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -3579,6 +3579,56 @@
     ]
 }
 
+// Diamond Weapon
+{
+    "name": "Diamond Weapon",
+    "manaCost": "{7}{G}{G}",
+    "typeLine": "Legendary Artifact Creature — Elemental",
+    "oracleText": "This spell costs {1} less to cast for each permanent card in your graveyard.\nReach\nImmune — Prevent all combat damage that would be dealt to Diamond Weapon.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "CardsInGraveyardMatchingFilter",
+                        "filter": "permanent"
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "PreventDamage",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "RecipientSelf",
+                    "damageType": "DamageCombat"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "UNCOMMON",
+        "artist": "Esuthio",
+        "flavorText": "A tutelary creature said only to appear when the planet is in grave danger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6ce7f494-2a19-4b11-94d4-fc5e5a7068bd.jpg?1748706442"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Dragoon's Lance
 {
     "name": "Dragoon's Lance",
@@ -4036,6 +4086,99 @@
     ]
 }
 
+// Excalibur II
+{
+    "name": "Excalibur II",
+    "manaCost": "{1}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Whenever you gain life, put a charge counter on Excalibur II.\nEquipped creature gets +1/+1 for each charge counter on Excalibur II.\nEquip {3}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "charge",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": {
+                        "type": "CounterCount",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "charge"
+                        }
+                    }
+                },
+                "toughnessBonus": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": {
+                        "type": "CounterCount",
+                        "counterType": {
+                            "type": "Named",
+                            "name": "charge"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "257",
+        "rarity": "RARE",
+        "artist": "Russell Dongjun Lu",
+        "flavorText": "The ultimate sword, used by a legendary king. It was forged in another world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d42e5fed-67ac-46d7-a5d4-78f661f3e8b4.jpg?1748706751"
+    },
+    "colorIdentityOverride": []
+}
+
 // Fang, Fearless l'Cie
 {
     "name": "Fang, Fearless l'Cie",
@@ -4265,6 +4408,91 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// From Father to Son
+{
+    "name": "From Father to Son",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Search your library for a Vehicle card, reveal it, and put it into your hand. If this spell was cast from a graveyard, put that card onto the battlefield instead. Then shuffle.\nFlashback {4}{W}{W}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{4}{W}{W}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Library",
+                        "filter": "artifact Vehicle"
+                    },
+                    "storeAs": "searchable"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "searchable",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "storeSelected": "found",
+                    "prompt": "Search for a Vehicle card",
+                    "selectedLabel": "Reveal it"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "WasCastFromZone",
+                            "zone": "Graveyard"
+                        }
+                    },
+                    "then": {
+                        "type": "MoveCollection",
+                        "from": "found",
+                        "destination": {
+                            "type": "ToZone",
+                            "zone": "Battlefield"
+                        },
+                        "revealed": true
+                    },
+                    "otherwise": {
+                        "type": "MoveCollection",
+                        "from": "found",
+                        "destination": {
+                            "type": "ToZone",
+                            "zone": "Hand"
+                        },
+                        "revealed": true
+                    }
+                },
+                "ShuffleLibrary"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "RARE",
+        "artist": "Jeremy Chong",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c730a3b-334e-466b-bb9b-4b41fce2af6d.jpg?1748705832"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -13218,6 +13446,97 @@
     ]
 }
 
+// Ultros, Obnoxious Octopus
+{
+    "name": "Ultros, Obnoxious Octopus",
+    "manaCost": "{1}{U}",
+    "typeLine": "Legendary Creature — Octopus",
+    "oracleText": "Whenever you cast a noncreature spell, if at least four mana was spent to cast it, tap target creature an opponent controls and put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)\nWhenever you cast a noncreature spell, if at least eight mana was spent to cast it, put eight +1/+1 counters on Ultros.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "target"
+                },
+                "triggerCondition": {
+                    "type": "TriggeringSpellManaSpentAtLeast",
+                    "amount": 4
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 8,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "TriggeringSpellManaSpentAtLeast",
+                    "amount": 8
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Domenico Cava",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14379198-9a0a-4853-9d51-fb074a24b1c0.jpg?1748706073"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Undercity Dire Rat
 {
     "name": "Undercity Dire Rat",
@@ -13715,6 +14034,96 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Weapons Vendor
+{
+    "name": "Weapons Vendor",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "When this creature enters, draw a card.\nAt the beginning of combat on your turn, if you control an Equipment, you may pay {1}. When you do, attach target Equipment you control to target creature you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "AttachTargetEquipmentToCreature",
+                        "equipmentTarget": {
+                            "type": "BoundVariable",
+                            "name": "target Equipment you control"
+                        },
+                        "creatureTarget": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "artifact Equipment ctrl:you"
+                    },
+                    "id": "target Equipment you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "artifact Equipment"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "artist": "Mushk Rizvi",
+        "flavorText": "\"Man in your line of work needs weapons, no? Why not try that one on for size?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9e6b374-3e44-4df7-b0a3-4ef98dc08267.jpg?1748705905"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -678,6 +678,7 @@ class CostCalculator(
             is CardPredicate.IsLand -> cardDef.typeLine.isLand
             is CardPredicate.IsInstant -> cardDef.typeLine.isInstant
             is CardPredicate.IsSorcery -> cardDef.typeLine.isSorcery
+            is CardPredicate.IsPermanent -> cardDef.typeLine.isPermanent
             is CardPredicate.HasSubtype -> predicate.subtype in cardDef.typeLine.subtypes
             is CardPredicate.Or -> predicate.predicates.any { matchesGraveyardPredicate(cardDef, it) }
             is CardPredicate.And -> predicate.predicates.all { matchesGraveyardPredicate(cardDef, it) }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiamondWeaponScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiamondWeaponScenarioTest.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Diamond Weapon (FIN #183).
+ *
+ * Diamond Weapon {7}{G}{G} Legendary Artifact Creature — Elemental 8/8
+ * This spell costs {1} less to cast for each permanent card in your graveyard.
+ * Reach
+ * Immune — Prevent all combat damage that would be dealt to Diamond Weapon.
+ *
+ * Verifies the graveyard cost reduction: with three permanent cards in the graveyard, the
+ * {7}{G}{G} (9 mana) spell is castable off only six lands. (The combat-damage prevention uses
+ * the same self-recipient PreventDamage replacement proven by Argothian Treefolk.)
+ */
+class DiamondWeaponScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("costs {1} less for each permanent card in the graveyard") {
+            val game = scenario()
+                .withPlayers()
+                // Three permanent (creature) cards in the graveyard -> {3} reduction.
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withCardInGraveyard(1, "Hill Giant")
+                .withCardInGraveyard(1, "Cargo Ship")
+                .withCardInHand(1, "Diamond Weapon")
+                // Only six lands: enough for the reduced {4}{G}{G}, far short of the full {7}{G}{G}.
+                .withLandsOnBattlefield(1, "Forest", 6)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cast = game.castSpell(1, "Diamond Weapon")
+            withClue("Diamond Weapon should be castable off six lands thanks to the {3} reduction: ${cast.error}") {
+                cast.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("Diamond Weapon resolves onto the battlefield") {
+                game.isOnBattlefield("Diamond Weapon") shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExcaliburIIScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExcaliburIIScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Excalibur II (FIN #257).
+ *
+ * Excalibur II {1} Legendary Artifact — Equipment
+ * Whenever you gain life, put a charge counter on Excalibur II.
+ * Equipped creature gets +1/+1 for each charge counter on Excalibur II.
+ * Equip {3}
+ *
+ * Verifies the life-gain → charge-counter trigger and the dynamic equipped-creature buff
+ * scaling with the source's charge-counter count (one charge counter per life-gain *event*,
+ * regardless of amount — Scryfall ruling).
+ */
+class ExcaliburIIScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    private val equipAbilityId by lazy {
+        cardRegistry.requireCard("Excalibur II").activatedAbilities[0].id
+    }
+
+    init {
+        // A simple "gain 3 life" instant to produce a single life-gain event.
+        cardRegistry.register(
+            CardDefinition.instant(
+                name = "Test Healing Light",
+                manaCost = ManaCost.parse("{W}"),
+                oracleText = "You gain 3 life.",
+                script = CardScript(spellEffect = Effects.GainLife(3))
+            )
+        )
+
+        test("gaining life adds one charge counter and scales the equipped creature's stats") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 base
+                .withCardOnBattlefield(1, "Excalibur II")
+                .withLandsOnBattlefield(1, "Plains", 4)     // Equip {3} + cast {W}
+                .withCardInHand(1, "Test Healing Light")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val excalibur = game.findPermanent("Excalibur II")!!
+
+            // Equip Excalibur II onto Grizzly Bears.
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = excalibur,
+                    abilityId = equipAbilityId,
+                    targets = listOf(ChosenTarget.Permanent(bears))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            // Zero charge counters → no bonus yet.
+            withClue("Equipped Bears with 0 charge counters should be a vanilla 2/2") {
+                stateProjector.project(game.state).getPower(bears) shouldBe 2
+                stateProjector.project(game.state).getToughness(bears) shouldBe 2
+            }
+
+            // Gain 3 life as a single event.
+            game.castSpell(1, "Test Healing Light").error shouldBe null
+            game.resolveStack()
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+
+            val charges = game.state.getEntity(excalibur)
+                ?.get<CountersComponent>()?.getCount(CounterType.CHARGE) ?: 0
+            withClue("One life-gain event adds exactly one charge counter regardless of amount") {
+                charges shouldBe 1
+            }
+            withClue("Equipped Bears should now be 3/3 (2/2 + one charge counter)") {
+                stateProjector.project(game.state).getPower(bears) shouldBe 3
+                stateProjector.project(game.state).getToughness(bears) shouldBe 3
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FromFatherToSonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FromFatherToSonScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for From Father to Son (FIN #20).
+ *
+ * From Father to Son {1}{W} Sorcery
+ * Search your library for a Vehicle card, reveal it, and put it into your hand. If this spell
+ * was cast from a graveyard, put that card onto the battlefield instead. Then shuffle.
+ * Flashback {4}{W}{W}{W}
+ *
+ * The destination is chosen at resolution by where the spell was cast from
+ * ([com.wingedsheep.sdk.scripting.conditions.WasCastFromZone] GRAVEYARD): hand on a normal cast,
+ * battlefield on a flashback (graveyard) cast.
+ */
+class FromFatherToSonScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("cast from hand puts the found Vehicle into hand") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInHand(1, "From Father to Son")
+                .withLandsOnBattlefield(1, "Plains", 2) // {1}{W}
+                .withCardInLibrary(1, "Cargo Ship")     // a Vehicle to find
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cargoShip = game.findCardsInLibrary(1, "Cargo Ship").single()
+
+            game.castSpell(1, "From Father to Son").error shouldBe null
+            game.resolveStack()
+            withClue("Search should pause to choose a Vehicle") {
+                game.hasPendingDecision() shouldBe true
+            }
+            game.selectCards(listOf(cargoShip))
+            game.resolveStack()
+
+            withClue("Found Vehicle goes to hand on a normal cast") {
+                game.isInHand(1, "Cargo Ship") shouldBe true
+                game.isOnBattlefield("Cargo Ship") shouldBe false
+            }
+        }
+
+        test("cast from graveyard via flashback puts the found Vehicle onto the battlefield") {
+            val game = scenario()
+                .withPlayers()
+                .withCardInGraveyard(1, "From Father to Son")
+                .withLandsOnBattlefield(1, "Plains", 7) // Flashback {4}{W}{W}{W}
+                .withCardInLibrary(1, "Cargo Ship")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cargoShip = game.findCardsInLibrary(1, "Cargo Ship").single()
+
+            game.castSpellFromGraveyard(1, "From Father to Son").error shouldBe null
+            game.resolveStack()
+            withClue("Search should pause to choose a Vehicle") {
+                game.hasPendingDecision() shouldBe true
+            }
+            game.selectCards(listOf(cargoShip))
+            game.resolveStack()
+
+            withClue("Found Vehicle enters the battlefield on a graveyard (flashback) cast") {
+                game.isOnBattlefield("Cargo Ship") shouldBe true
+                game.isInHand(1, "Cargo Ship") shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UltrosObnoxiousOctopusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UltrosObnoxiousOctopusScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Ultros, Obnoxious Octopus (FIN #83).
+ *
+ * Ultros {1}{U} Legendary Creature — Octopus 2/1
+ * Whenever you cast a noncreature spell, if at least four mana was spent to cast it, tap target
+ *   creature an opponent controls and put a stun counter on it.
+ * Whenever you cast a noncreature spell, if at least eight mana was spent to cast it, put eight
+ *   +1/+1 counters on Ultros.
+ *
+ * Both abilities are intervening-"if"s on mana actually spent. The ≥8 ability is isolated by
+ * casting with no opponent creature in play, so the ≥4 ability finds no legal target and is
+ * never put on the stack — leaving only the +1/+1 payoff to resolve.
+ */
+class UltrosObnoxiousOctopusScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        cardRegistry.register(
+            CardDefinition.sorcery(
+                name = "Test Four Drop",
+                manaCost = ManaCost.parse("{4}"),
+                oracleText = "You gain 1 life.",
+                script = CardScript(spellEffect = Effects.GainLife(1))
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.sorcery(
+                name = "Test Eight Drop",
+                manaCost = ManaCost.parse("{8}"),
+                oracleText = "You gain 1 life.",
+                script = CardScript(spellEffect = Effects.GainLife(1))
+            )
+        )
+
+        test("a four-mana noncreature spell taps and stuns an opponent creature, no +1/+1 counters") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Ultros, Obnoxious Octopus")
+                .withCardOnBattlefield(2, "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 4)
+                .withCardInHand(1, "Test Four Drop")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ultros = game.findPermanent("Ultros, Obnoxious Octopus")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.castSpell(1, "Test Four Drop").error shouldBe null
+            game.resolveStack()
+            withClue("The ≥4 ability should pause to choose its opponent-creature target") {
+                game.hasPendingDecision() shouldBe true
+            }
+            game.selectTargets(listOf(bears))
+            game.resolveStack()
+
+            withClue("Opponent's Grizzly Bears is tapped") {
+                game.state.getEntity(bears)!!.has<TappedComponent>() shouldBe true
+            }
+            withClue("Opponent's Grizzly Bears has a stun counter") {
+                (game.state.getEntity(bears)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0) shouldBe 1
+            }
+            withClue("Four mana is below the eight-mana threshold — no +1/+1 counters on Ultros") {
+                stateProjector.project(game.state).getPower(ultros) shouldBe 2
+            }
+        }
+
+        test("an eight-mana noncreature spell puts eight +1/+1 counters on Ultros") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Ultros, Obnoxious Octopus")
+                .withLandsOnBattlefield(1, "Island", 8)
+                .withCardInHand(1, "Test Eight Drop")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val ultros = game.findPermanent("Ultros, Obnoxious Octopus")!!
+
+            // No opponent creature exists, so the ≥4 "tap target" ability has no legal target and
+            // is not put on the stack. Only the ≥8 ability resolves.
+            game.castSpell(1, "Test Eight Drop").error shouldBe null
+            game.resolveStack()
+            if (game.state.stack.isNotEmpty()) game.resolveStack()
+
+            withClue("Eight +1/+1 counters land on Ultros (2/1 -> 10/9)") {
+                (game.state.getEntity(ultros)?.get<CountersComponent>()
+                    ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 8
+                stateProjector.project(game.state).getPower(ultros) shouldBe 10
+                stateProjector.project(game.state).getToughness(ultros) shouldBe 9
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeaponsVendorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeaponsVendorScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Weapons Vendor (FIN #40).
+ *
+ * Weapons Vendor {3}{W} Creature — Human Artificer 2/2
+ * When this creature enters, draw a card.
+ * At the beginning of combat on your turn, if you control an Equipment, you may pay {1}. When
+ * you do, attach target Equipment you control to target creature you control.
+ *
+ * Verifies the begin-combat reflexive may-pay: paying {1} fires the "when you do" reflexive
+ * ability which attaches the chosen Equipment to the chosen creature (Scryfall ruling — targets
+ * chosen as the reflexive ability goes on the stack).
+ */
+class WeaponsVendorScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        test("paying {1} at combat attaches a controlled Equipment to a controlled creature") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Weapons Vendor")
+                .withCardOnBattlefield(1, "Buster Sword")   // an Equipment to move (+3/+2)
+                .withCardOnBattlefield(1, "Grizzly Bears")   // 2/2 to receive it
+                .withLandsOnBattlefield(1, "Plains", 1)      // pays the {1}
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val sword = game.findPermanent("Buster Sword")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            // Step into begin-of-combat; the trigger goes on the stack (no target of its own).
+            game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+            game.resolveStack()
+
+            withClue("the begin-combat ability offers the may-pay {1}") {
+                (game.getPendingDecision() is YesNoDecision) shouldBe true
+            }
+            game.answerYesNo(true).error shouldBe null
+            withClue("paying then asks which mana sources to use") {
+                (game.getPendingDecision() is SelectManaSourcesDecision) shouldBe true
+            }
+            game.submitManaSourcesAutoPay().error shouldBe null
+
+            // The reflexive "when you do" ability now chooses its two targets:
+            // slot 0 = Equipment, slot 1 = creature.
+            withClue("reflexive ability pauses to choose Equipment + creature targets") {
+                game.hasPendingDecision() shouldBe true
+            }
+            val td = game.getPendingDecision()!!
+            game.submitDecision(TargetsResponse(td.id, mapOf(0 to listOf(sword), 1 to listOf(bears))))
+            game.resolveStack()
+
+            withClue("Buster Sword is now attached to Grizzly Bears (2/2 + 3/+2 = 5/4)") {
+                stateProjector.project(game.state).getPower(bears) shouldBe 5
+                stateProjector.project(game.state).getToughness(bears) shouldBe 4
+            }
+        }
+    }
+}


### PR DESCRIPTION
A handful of Final Fantasy (FIN) cards, each composed from **existing** SDK primitives — no new effects, triggers, conditions, or keywords. Brings FIN from 190 → 195 implemented.

## Cards

| Card | Cost | What it does | Built from |
|------|------|--------------|------------|
| **Excalibur II** | {1} | Legendary Equipment. Whenever you gain life, put a charge counter on it; equipped creature gets +1/+1 per charge counter. Equip {3} | `YouGainLife` trigger + `GrantDynamicStatsEffect` reading `EntityProperty(Source, CounterCount(CHARGE))` — the Withering Hex shape, inverted to a positive buff |
| **Ultros, Obnoxious Octopus** | {1}{U} | 2/1. Two "cast a noncreature spell" triggers: ≥4 mana spent → tap + stun an opponent's creature; ≥8 mana → eight +1/+1 counters on Ultros | `Triggers.YouCastNoncreature` + `Conditions.TriggeringSpellManaSpentAtLeast` (the Sahagin primitive) |
| **Weapons Vendor** | {3}{W} | 2/2. ETB draw; at combat, if you control an Equipment, may pay {1} to attach a controlled Equipment to a controlled creature | `MayPayManaEffect` reflexive + `AttachTargetEquipmentToCreature` — the Spellbook Vendor shape |
| **From Father to Son** | {1}{W} | Sorcery. Tutor a Vehicle to hand; if cast from a graveyard, onto the battlefield instead. Flashback {4}{W}{W}{W} | Gather→Select→Move with a `ConditionalEffect(WasCastFromZone(GRAVEYARD))` destination branch |
| **Diamond Weapon** | {7}{G}{G} | 8/8 Reach. Costs {1} less per permanent card in your graveyard; prevents all combat damage dealt to itself | `ModifySpellCost` + `CardsInGraveyardMatchingFilter(Permanent)` + a self-recipient combat-only `PreventDamage` (the Argothian Treefolk mechanism) |

## Engine fix

`CostCalculator.matchesGraveyardPredicate` fell through to `false` for `CardPredicate.IsPermanent`, so `CardsInGraveyardMatchingFilter(Permanent)` ("costs {1} less for each permanent card in your graveyard") counted zero. The projected/battlefield matcher already handled `IsPermanent`; this mirrors that single branch for the graveyard path. Diamond Weapon is the first card to exercise it.

## Tests

- A scenario test per card (`rules-engine` Kotest): counter scaling, the ≥4/≥8 mana thresholds, the reflexive attach, both tutor destinations, and the graveyard cost reduction.
- `CardDefinitionSnapshotTest` golden re-blessed (only the five new card trees added).
- Full `:rules-engine:test` and `:mtg-sets:test` suites green (`CardLintTest` included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)