### PR TITLE
Add three Duskmourn cards: The Rollercrusher Ride, Marina Vendrell, Victor

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5274,6 +5274,16 @@ replacementEffect {
   "as long as …, prevent …" statics (Spirit of Resistance: a five-distinct-colors `Compare` gate).
 - `CapDamage(maxAmount, appliesTo)` — clamp matching damage to `maxAmount` (a *replacement* distinct
   from prevent/modify; applied after all amplification). Divine Presence: `CapDamage(3, DamageEvent(recipient = Any))`.
+- `DoubleDamage(restrictions?, appliesTo)` — double matching damage (Gratuitous Violence, Furnace of
+  Rath). `restrictions: List<Condition>` (default empty) gates the doubling on extra conditions
+  evaluated against the source's controller — the same pattern as `PreventDamage.restrictions`. The
+  doubling also honours `appliesTo.damageType` (`Combat` / `NonCombat` / `Any`). The Rollercrusher
+  Ride: `DoubleDamage(restrictions = listOf(Conditions.Delirium(4)), appliesTo = DamageEvent(source =
+  SourceFilter.Matching(GameObjectFilter.Any.youControl()), damageType = DamageType.NonCombat))` — a
+  delirium-gated "double all noncombat damage from sources you control". The doubled damage stays
+  attributed to the original source (the engine scales the amount in place).
+- `ModifyDamageAmount(modifier, appliesTo)` — add a flat `modifier` to matching damage (Valley
+  Flamecaller: "deals that much damage plus 1").
 - `RedirectDamage(redirectTo, appliesTo, condition = null)` — redirect matching damage to another
   recipient. Now wired as a continuous static replacement (each source applies at most once per damage
   event). `redirectTo` supports `EffectTarget.ControllerOfDamageSource` (the controller of the damaging

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1392,6 +1392,11 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
   Brown / Star Charter shape: look at top `count`, **optionally** reveal one card matching `filter` to
   hand, rest to `restDestination` (default bottom of library) in `restOrder` (default
   `CardOrder.Random`). `count` is a `DynamicAmount` (e.g. `DynamicAmounts.triggeringManaValue()`).
+- `revealTopPutAllMatchingToHand(count, filter, restDestination?, restOrder?)` — Marina Vendrell shape:
+  **mandatorily** reveal the top `count`, auto-route *every* card matching `filter` to hand (a
+  choice-free `FilterCollection` partition, not a "keep up to one" choice), rest to `restDestination`
+  (default bottom of library) in `restOrder` (default `CardOrder.Random`). Use this for "reveal the top
+  N, put all [type] cards into your hand and the rest on the bottom" wording.
 - `lookAtTopAndReorder(count)` — reorder top N.
 - `manifest(count = 1)` — manifest the top N cards (CR 701.40): each is put onto the battlefield
   face down as a 2/2 creature (one at a time). A manifested creature card can be turned face up for

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -9,8 +9,10 @@ import com.wingedsheep.sdk.scripting.effects.ChoosePileEffect
 import com.wingedsheep.sdk.scripting.effects.Chooser
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.EmitManifestedDreadEventEffect
 import com.wingedsheep.sdk.scripting.effects.EmitScriedEventEffect
 import com.wingedsheep.sdk.scripting.effects.EmitSurveiledEventEffect
@@ -212,6 +214,46 @@ object LibraryPatterns {
                 from = "kept",
                 destination = CardDestination.ToZone(Zone.HAND),
                 revealed = true
+            ),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = restDestination,
+                order = restOrder
+            )
+        )
+    )
+
+    /**
+     * "Reveal the top [count] cards of your library. Put all cards matching [filter] from among them
+     * into your hand and the rest [restDestination] (defaults to the bottom of your library)
+     * [restOrder] (defaults to a random order)." — Marina Vendrell's enters-the-battlefield shape.
+     *
+     * Unlike [lookAtTopRevealMatchingToHand] (which lets the player keep *up to one* matching card),
+     * this is a mandatory full reveal that automatically routes *every* matching card to hand via a
+     * choice-free [FilterCollectionEffect] partition. The remainder keeps its original gather order
+     * unless [restOrder] reshuffles it.
+     */
+    fun revealTopPutAllMatchingToHand(
+        count: DynamicAmount,
+        filter: GameObjectFilter,
+        restDestination: CardDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+        restOrder: CardOrder = CardOrder.Random
+    ): CompositeEffect = CompositeEffect(
+        listOf(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(count),
+                storeAs = "looked"
+            ),
+            RevealCollectionEffect(from = "looked"),
+            FilterCollectionEffect(
+                from = "looked",
+                filter = CollectionFilter.MatchesFilter(filter),
+                storeMatching = "kept",
+                storeNonMatching = "rest"
+            ),
+            MoveCollectionEffect(
+                from = "kept",
+                destination = CardDestination.ToZone(Zone.HAND)
             ),
             MoveCollectionEffect(
                 from = "rest",

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -454,18 +454,39 @@ data class RedirectDamage(
 /**
  * Double damage dealt.
  * Example: Furnace of Rath, Insult // Injury
+ *
+ * The optional [restrictions] list lets a card gate the doubling on arbitrary
+ * additional conditions (mirroring [PreventDamage.restrictions]). Each entry is a
+ * [Condition] evaluated against the source permanent's controller; the doubling only
+ * applies when *all* restrictions hold — this is how delirium-gated forms are expressed
+ * without a dedicated conditional-replacement wrapper, e.g. The Rollercrusher Ride
+ * ("…while there are four or more card types among cards in your graveyard, it deals
+ * double that damage instead").
  */
 @SerialName("DoubleDamage")
 @Serializable
 data class DoubleDamage(
+    val restrictions: List<Condition> = emptyList(),
     override val appliesTo: EventPattern
 ) : ReplacementEffect {
-    override val description: String =
-        "If ${appliesTo.description}, it deals double that damage instead"
+    override val description: String = buildString {
+        val restrictionDesc = restrictions.joinToString(" and ") { it.description.removePrefix("if ") }
+        if (restrictionDesc.isNotEmpty()) {
+            append(restrictionDesc.replaceFirstChar { it.uppercase() })
+            append(", if ")
+        } else {
+            append("If ")
+        }
+        append(appliesTo.description)
+        append(", it deals double that damage instead")
+    }
 
     override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
         val newAppliesTo = appliesTo.applyTextReplacement(replacer)
-        return if (newAppliesTo !== appliesTo) copy(appliesTo = newAppliesTo) else this
+        val newRestrictions = restrictions.map { it.applyTextReplacement(replacer) }
+        val anyChanged = newAppliesTo !== appliesTo ||
+            newRestrictions.zip(restrictions).any { (n, o) -> n !== o }
+        return if (anyChanged) copy(appliesTo = newAppliesTo, restrictions = newRestrictions) else this
     }
 }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MarinaVendrell.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MarinaVendrell.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Marina Vendrell — Duskmourn: House of Horror #221
+ * {W}{U}{B}{R}{G} · Legendary Creature — Human Warlock · 3/5
+ *
+ * When Marina Vendrell enters, reveal the top seven cards of your library. Put all enchantment
+ * cards from among them into your hand and the rest on the bottom of your library in a random order.
+ * {T}: Lock or unlock a door of target Room you control. Activate only as a sorcery.
+ *
+ * The ETB is the new [Patterns.Library.revealTopPutAllMatchingToHand] recipe — a mandatory reveal of
+ * the top seven that auto-routes *every* enchantment to hand (a choice-free filter partition, not a
+ * "keep up to one" choice) and drops the rest to the bottom in a random order.
+ *
+ * The activated ability is the established "lock or unlock a door" choice
+ * ([Effects.LockOrUnlockDoor], a modal of lock/unlock that prompts which door when the Room has more
+ * than one eligible) over a sorcery-speed `{T}` — the same shape as Keys to the House's second
+ * ability, minus the mana/sacrifice cost. "Target Room you control" carries no door restriction:
+ * any Room you control always has at least one door of one kind, so either choice can do something.
+ */
+val MarinaVendrell = card("Marina Vendrell") {
+    manaCost = "{W}{U}{B}{R}{G}"
+    colorIdentity = "WUBRG"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 3
+    toughness = 5
+    oracleText = "When Marina Vendrell enters, reveal the top seven cards of your library. Put all " +
+        "enchantment cards from among them into your hand and the rest on the bottom of your " +
+        "library in a random order.\n" +
+        "{T}: Lock or unlock a door of target Room you control. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.revealTopPutAllMatchingToHand(
+            count = DynamicAmount.Fixed(7),
+            filter = GameObjectFilter.Enchantment,
+        )
+        description = "When Marina Vendrell enters, reveal the top seven cards of your library. Put " +
+            "all enchantment cards from among them into your hand and the rest on the bottom of " +
+            "your library in a random order."
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        timing = TimingRule.SorcerySpeed
+        target(
+            "target Room",
+            TargetObject(filter = TargetFilter(GameObjectFilter.Any.withSubtype(Subtype.ROOM).youControl())),
+        )
+        effect = Effects.LockOrUnlockDoor(EffectTarget.ContextTarget(0))
+        description = "{T}: Lock or unlock a door of target Room you control. Activate only as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "221"
+        artist = "Magali Villeneuve"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/6428cddc-2fb6-41af-a643-e83c81dc04f5.jpg?1726298170"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TheRollercrusherRide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TheRollercrusherRide.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DoubleDamage
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Rollercrusher Ride — Duskmourn: House of Horror #155
+ * {X}{2}{R} · Legendary Enchantment
+ *
+ * Delirium — If a source you control would deal noncombat damage to a permanent or player while
+ * there are four or more card types among cards in your graveyard, it deals double that damage
+ * instead.
+ * When The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.
+ *
+ * **Delirium doubling** — a damage-amount replacement ([DoubleDamage], CR 616) gated on the new
+ * `restrictions` list: it only doubles while [Conditions.Delirium] (four or more card types among
+ * cards in your graveyard) holds, checked each time the source you control would deal *noncombat*
+ * damage (`DamageType.NonCombat`) to any permanent or player. The source filter is
+ * `GameObjectFilter.Any.youControl()` — "a source you control", not just creatures. The doubled
+ * damage stays attributed to the original source (printed ruling 2024-09-20), which the engine's
+ * amplification pass already does (it scales the amount in place without re-attributing).
+ *
+ * **ETB** — [DynamicAmount.CastX] reads the `{X}` paid to cast the enchantment and rides it onto
+ * the permanent, so the enters trigger targets up to X creatures
+ * (`TargetCreature.dynamicMaxCount = CastX`, snapshotted when the trigger goes on the stack) and
+ * deals X to each via [ForEachTargetEffect] + [DealDamageEffect]. Leaving `damageSource` null
+ * attributes the damage to the trigger's source (The Rollercrusher Ride), matching "it deals X
+ * damage". X = 0 puts the trigger on the stack with no targets and deals nothing.
+ *
+ * The two abilities interact as printed: an X-damage ETB during delirium is itself noncombat
+ * damage from a source you control, so each instance is doubled before being dealt.
+ */
+val TheRollercrusherRide = card("The Rollercrusher Ride") {
+    manaCost = "{X}{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Enchantment"
+    oracleText = "Delirium — If a source you control would deal noncombat damage to a permanent or " +
+        "player while there are four or more card types among cards in your graveyard, it deals " +
+        "double that damage instead.\n" +
+        "When The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures."
+
+    // Delirium — double noncombat damage from sources you control while you have delirium.
+    replacementEffect(
+        DoubleDamage(
+            restrictions = listOf(Conditions.Delirium(4)),
+            appliesTo = EventPattern.DamageEvent(
+                source = SourceFilter.Matching(GameObjectFilter.Any.youControl()),
+                damageType = DamageType.NonCombat,
+            ),
+        )
+    )
+
+    // When The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to X target creatures",
+            TargetCreature(optional = true, dynamicMaxCount = DynamicAmount.CastX),
+        )
+        effect = ForEachTargetEffect(
+            listOf(DealDamageEffect(DynamicAmount.CastX, EffectTarget.ContextTarget(0)))
+        )
+        description = "When The Rollercrusher Ride enters, it deals X damage to each of up to X " +
+            "target creatures."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "155"
+        artist = "Deruchenko Alexander"
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/70019956-fca1-4090-b3b6-6a963528e05b.jpg?1726286431"
+
+        ruling(
+            "2024-09-20",
+            "The damage is dealt by the same source as the original source of damage. The doubled " +
+                "damage isn't dealt by The Rollercrusher Ride unless it was the original source of damage."
+        )
+        ruling(
+            "2024-09-20",
+            "If damage dealt by a source you control is being divided among multiple permanents " +
+                "and/or players while you have delirium, that damage is divided before doubling."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/VictorValgavothsSeneschal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/VictorValgavothsSeneschal.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IncrementAbilityResolutionCountEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Victor, Valgavoth's Seneschal — Duskmourn: House of Horror #238
+ * {1}{W}{B} · Legendary Creature — Human Warlock · 3/3
+ *
+ * Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 2
+ * if this is the first time this ability has resolved this turn. If it's the second time, each
+ * opponent discards a card. If it's the third time, put a creature card from a graveyard onto the
+ * battlefield under your control.
+ *
+ * One Eerie ability with two trigger conditions (an enchantment you control entering, and fully
+ * unlocking a Room) and an escalating payoff keyed off how many times *this ability* has resolved
+ * this turn. Modeled as the two standard Eerie triggers (cf. Ghostly Dancers), each running the same
+ * [eerieEscalation] effect: it bumps the source's per-turn resolution counter
+ * ([IncrementAbilityResolutionCountEffect]) and then branches on the exact count via
+ * [Conditions.SourceAbilityResolvedNTimes] (== n). Because the counter lives on the *source
+ * permanent* (not per-ability), both triggers share it, so a Room unlock followed by an enchantment
+ * ETB escalate as one sequence — surveil 2, then each opponent discards, then reanimate; the 4th+
+ * resolution does nothing.
+ *
+ * The reanimation gathers creature cards from *every* graveyard (`Player.Each` fans the gather across
+ * all players' graveyards — "a graveyard"), lets you pick one, and puts it onto the battlefield under
+ * your control (the default control for a battlefield move by the resolving controller).
+ */
+val VictorValgavothsSeneschal = card("Victor, Valgavoth's Seneschal") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Human Warlock"
+    power = 3
+    toughness = 3
+    oracleText = "Eerie — Whenever an enchantment you control enters and whenever you fully unlock " +
+        "a Room, surveil 2 if this is the first time this ability has resolved this turn. If it's " +
+        "the second time, each opponent discards a card. If it's the third time, put a creature " +
+        "card from a graveyard onto the battlefield under your control."
+
+    keywords(Keyword.EERIE)
+
+    // Eerie — part 1: whenever an enchantment you control enters.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = eerieEscalation()
+        description = "Eerie — Whenever an enchantment you control enters, surveil 2 if this is the " +
+            "first time this ability has resolved this turn. If it's the second time, each opponent " +
+            "discards a card. If it's the third time, put a creature card from a graveyard onto the " +
+            "battlefield under your control."
+    }
+
+    // Eerie — part 2: whenever you fully unlock a Room.
+    triggeredAbility {
+        trigger = Triggers.RoomFullyUnlocked
+        effect = eerieEscalation()
+        description = "Eerie — Whenever you fully unlock a Room, surveil 2 if this is the first time " +
+            "this ability has resolved this turn. If it's the second time, each opponent discards a " +
+            "card. If it's the third time, put a creature card from a graveyard onto the battlefield " +
+            "under your control."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "238"
+        artist = "Jeremy Wilson"
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/51392ece-c9f5-46b0-9dce-0a1a0343a536.jpg?1726286757"
+    }
+}
+
+/**
+ * The shared Eerie payoff: increment the source's per-turn resolution count, then run exactly one
+ * tier based on whether this is the 1st / 2nd / 3rd resolution this turn.
+ */
+private fun eerieEscalation(): Effect = Effects.Composite(
+    IncrementAbilityResolutionCountEffect,
+    // 1st time — surveil 2.
+    ConditionalEffect(
+        condition = Conditions.SourceAbilityResolvedNTimes(1),
+        effect = Patterns.Library.surveil(2),
+    ),
+    // 2nd time — each opponent discards a card.
+    ConditionalEffect(
+        condition = Conditions.SourceAbilityResolvedNTimes(2),
+        effect = Effects.EachOpponentDiscards(1),
+    ),
+    // 3rd time — put a creature card from a graveyard onto the battlefield under your control.
+    ConditionalEffect(
+        condition = Conditions.SourceAbilityResolvedNTimes(3),
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.GRAVEYARD, Player.Each, GameObjectFilter.Creature),
+                storeAs = "victorReanimatable",
+            ),
+            SelectFromCollectionEffect(
+                from = "victorReanimatable",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                storeSelected = "victorReanimated",
+                showAllCards = true,
+                prompt = "Put a creature card from a graveyard onto the battlefield under your control",
+            ),
+            MoveCollectionEffect(
+                from = "victorReanimated",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD),
+            ),
+        ),
+    ),
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -19207,6 +19207,287 @@
     ]
 }
 
