### PR TITLE
Default MAIL_PORT to 2525 (587 is blocked on many hosts)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,6 @@ GAME_AI_ENABLED=false
 #
 # --- Mailgun SMTP (leave MAIL_USERNAME blank in dev to log the link to the console) ---
 # MAIL_HOST=smtp.mailgun.org
-# MAIL_PORT=587
+# MAIL_PORT=2525            # default; many hosts block 25/465/587, Mailgun also listens on 2525
 # MAIL_USERNAME=postmaster@your-domain.mailgun.org
 # MAIL_PASSWORD=your-mailgun-smtp-password

--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -56,7 +56,7 @@ design). The deploy writes them into the server `.env`; the bundled `postgres` s
 | `ACCOUNTS_AUTH_SECRET` | HMAC secret for signing auth tokens — long & random; don't rotate casually  | (a long random string)               |
 | `ACCOUNTS_FROM_EMAIL`  | From address — **must be on your verified Mailgun domain**                  | `no-reply@mg.wingedsheep.com`        |
 | `MAIL_HOST`            | Mailgun SMTP host — **`smtp.eu.mailgun.org` for EU-region accounts**, else `smtp.mailgun.org` | `smtp.eu.mailgun.org`                |
-| `MAIL_PORT`            | SMTP port (optional, defaults to 587)                                       | `587`                                |
+| `MAIL_PORT`            | SMTP port (optional, defaults to `2525`). Many hosts block 25/465/587; Mailgun also listens on 2525. | `2525`                       |
 | `MAIL_USERNAME`        | Mailgun SMTP username (the domain's SMTP login)                             | `postmaster@mg.wingedsheep.com`      |
 | `MAIL_PASSWORD`        | Mailgun SMTP password                                                       | (from the Mailgun dashboard)         |
 
@@ -93,7 +93,9 @@ is US, swap `eu.mailgun.org` hosts for the non-EU ones and use `app.mailgun.com`
    propagate; SPF + DKIM must show green before delivery is reliable.
 
 5. **Grab the SMTP credentials.** Open the domain → **SMTP** tab. You'll see:
-   - Host `smtp.eu.mailgun.org`, port `587` (STARTTLS — matches the server config).
+   - Host `smtp.eu.mailgun.org`. Mailgun accepts STARTTLS on `587` **and `2525`** — we default to
+     `2525` because many hosts (Scaleway, GCP, …) block outbound 25/465/587. Set `MAIL_PORT=587` only
+     if your host allows it.
    - Default login `postmaster@mg.wingedsheep.com` and a generated password (you can reset it here, or
      add a dedicated SMTP user).
 
@@ -102,7 +104,7 @@ is US, swap `eu.mailgun.org` hosts for the non-EU ones and use `app.mailgun.com`
    | Mailgun value                          | Secret                | Example                          |
    |----------------------------------------|-----------------------|----------------------------------|
    | SMTP host                              | `MAIL_HOST`           | `smtp.eu.mailgun.org`            |
-   | SMTP port                              | `MAIL_PORT`           | `587`                            |
+   | SMTP port                              | `MAIL_PORT`           | `2525` (or `587` if not blocked) |
    | SMTP login                             | `MAIL_USERNAME`       | `postmaster@mg.wingedsheep.com`  |
    | SMTP password                          | `MAIL_PASSWORD`       | (from the SMTP tab)              |
    | any address on the verified domain     | `ACCOUNTS_FROM_EMAIL` | `no-reply@mg.wingedsheep.com`    |
@@ -113,7 +115,7 @@ is US, swap `eu.mailgun.org` hosts for the non-EU ones and use `app.mailgun.com`
 7. **Test the credentials** before wiring them in (optional but saves a round-trip). With
    [`swaks`](https://github.com/jetmore/swaks):
    ```bash
-   swaks --server smtp.eu.mailgun.org:587 --tls \
+   swaks --server smtp.eu.mailgun.org:2525 --tls \
      --auth-user postmaster@mg.wingedsheep.com --auth-password '<smtp-password>' \
      --from no-reply@mg.wingedsheep.com --to you@youraddress.com \
      --header 'Subject: Mailgun test' --body 'it works'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,8 @@ services:
       - APP_BASE_URL=${APP_BASE_URL:-https://${APP_DOMAIN}}
       - ACCOUNTS_FROM_EMAIL=${ACCOUNTS_FROM_EMAIL:-no-reply@wingedsheep.com}
       - MAIL_HOST=${MAIL_HOST:-smtp.mailgun.org}
-      - MAIL_PORT=${MAIL_PORT:-587}
+      # 2525 by default — many hosts block outbound 25/465/587; Mailgun also listens on 2525.
+      - MAIL_PORT=${MAIL_PORT:-2525}
       - MAIL_USERNAME=${MAIL_USERNAME:-}
       - MAIL_PASSWORD=${MAIL_PASSWORD:-}
       - GAME_AI_ENABLED=${GAME_AI_ENABLED:-false}

--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -32,14 +32,23 @@ ACCOUNTS_AUTH_SECRET=<long-random-string>   # blank => random per restart (dev o
 APP_BASE_URL=http://localhost:5173          # origin the magic link points at
 ACCOUNTS_FROM_EMAIL=no-reply@wingedsheep.com
 # Mailgun SMTP — leave MAIL_USERNAME blank in dev to log the link to the console instead of sending.
-MAIL_HOST=smtp.mailgun.org
-MAIL_PORT=587
+MAIL_HOST=smtp.mailgun.org      # smtp.eu.mailgun.org for an EU-region Mailgun domain
+MAIL_PORT=2525                   # default; see "Outbound SMTP ports" below
 MAIL_USERNAME=postmaster@your-domain.mailgun.org
 MAIL_PASSWORD=<mailgun-smtp-password>
 ```
 
 In Docker, `docker-compose.yml` already defines a `postgres` service; set `ACCOUNTS_ENABLED=true`
 and `ACCOUNTS_AUTOCONFIG_EXCLUDE=` in the deploy env to turn it on.
+
+### Outbound SMTP ports
+
+`MAIL_PORT` defaults to **2525**, not the usual 587. Many cloud hosts (Scaleway, GCP, …) block
+outbound connections on 25 / 465 / 587 to curb spam, and Mailgun listens on **2525** for exactly this
+case. A blocked port shows up as the sign-in request hanging, then a server-side
+`MailConnectException: Couldn't connect to host … Operation timed out`. If your host *does* allow 587
+(or you use a provider that needs it), set `MAIL_PORT=587`. Verify from the host with
+`nc -zv <MAIL_HOST> 2525`.
 
 ### Gating (why the exclude env var exists)
 

--- a/game-server/src/main/resources/application.yml
+++ b/game-server/src/main/resources/application.yml
@@ -23,8 +23,10 @@ spring:
   mail:
     # Mailgun SMTP by default; override host/credentials for any provider. Unused when accounts are
     # disabled or when no username is set (the magic link is logged to the console instead).
+    # Port 2525 (not 587) by default: many cloud hosts (Scaleway, GCP, …) block outbound 25/465/587
+    # to curb spam, and Mailgun listens on 2525 for exactly this case. Override MAIL_PORT if needed.
     host: ${MAIL_HOST:smtp.mailgun.org}
-    port: ${MAIL_PORT:587}
+    port: ${MAIL_PORT:2525}
     username: ${MAIL_USERNAME:}
     password: ${MAIL_PASSWORD:}
     properties:


### PR DESCRIPTION
## Why

Magic-link sign-in emails weren't delivering on the prod host. Diagnosis (verified by testing outbound connectivity from the server itself):

| Port | From prod host (Scaleway) |
|------|---------------------------|
| `smtp.eu.mailgun.org:587` | ❌ blocked (connect timeout) |
| `:465` | ❌ blocked |
| `:25`  | ❌ blocked |
| `:2525` | ✅ open — full SMTP handshake (`220 Mailgun Influx ready`, `AUTH PLAIN LOGIN`) |

Many cloud providers block outbound 25/465/587 to curb spam. Mailgun listens on **2525** for exactly this situation. With the old default of 587 the request hung until the OS connect timeout and failed server-side with:

```
MailConnectException: Couldn't connect to host, port: smtp.eu.mailgun.org, 587; timeout -1
```

## Change

Make **2525** the default everywhere, so a fresh deploy works out of the box. `MAIL_PORT` still overrides it for hosts/providers where 587 is fine.

- `application.yml`: `spring.mail.port` default `587` → `2525`
- `docker-compose.yml`: `MAIL_PORT` default `587` → `2525`
- `.env.example`, `docs/accounts-and-persistence.md`, `.github/DEPLOYMENT.md`: document the blocked-port gotcha + the 2525 default

## Related

- Companion to #1035 (which stopped the UI hanging on "Sending…" and gated the account UI). That PR makes a mail failure non-blocking; this one makes mail actually deliver on the default deploy.
- On the live server the same fix is already staged in `/home/vincent/apps/magic/.env` (`MAIL_PORT=2525`, with a backup), pending a `docker compose up -d backend`. This PR brings the repo default in line so it's not a per-host override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)