### PR TITLE
Hide sign-in UI when the server has accounts disabled

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/SpaWebConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/SpaWebConfig.kt
@@ -24,6 +24,13 @@ class SpaWebConfig : WebMvcConfigurer {
             .resourceChain(true)
             .addResolver(object : PathResourceResolver() {
                 override fun getResource(resourcePath: String, location: Resource): Resource? {
+                    // Never SPA-fallback API/WebSocket paths: an unmatched `/api/**` route must 404
+                    // rather than return the HTML shell. A disabled subsystem (e.g. accounts) leaves
+                    // its endpoints unmounted, and a JSON client choking on index.html — or getting a
+                    // confusing 405 on POST — is exactly the bug this avoids. Returning null yields 404.
+                    if (resourcePath.startsWith("api/") || resourcePath.startsWith("game/")) {
+                        return null
+                    }
                     val requested = location.createRelative(resourcePath)
                     return if (requested.exists() && requested.isReadable) {
                         requested

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/ConfigController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/ConfigController.kt
@@ -1,0 +1,28 @@
+package com.wingedsheep.gameserver.controller
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Always-mounted client bootstrap config. Lets the web client learn which optional subsystems the
+ * server actually runs, so it can hide UI for features that aren't available.
+ *
+ * Unlike [AuthController] / [AccountDeckController] / [AccountStatsController], this is deliberately
+ * NOT gated on `accounts.enabled` — that's the whole point: the client needs an answer even when
+ * accounts are off, otherwise it shows a magic-link sign-in form that can only fail (the request
+ * falls through to the SPA resource handler and 404s/405s).
+ *
+ *  - GET /api/config → { accountsEnabled }
+ */
+@RestController
+@RequestMapping("/api/config")
+class ConfigController(
+    @Value("\${accounts.enabled:false}") private val accountsEnabled: Boolean,
+) {
+    data class AppConfig(val accountsEnabled: Boolean)
+
+    @GetMapping
+    fun config(): AppConfig = AppConfig(accountsEnabled)
+}

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -1,7 +1,8 @@
 /**
  * REST client for the optional accounts subsystem: magic-link auth, server-side saved decks, and
- * win/loss stats. All endpoints 404 when the server has accounts disabled — callers should treat
- * failures gracefully (the UI hides account features until {@link fetchMe} succeeds).
+ * win/loss stats. The account endpoints aren't mounted when the server has accounts disabled, so the
+ * client first asks {@link fetchAppConfig} whether accounts exist and hides all account UI when they
+ * don't; the individual calls still fail gracefully as a backstop.
  *
  * The auth token (a signed token from magic-link login) lives in localStorage under `argentum-auth`
  * and is sent as `Authorization: Bearer <token>` on authenticated calls. It is also picked up by the
@@ -43,6 +44,29 @@ export interface AccountUser {
 export interface LoginResponse {
   readonly authToken: string
   readonly user: AccountUser
+}
+
+// ----- App config -----
+
+/** Client bootstrap config from the always-mounted `/api/config` endpoint. */
+export interface AppConfig {
+  /** True when the server runs the optional accounts/magic-link subsystem. */
+  readonly accountsEnabled: boolean
+}
+
+/**
+ * Fetch server feature availability. Used on startup to decide whether to show the accounts/sign-in
+ * UI at all — on a server with accounts disabled the auth endpoints don't exist, so showing a
+ * sign-in form would only produce a confusing error. Fails closed (accounts hidden) on any error.
+ */
+export async function fetchAppConfig(): Promise<AppConfig> {
+  try {
+    const res = await fetch('/api/config')
+    if (!res.ok) return { accountsEnabled: false }
+    return (await res.json()) as AppConfig
+  } catch {
+    return { accountsEnabled: false }
+  }
 }
 
 // ----- Auth -----

--- a/web-client/src/components/auth/AuthWidget.module.css
+++ b/web-client/src/components/auth/AuthWidget.module.css
@@ -1,0 +1,102 @@
+/**
+ * Landing-screen account widget. Anchored top-right (top-left is the fullscreen control). Frosted
+ * pills matching the app's other overlay controls, kept visually distinct from the navigation row.
+ */
+.widget {
+  position: fixed;
+  top: var(--space-3);
+  right: var(--space-3);
+  z-index: var(--z-controls);
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-2);
+}
+
+@media (max-width: 639px) {
+  .widget {
+    top: var(--space-2);
+    right: var(--space-2);
+    gap: var(--space-1);
+  }
+}
+
+/* Shared frosted-pill base for every control in the widget. */
+.identity,
+.login,
+.logout {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  cursor: pointer;
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+/* Signed-in identity: a small status dot + a two-line "Signed in as / Name" label. */
+.identity {
+  padding: var(--space-1) var(--space-3);
+  text-align: left;
+}
+
+.identity:hover {
+  background-color: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--color-success-light);
+  box-shadow: 0 0 6px var(--color-success-light);
+  flex-shrink: 0;
+}
+
+.labels {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.15;
+}
+
+.muted {
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+}
+
+.name {
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.logout {
+  padding: var(--space-2) var(--space-3);
+}
+
+.logout:hover {
+  background-color: rgba(255, 68, 68, 0.16);
+  border-color: rgba(255, 68, 68, 0.4);
+  color: var(--text-primary);
+}
+
+/* Anonymous: a single inviting "Log in" pill in the accent color. */
+.login {
+  padding: var(--space-2) var(--space-4);
+  background-color: var(--color-accent-dark);
+  border-color: var(--color-accent);
+  color: #fff;
+  font-weight: var(--font-weight-semibold);
+}
+
+.login:hover {
+  background-color: var(--color-accent);
+}

--- a/web-client/src/components/auth/AuthWidget.tsx
+++ b/web-client/src/components/auth/AuthWidget.tsx
@@ -1,0 +1,55 @@
+/**
+ * Account presence widget for the landing screen — deliberately separate from the navigation
+ * buttons so the sign-in state reads as a distinct, persistent affordance. Anchored top-right.
+ *
+ *  - signed in  → "Signed in as <name>" (opens the profile) + a Log out action
+ *  - anonymous  → a single Log in button that opens the magic-link modal
+ *
+ * Renders nothing when the server has accounts disabled, so a no-accounts deployment shows no
+ * sign-in UI at all (the whole point — a login form there can only fail).
+ */
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { LoginModal } from '@/components/auth/LoginModal'
+import { useAuthStore } from '@/store/authStore'
+import styles from './AuthWidget.module.css'
+
+export function AuthWidget() {
+  const navigate = useNavigate()
+  const accountsEnabled = useAuthStore((s) => s.accountsEnabled)
+  const status = useAuthStore((s) => s.status)
+  const user = useAuthStore((s) => s.user)
+  const logout = useAuthStore((s) => s.logout)
+  const [loginOpen, setLoginOpen] = useState(false)
+
+  if (!accountsEnabled) return null
+
+  return (
+    <div className={styles.widget}>
+      {status === 'authenticated' && user ? (
+        <>
+          <button
+            type="button"
+            className={styles.identity}
+            onClick={() => navigate('/profile')}
+            title="View your profile"
+          >
+            <span className={styles.dot} aria-hidden="true" />
+            <span className={styles.labels}>
+              <span className={styles.muted}>Signed in as</span>
+              <span className={styles.name}>{user.displayName}</span>
+            </span>
+          </button>
+          <button type="button" className={styles.logout} onClick={logout} title="Sign out">
+            Log out
+          </button>
+        </>
+      ) : (
+        <button type="button" className={styles.login} onClick={() => setLoginOpen(true)}>
+          Log in
+        </button>
+      )}
+      <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
+    </div>
+  )
+}

--- a/web-client/src/components/deckbuilder/AccountDeckBar.tsx
+++ b/web-client/src/components/deckbuilder/AccountDeckBar.tsx
@@ -26,6 +26,7 @@ interface AccountDeckBarProps {
 
 export function AccountDeckBar({ buildSharedDeck, onLoad, className }: AccountDeckBarProps) {
   const status = useAuthStore((s) => s.status)
+  const accountsEnabled = useAuthStore((s) => s.accountsEnabled)
   const init = useAuthStore((s) => s.init)
   const [loginOpen, setLoginOpen] = useState(false)
   const [listOpen, setListOpen] = useState(false)
@@ -78,6 +79,9 @@ export function AccountDeckBar({ buildSharedDeck, onLoad, className }: AccountDe
     await apiDeleteDeck(id)
     setDecks((prev) => prev.filter((d) => d.id !== id))
   }
+
+  // No accounts subsystem on this server → no cloud-save controls at all.
+  if (!accountsEnabled) return null
 
   if (status !== 'authenticated') {
     return (

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -18,6 +18,7 @@ import { JoinQrModal } from './JoinQrModal'
 import { buildJoinUrl } from '@/utils/joinLink'
 import { labelForFormat } from '@/utils/deckLegality'
 import { useAuthStore } from '@/store/authStore'
+import { AuthWidget } from '@/components/auth/AuthWidget'
 import { DeckMigrationPrompt } from '@/components/auth/DeckMigrationPrompt'
 import styles from './GameUI.module.css'
 
@@ -131,9 +132,9 @@ function ConnectionOverlay({
   const onlinePlayers = useGameStore((state) => state.onlinePlayers)
   const spectateGame = useGameStore((state) => state.spectateGame)
   const setPendingSpectateGameId = useGameStore((state) => state.setPendingSpectateGameId)
-  const authUser = useAuthStore((state) => state.user)
   const authStatus = useAuthStore((state) => state.status)
   const authInit = useAuthStore((state) => state.init)
+  // Bootstrap server config + session on landing so the AuthWidget knows whether to show at all.
   useEffect(() => {
     if (authStatus === 'idle') void authInit()
   }, [authStatus, authInit])
@@ -306,6 +307,7 @@ function ConnectionOverlay({
   return (
     <div className={styles.connectionOverlay} style={{ backgroundImage: `url(${randomBackground})` }}>
       <FullscreenButton />
+      <AuthWidget />
       <div className={styles.landingLayout}>
         <div className={styles.contentBackdrop}>
           <h1 className={styles.title}>Argentum Engine</h1>
@@ -447,12 +449,6 @@ function ConnectionOverlay({
                     LLM Tournament
                   </button>
                 )}
-                <button
-                  onClick={() => navigate('/profile')}
-                  className={styles.secondaryButton}
-                >
-                  {authUser ? authUser.displayName : 'Sign in'}
-                </button>
                 <button
                   onClick={() => setShowReplays(true)}
                   className={styles.secondaryButton}

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -19,6 +19,7 @@ export function ProfilePage() {
   const navigate = useNavigate()
   const user = useAuthStore((s) => s.user)
   const status = useAuthStore((s) => s.status)
+  const accountsEnabled = useAuthStore((s) => s.accountsEnabled)
   const init = useAuthStore((s) => s.init)
   const logout = useAuthStore((s) => s.logout)
 
@@ -91,6 +92,8 @@ export function ProfilePage() {
     )
   }
 
+  const resolving = status === 'idle' || status === 'loading'
+
   return (
     <div style={styles.wrap}>
       <div style={styles.container}>
@@ -98,11 +101,21 @@ export function ProfilePage() {
           ← Home
         </button>
         <h1 style={styles.title}>Your account</h1>
-        <p style={styles.muted}>Sign in to save decks to the cloud and track your win/loss record.</p>
-        <button type="button" style={styles.primary} onClick={() => setLoginOpen(true)}>
-          Sign in
-        </button>
-        <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
+        {accountsEnabled ? (
+          <>
+            <p style={styles.muted}>
+              Sign in to save decks to the cloud and track your win/loss record.
+            </p>
+            <button type="button" style={styles.primary} onClick={() => setLoginOpen(true)}>
+              Sign in
+            </button>
+            <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
+          </>
+        ) : resolving ? (
+          <p style={styles.muted}>Loading…</p>
+        ) : (
+          <p style={styles.muted}>Accounts aren't available on this server.</p>
+        )}
       </div>
     </div>
   )

--- a/web-client/src/store/authStore.ts
+++ b/web-client/src/store/authStore.ts
@@ -8,6 +8,7 @@ import {
   type AccountUser,
   type LoginResponse,
   clearAuthToken,
+  fetchAppConfig,
   fetchMe,
   setAuthToken,
 } from '@/api/account'
@@ -17,7 +18,13 @@ export type AuthStatus = 'idle' | 'loading' | 'authenticated' | 'anonymous'
 interface AuthState {
   user: AccountUser | null
   status: AuthStatus
-  /** Resolve the current session from a stored token (call once on app start). */
+  /**
+   * Whether the server runs the accounts subsystem. Defaults to false (hide all account UI) until
+   * {@link init} learns otherwise, so a server with accounts disabled never shows a sign-in form
+   * that can only fail.
+   */
+  accountsEnabled: boolean
+  /** Resolve server config + the current session from a stored token (call once on app start). */
   init: () => Promise<void>
   /** Apply a fresh login (stores the token and the user). */
   setSession: (login: LoginResponse) => void
@@ -28,11 +35,21 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   status: 'idle',
+  accountsEnabled: false,
 
   init: async () => {
     set({ status: 'loading' })
+    const { accountsEnabled } = await fetchAppConfig()
+    if (!accountsEnabled) {
+      set({ user: null, status: 'anonymous', accountsEnabled: false })
+      return
+    }
     const user = await fetchMe()
-    set(user ? { user, status: 'authenticated' } : { user: null, status: 'anonymous' })
+    set(
+      user
+        ? { user, status: 'authenticated', accountsEnabled: true }
+        : { user: null, status: 'anonymous', accountsEnabled: true },
+    )
   },
 
   setSession: (login) => {


### PR DESCRIPTION
## Problem

On a deployment where the accounts subsystem is **off** (`ACCOUNTS_ENABLED=false`, the production default), the landing page still showed a **Sign in** button. Entering an email and clicking **Send sign-in link** POSTed to `/api/auth/request-login` — which isn't mounted when accounts are disabled (`@ConditionalOnProperty`). The request fell through to the SPA static resource handler (GET-only), so the user saw a confusing **"Method Not Allowed"**.

## Fix

**Server**
- New always-mounted `GET /api/config` → `{ accountsEnabled }`. The account controllers stay gated on `accounts.enabled`, so they can't report their own absence — the client needs a stable endpoint that answers either way.
- `SpaWebConfig` no longer SPA-falls-back `/api/**` and `/game/**`: an unmatched API route now returns a clean **404** instead of `index.html` (or **405** on POST). This realigns reality with what `api/account.ts` already assumed.

**Client**
- `authStore.init()` now fetches `/api/config` first and tracks `accountsEnabled`. It **fails closed** — all account UI stays hidden until the server confirms accounts exist, so a no-accounts server shows no sign-in UI at all.
- `AccountDeckBar` and the profile page respect `accountsEnabled`.

**Auth widget redesign** (per request — make the auth state distinct from the nav buttons)
- The old "Sign in" secondary button is gone. A dedicated **`AuthWidget`** is anchored **top-right** of the landing screen (top-left is the fullscreen control):
  - signed in → `Signed in as <name>` (opens the profile) + **Log out**
  - anonymous → a single accent **Log in** pill that opens the magic-link modal
  - renders nothing when accounts are disabled

## Notes / testing
- `web-client` typecheck passes; `:game-server:compileKotlin` succeeds.
- No screenshot attached (a live capture of the enabled state would need a Postgres-backed accounts server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)