+// Victor, Valgavoth's Seneschal
+{
+    "name": "Victor, Valgavoth's Seneschal",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 2 if this is the first time this ability has resolved this turn. If it's the second time, each opponent discards a card. If it's the third time, put a creature card from a graveyard onto the battlefield under your control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "EERIE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "IncrementAbilityResolutionCount",
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 1
+                                }
+                            },
+                            "then": {
+                                "type": "Surveil",
+                                "count": 2
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 2
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Players",
+                                    "players": "EachOpponent"
+                                },
+                                "body": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 3
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Graveyard",
+                                            "player": "Each",
+                                            "filter": "creature"
+                                        },
+                                        "storeAs": "victorReanimatable"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "victorReanimatable",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "victorReanimated",
+                                        "prompt": "Put a creature card from a graveyard onto the battlefield under your control",
+                                        "showAllCards": true
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "victorReanimated",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Battlefield"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Eerie — Whenever an enchantment you control enters, surveil 2 if this is the first time this ability has resolved this turn. If it's the second time, each opponent discards a card. If it's the third time, put a creature card from a graveyard onto the battlefield under your control."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "RoomFullyUnlockedEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "IncrementAbilityResolutionCount",
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 1
+                                }
+                            },
+                            "then": {
+                                "type": "Surveil",
+                                "count": 2
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 2
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Players",
+                                    "players": "EachOpponent"
+                                },
+                                "body": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Hand"
+                                            },
+                                            "storeAs": "hand"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "hand",
+                                            "selection": {
+                                                "type": "ChooseExactly",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "discarded"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "discarded",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Graveyard"
+                                            },
+                                            "moveType": "Discard"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "SourceAbilityResolvedNTimesThisTurn",
+                                    "count": 3
+                                }
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Graveyard",
+                                            "player": "Each",
+                                            "filter": "creature"
+                                        },
+                                        "storeAs": "victorReanimatable"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "victorReanimatable",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "victorReanimated",
+                                        "prompt": "Put a creature card from a graveyard onto the battlefield under your control",
+                                        "showAllCards": true
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "victorReanimated",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Battlefield"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Eerie — Whenever you fully unlock a Room, surveil 2 if this is the first time this ability has resolved this turn. If it's the second time, each opponent discards a card. If it's the third time, put a creature card from a graveyard onto the battlefield under your control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "RARE",
+        "artist": "Jeremy Wilson",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/51392ece-c9f5-46b0-9dce-0a1a0343a536.jpg?1726286757"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Vile Mutilator
 {
     "name": "Vile Mutilator",

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -16228,6 +16228,95 @@
     ]
 }
 
