### PR TITLE
Fix auth widget overlapping panels + magic-link hanging on Sending

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/EmailService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/EmailService.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.gameserver.auth
 
 import com.wingedsheep.gameserver.config.AccountsProperties
+import jakarta.annotation.PreDestroy
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
@@ -8,11 +9,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.stereotype.Component
+import java.util.concurrent.Executors
 
 /**
  * Sends the magic-link email. Uses the auto-configured [JavaMailSender] (Mailgun SMTP by default)
  * when mail credentials are configured; otherwise logs the link to the console so the whole login
  * flow is testable in local dev with no email account.
+ *
+ * The actual SMTP send runs on a background thread: connecting to the mail host can take seconds (or
+ * stall on the configured timeout if it's unreachable), and the sign-in request must not block on it
+ * — the login token is already persisted by the time we're called, and `request-login` deliberately
+ * returns 200 regardless of delivery. Send failures are logged, not surfaced to the caller.
  */
 @Component
 @ConditionalOnProperty(name = ["accounts.enabled"], havingValue = "true")
@@ -22,6 +29,10 @@ class EmailService(
     @Value("\${spring.mail.username:}") private val mailUsername: String,
 ) {
     private val logger = LoggerFactory.getLogger(EmailService::class.java)
+
+    private val sendExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "magic-link-mailer").apply { isDaemon = true }
+    }
 
     private val canSend: Boolean get() = mailUsername.isNotBlank() && mailSender.ifAvailable != null
 
@@ -46,7 +57,20 @@ class EmailService(
                 appendLine("If you didn't request this, you can ignore this email.")
             }
         }
-        mailSender.ifAvailable?.send(message)
-        logger.info("Sent magic-link email to {}", toEmail)
+        sendExecutor.submit {
+            try {
+                mailSender.ifAvailable?.send(message)
+                logger.info("Sent magic-link email to {}", toEmail)
+            } catch (e: Exception) {
+                // Don't fail the (already-200) login request; a misconfigured/unreachable mail host
+                // must not stall sign-in. Log loudly so the operator can fix delivery.
+                logger.error("Failed to send magic-link email to {}: {}", toEmail, e.message, e)
+            }
+        }
+    }
+
+    @PreDestroy
+    fun shutdown() {
+        sendExecutor.shutdown()
     }
 }

--- a/game-server/src/main/resources/application.yml
+++ b/game-server/src/main/resources/application.yml
@@ -35,6 +35,11 @@ spring:
           auth: true
           starttls:
             enable: true
+          # Bound every phase of the SMTP exchange so an unreachable mail host fails fast instead of
+          # hanging the sender thread (JavaMail defaults to no timeout / -1 = wait indefinitely).
+          connectiontimeout: ${MAIL_CONNECT_TIMEOUT_MS:10000}
+          timeout: ${MAIL_READ_TIMEOUT_MS:10000}
+          writetimeout: ${MAIL_WRITE_TIMEOUT_MS:10000}
 
 accounts:
   # Master switch for the whole accounts/persistence/auth subsystem.

--- a/web-client/src/components/auth/AuthWidget.module.css
+++ b/web-client/src/components/auth/AuthWidget.module.css
@@ -1,23 +1,14 @@
 /**
- * Landing-screen account widget. Anchored top-right (top-left is the fullscreen control). Frosted
- * pills matching the app's other overlay controls, kept visually distinct from the navigation row.
+ * Landing-screen account widget. Lives at the top of the fixed top-right side-panel stack (above the
+ * Public Lobbies / Live Games panels), right-aligned so it never overlaps them. Frosted pills
+ * matching the app's other overlay controls, kept visually distinct from the navigation row.
  */
 .widget {
-  position: fixed;
-  top: var(--space-3);
-  right: var(--space-3);
-  z-index: var(--z-controls);
   display: flex;
+  justify-content: flex-end;
   align-items: stretch;
   gap: var(--space-2);
-}
-
-@media (max-width: 639px) {
-  .widget {
-    top: var(--space-2);
-    right: var(--space-2);
-    gap: var(--space-1);
-  }
+  width: 100%;
 }
 
 /* Shared frosted-pill base for every control in the widget. */

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -133,6 +133,7 @@ function ConnectionOverlay({
   const spectateGame = useGameStore((state) => state.spectateGame)
   const setPendingSpectateGameId = useGameStore((state) => state.setPendingSpectateGameId)
   const authStatus = useAuthStore((state) => state.status)
+  const accountsEnabled = useAuthStore((state) => state.accountsEnabled)
   const authInit = useAuthStore((state) => state.init)
   // Bootstrap server config + session on landing so the AuthWidget knows whether to show at all.
   useEffect(() => {
@@ -307,7 +308,6 @@ function ConnectionOverlay({
   return (
     <div className={styles.connectionOverlay} style={{ backgroundImage: `url(${randomBackground})` }}>
       <FullscreenButton />
-      <AuthWidget />
       <div className={styles.landingLayout}>
         <div className={styles.contentBackdrop}>
           <h1 className={styles.title}>Argentum Engine</h1>
@@ -464,8 +464,9 @@ function ConnectionOverlay({
           )}
         </div>
 
-        {(showPublicLobbies || showLiveGames) && (
+        {(accountsEnabled || showPublicLobbies || showLiveGames) && (
           <div className={styles.sidePanelStack}>
+            <AuthWidget />
             {showPublicLobbies && (
               <PublicLobbyList
                 lobbies={publicLobbies}


### PR DESCRIPTION
Follow-up to #1035. These two fixes were pushed to that branch *after* it was merged, so they never landed on `main` — this PR brings them in.

## 1. Auth widget overlapped the Public Lobbies / Live Games panels

The `AuthWidget` was `position: fixed` top-right, but the side-panel stack (`sidePanelStack`) is *also* fixed top-right — so the "Log in" pill sat on top of the panels.

Fix: move the widget into the top of that same stack, right-aligned, so it stacks above the panels instead of overlapping. The standalone fixed layer is gone; the stack now renders when accounts are enabled **or** panels are present.

## 2. Magic-link request hung on "Sending…"

`POST /api/auth/request-login` sent the email **synchronously on the request thread**, and JavaMail has no timeout by default (`-1` = wait forever). An unreachable SMTP host stalled the whole request until the OS connect timeout, so the client sat on "Sending…".

- `EmailService` now sends on a background daemon thread and **logs** (not throws) delivery failures, so `request-login` returns 200 immediately as designed (the login token is already persisted before the send).
- Added SMTP connect/read/write timeouts (default 10s, overridable via `MAIL_*_TIMEOUT_MS`) so a bad mail host fails fast instead of pinning a thread.

## Notes
- Cherry-picked from the merged #1035 branch; `application.yml` auto-merged cleanly with #1036's `MAIL_PORT=2525` default — the result has both the 2525 default and the new timeouts.
- `:game-server:compileKotlin` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)