### PR TITLE
Unify deck save (cloud vs local), editable username, shared deck list

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -94,6 +94,7 @@ the account's stats.
 | POST | `/api/auth/request-login` | `{ email }` → 200 |
 | POST | `/api/auth/verify` | `{ token }` → `{ authToken, user }` |
 | GET | `/api/auth/me` | Bearer → `user` |
+| PUT | `/api/auth/me` | Bearer + `{ displayName }` → updated `user` (1–40 chars; duplicates allowed) |
 | GET | `/api/account/decks` | list summaries |
 | GET | `/api/account/decks/{id}` | full deck |
 | POST | `/api/account/decks` | body = `SharedDeck` JSON → created deck |
@@ -108,8 +109,15 @@ the account's stats.
 
 - `authStore` (standalone Zustand) holds the signed-in user; `api/account.ts` is the REST client.
 - Sign-in modal (`LoginModal`) + `/login/verify` page; a nav entry in the connection overlay.
-- Deckbuilder: "Save online" / "My decks" via `AccountDeckBar`; profile page at `/profile` shows
-  stats + saved decks (deep-linking to `/deckbuilder?accountDeck=<id>`).
+- **Unified Save:** the deckbuilder has one Save / Save as. When signed in it saves to the account
+  (cloud); when anonymous it saves to the browser library (localStorage). The cloud path dedupes by
+  deck name (same rule as the migration prompt) so re-saving overwrites rather than duplicating.
+  `AccountDeckBar` is now just the cloud "My decks" browser + a sign-in affordance.
+- **Display name:** editable on the profile page (`PUT /api/auth/me`); the email stays the identity.
+- Profile page at `/profile` shows stats + saved decks via the shared `SavedDeckList`, which renders
+  both account (online) and browser-only decks with an **Online / Browser only** badge so the user
+  can see what's backed up. Deck names deep-link into the deckbuilder
+  (`/deckbuilder?accountDeck=<id>` for cloud, `/deckbuilder/<id>` for local).
 - On sign-in, a landing-page prompt (`DeckMigrationPrompt`) offers to copy browser-only decks to the
   account.
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/MagicLinkService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/MagicLinkService.kt
@@ -79,6 +79,16 @@ class MagicLinkService(
 
     fun findUser(userId: Long): UserRow? = users.findById(userId).orElse(null)
 
+    /**
+     * Set a user's chosen display name. The email stays the immutable identity; the display name is a
+     * free-form label (duplicates across accounts are allowed). Returns the updated account, or null if
+     * it no longer exists. Caller is responsible for trimming/length-validating [displayName].
+     */
+    fun updateDisplayName(userId: Long, displayName: String): UserRow? {
+        val user = users.findById(userId).orElse(null) ?: return null
+        return users.save(user.copy(displayName = displayName))
+    }
+
     private fun sha256Hex(value: String): String =
         MessageDigest.getInstance("SHA-256")
             .digest(value.toByteArray(Charsets.UTF_8))

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AuthController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AuthController.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
@@ -32,8 +33,13 @@ class AuthController(
 ) {
     data class RequestLoginBody(val email: String)
     data class VerifyBody(val token: String)
+    data class UpdateProfileBody(val displayName: String)
     data class UserDto(val id: Long, val email: String, val displayName: String)
     data class LoginResponse(val authToken: String, val user: UserDto)
+
+    companion object {
+        const val MAX_DISPLAY_NAME_LENGTH = 40
+    }
 
     @PostMapping("/request-login")
     fun requestLogin(@RequestBody body: RequestLoginBody): ResponseEntity<Any> {
@@ -61,6 +67,23 @@ class AuthController(
         val user = magicLinkService.findUser(claims.uid)
             ?: return ResponseEntity.status(401).body(mapOf("error" to "Account no longer exists"))
         return ResponseEntity.ok(user.toDto())
+    }
+
+    /** Update the signed-in account's display name (free-form label; the email stays the identity). */
+    @PutMapping("/me")
+    fun updateMe(
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @RequestBody body: UpdateProfileBody,
+    ): ResponseEntity<Any> {
+        val claims = authSupport.requireUser(authorization)
+        val name = body.displayName.trim()
+        if (name.isEmpty() || name.length > MAX_DISPLAY_NAME_LENGTH) {
+            return ResponseEntity.badRequest()
+                .body(mapOf("error" to "Display name must be 1–$MAX_DISPLAY_NAME_LENGTH characters"))
+        }
+        val updated = magicLinkService.updateDisplayName(claims.uid, name)
+            ?: return ResponseEntity.status(401).body(mapOf("error" to "Account no longer exists"))
+        return ResponseEntity.ok(updated.toDto())
     }
 
     private fun UserRow.toDto() = UserDto(id = id!!, email = email, displayName = displayName)

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -92,6 +92,18 @@ export async function verifyLogin(token: string): Promise<LoginResponse> {
   return (await res.json()) as LoginResponse
 }
 
+/** Update the signed-in account's display name. Returns the updated account. */
+export async function updateProfile(displayName: string): Promise<AccountUser> {
+  const res = await fetch('/api/auth/me', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ displayName }),
+  })
+  if (res.status === 401) throw new UnauthorizedError()
+  if (!res.ok) throw new Error(await errorMessage(res, `Failed to update profile (${res.status})`))
+  return (await res.json()) as AccountUser
+}
+
 /** Fetch the current account, or null if not signed in / accounts disabled. */
 export async function fetchMe(): Promise<AccountUser | null> {
   if (!getAuthToken()) return null
@@ -136,6 +148,17 @@ export async function saveDeck(deck: SharedDeck): Promise<DeckDetail> {
   })
   if (res.status === 401) throw new UnauthorizedError()
   if (!res.ok) throw new Error(`Failed to save deck (${res.status})`)