+// The Rollercrusher Ride
+{
+    "name": "The Rollercrusher Ride",
+    "manaCost": "{X}{2}{R}",
+    "typeLine": "Legendary Enchantment",
+    "oracleText": "Delirium — If a source you control would deal noncombat damage to a permanent or player while there are four or more card types among cards in your graveyard, it deals double that damage instead.\nWhen The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": "CastX",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "up to X target creatures",
+                    "dynamicMaxCount": "CastX"
+                },
+                "descriptionOverride": "When The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "DoubleDamage",
+                "restrictions": [
+                    {
+                        "type": "Compare",
+                        "left": {
+                            "type": "AggregateZone",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "aggregation": "DISTINCT_TYPES"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                ],
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "source": {
+                        "type": "SourceMatching",
+                        "filter": "ctrl:you"
+                    },
+                    "damageType": "DamageNonCombat"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "rarity": "MYTHIC",
+        "artist": "Deruchenko Alexander",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/70019956-fca1-4090-b3b6-6a963528e05b.jpg?1726286431",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "The damage is dealt by the same source as the original source of damage. The doubled damage isn't dealt by The Rollercrusher Ride unless it was the original source of damage."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If damage dealt by a source you control is being divided among multiple permanents and/or players while you have delirium, that damage is divided before doubling."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // The Swarmweaver
 {
     "name": "The Swarmweaver",

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -10173,6 +10173,122 @@
     ]
 }
 
+// Marina Vendrell
+{
+    "name": "Marina Vendrell",
+    "manaCost": "{W}{U}{B}{R}{G}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "When Marina Vendrell enters, reveal the top seven cards of your library. Put all enchantment cards from among them into your hand and the rest on the bottom of your library in a random order.\n{T}: Lock or unlock a door of target Room you control. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 7
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "looked"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "looked",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "enchantment"
+                            },
+                            "storeMatching": "kept",
+                            "storeNonMatching": "rest"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "descriptionOverride": "When Marina Vendrell enters, reveal the top seven cards of your library. Put all enchantment cards from among them into your hand and the rest on the bottom of your library in a random order."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": "LockDoor",
+                            "description": "Lock a door"
+                        },
+                        {
+                            "effect": "UnlockDoor",
+                            "description": "Unlock a door"
+                        }
+                    ],
+                    "countsAsModalSpell": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "Room ctrl:you"
+                        },
+                        "id": "target Room"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{T}: Lock or unlock a door of target Room you control. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "RARE",
+        "artist": "Magali Villeneuve",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/6428cddc-2fb6-41af-a643-e83c81dc04f5.jpg?1726298170"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
+        "BLACK",
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Marvin, Murderous Mimic
 {
     "name": "Marvin, Murderous Mimic",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1281,6 +1281,25 @@ object DamageUtils {
                 val damageEvent = effect.appliesTo
                 if (damageEvent !is com.wingedsheep.sdk.scripting.EventPattern.DamageEvent) continue
 
+                // Check damage type filter (combat vs non-combat) — The Rollercrusher Ride
+                // only doubles noncombat damage.
+                val damageTypeMatches = when (damageEvent.damageType) {
+                    is DamageType.Any -> true
+                    is DamageType.Combat -> isCombatDamage
+                    is DamageType.NonCombat -> !isCombatDamage
+                }
+                if (!damageTypeMatches) continue
+
+                // Additional gating conditions evaluated against the source's controller
+                // (The Rollercrusher Ride: delirium — "four or more card types … in your graveyard").
+                if (effect.restrictions.isNotEmpty()) {
+                    val context = EffectContext(
+                        sourceId = entityId,
+                        controllerId = sourceControllerId,
+                    )
+                    if (effect.restrictions.any { !conditionEvaluator.evaluate(state, it, context) }) continue
+                }
+
                 // Check if the damage source matches the source filter
                 val sourceMatches = when (val sourceFilter = damageEvent.source) {
                     is SourceFilter.Any -> true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarinaVendrellScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarinaVendrellScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Marina Vendrell (DSK) — the enters-the-battlefield reveal-and-sort.
+ *
+ * Oracle: "When Marina Vendrell enters, reveal the top seven cards of your library. Put all
+ * enchantment cards from among them into your hand and the rest on the bottom of your library in a
+ * random order."
+ *
+ * Exercises the new [Patterns.Library.revealTopPutAllMatchingToHand] recipe: every enchantment among
+ * the top seven goes to hand (no player choice), the rest leave the top of the library. The {T}
+ * lock/unlock-door ability reuses the already-tested [Effects.LockOrUnlockDoor] and is not re-covered
+ * here.
+ */
+class MarinaVendrellScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply { registerCards(TestCards.all) }
+
+    fun GameTestDriver.handNames(playerId: EntityId): List<String> =
+        getHand(playerId).mapNotNull { state.getEntity(it)?.get<CardComponent>()?.name }
+
+    fun GameTestDriver.libraryNames(playerId: EntityId): List<String> =
+        state.getZone(com.wingedsheep.engine.state.ZoneKey(playerId, Zone.LIBRARY))
+            .mapNotNull { state.getEntity(it)?.get<CardComponent>()?.name }
+
+    test("ETB: all enchantments among the top seven go to hand, the rest leave the top") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Stack a known top seven: two enchantments + five non-enchantments.
+        listOf(
+            "Test Enchantment", "Test Enchantment",
+            "Lightning Bolt", "Centaur Courser", "Black Creature", "Artifact Creature", "Lightning Bolt",
+        ).forEach { d.putCardOnTopOfLibrary(active, it) }
+
+        val handEnchantmentsBefore = d.handNames(active).count { it == "Test Enchantment" }
+
+        val marina = d.putCardInHand(active, "Marina Vendrell")
+        d.giveMana(active, Color.WHITE, 1)
+        d.giveMana(active, Color.BLUE, 1)
+        d.giveMana(active, Color.BLACK, 1)
+        d.giveMana(active, Color.RED, 1)
+        d.giveMana(active, Color.GREEN, 1)
+        d.castSpell(active, marina, emptyList()).isSuccess shouldBe true
+        repeat(10) { if (d.pendingDecision == null) d.bothPass() }
+
+        withClue("Both enchantments among the top seven were put into hand") {
+            d.handNames(active).count { it == "Test Enchantment" } shouldBe handEnchantmentsBefore + 2
+        }
+        withClue("The revealed non-enchantments are no longer on top (moved to the bottom)") {
+            val topSeven = d.libraryNames(active).take(7)
+            topSeven.none { it in setOf("Lightning Bolt", "Centaur Courser", "Black Creature", "Artifact Creature") } shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRollercrusherRideScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRollercrusherRideScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Rollercrusher Ride (DSK).
+ *
+ * Oracle:
+ *  - Delirium — If a source you control would deal noncombat damage to a permanent or player while
+ *    there are four or more card types among cards in your graveyard, it deals double that damage
+ *    instead.
+ *  - When The Rollercrusher Ride enters, it deals X damage to each of up to X target creatures.
+ *
+ * Damage is asserted via lethality (toughness thresholds) rather than marked damage, because marked
+ * damage is wiped at cleanup: the contrast between a 3/3 surviving the base X = 2 (no delirium) and
+ * dying once X is doubled to 4 (with delirium) pins the doubling precisely.
+ *
+ * Covers: the `{X}` riding onto the permanent ([DynamicAmount.CastX]) so the enters trigger targets
+ * *up to X* creatures and deals X to each; the new delirium-gated [DoubleDamage.restrictions]; X = 0.
+ */
+class TheRollercrusherRideScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply { registerCards(TestCards.all) }
+
+    fun GameTestDriver.isAlive(id: EntityId): Boolean = getController(id) != null
+
+    /** Put a 4th-or-more card type into your graveyard so [Conditions.Delirium] holds (4 types). */
+    fun GameTestDriver.giveDelirium(playerId: EntityId) {
+        putCardInGraveyard(playerId, "Artifact Creature") // artifact + creature
+        putCardInGraveyard(playerId, "Lightning Bolt")    // instant
+        putCardInGraveyard(playerId, "Test Enchantment")  // enchantment
+    }
+
+    fun GameTestDriver.resolveStack(maxPasses: Int = 8) {
+        repeat(maxPasses) { if (pendingDecision == null) bothPass() }
+    }
+
+    test("ETB deals X damage to each of up to X target creatures (no delirium → not doubled)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val small = d.putCreatureOnBattlefield(active, "Black Creature")   // 2/2
+        val medium = d.putCreatureOnBattlefield(active, "Centaur Courser") // 3/3
+
+        val ride = d.putCardInHand(active, "The Rollercrusher Ride")
+        d.giveMana(active, Color.RED, 5) // {X=2}{2}{R}
+        d.castXSpell(active, ride, xValue = 2).isSuccess shouldBe true
+        d.resolveStack()
+
+        // The enters trigger asks for up to X (=2) target creatures.
+        val decision = d.pendingDecision as? ChooseTargetsDecision
+            ?: error("Expected ChooseTargetsDecision, got ${d.pendingDecision}")
+        d.submitTargetSelection(active, listOf(small, medium))
+        d.resolveStack()
+
+        withClue("X = 2 to each: the 2/2 dies, the 3/3 survives (took exactly 2, undoubled)") {
+            d.isAlive(small) shouldBe false
+            d.isAlive(medium) shouldBe true
+        }
+    }
+
+    test("with delirium, the noncombat ETB damage is doubled (3/3 now dies)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveDelirium(active)
+
+        val medium = d.putCreatureOnBattlefield(active, "Centaur Courser") // 3/3
+
+        val ride = d.putCardInHand(active, "The Rollercrusher Ride")
+        d.giveMana(active, Color.RED, 5) // {X=2}{2}{R}
+        d.castXSpell(active, ride, xValue = 2).isSuccess shouldBe true
+        d.resolveStack()
+
+        (d.pendingDecision as? ChooseTargetsDecision)
+            ?: error("Expected ChooseTargetsDecision, got ${d.pendingDecision}")
+        d.submitTargetSelection(active, listOf(medium))
+        d.resolveStack()
+
+        withClue("X = 2 doubled to 4 by delirium kills the 3/3") {
+            d.isAlive(medium) shouldBe false
+        }
+    }
+
+    test("X = 0 enters with no targets and deals no damage") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val medium = d.putCreatureOnBattlefield(active, "Centaur Courser") // 3/3
+
+        val ride = d.putCardInHand(active, "The Rollercrusher Ride")
+        d.giveMana(active, Color.RED, 3) // {X=0}{2}{R}
+        d.castXSpell(active, ride, xValue = 0).isSuccess shouldBe true
+        d.resolveStack()
+
+        withClue("With X = 0 there is nothing to target and no creature is harmed") {
+            d.isAlive(medium) shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VictorValgavothsSeneschalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VictorValgavothsSeneschalScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Victor, Valgavoth's Seneschal (DSK) — the escalating Eerie ability.
+ *
+ * "Eerie — Whenever an enchantment you control enters and whenever you fully unlock a Room, surveil 2
+ * if this is the first time this ability has resolved this turn. If it's the second time, each
+ * opponent discards a card. If it's the third time, put a creature card from a graveyard onto the
+ * battlefield under your control."
+ *
+ * Drives the enchantment-enters half three times in one turn (casting three Test Enchantments) and
+ * verifies the per-turn resolution counter escalates the payoff: 1st = surveil, 2nd = opponent
+ * discards, 3rd = reanimate from any graveyard under your control. The counter lives on the source
+ * permanent, so both Eerie triggers would share it (only the enchantment half is exercised here).
+ */
+class VictorValgavothsSeneschalScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), startingLife = 20)
+    }
+
+    fun GameTestDriver.castEnchantmentAndResolveToDecision(you: EntityId) {
+        // A prior Eerie resolution that routed a decision to the opponent can leave priority with
+        // them; hand it back to the active player (passing with an empty stack just returns priority,
+        // it doesn't end the step) so the next sorcery-speed cast is legal.
+        var p = 0
+        while (state.priorityPlayerId != null && state.priorityPlayerId != you && !isPaused && p++ < 4) {
+            passPriority(state.priorityPlayerId!!)
+        }
+        val ench = putCardInHand(you, "Test Enchantment") // {1}{W}
+        giveMana(you, Color.WHITE, 2)
+        castSpell(you, ench).isSuccess shouldBe true
+        // Resolve the enchantment spell, then its on-enter Eerie trigger, until something pauses.
+        var guard = 0
+        while (!isPaused && state.stack.isNotEmpty() && guard++ < 20) bothPass()
+    }
+
+    test("Eerie escalates: 1st surveils, 2nd makes each opponent discard, 3rd reanimates") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opp = d.getOpponent(you)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putCreatureOnBattlefield(you, "Victor, Valgavoth's Seneschal")
+        // Two creatures across both graveyards ("a graveyard") so the 3rd-time reanimation is a real
+        // choice (ChooseExactly(1) of one candidate would auto-resolve without a decision).
+        val corpse = d.putCardInGraveyard(opp, "Centaur Courser")
+        d.putCardInGraveyard(you, "Black Creature")
+
+        // --- 1st resolution: surveil 2 (controller looks at the top, chooses up to 2 → graveyard). ---
+        d.castEnchantmentAndResolveToDecision(you)
+        withClue("First Eerie resolution surveils — a min-0 card selection for the controller") {
+            d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            val surveil = d.pendingDecision as SelectCardsDecision
+            surveil.playerId shouldBe you
+            surveil.minSelections shouldBe 0
+        }
+        d.submitCardSelection(you, emptyList()) // keep both on top
+        if (d.pendingDecision is ReorderLibraryDecision) {
+            d.submitOrderedResponse(you, (d.pendingDecision as ReorderLibraryDecision).cards)
+        }
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // --- 2nd resolution: each opponent discards a card. ---
+        val oppHandBefore = d.getHandSize(opp)
+        d.castEnchantmentAndResolveToDecision(you)
+        withClue("Second Eerie resolution asks the opponent to discard") {
+            d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            (d.pendingDecision as SelectCardsDecision).playerId shouldBe opp
+        }
+        val discard = d.pendingDecision as SelectCardsDecision
+        d.submitCardSelection(opp, discard.options.take(1))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        withClue("The opponent discarded exactly one card") {
+            d.getHandSize(opp) shouldBe oppHandBefore - 1
+        }
+
+        // --- 3rd resolution: put a creature card from a graveyard onto the battlefield (your control). ---
+        d.castEnchantmentAndResolveToDecision(you)
+        withClue("Third Eerie resolution asks the controller to choose a creature to reanimate") {
+            d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+            val reanimate = d.pendingDecision as SelectCardsDecision
+            reanimate.playerId shouldBe you
+            reanimate.options.contains(corpse) shouldBe true
+        }
+        d.submitCardSelection(you, listOf(corpse))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        withClue("The opponent's creature is reanimated onto the battlefield under YOUR control") {
+            d.getController(corpse) shouldBe you
+        }
+    }
+})


### PR DESCRIPTION
Implements a handful of missing **Duskmourn: House of Horror** cards via the `add-card` skill. Each card is rules-faithful, has a passing scenario test, and the `DSK` card snapshot golden is re-blessed (only these three cards added).

## Cards

### The Rollercrusher Ride — `{X}{2}{R}` Legendary Enchantment
- **Delirium** — doubles noncombat damage from sources you control while you have four+ card types in your graveyard.
- **ETB** — deals X damage to each of up to X target creatures (X = the cast value, ridden onto the permanent).

SDK work: `DoubleDamage` gains a `restrictions: List<Condition>` gate (mirroring `PreventDamage.restrictions`), and the engine's damage-amplification pass now honours the event's damage type — so "double noncombat damage … while you have delirium" is expressible without a bespoke conditional-replacement wrapper. ETB uses `DynamicAmount.CastX` for both the up-to-X target count and the X damage.

### Marina Vendrell — `{W}{U}{B}{R}{G}` Legendary Creature
- **ETB** — reveal the top seven, put all enchantments into hand, the rest on the bottom in a random order.
- `{T}` — lock or unlock a door of target Room you control (sorcery speed; reuses the existing `Effects.LockOrUnlockDoor`).

SDK work: new `Patterns.Library.revealTopPutAllMatchingToHand` recipe — a mandatory reveal that auto-routes *all* matching cards to hand (choice-free `FilterCollection` partition), distinct from the keep-up-to-one `lookAtTopRevealMatchingToHand`.

### Victor, Valgavoth's Seneschal — `{1}{W}{B}` Legendary Creature
- **Eerie** — on each enchantment-you-control-enters / fully-unlock-a-Room: surveil 2 the 1st time it resolves this turn, each opponent discards the 2nd time, reanimate a creature from any graveyard the 3rd time.

Fully composed from existing primitives — the per-turn resolution counter lives on the source permanent, so both Eerie triggers share one escalating sequence.

## SDK reference
`docs/card-sdk-language-reference.md` updated for `DoubleDamage.restrictions` / `ModifyDamageAmount` and the new `revealTopPutAllMatchingToHand` pattern.

## Testing
- New scenario tests for all three cards (delirium doubling + X-damage; reveal-and-sort ETB; Eerie escalation across all three tiers).
- Full `:rules-engine:test` suite and full `just build` pass; `DSK` snapshot re-blessed; `CardLintTest` / `FacadeBoundaryTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)