+  return (await res.json()) as DeckDetail
+}
+
+export async function updateDeck(id: number, deck: SharedDeck): Promise<DeckDetail> {
+  const res = await fetch(`/api/account/decks/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(deck),
+  })
+  if (res.status === 401) throw new UnauthorizedError()
+  if (!res.ok) throw new Error(`Failed to update deck (${res.status})`)
   return (await res.json()) as DeckDetail
 }
 

--- a/web-client/src/components/deckbuilder/AccountDeckBar.tsx
+++ b/web-client/src/components/deckbuilder/AccountDeckBar.tsx
@@ -1,37 +1,36 @@
 /**
- * Deckbuilder toolbar control for cloud-saved decks. When signed in, lets you save the current deck
- * to your account and load/delete your saved decks; when anonymous, offers a sign-in prompt. Kept
- * self-contained so the (large) DeckbuilderPage only has to provide a build + load callback.
+ * Deckbuilder toolbar control for browsing the signed-in user's cloud-saved decks. Saving is handled
+ * by the deckbuilder's unified Save button (which routes to the account when signed in, or to
+ * localStorage when not), so this control is purely the cloud "My decks" browser plus a sign-in
+ * affordance when anonymous. Kept self-contained so the (large) DeckbuilderPage only provides a load
+ * callback.
  */
 import { useEffect, useState } from 'react'
 import type React from 'react'
 import {
+  type DeckDetail,
   type DeckSummary,
   deleteDeck as apiDeleteDeck,
   getDeck,
   listDecks,
-  saveDeck,
 } from '@/api/account'
 import { LoginModal } from '@/components/auth/LoginModal'
-import type { SharedDeck } from '@/components/deckbuilder/shareDeck'
+import { SavedDeckList, type SavedDeckListItem } from '@/components/deckbuilder/SavedDeckList'
 import { useAuthStore } from '@/store/authStore'
 
 interface AccountDeckBarProps {
-  /** Build a SharedDeck from the current builder state, or null if the deck is empty. */
-  buildSharedDeck: () => SharedDeck | null
-  /** Apply a loaded SharedDeck into the builder. */
-  onLoad: (shared: SharedDeck) => void
+  /** Apply a loaded cloud deck (with its id, so the builder can overwrite it on the next save). */
+  onLoad: (detail: DeckDetail) => void
   className?: string
 }
 
-export function AccountDeckBar({ buildSharedDeck, onLoad, className }: AccountDeckBarProps) {
+export function AccountDeckBar({ onLoad, className }: AccountDeckBarProps) {
   const status = useAuthStore((s) => s.status)
   const accountsEnabled = useAuthStore((s) => s.accountsEnabled)
   const init = useAuthStore((s) => s.init)
   const [loginOpen, setLoginOpen] = useState(false)
   const [listOpen, setListOpen] = useState(false)
   const [decks, setDecks] = useState<DeckSummary[]>([])
-  const [feedback, setFeedback] = useState<string | null>(null)
 
   useEffect(() => {
     if (status === 'idle') void init()
@@ -45,33 +44,13 @@ export function AccountDeckBar({ buildSharedDeck, onLoad, className }: AccountDe
     if (listOpen) refresh()
   }, [listOpen])
 
-  const flash = (msg: string) => {
-    setFeedback(msg)
-    window.setTimeout(() => setFeedback(null), 2000)
-  }
-
-  const handleSave = async () => {
-    const shared = buildSharedDeck()
-    if (!shared) {
-      flash('Deck is empty')
-      return
-    }
-    try {
-      await saveDeck(shared)
-      flash('Saved!')
-      if (listOpen) refresh()
-    } catch {
-      flash('Save failed')
-    }
-  }
-
   const handleLoad = async (id: number) => {
     try {
       const detail = await getDeck(id)
-      onLoad(detail.deck)
+      onLoad(detail)
       setListOpen(false)
     } catch {
-      flash('Load failed')
+      /* not found / not signed in — leave the builder as-is */
     }
   }
 
@@ -80,47 +59,39 @@ export function AccountDeckBar({ buildSharedDeck, onLoad, className }: AccountDe
     setDecks((prev) => prev.filter((d) => d.id !== id))
   }
 
-  // No accounts subsystem on this server → no cloud-save controls at all.
+  // No accounts subsystem on this server → no cloud-deck controls at all.
   if (!accountsEnabled) return null
 
   if (status !== 'authenticated') {
     return (
       <div className={className}>
         <button type="button" style={styles.button} onClick={() => setLoginOpen(true)}>
-          Sign in to save
+          Sign in
         </button>
         <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
       </div>
     )
   }
 
+  const items: SavedDeckListItem[] = decks.map((d) => ({
+    key: `c:${d.id}`,
+    name: d.name,
+    online: true,
+    ...(d.format ? { format: d.format } : {}),
+  }))
+
   return (
     <div className={className} style={styles.wrap}>
-      <button type="button" style={styles.button} onClick={() => void handleSave()}>
-        {feedback ?? 'Save online'}
-      </button>
       <button type="button" style={styles.button} onClick={() => setListOpen((v) => !v)}>
         My decks
       </button>
       {listOpen && (
         <div style={styles.popover}>
-          {decks.length === 0 ? (
-            <div style={styles.empty}>No saved decks yet.</div>
-          ) : (
-            <ul style={styles.list}>
-              {decks.map((deck) => (
-                <li key={deck.id} style={styles.item}>
-                  <button type="button" style={styles.itemName} onClick={() => void handleLoad(deck.id)}>
-                    {deck.name}
-                    {deck.format ? <span style={styles.format}> · {deck.format}</span> : null}
-                  </button>
-                  <button type="button" style={styles.delete} onClick={() => void handleDelete(deck.id)}>
-                    ×
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
+          <SavedDeckList
+            decks={items}
+            onOpen={(item) => void handleLoad(Number(item.key.slice(2)))}
+            onDelete={(item) => void handleDelete(Number(item.key.slice(2)))}
+          />
         </div>
       )}
     </div>
@@ -143,7 +114,7 @@ const styles: Record<string, React.CSSProperties> = {
     top: '100%',
     right: 0,
     marginTop: 6,
-    minWidth: 240,
+    minWidth: 280,
     maxHeight: 320,
     overflowY: 'auto',
     backgroundColor: '#14141f',
@@ -153,20 +124,4 @@ const styles: Record<string, React.CSSProperties> = {
     zIndex: 1500,
     boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
   },
-  empty: { color: '#888', fontSize: 13, padding: 8 },
-  list: { listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 4 },
-  item: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
-  itemName: {
-    flex: 1,
-    background: 'none',
-    border: 'none',
-    color: '#fff',
-    textAlign: 'left',
-    cursor: 'pointer',
-    fontSize: 14,
-    padding: '6px 8px',
-    borderRadius: 6,
-  },
-  format: { color: '#888', fontSize: 12 },
-  delete: { background: 'none', border: 'none', color: '#ff6b6b', cursor: 'pointer', fontSize: 16 },
 }

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -50,7 +50,13 @@ import {
   type SharedDeck,
 } from './shareDeck'
 import { AccountDeckBar } from './AccountDeckBar'
-import { getDeck as getAccountDeck } from '@/api/account'
+import {
+  getDeck as getAccountDeck,
+  listDecks as apiListDecks,
+  saveDeck as apiSaveDeck,
+  updateDeck as apiUpdateDeck,
+} from '@/api/account'
+import { useAuthStore } from '@/store/authStore'
 import {
   detectProducedColors,
   suggestBasicLands,
@@ -302,6 +308,14 @@ export function DeckbuilderPage() {
   // derived server-side (CR 100.4b).
   const [sideboardCards, setSideboardCards] = useState<Record<string, number>>({})
   const [activeDeckId, setActiveDeckId] = useState<string | null>(null)
+  // When signed in, the unified Save targets the account (cloud); otherwise it writes to the local
+  // browser library. `saveFlash` briefly overrides the Save button label to confirm the result.
+  const isLoggedIn = useAuthStore((s) => s.status) === 'authenticated'
+  const [saveFlash, setSaveFlash] = useState<string | null>(null)
+  const flashSave = useCallback((msg: string) => {
+    setSaveFlash(msg)
+    window.setTimeout(() => setSaveFlash(null), 2000)
+  }, [])
   // Pinned printings, keyed by card name. Empty unless the user opens the printing picker
   // and chooses a non-default printing for some row. Persisted via [SavedDeck.entries] (v2)
   // and round-tripped on load. Same-name-different-printing rows are not surfaced as separate
@@ -855,7 +869,30 @@ export function DeckbuilderPage() {
     navigate(`/deckbuilder${searchSuffix()}`)
   }
 
-  const handleSave = () => {
+  // Unified Save: when signed in, persist to the account (cloud); otherwise to the local browser
+  // library. We dedupe the cloud deck by name (the same rule the sign-in migration prompt uses) so
+  // re-saving the same deck overwrites it rather than piling up duplicates — no client-side id to
+  // thread through every load path. `optionalName` overrides the deck name for "Save as".
+  const saveToCloud = async (overrideName?: string) => {
+    const built = buildSharedDeck()
+    if (!built) {
+      flashSave('Deck is empty')
+      return
+    }
+    const shared = overrideName ? { ...built, name: overrideName } : built
+    try {
+      const existing = await apiListDecks()
+      const match = existing.find((d) => d.name.toLowerCase() === shared.name.toLowerCase())
+      if (match) await apiUpdateDeck(match.id, shared)
+      else await apiSaveDeck(shared)
+      if (overrideName) setDeckName(overrideName)
+      flashSave('Saved to account')
+    } catch {
+      flashSave('Save failed')
+    }
+  }
+
+  const saveLocal = (overrideName?: string): string => {
     // Per `SavedDeck.commander`: the commander is stored separately from `cards` (the
     // library), matching the server's `Deck.cards` convention. Strip it out on save so
     // reloading + re-validating doesn't double-count.
@@ -863,29 +900,11 @@ export function DeckbuilderPage() {
     const cardsForSave = stripCommanderFromCards(deckCards, designated)
     const entries = entriesFromCards(cardsForSave, pinnedPrintings)
     const commanderPrintingForSave = designated ? pinnedPrintings[designated] : undefined
+    const isRename = overrideName !== undefined
     const saved = saveDeck({
-      ...(activeDeckId ? { id: activeDeckId } : {}),
-      name: deckName.trim() || 'Untitled deck',
-      cards: cardsForSave,
-      ...(activeFormat ? { format: activeFormat } : {}),
-      ...(designated ? { commander: designated } : {}),
-      ...(commanderPrintingForSave ? { commanderPrinting: commanderPrintingForSave } : {}),
-      ...(entries ? { entries } : {}),
-      ...(Object.keys(sideboardCards).length > 0 ? { sideboard: sideboardCards } : {}),
-    })
-    setActiveDeckId(saved.id)
-    if (saved.id !== deckId) navigate(`/deckbuilder/${saved.id}${searchSuffix()}`, { replace: true })
-  }
-
-  const handleSaveAs = () => {
-    const name = window.prompt('New deck name', `${deckName} (copy)`)
-    if (!name) return
-    const designated = isCommanderFormat ? commander : null
-    const cardsForSave = stripCommanderFromCards(deckCards, designated)
-    const entries = entriesFromCards(cardsForSave, pinnedPrintings)
-    const commanderPrintingForSave = designated ? pinnedPrintings[designated] : undefined
-    const saved = saveDeck({
-      name: name.trim(),
+      // "Save as" always creates a fresh local deck; plain Save updates the active one.
+      ...(!isRename && activeDeckId ? { id: activeDeckId } : {}),
+      name: (overrideName ?? deckName).trim() || 'Untitled deck',
       cards: cardsForSave,
       ...(activeFormat ? { format: activeFormat } : {}),
       ...(designated ? { commander: designated } : {}),
@@ -895,7 +914,27 @@ export function DeckbuilderPage() {
     })
     setDeckName(saved.name)
     setActiveDeckId(saved.id)
-    navigate(`/deckbuilder/${saved.id}${searchSuffix()}`, { replace: true })
+    return saved.id
+  }
+
+  const handleSave = async () => {
+    if (isLoggedIn) {
+      await saveToCloud()
+      return
+    }
+    const id = saveLocal()
+    if (id !== deckId) navigate(`/deckbuilder/${id}${searchSuffix()}`, { replace: true })
+  }
+
+  const handleSaveAs = async () => {
+    const name = window.prompt('New deck name', `${deckName} (copy)`)
+    if (!name || !name.trim()) return
+    if (isLoggedIn) {
+      await saveToCloud(name.trim())
+      return
+    }
+    const id = saveLocal(name.trim())
+    navigate(`/deckbuilder/${id}${searchSuffix()}`, { replace: true })
   }
 
   const handleDelete = () => {
@@ -911,7 +950,7 @@ export function DeckbuilderPage() {
   // any pinned printings. Mirrors the save path's commander-stripping so a shared deck
   // re-imports without double-counting the commander.
   // Snapshot the working deck as a SharedDeck (the canonical wire shape), or null if empty. Used by
-  // both the share-link path and the account "Save online" path so they capture identical content.
+  // both the share-link path and the account (cloud) save path so they capture identical content.
   const buildSharedDeck = useCallback((): SharedDeck | null => {
     const designated = isCommanderFormat ? commander : null
     const cardsForShare = stripCommanderFromCards(deckCards, designated)
@@ -1220,7 +1259,7 @@ export function DeckbuilderPage() {
         >
           {shareCopied ? 'Link copied!' : 'Share'}
         </button>
-        <AccountDeckBar buildSharedDeck={buildSharedDeck} onLoad={applySharedDeck} />
+        <AccountDeckBar onLoad={(detail) => applySharedDeck(detail.deck)} />
         <button className={styles.iconButton} onClick={handleNew}>
           New deck
         </button>
@@ -1384,7 +1423,8 @@ export function DeckbuilderPage() {
             </div>
 
             <DeckActionRow
-              activeDeckId={activeDeckId}
+              saveLabel={saveFlash ?? (activeDeckId ? 'Save' : 'Save deck')}
+              canDelete={!!activeDeckId}
               isEmpty={Object.keys(deckCards).length === 0}
               onSave={handleSave}
               onSaveAs={handleSaveAs}
@@ -1451,7 +1491,8 @@ export function DeckbuilderPage() {
             validation={validation}
             totalCards={totalCards}
             stats={stats}
-            activeDeckId={activeDeckId}
+            saveLabel={saveFlash ?? (activeDeckId ? 'Save' : 'Save deck')}
+            canDelete={!!activeDeckId}
             isEmpty={Object.keys(deckCards).length === 0}
             onSave={handleSave}
             onSaveAs={handleSaveAs}
@@ -1484,13 +1525,15 @@ export function DeckbuilderPage() {
 // ---------------------------------------------------------------------------
 
 function DeckActionRow({
-  activeDeckId,
+  saveLabel,
+  canDelete,
   isEmpty,
   onSave,
   onSaveAs,
   onDelete,
 }: {
-  activeDeckId: string | null
+  saveLabel: string
+  canDelete: boolean
   isEmpty: boolean
   onSave: () => void
   onSaveAs: () => void
@@ -1499,12 +1542,12 @@ function DeckActionRow({
   return (
     <div className={styles.actionRow}>
       <button className={styles.primaryButton} onClick={onSave} disabled={isEmpty}>
-        {activeDeckId ? 'Save' : 'Save deck'}
+        {saveLabel}
       </button>
       <button className={styles.secondaryButton} onClick={onSaveAs} disabled={isEmpty}>
         Save as
       </button>
-      <button className={styles.dangerButton} onClick={onDelete} disabled={!activeDeckId}>
+      <button className={styles.dangerButton} onClick={onDelete} disabled={!canDelete}>
         Delete
       </button>
     </div>
@@ -1523,7 +1566,8 @@ function DeckCentricFooter({
   validation,
   totalCards,
   stats,
-  activeDeckId,
+  saveLabel,
+  canDelete,
   isEmpty,
   onSave,
   onSaveAs,
@@ -1532,7 +1576,8 @@ function DeckCentricFooter({
   validation: ValidationResult | null
   totalCards: number
   stats: DeckStats
-  activeDeckId: string | null
+  saveLabel: string
+  canDelete: boolean
   isEmpty: boolean
   onSave: () => void
   onSaveAs: () => void
@@ -1577,12 +1622,12 @@ function DeckCentricFooter({
 
       <div className={styles.footerActions}>
         <button className={styles.primaryButton} onClick={onSave} disabled={isEmpty}>
-          {activeDeckId ? 'Save' : 'Save deck'}
+          {saveLabel}
         </button>
         <button className={styles.secondaryButton} onClick={onSaveAs} disabled={isEmpty}>
           Save as
         </button>
-        <button className={styles.dangerButton} onClick={onDelete} disabled={!activeDeckId}>
+        <button className={styles.dangerButton} onClick={onDelete} disabled={!canDelete}>
           Delete
         </button>
       </div>

--- a/web-client/src/components/deckbuilder/SavedDeckList.tsx
+++ b/web-client/src/components/deckbuilder/SavedDeckList.tsx
@@ -1,0 +1,114 @@
+/**
+ * Shared presentational list of a user's saved decks, reused by the profile page and the deckbuilder's
+ * "My decks" popover so the two stay in visual lockstep (one place to restyle a deck row).
+ *
+ * Each row carries an {@link SavedDeckListItem.online} flag and shows a badge for it, so a user can
+ * tell at a glance which decks are backed up to their account (Online) and which live only in this
+ * browser (Browser only) and would be lost if storage is cleared.
+ */
+import type React from 'react'
+
+export interface SavedDeckListItem {
+  /** Stable React key — callers prefix by source (e.g. `c:<id>` cloud, `l:<id>` local). */
+  readonly key: string
+  readonly name: string
+  readonly format?: string
+  /** True = backed up in the account (cloud); false = browser-only (localStorage). */
+  readonly online: boolean
+}
+
+interface SavedDeckListProps {
+  decks: readonly SavedDeckListItem[]
+  /** Open / load a deck. */
+  onOpen: (item: SavedDeckListItem) => void
+  /** Delete a deck. Omit to hide the delete affordance. */
+  onDelete?: (item: SavedDeckListItem) => void
+  /** Copy shown when there are no decks. */
+  emptyText?: string
+}
+
+export function SavedDeckList({ decks, onOpen, onDelete, emptyText }: SavedDeckListProps) {
+  if (decks.length === 0) {
+    return <div style={styles.empty}>{emptyText ?? 'No saved decks yet.'}</div>
+  }
+  return (
+    <ul style={styles.list}>
+      {decks.map((deck) => (
+        <li key={deck.key} style={styles.item}>
+          <button type="button" style={styles.name} onClick={() => onOpen(deck)}>
+            <span style={styles.nameText}>{deck.name}</span>
+            {deck.format ? <span style={styles.format}> · {deck.format}</span> : null}
+          </button>
+          <StorageBadge online={deck.online} />
+          {onDelete ? (
+            <button
+              type="button"
+              style={styles.delete}
+              title="Delete deck"
+              aria-label={`Delete ${deck.name}`}
+              onClick={() => onDelete(deck)}
+            >
+              ×
+            </button>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function StorageBadge({ online }: { online: boolean }) {
+  const style = online ? styles.badgeOnline : styles.badgeLocal
+  return (
+    <span style={{ ...styles.badge, ...style }} title={online ? 'Backed up to your account' : 'Saved only in this browser'}>
+      <span style={{ ...styles.badgeDot, background: online ? '#3ecf7a' : '#8a8a99' }} aria-hidden="true" />
+      {online ? 'Online' : 'Browser only'}
+    </span>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  list: { listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 6 },
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: '#14141f',
+    border: '1px solid #2a2a3e',
+    borderRadius: 10,
+    padding: '8px 12px',
+  },
+  name: {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: 2,
+    background: 'none',
+    border: 'none',
+    color: '#fff',
+    textAlign: 'left',
+    cursor: 'pointer',
+    fontSize: 14,
+    padding: 0,
+  },
+  nameText: { overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  format: { color: '#888', fontSize: 12, flexShrink: 0 },
+  badge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 5,
+    flexShrink: 0,
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: 0.2,
+    padding: '3px 8px',
+    borderRadius: 999,
+    border: '1px solid',
+  },
+  badgeOnline: { color: '#9be8bd', borderColor: 'rgba(62, 207, 122, 0.35)', backgroundColor: 'rgba(62, 207, 122, 0.1)' },
+  badgeLocal: { color: '#b8b8c4', borderColor: '#3a3a4e', backgroundColor: 'rgba(255, 255, 255, 0.04)' },
+  badgeDot: { width: 6, height: 6, borderRadius: '50%' },
+  delete: { background: 'none', border: 'none', color: '#ff6b6b', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: '0 2px', flexShrink: 0 },
+  empty: { color: '#888', fontSize: 13, padding: 8 },
+}

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -1,8 +1,10 @@
 /**
- * Account profile: shows the signed-in user, their win/loss record, and their saved decks (with a
- * deep link to open each in the deckbuilder). Prompts sign-in when anonymous.
+ * Account profile: shows the signed-in user, lets them rename their display name, shows their
+ * win/loss record, and lists their saved decks — both account (online) and browser-only — via the
+ * shared {@link SavedDeckList}, so they can see at a glance which decks are backed up. Prompts sign-in
+ * when anonymous.
  */
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type React from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -13,7 +15,9 @@ import {
   listDecks,
 } from '@/api/account'
 import { LoginModal } from '@/components/auth/LoginModal'
+import { SavedDeckList, type SavedDeckListItem } from '@/components/deckbuilder/SavedDeckList'
 import { useAuthStore } from '@/store/authStore'
+import { useDeckLibrary } from '@/store/deckLibrary'
 
 export function ProfilePage() {
   const navigate = useNavigate()
@@ -22,14 +26,29 @@ export function ProfilePage() {
   const accountsEnabled = useAuthStore((s) => s.accountsEnabled)
   const init = useAuthStore((s) => s.init)
   const logout = useAuthStore((s) => s.logout)
+  const updateDisplayName = useAuthStore((s) => s.updateDisplayName)
+
+  const localDecks = useDeckLibrary((s) => s.decks)
+  const hydrateLocal = useDeckLibrary((s) => s.hydrate)
+  const hydratedLocal = useDeckLibrary((s) => s.hydrated)
+  const deleteLocalDeck = useDeckLibrary((s) => s.deleteDeck)
 
   const [stats, setStats] = useState<AccountStats | null>(null)
   const [decks, setDecks] = useState<DeckSummary[]>([])
   const [loginOpen, setLoginOpen] = useState(false)
 
+  const [editingName, setEditingName] = useState(false)
+  const [nameDraft, setNameDraft] = useState('')
+  const [nameError, setNameError] = useState<string | null>(null)
+  const [savingName, setSavingName] = useState(false)
+
   useEffect(() => {
     if (status === 'idle') void init()
   }, [status, init])
+
+  useEffect(() => {
+    if (!hydratedLocal) hydrateLocal()
+  }, [hydratedLocal, hydrateLocal])
 
   useEffect(() => {
     if (status !== 'authenticated') return
@@ -37,9 +56,65 @@ export function ProfilePage() {
     void listDecks().then(setDecks).catch(() => setDecks([]))
   }, [status])
 
-  const removeDeck = async (id: number) => {
-    await apiDeleteDeck(id)
-    setDecks((prev) => prev.filter((d) => d.id !== id))
+  // Combine the user's account decks (online) with browser-only locals not yet backed up, so the
+  // list doubles as a "what's backed up where" view. A local deck whose name matches a cloud deck is
+  // considered the backed-up copy and isn't shown twice (same name-based rule as the save/migration).
+  const deckItems: SavedDeckListItem[] = useMemo(() => {
+    const cloudNames = new Set(decks.map((d) => d.name.toLowerCase()))
+    const cloudItems: SavedDeckListItem[] = decks.map((d) => ({
+      key: `c:${d.id}`,
+      name: d.name,
+      online: true,
+      ...(d.format ? { format: d.format } : {}),
+    }))
+    const localItems: SavedDeckListItem[] = localDecks
+      .filter((d) => !cloudNames.has(d.name.toLowerCase()))
+      .map((d) => ({
+        key: `l:${d.id}`,
+        name: d.name,
+        online: false,
+        ...(d.format ? { format: d.format } : {}),
+      }))
+    return [...cloudItems, ...localItems]
+  }, [decks, localDecks])
+
+  const openDeck = (item: SavedDeckListItem) => {
+    if (item.key.startsWith('c:')) navigate(`/deckbuilder?accountDeck=${item.key.slice(2)}`)
+    else navigate(`/deckbuilder/${item.key.slice(2)}`)
+  }
+
+  const removeDeck = async (item: SavedDeckListItem) => {
+    if (item.key.startsWith('c:')) {
+      const id = Number(item.key.slice(2))
+      await apiDeleteDeck(id)
+      setDecks((prev) => prev.filter((d) => d.id !== id))
+    } else {
+      deleteLocalDeck(item.key.slice(2))
+    }
+  }
+
+  const startEditName = () => {
+    setNameDraft(user?.displayName ?? '')
+    setNameError(null)
+    setEditingName(true)
+  }
+
+  const submitName = async () => {
+    const trimmed = nameDraft.trim()
+    if (!trimmed) {
+      setNameError('Name cannot be empty')
+      return
+    }
+    setSavingName(true)
+    setNameError(null)
+    try {
+      await updateDisplayName(trimmed)
+      setEditingName(false)
+    } catch (e) {
+      setNameError(e instanceof Error ? e.message : 'Could not update name')
+    } finally {
+      setSavingName(false)
+    }
   }
 
   if (status === 'authenticated' && user) {
@@ -55,8 +130,35 @@ export function ProfilePage() {
             </button>
           </div>
 
-          <h1 style={styles.title}>{user.displayName}</h1>
-          <p style={styles.muted}>{user.email}</p>
+          {editingName ? (
+            <div style={styles.nameEditRow}>
+              <input
+                style={styles.nameInput}
+                value={nameDraft}
+                maxLength={40}
+                autoFocus
+                onChange={(e) => setNameDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void submitName()
+                  if (e.key === 'Escape') setEditingName(false)
+                }}
+              />
+              <button type="button" style={styles.smallPrimary} disabled={savingName} onClick={() => void submitName()}>
+                {savingName ? 'Saving…' : 'Save'}
+              </button>
+              <button type="button" style={styles.smallGhost} onClick={() => setEditingName(false)}>
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <div style={styles.nameRow}>
+              <h1 style={styles.title}>{user.displayName}</h1>
+              <button type="button" style={styles.editLink} onClick={startEditName}>
+                Edit name
+              </button>
+            </div>
+          )}
+          {nameError ? <p style={styles.error}>{nameError}</p> : <p style={styles.muted}>{user.email}</p>}
 
           <div style={styles.statsRow}>
             <Stat label="Games" value={stats?.games ?? 0} />
@@ -66,27 +168,12 @@ export function ProfilePage() {
           </div>
 
           <h2 style={styles.section}>Saved decks</h2>
-          {decks.length === 0 ? (
-            <p style={styles.muted}>No saved decks yet. Build one and save it from the deckbuilder.</p>
-          ) : (
-            <ul style={styles.deckList}>
-              {decks.map((deck) => (
-                <li key={deck.id} style={styles.deckItem}>
-                  <button
-                    type="button"
-                    style={styles.deckName}
-                    onClick={() => navigate(`/deckbuilder?accountDeck=${deck.id}`)}
-                  >
-                    {deck.name}
-                    {deck.format ? <span style={styles.format}> · {deck.format}</span> : null}
-                  </button>
-                  <button type="button" style={styles.deleteBtn} onClick={() => void removeDeck(deck.id)}>
-                    Delete
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
+          <SavedDeckList
+            decks={deckItems}
+            onOpen={openDeck}
+            onDelete={(item) => void removeDeck(item)}
+            emptyText="No saved decks yet. Build one and save it from the deckbuilder."
+          />
         </div>
       </div>
     )
@@ -136,6 +223,39 @@ const styles: Record<string, React.CSSProperties> = {
   header: { display: 'flex', justifyContent: 'space-between' },
   link: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 14, padding: 0 },
   title: { margin: '8px 0 0', color: '#fff', fontSize: 28 },
+  nameRow: { display: 'flex', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' },
+  editLink: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 13, padding: 0 },
+  nameEditRow: { display: 'flex', alignItems: 'center', gap: 8, marginTop: 8, flexWrap: 'wrap' },
+  nameInput: {
+    flex: '1 1 200px',
+    minWidth: 0,
+    backgroundColor: '#14141f',
+    border: '1px solid #2a2a3e',
+    borderRadius: 8,
+    padding: '8px 12px',
+    color: '#fff',
+    fontSize: 18,
+  },
+  smallPrimary: {
+    padding: '8px 14px',
+    borderRadius: 8,
+    border: 'none',
+    backgroundColor: '#5b6ee1',
+    color: '#fff',
+    fontWeight: 600,
+    fontSize: 13,
+    cursor: 'pointer',
+  },
+  smallGhost: {
+    padding: '8px 14px',
+    borderRadius: 8,
+    border: '1px solid #2a2a3e',
+    backgroundColor: 'transparent',
+    color: '#aaa',
+    fontSize: 13,
+    cursor: 'pointer',
+  },
+  error: { margin: 0, color: '#ff6b6b', fontSize: 13 },
   muted: { margin: 0, color: '#888', fontSize: 14 },
   section: { margin: '20px 0 4px', color: '#fff', fontSize: 18 },
   statsRow: { display: 'flex', gap: 12, marginTop: 12, flexWrap: 'wrap' },
@@ -149,19 +269,6 @@ const styles: Record<string, React.CSSProperties> = {
   },
   statValue: { color: '#fff', fontSize: 26, fontWeight: 700 },
   statLabel: { color: '#888', fontSize: 12, marginTop: 4, textTransform: 'uppercase', letterSpacing: 0.5 },
-  deckList: { listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 8 },
-  deckItem: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: '#14141f',
-    border: '1px solid #2a2a3e',
-    borderRadius: 10,
-    padding: '10px 14px',
-  },
-  deckName: { background: 'none', border: 'none', color: '#fff', cursor: 'pointer', fontSize: 15, textAlign: 'left' },
-  format: { color: '#888', fontSize: 13 },
-  deleteBtn: { background: 'none', border: 'none', color: '#ff6b6b', cursor: 'pointer', fontSize: 13 },
   primary: {
     alignSelf: 'flex-start',
     marginTop: 8,

--- a/web-client/src/store/authStore.ts
+++ b/web-client/src/store/authStore.ts
@@ -11,6 +11,7 @@ import {
   fetchAppConfig,
   fetchMe,
   setAuthToken,
+  updateProfile,
 } from '@/api/account'
 
 export type AuthStatus = 'idle' | 'loading' | 'authenticated' | 'anonymous'
@@ -28,6 +29,8 @@ interface AuthState {
   init: () => Promise<void>
   /** Apply a fresh login (stores the token and the user). */
   setSession: (login: LoginResponse) => void
+  /** Change the signed-in user's display name (persists to the server, then updates the store). */
+  updateDisplayName: (displayName: string) => Promise<void>
   /** Sign out: drop the token and the user. */
   logout: () => void
 }
@@ -55,6 +58,11 @@ export const useAuthStore = create<AuthState>((set) => ({
   setSession: (login) => {
     setAuthToken(login.authToken)
     set({ user: login.user, status: 'authenticated' })
+  },
+
+  updateDisplayName: async (displayName) => {
+    const user = await updateProfile(displayName)
+    set({ user })
   },
 
   logout: () => {


### PR DESCRIPTION
## Why

The magic-link account integration shipped, but the save UX was confusing: the deckbuilder had **two** competing save concepts — a local **"Save deck"** and a separate **"Save online"** (`AccountDeckBar`). This unifies them and rounds out the account profile.

## What changed

**Unified Save (no more "Save deck" vs "Save online")**
- The deckbuilder's single **Save / Save as** routes by auth state:
  - **Signed in →** saves to the account (cloud), deduped by deck name (re-saving overwrites instead of duplicating — same rule the migration prompt uses).
  - **Anonymous →** saves to the browser library (localStorage), unchanged.
- `AccountDeckBar` is now purely the cloud **My decks** browser + a sign-in affordance (its redundant "Save online" button is gone). Save flashes "Saved to account" / "Save failed".

**Editable username**
- `PUT /api/auth/me` (`{ displayName }`, trimmed, 1–40 chars, duplicates allowed — email stays the identity). `AuthController` + `MagicLinkService.updateDisplayName`.
- Profile page gets an **Edit name** field; the change reflects in the top-right auth widget.

**Shared saved-decks component**
- New `SavedDeckList.tsx`, reused by **both** the profile page and the My-decks popover (profile previously hand-rolled its own list).
- Per-deck **Online / Browser only** badge so you can see what's backed up. The profile merges account decks + browser-only locals (a local deck whose name matches a cloud one is treated as the backed-up copy, not shown twice).

**Migration prompt** — already fires on the landing page after sign-in when browser-only decks exist; no change needed.

## Notes

- Cloud-deck JSON intentionally keeps `name` at both the envelope level (denormalized DB columns for cheap list queries) and inside `deck` (self-contained `SharedDeck`). Not a bug.
- Docs updated: `docs/accounts-and-persistence.md`.

## Verification

- `npm run typecheck` ✅ and `:game-server:compileKotlin` ✅.
- Not exercised against a running stack — the accounts subsystem needs `ACCOUNTS_ENABLED=true` + Postgres + SMTP. Screenshots of the profile + save flow to follow once the accounts stack is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)