### PR TITLE
Unify deck saving + saved-deck browsing (tournament, picker, profile)

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -96,6 +96,7 @@ the account's stats.
 | GET | `/api/auth/me` | Bearer → `user` |
 | PUT | `/api/auth/me` | Bearer + `{ displayName }` → updated `user` (1–40 chars; duplicates allowed) |
 | GET | `/api/account/decks` | list summaries |
+| GET | `/api/account/decks?full` | every deck in full (one round-trip; powers the unified deck browser) |
 | GET | `/api/account/decks/{id}` | full deck |
 | POST | `/api/account/decks` | body = `SharedDeck` JSON → created deck |
 | PUT | `/api/account/decks/{id}` | replace |
@@ -109,15 +110,18 @@ the account's stats.
 
 - `authStore` (standalone Zustand) holds the signed-in user; `api/account.ts` is the REST client.
 - Sign-in modal (`LoginModal`) + `/login/verify` page; a nav entry in the connection overlay.
-- **Unified Save:** the deckbuilder has one Save / Save as. When signed in it saves to the account
-  (cloud); when anonymous it saves to the browser library (localStorage). The cloud path dedupes by
-  deck name (same rule as the migration prompt) so re-saving overwrites rather than duplicating.
-  `AccountDeckBar` is now just the cloud "My decks" browser + a sign-in affordance.
+- **Unified Save (everywhere):** every "save a deck" button routes through `useSaveDeck` — when signed
+  in it saves to the account (cloud, overwriting a same-named deck via `upsertDeckByName`), otherwise
+  to the browser library (localStorage). This covers the deckbuilder Save/Save-as, the tournament/draft
+  "Save Deck" + deck-viewer save (previously always localStorage, even when signed in), and the lobby
+  deck picker's Paste-tab save.
+- **Unified deck library (`useUnifiedDecks`):** merges account decks (fetched in full via `?full`) with
+  browser-only decks, each tagged `online`. Feeds (a) the deckbuilder's saved-deck **browser** overlay,
+  which shows an **Online / Browser** badge per deck and routes load/rename/delete to the right store,
+  and (b) the lobby deck picker's "My Decks" tab, so signed-in users can pick their cloud decks to play.
 - **Display name:** editable on the profile page (`PUT /api/auth/me`); the email stays the identity.
-- Profile page at `/profile` shows stats + saved decks via the shared `SavedDeckList`, which renders
-  both account (online) and browser-only decks with an **Online / Browser only** badge so the user
-  can see what's backed up. Deck names deep-link into the deckbuilder
-  (`/deckbuilder?accountDeck=<id>` for cloud, `/deckbuilder/<id>` for local).
+- Profile page at `/profile` shows stats + a small **Manage my decks** launcher that opens the
+  deckbuilder's deck browser (`/deckbuilder?decks=open`) — one polished list instead of a second copy.
 - On sign-in, a landing-page prompt (`DeckMigrationPrompt`) offers to copy browser-only decks to the
   account.
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AccountDeckController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AccountDeckController.kt
@@ -4,7 +4,9 @@ import com.wingedsheep.gameserver.auth.AuthSupport
 import com.wingedsheep.gameserver.persistence.DeckRepository
 import com.wingedsheep.gameserver.persistence.DeckRow
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
@@ -49,6 +51,20 @@ class AccountDeckController(
     fun list(@RequestHeader(HttpHeaders.AUTHORIZATION, required = false) auth: String?): List<DeckSummary> {
         val userId = authSupport.requireUser(auth).uid
         return decks.findByUserIdOrderByUpdatedAtDesc(userId).map { it.toSummary() }
+    }
+
+    /**
+     * Full detail for every deck in one round-trip (`GET /api/account/decks?full`). Lets the deck
+     * browser render rich metadata (card counts, colors, art) for cloud decks without an N+1 of
+     * per-deck `GET /{id}` calls. Returns the same shape as repeated `get`, as a JSON array.
+     */
+    @GetMapping(params = ["full"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun listFull(@RequestHeader(HttpHeaders.AUTHORIZATION, required = false) auth: String?): ResponseEntity<Any> {
+        val userId = authSupport.requireUser(auth).uid
+        val rows = decks.findByUserIdOrderByUpdatedAtDesc(userId)
+        val array = buildJsonArray { rows.forEach { add(it.toDetailObject()) } }
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON)
+            .body(json.encodeToString(JsonArray.serializer(), array))
     }
 
     @GetMapping("/{id}", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -112,15 +128,14 @@ class AccountDeckController(
 
     private fun DeckRow.toSummary() = DeckSummary(id = id!!, name = name, format = format, updatedAt = updatedAt.toString())
 
-    /** Build the deck-detail response, embedding the stored deck JSON inline (no re-encoding). */
-    private fun DeckRow.toDetailJson(): String {
-        val obj = buildJsonObject {
-            put("id", id)
-            put("name", name)
-            format?.let { put("format", it) }
-            put("updatedAt", updatedAt.toString())
-            put("deck", json.parseToJsonElement(data))
-        }
-        return json.encodeToString(JsonObject.serializer(), obj)
+    /** Build the deck-detail object, embedding the stored deck JSON inline (no re-encoding). */
+    private fun DeckRow.toDetailObject(): JsonObject = buildJsonObject {
+        put("id", id)
+        put("name", name)
+        format?.let { put("format", it) }
+        put("updatedAt", updatedAt.toString())
+        put("deck", json.parseToJsonElement(data))
     }
+
+    private fun DeckRow.toDetailJson(): String = json.encodeToString(JsonObject.serializer(), toDetailObject())
 }

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -133,6 +133,14 @@ export async function listDecks(): Promise<DeckSummary[]> {
   return (await res.json()) as DeckSummary[]
 }
 
+/** Full detail for every saved deck in one request (`?full`) — used by the unified deck browser. */
+export async function listDeckDetails(): Promise<DeckDetail[]> {
+  const res = await fetch('/api/account/decks?full', { headers: authHeaders() })
+  if (res.status === 401) throw new UnauthorizedError()
+  if (!res.ok) throw new Error(`Failed to load decks (${res.status})`)
+  return (await res.json()) as DeckDetail[]
+}
+
 export async function getDeck(id: number): Promise<DeckDetail> {
   const res = await fetch(`/api/account/decks/${id}`, { headers: authHeaders() })
   if (res.status === 401) throw new UnauthorizedError()
@@ -166,6 +174,18 @@ export async function deleteDeck(id: number): Promise<void> {
   const res = await fetch(`/api/account/decks/${id}`, { method: 'DELETE', headers: authHeaders() })
   if (res.status === 401) throw new UnauthorizedError()
   if (!res.ok && res.status !== 404) throw new Error(`Failed to delete deck (${res.status})`)
+}
+
+/**
+ * Save a deck to the account, overwriting any existing deck with the same name (case-insensitive)
+ * rather than creating a duplicate. This is the single cloud-save path shared by the deckbuilder, the
+ * tournament/draft save, the deck picker, and the sign-in migration — so "save when signed in" means
+ * the same thing everywhere.
+ */
+export async function upsertDeckByName(deck: SharedDeck): Promise<DeckDetail> {
+  const existing = await listDecks()
+  const match = existing.find((d) => d.name.toLowerCase() === deck.name.toLowerCase())
+  return match ? updateDeck(match.id, deck) : saveDeck(deck)
 }
 
 // ----- Stats -----

--- a/web-client/src/components/auth/DeckMigrationPrompt.tsx
+++ b/web-client/src/components/auth/DeckMigrationPrompt.tsx
@@ -7,28 +7,12 @@
  */
 import { useEffect, useMemo, useState } from 'react'
 import type React from 'react'
-import { type PrintingRef } from '@/types'
-import { listDecks, saveDeck } from '@/api/account'
-import type { SharedDeck } from '@/components/deckbuilder/shareDeck'
-import { type SavedDeck, useDeckLibrary } from '@/store/deckLibrary'
+import { listDecks, upsertDeckByName } from '@/api/account'
+import { useDeckLibrary } from '@/store/deckLibrary'
+import { savedDeckToShared } from '@/store/useSaveDeck'
 import { useAuthStore } from '@/store/authStore'
 
 const DISMISS_KEY = 'argentum-deck-migration-dismissed'
-
-function savedToShared(deck: SavedDeck): SharedDeck {
-  const printings: Record<string, PrintingRef> = {}
-  for (const entry of deck.entries ?? []) {
-    if (entry.printing) printings[entry.name] = entry.printing
-  }
-  return {
-    name: deck.name,
-    cards: deck.cards,
-    ...(Object.keys(printings).length > 0 ? { printings } : {}),
-    ...(deck.format ? { format: deck.format } : {}),
-    ...(deck.commander ? { commander: deck.commander } : {}),
-    ...(deck.commanderPrinting ? { commanderPrinting: deck.commanderPrinting } : {}),
-  }
-}
 
 export function DeckMigrationPrompt() {
   const status = useAuthStore((s) => s.status)
@@ -68,7 +52,7 @@ export function DeckMigrationPrompt() {
     setState('saving')
     for (const deck of candidates) {
       try {
-        await saveDeck(savedToShared(deck))
+        await upsertDeckByName(savedDeckToShared(deck))
       } catch {
         /* skip the ones that fail; the rest still migrate */
       }

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -50,13 +50,9 @@ import {
   type SharedDeck,
 } from './shareDeck'
 import { AccountDeckBar } from './AccountDeckBar'
-import {
-  getDeck as getAccountDeck,
-  listDecks as apiListDecks,
-  saveDeck as apiSaveDeck,
-  updateDeck as apiUpdateDeck,
-} from '@/api/account'
+import { getDeck as getAccountDeck, upsertDeckByName } from '@/api/account'
 import { useAuthStore } from '@/store/authStore'
+import { type UnifiedDeck, useUnifiedDecks } from '@/store/useUnifiedDecks'
 import {
   detectProducedColors,
   suggestBasicLands,
@@ -218,12 +214,19 @@ export function DeckbuilderPage() {
     return s ? `?${s}` : ''
   }, [searchParams])
 
-  const decks = useDeckLibrary((s) => s.decks)
+  // The saved-deck browser + "My decks" card show the unified library (cloud decks when signed in,
+  // plus browser-only locals), each tagged online/local. Plain localStorage actions below still back
+  // the anonymous save path and the active-deck (local) operations.
+  const {
+    decks: browserDecks,
+    reload: reloadUnifiedDecks,
+    removeDeck: removeUnifiedDeck,
+    renameDeck: renameUnifiedDeck,
+  } = useUnifiedDecks()
   const hydrate = useDeckLibrary((s) => s.hydrate)
   const hydrated = useDeckLibrary((s) => s.hydrated)
   const saveDeck = useDeckLibrary((s) => s.saveDeck)
   const deleteDeck = useDeckLibrary((s) => s.deleteDeck)
-  const renameDeck = useDeckLibrary((s) => s.renameDeck)
   const getDeck = useDeckLibrary((s) => s.getDeck)
 
   // Hydrate localStorage once on mount.
@@ -441,6 +444,21 @@ export function DeckbuilderPage() {
   const [bulkEditOpen, setBulkEditOpen] = useState(false)
   // Saved-decks browser overlay visibility.
   const [decksBrowserOpen, setDecksBrowserOpen] = useState(false)
+  // Deep link from the profile's "Manage decks" button (/deckbuilder?decks=open): open the saved-deck
+  // browser straight away, then strip the param so it doesn't re-open on later navigations.
+  useEffect(() => {
+    if (searchParams.get('decks') !== 'open') return
+    reloadUnifiedDecks()
+    setDecksBrowserOpen(true)
+    setSearchParams(
+      (prev) => {
+        const params = new URLSearchParams(prev)
+        params.delete('decks')
+        return params
+      },
+      { replace: true },
+    )
+  }, [searchParams, setSearchParams, reloadUnifiedDecks])
   // Example-decks picker overlay visibility.
   const [examplesOpen, setExamplesOpen] = useState(false)
 
@@ -881,10 +899,7 @@ export function DeckbuilderPage() {
     }
     const shared = overrideName ? { ...built, name: overrideName } : built
     try {
-      const existing = await apiListDecks()
-      const match = existing.find((d) => d.name.toLowerCase() === shared.name.toLowerCase())
-      if (match) await apiUpdateDeck(match.id, shared)
-      else await apiSaveDeck(shared)
+      await upsertDeckByName(shared)
       if (overrideName) setDeckName(overrideName)
       flashSave('Saved to account')
     } catch {
@@ -1028,7 +1043,16 @@ export function DeckbuilderPage() {
     }
   }
 
-  const handleLoadSaved = (deck: SavedDeck) => {
+  const handleLoadSaved = (deck: UnifiedDeck) => {
+    // Cloud decks load through the SharedDeck path (fetched fresh, then applied like a deep link);
+    // local decks load straight from their stored shape and deep-link to /deckbuilder/<id>.
+    if (deck.cloudId != null) {
+      void getAccountDeck(deck.cloudId)
+        .then((detail) => applySharedDeck(detail.deck))
+        .catch(() => {})
+      setDecksBrowserOpen(false)
+      return
+    }
     setDeckName(deck.name)
     setDeckCards(mergeCommanderIntoCards(deck.cards, deck.commander ?? null))
     setSideboardCards(deck.sideboard ? { ...deck.sideboard } : {})
@@ -1048,16 +1072,16 @@ export function DeckbuilderPage() {
     setDecksBrowserOpen(false)
   }
 
-  const handleRenameSaved = (deck: SavedDeck) => {
+  const handleRenameSaved = (deck: UnifiedDeck) => {
     const next = window.prompt('Rename deck', deck.name)
     if (!next || !next.trim()) return
-    renameDeck(deck.id, next.trim())
+    void renameUnifiedDeck(deck, next.trim())
     if (deck.id === activeDeckId) setDeckName(next.trim())
   }
 
-  const handleDeleteSaved = (deck: SavedDeck) => {
+  const handleDeleteSaved = (deck: UnifiedDeck) => {
     if (!window.confirm(`Delete "${deck.name}"?`)) return
-    deleteDeck(deck.id)
+    void removeUnifiedDeck(deck)
     if (deck.id === activeDeckId) handleNew()
   }
 
@@ -1291,7 +1315,7 @@ export function DeckbuilderPage() {
 
       {decksBrowserOpen && (
         <SavedDecksBrowser
-          decks={decks}
+          decks={browserDecks}
           catalog={catalogIndex}
           activeDeckId={activeDeckId}
           onClose={() => setDecksBrowserOpen(false)}
@@ -1312,9 +1336,12 @@ export function DeckbuilderPage() {
       {/* Left rail */}
       <aside className={styles.left}>
         <SavedDecksSummary
-          decks={decks}
+          decks={browserDecks}
           activeDeckId={activeDeckId}
-          onOpen={() => setDecksBrowserOpen(true)}
+          onOpen={() => {
+            reloadUnifiedDecks()
+            setDecksBrowserOpen(true)
+          }}
         />
         {viewMode === 'deck' ? (
           <DeckHoverPreview
@@ -2219,13 +2246,13 @@ function SavedDecksBrowser({
   onRename,
   onDelete,
 }: {
-  decks: SavedDeck[]
+  decks: UnifiedDeck[]
   catalog: Record<string, CardSummary>
   activeDeckId: string | null
   onClose: () => void
-  onLoad: (d: SavedDeck) => void
-  onRename: (d: SavedDeck) => void
-  onDelete: (d: SavedDeck) => void
+  onLoad: (d: UnifiedDeck) => void
+  onRename: (d: UnifiedDeck) => void
+  onDelete: (d: UnifiedDeck) => void
 }) {
   const [filter, setFilter] = useState('')
   const [sort, setSort] = useState<DecksBrowserSort>('updated')
@@ -2485,15 +2512,15 @@ function DeckCard({
   onRename,
   onDelete,
 }: {
-  deck: SavedDeck
+  deck: UnifiedDeck
   total: number
   colors: string[]
   legalFormats: string[]
   isActive: boolean
   heroArt: string | undefined
-  onLoad: (d: SavedDeck) => void
-  onRename: (d: SavedDeck) => void
-  onDelete: (d: SavedDeck) => void
+  onLoad: (d: UnifiedDeck) => void
+  onRename: (d: UnifiedDeck) => void
+  onDelete: (d: UnifiedDeck) => void
 }) {
   const updated = useMemo(() => formatRelativeTime(deck.updatedAt), [deck.updatedAt])
   // Banner gradient derived from the deck's colour identity. Falls back to a
@@ -2547,6 +2574,13 @@ function DeckCard({
         <div className={styles.deckCardName}>{deck.name}</div>
         <div className={styles.deckCardMeta}>
           <span>{updated}</span>
+          <span aria-hidden="true">·</span>
+          <span
+            style={{ color: deck.online ? '#9be8bd' : '#9a9aa8', fontWeight: 600 }}
+            title={deck.online ? 'Backed up to your account' : 'Saved only in this browser'}
+          >
+            {deck.online ? '● Online' : '○ Browser'}
+          </span>
         </div>
         {(deck.format || legalFormats.length > 0) && (
           <span className={styles.formatBadges}>

--- a/web-client/src/components/ui/DeckPicker.tsx
+++ b/web-client/src/components/ui/DeckPicker.tsx
@@ -23,11 +23,11 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import type { PrintingRef } from '@/types'
 import type { AvailableSet } from '@/types/messages'
 import {
-  useDeckLibrary,
   mergeCommanderIntoCards,
   stripCommanderFromCards,
-  type SavedDeck,
 } from '@/store/deckLibrary'
+import { type UnifiedDeck, useUnifiedDecks } from '@/store/useUnifiedDecks'
+import { useSaveDeck } from '@/store/useSaveDeck'
 import {
   labelForFormat,
   useDeckLegalFormats,
@@ -155,10 +155,10 @@ export function DeckPicker({
   tabs = ALL_TABS,
   format = null,
 }: DeckPickerProps) {
-  const decks = useDeckLibrary((s) => s.decks)
-  const hydrate = useDeckLibrary((s) => s.hydrate)
-  const saveDeck = useDeckLibrary((s) => s.saveDeck)
-  const deleteDeck = useDeckLibrary((s) => s.deleteDeck)
+  // Unified library: cloud decks (when signed in) + browser-only decks, each tagged with where it
+  // lives. Selecting a cloud deck works the same as a local one because both carry their card list.
+  const { decks, reload: reloadDecks, removeDeck } = useUnifiedDecks()
+  const { save: saveDeckRouted } = useSaveDeck()
 
   const showSaved = tabs.includes('saved')
   const showExamples = tabs.includes('examples')
@@ -193,11 +193,6 @@ export function DeckPicker({
   useEffect(() => {
     setRandomSetCode(initialSetCode)
   }, [initialSetCode])
-
-  // Hydrate localStorage once.
-  useEffect(() => {
-    hydrate()
-  }, [hydrate])
 
   // Move off `random` to `saved` once decks are hydrated, so users land on their own list.
   useEffect(() => {
@@ -367,10 +362,12 @@ export function DeckPicker({
     setTab('paste')
   }
 
-  const handleSaveCurrent = () => {
+  const handleSaveCurrent = async () => {
     if (!pendingName.trim() || Object.keys(currentDeck).length === 0) return
-    const saved = saveDeck({ name: pendingName.trim(), cards: currentDeck })
-    setSelectedSavedId(saved.id)
+    // Routes to the account when signed in (then refresh so the new cloud deck appears), else local.
+    const { id } = await saveDeckRouted({ name: pendingName.trim(), cards: currentDeck })
+    reloadDecks()
+    setSelectedSavedId(id)
     setPendingName('')
     setTab('saved')
   }
@@ -426,9 +423,9 @@ export function DeckPicker({
             hiddenCount={decks.length - visibleDecks.length}
             selectedId={selectedSavedId}
             onSelect={setSelectedSavedId}
-            onDelete={(id) => {
-              deleteDeck(id)
-              if (selectedSavedId === id) setSelectedSavedId(null)
+            onDelete={(d) => {
+              void removeDeck(d)
+              if (selectedSavedId === d.id) setSelectedSavedId(null)
             }}
             onEdit={(d) => {
               // Show the full deck in the paste editor — including the commander,
@@ -570,14 +567,14 @@ function TabButton({
 function SavedDecksPanel({
   decks, legalityMap, format, hiddenCount, selectedId, onSelect, onDelete, onEdit,
 }: {
-  decks: SavedDeck[]
+  decks: UnifiedDeck[]
   legalityMap: Record<string, string[]>
   format: string | null
   hiddenCount: number
   selectedId: string | null
   onSelect: (id: string) => void
-  onDelete: (id: string) => void
-  onEdit: (d: SavedDeck) => void
+  onDelete: (d: UnifiedDeck) => void
+  onEdit: (d: UnifiedDeck) => void
 }) {
   if (decks.length === 0) {
     if (format && hiddenCount > 0) {
@@ -610,7 +607,20 @@ function SavedDecksPanel({
               onClick={() => onSelect(d.id)}
             >
               <div className={styles.savedItemMeta}>
-                <span className={styles.savedItemName}>{d.name}</span>
+                <span className={styles.savedItemName}>
+                  {d.name}
+                  <span
+                    className={styles.savedItemFormatBadge}
+                    style={{
+                      marginLeft: 6,
+                      color: d.online ? '#9be8bd' : '#b8b8c4',
+                      borderColor: d.online ? 'rgba(62,207,122,0.35)' : undefined,
+                    }}
+                    title={d.online ? 'Backed up to your account' : 'Saved only in this browser'}
+                  >
+                    {d.online ? 'Online' : 'Browser'}
+                  </span>
+                </span>
                 <span className={styles.savedItemCount}>{total} cards</span>
                 {(d.format || legalIn.length > 0) && (
                   <span className={styles.savedItemFormats}>
@@ -638,7 +648,7 @@ function SavedDecksPanel({
               </div>
               <div className={styles.savedItemActions}>
                 <button className={styles.linkButton} onClick={(e) => { e.stopPropagation(); onEdit(d) }} type="button">Edit</button>
-                <button className={styles.dangerButton} onClick={(e) => { e.stopPropagation(); onDelete(d.id) }} type="button">Delete</button>
+                <button className={styles.dangerButton} onClick={(e) => { e.stopPropagation(); onDelete(d) }} type="button">Delete</button>
               </div>
             </li>
           )

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -11,6 +11,7 @@ import { ReplayViewer, type GameSummary } from '../admin/ReplayViewer'
 import type { ReplayData } from '@/replay/reconstructSnapshots.ts'
 import { QuickGameLobbyOverlay } from './QuickGameLobbyOverlay'
 import { useDeckLibrary, buildDraftedDeckSave, type SavedDeckEntry } from '@/store/deckLibrary'
+import { useSaveDeck } from '@/store/useSaveDeck'
 import { DeckPicker } from './DeckPicker'
 import { BanListEditor } from './BanListEditor'
 import { SetPickerModal } from './SetPickerModal'
@@ -2003,7 +2004,7 @@ function TournamentOverlay({
   const [deckSavedAt, setDeckSavedAt] = useState<number | null>(null)
   const [saveDeckDialog, setSaveDeckDialog] = useState<{ name: string } | null>(null)
   const hydrateDeckLibrary = useDeckLibrary((s) => s.hydrate)
-  const saveDeckToLibrary = useDeckLibrary((s) => s.saveDeck)
+  const { save: saveDeckRouted, isLoggedIn } = useSaveDeck()
   useEffect(() => { hydrateDeckLibrary() }, [hydrateDeckLibrary])
 
   const buildDeckSave = (): { cards: Record<string, number>; entries: SavedDeckEntry[] | undefined } | null => {
@@ -2029,7 +2030,8 @@ function TournamentOverlay({
     const built = buildDeckSave()
     if (!built) return
     const name = saveDeckDialog.name.trim() || `Drafted deck – ${new Date().toLocaleDateString()}`
-    saveDeckToLibrary({ name, cards: built.cards, ...(built.entries ? { entries: built.entries } : {}) })
+    // Routes to the account when signed in, localStorage otherwise — same as the deckbuilder.
+    void saveDeckRouted({ name, cards: built.cards, ...(built.entries ? { entries: built.entries } : {}) })
     setSaveDeckDialog(null)
     setDeckSavedAt(Date.now())
     setTimeout(() => setDeckSavedAt(null), 2000)
@@ -2140,7 +2142,7 @@ function TournamentOverlay({
                   color: '#fff',
                   fontWeight: 600,
                 }}
-                title="Save this drafted deck to your local My Decks library"
+                title={isLoggedIn ? 'Save this drafted deck to your account' : 'Save this drafted deck to your browser My Decks library'}
               >
                 {deckSavedAt ? 'Saved ✓' : 'Save Deck'}
               </button>
@@ -2478,6 +2480,7 @@ function TournamentOverlay({
       {saveDeckDialog && (
         <SaveDeckDialog
           name={saveDeckDialog.name}
+          online={isLoggedIn}
           onNameChange={(name) => setSaveDeckDialog({ name })}
           onCancel={() => setSaveDeckDialog(null)}
           onConfirm={confirmSaveDeck}
@@ -2489,11 +2492,13 @@ function TournamentOverlay({
 
 function SaveDeckDialog({
   name,
+  online,
   onNameChange,
   onConfirm,
   onCancel,
 }: {
   name: string
+  online: boolean
   onNameChange: (name: string) => void
   onConfirm: () => void
   onCancel: () => void
@@ -2521,6 +2526,11 @@ function SaveDeckDialog({
           <label style={{ fontSize: 'var(--font-sm)', color: 'var(--text-faint)' }}>
             Deck name
           </label>
+          <p style={{ margin: 0, fontSize: 'var(--font-xs, 0.75rem)', color: 'var(--text-faint)' }}>
+            {online
+              ? 'Saving to your account — available on any device you sign in from.'
+              : 'Saving to this browser. Sign in to save decks to your account.'}
+          </p>
           <input
             ref={inputRef}
             type="text"
@@ -2576,7 +2586,7 @@ function DeckViewerModal({
   const [hoveredCard, setHoveredCard] = useState<SealedCardInfo | null>(null)
   const [hoverPos, setHoverPos] = useState<{ x: number; y: number } | null>(null)
   const hydrateDeckLibrary = useDeckLibrary((s) => s.hydrate)
-  const saveDeck = useDeckLibrary((s) => s.saveDeck)
+  const { save: saveDeckRouted, isLoggedIn } = useSaveDeck()
   useEffect(() => { hydrateDeckLibrary() }, [hydrateDeckLibrary])
   const defaultDeckName = `Drafted ${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
   const [saveName, setSaveName] = useState(defaultDeckName)
@@ -2758,15 +2768,17 @@ function DeckViewerModal({
                 deckBuildingState.landCounts,
                 [...deckBuildingState.cardPool, ...deckBuildingState.basicLands],
               )
-              saveDeck({ name: saveName.trim() || defaultDeckName, cards, ...(entries ? { entries } : {}) })
+              // Routes to the account when signed in, localStorage otherwise.
+              void saveDeckRouted({ name: saveName.trim() || defaultDeckName, cards, ...(entries ? { entries } : {}) })
               setSavedAt(Date.now())
               setTimeout(() => setSavedAt(null), 2000)
             }}
             disabled={totalCards === 0}
             className={styles.startButton}
             style={{ flexShrink: 0 }}
+            title={isLoggedIn ? 'Save to your account' : 'Save to your browser My Decks library'}
           >
-            {savedAt ? 'Saved ✓' : 'Save to My Decks'}
+            {savedAt ? 'Saved ✓' : isLoggedIn ? 'Save to My Decks (online)' : 'Save to My Decks'}
           </button>
         </div>
       </div>

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -1,23 +1,14 @@
 /**
  * Account profile: shows the signed-in user, lets them rename their display name, shows their
- * win/loss record, and lists their saved decks — both account (online) and browser-only — via the
- * shared {@link SavedDeckList}, so they can see at a glance which decks are backed up. Prompts sign-in
- * when anonymous.
+ * win/loss record, and offers a small launcher into the deckbuilder's saved-deck browser (the polished
+ * overlay that lists account + browser decks with online badges). Prompts sign-in when anonymous.
  */
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import type React from 'react'
 import { useNavigate } from 'react-router-dom'
-import {
-  type AccountStats,
-  type DeckSummary,
-  deleteDeck as apiDeleteDeck,
-  fetchStats,
-  listDecks,
-} from '@/api/account'
+import { type AccountStats, type DeckSummary, fetchStats, listDecks } from '@/api/account'
 import { LoginModal } from '@/components/auth/LoginModal'
-import { SavedDeckList, type SavedDeckListItem } from '@/components/deckbuilder/SavedDeckList'
 import { useAuthStore } from '@/store/authStore'
-import { useDeckLibrary } from '@/store/deckLibrary'
 
 export function ProfilePage() {
   const navigate = useNavigate()
@@ -27,11 +18,6 @@ export function ProfilePage() {
   const init = useAuthStore((s) => s.init)
   const logout = useAuthStore((s) => s.logout)
   const updateDisplayName = useAuthStore((s) => s.updateDisplayName)
-
-  const localDecks = useDeckLibrary((s) => s.decks)
-  const hydrateLocal = useDeckLibrary((s) => s.hydrate)
-  const hydratedLocal = useDeckLibrary((s) => s.hydrated)
-  const deleteLocalDeck = useDeckLibrary((s) => s.deleteDeck)
 
   const [stats, setStats] = useState<AccountStats | null>(null)
   const [decks, setDecks] = useState<DeckSummary[]>([])
@@ -47,51 +33,10 @@ export function ProfilePage() {
   }, [status, init])
 
   useEffect(() => {
-    if (!hydratedLocal) hydrateLocal()
-  }, [hydratedLocal, hydrateLocal])
-
-  useEffect(() => {
     if (status !== 'authenticated') return
     void fetchStats().then(setStats).catch(() => setStats(null))
     void listDecks().then(setDecks).catch(() => setDecks([]))
   }, [status])
-
-  // Combine the user's account decks (online) with browser-only locals not yet backed up, so the
-  // list doubles as a "what's backed up where" view. A local deck whose name matches a cloud deck is
-  // considered the backed-up copy and isn't shown twice (same name-based rule as the save/migration).
-  const deckItems: SavedDeckListItem[] = useMemo(() => {
-    const cloudNames = new Set(decks.map((d) => d.name.toLowerCase()))
-    const cloudItems: SavedDeckListItem[] = decks.map((d) => ({
-      key: `c:${d.id}`,
-      name: d.name,
-      online: true,
-      ...(d.format ? { format: d.format } : {}),
-    }))
-    const localItems: SavedDeckListItem[] = localDecks
-      .filter((d) => !cloudNames.has(d.name.toLowerCase()))
-      .map((d) => ({
-        key: `l:${d.id}`,
-        name: d.name,
-        online: false,
-        ...(d.format ? { format: d.format } : {}),
-      }))
-    return [...cloudItems, ...localItems]
-  }, [decks, localDecks])
-
-  const openDeck = (item: SavedDeckListItem) => {
-    if (item.key.startsWith('c:')) navigate(`/deckbuilder?accountDeck=${item.key.slice(2)}`)
-    else navigate(`/deckbuilder/${item.key.slice(2)}`)
-  }
-
-  const removeDeck = async (item: SavedDeckListItem) => {
-    if (item.key.startsWith('c:')) {
-      const id = Number(item.key.slice(2))
-      await apiDeleteDeck(id)
-      setDecks((prev) => prev.filter((d) => d.id !== id))
-    } else {
-      deleteLocalDeck(item.key.slice(2))
-    }
-  }
 
   const startEditName = () => {
     setNameDraft(user?.displayName ?? '')
@@ -167,13 +112,20 @@ export function ProfilePage() {
             <Stat label="Win rate" value={stats ? `${Math.round(stats.winRate * 100)}%` : '—'} />
           </div>
 
-          <h2 style={styles.section}>Saved decks</h2>
-          <SavedDeckList
-            decks={deckItems}
-            onOpen={openDeck}
-            onDelete={(item) => void removeDeck(item)}
-            emptyText="No saved decks yet. Build one and save it from the deckbuilder."
-          />
+          <h2 style={styles.section}>Decks</h2>
+          {/* Small launcher into the deckbuilder's saved-deck browser (the polished overlay that lists
+              account + browser decks with online badges) — no need to duplicate that UI here. */}
+          <button type="button" style={styles.deckManager} onClick={() => navigate('/deckbuilder?decks=open')}>
+            <span style={styles.deckManagerText}>
+              <span style={styles.deckManagerTitle}>Manage my decks</span>
+              <span style={styles.muted}>
+                {decks.length === 0
+                  ? 'No decks saved to your account yet'
+                  : `${decks.length} deck${decks.length === 1 ? '' : 's'} saved to your account`}
+              </span>
+            </span>
+            <span style={styles.deckManagerArrow}>Open deck browser →</span>
+          </button>
         </div>
       </div>
     )
@@ -269,6 +221,22 @@ const styles: Record<string, React.CSSProperties> = {
   },
   statValue: { color: '#fff', fontSize: 26, fontWeight: 700 },
   statLabel: { color: '#888', fontSize: 12, marginTop: 4, textTransform: 'uppercase', letterSpacing: 0.5 },
+  deckManager: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    textAlign: 'left',
+    backgroundColor: '#14141f',
+    border: '1px solid #2a2a3e',
+    borderRadius: 12,
+    padding: '16px 18px',
+    color: '#fff',
+    cursor: 'pointer',
+  },
+  deckManagerText: { display: 'flex', flexDirection: 'column', gap: 4 },
+  deckManagerTitle: { fontSize: 16, fontWeight: 600 },
+  deckManagerArrow: { color: '#8b9bff', fontSize: 14, fontWeight: 600, flexShrink: 0 },
   primary: {
     alignSelf: 'flex-start',
     marginTop: 8,

--- a/web-client/src/store/useSaveDeck.ts
+++ b/web-client/src/store/useSaveDeck.ts
@@ -1,0 +1,64 @@
+/**
+ * Auth-aware deck saving — the single entry point every "save a deck" button should use.
+ *
+ * When the user is signed in, the deck goes to their account (cloud), overwriting any same-named
+ * deck rather than duplicating it; when anonymous, it goes to the browser library (localStorage).
+ * This is what makes "save when logged in saves online" true everywhere: the deckbuilder, the
+ * tournament/draft save, and the lobby deck picker all route through here instead of each deciding
+ * for themselves (the old tournament path always wrote to localStorage, even when signed in).
+ */
+import { useCallback } from 'react'
+import type { PrintingRef } from '@/types'
+import { upsertDeckByName } from '@/api/account'
+import type { SharedDeck } from '@/components/deckbuilder/shareDeck'
+import { type SavedDeck, useDeckLibrary } from '@/store/deckLibrary'
+import { useAuthStore } from '@/store/authStore'
+
+/** What a save needs: everything in a SavedDeck except the storage-assigned id/timestamp. */
+export type SaveDeckInput = Omit<SavedDeck, 'id' | 'updatedAt'>
+
+/** Convert a library/draft deck into the cloud wire shape (SharedDeck). */
+export function savedDeckToShared(input: SaveDeckInput): SharedDeck {
+  const printings: Record<string, PrintingRef> = {}
+  for (const entry of input.entries ?? []) {
+    if (entry.printing) printings[entry.name] = entry.printing
+  }
+  return {
+    name: input.name,
+    cards: input.cards,
+    ...(Object.keys(printings).length > 0 ? { printings } : {}),
+    ...(input.format ? { format: input.format } : {}),
+    ...(input.commander ? { commander: input.commander } : {}),
+    ...(input.commanderPrinting ? { commanderPrinting: input.commanderPrinting } : {}),
+  }
+}
+
+export interface SaveDeckResult {
+  /** True when the deck was saved to the account (cloud); false when saved to localStorage. */
+  online: boolean
+  /** Unified deck id of the saved deck (`cloud:<n>` for account decks, the local id otherwise). */
+  id: string
+}
+
+/**
+ * Returns a `save(input)` that persists to the account when signed in, or localStorage otherwise,
+ * plus the current `isLoggedIn` flag so callers can label their button ("Save online" vs "Save").
+ */
+export function useSaveDeck() {
+  const isLoggedIn = useAuthStore((s) => s.status === 'authenticated')
+  const saveLocal = useDeckLibrary((s) => s.saveDeck)
+
+  const save = useCallback(
+    async (input: SaveDeckInput): Promise<SaveDeckResult> => {
+      if (isLoggedIn) {
+        const detail = await upsertDeckByName(savedDeckToShared(input))
+        return { online: true, id: `cloud:${detail.id}` }
+      }
+      const saved = saveLocal(input)
+      return { online: false, id: saved.id }
+    },
+    [isLoggedIn, saveLocal],
+  )
+
+  return { save, isLoggedIn }
+}

--- a/web-client/src/store/useUnifiedDecks.ts
+++ b/web-client/src/store/useUnifiedDecks.ts
@@ -1,0 +1,117 @@
+/**
+ * One deck library that merges the user's account (cloud) decks with their browser-only (localStorage)
+ * decks, tagging each with where it lives. This is what lets the deck browser / picker show a single
+ * list with an "Online" badge on the decks that are backed up, instead of two disconnected lists.
+ *
+ * When signed in, cloud decks are fetched in full (one `?full` request) so they carry their card
+ * lists and can render the same rich metadata as local decks. A local deck whose name matches a cloud
+ * deck is treated as the same deck (the cloud copy wins) so it isn't shown twice. Mutations route to
+ * the right backing store automatically.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  type DeckDetail,
+  deleteDeck as apiDeleteDeck,
+  listDeckDetails,
+  updateDeck as apiUpdateDeck,
+} from '@/api/account'
+import { type SavedDeck, type SavedDeckEntry, useDeckLibrary } from '@/store/deckLibrary'
+import { useAuthStore } from '@/store/authStore'
+import { savedDeckToShared } from '@/store/useSaveDeck'
+
+export interface UnifiedDeck extends SavedDeck {
+  /** True = backed up in the account (cloud); false = browser-only (localStorage). */
+  online: boolean
+  /** Server id, present only for cloud decks (used to route updates/deletes). */
+  cloudId?: number
+}
+
+function detailToUnified(detail: DeckDetail): UnifiedDeck {
+  const d = detail.deck
+  // Rebuild per-card entries from the sparse printings map so pinned-printing art still renders.
+  const entries: SavedDeckEntry[] | undefined = d.printings
+    ? Object.entries(d.cards).map(([name, count]) => {
+        const printing = d.printings?.[name]
+        return printing ? { name, count, printing } : { name, count }
+      })
+    : undefined
+  return {
+    id: `cloud:${detail.id}`,
+    cloudId: detail.id,
+    online: true,
+    name: d.name,
+    cards: d.cards,
+    ...(d.format ? { format: d.format } : {}),
+    ...(d.commander ? { commander: d.commander } : {}),
+    ...(d.commanderPrinting ? { commanderPrinting: d.commanderPrinting } : {}),
+    ...(entries ? { entries } : {}),
+    updatedAt: Date.parse(detail.updatedAt) || 0,
+  }
+}
+
+export function useUnifiedDecks() {
+  const isLoggedIn = useAuthStore((s) => s.status === 'authenticated')
+  const localDecks = useDeckLibrary((s) => s.decks)
+  const hydrate = useDeckLibrary((s) => s.hydrate)
+  const hydrated = useDeckLibrary((s) => s.hydrated)
+  const deleteLocal = useDeckLibrary((s) => s.deleteDeck)
+  const renameLocal = useDeckLibrary((s) => s.renameDeck)
+
+  const [cloud, setCloud] = useState<DeckDetail[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!hydrated) hydrate()
+  }, [hydrated, hydrate])
+
+  const reload = useCallback(() => {
+    if (!isLoggedIn) {
+      setCloud([])
+      return
+    }
+    setLoading(true)
+    void listDeckDetails()
+      .then(setCloud)
+      .catch(() => setCloud([]))
+      .finally(() => setLoading(false))
+  }, [isLoggedIn])
+
+  useEffect(() => {
+    reload()
+  }, [reload])
+
+  const decks: UnifiedDeck[] = useMemo(() => {
+    const cloudDecks = cloud.map(detailToUnified)
+    const cloudNames = new Set(cloudDecks.map((d) => d.name.toLowerCase()))
+    const locals: UnifiedDeck[] = localDecks
+      .filter((d) => !cloudNames.has(d.name.toLowerCase()))
+      .map((d) => ({ ...d, online: false }))
+    return [...cloudDecks, ...locals]
+  }, [cloud, localDecks])
+
+  const removeDeck = useCallback(
+    async (deck: UnifiedDeck) => {
+      if (deck.cloudId != null) {
+        await apiDeleteDeck(deck.cloudId)
+        setCloud((prev) => prev.filter((d) => d.id !== deck.cloudId))
+      } else {
+        deleteLocal(deck.id)
+      }
+    },
+    [deleteLocal],
+  )
+
+  const renameDeck = useCallback(
+    async (deck: UnifiedDeck, name: string) => {
+      if (deck.cloudId != null) {
+        await apiUpdateDeck(deck.cloudId, { ...savedDeckToShared(deck), name })
+        reload()
+      } else {
+        renameLocal(deck.id, name)
+      }
+    },
+    [renameLocal, reload],
+  )
+
+  return { decks, loading, reload, removeDeck, renameDeck, isLoggedIn }
+}


### PR DESCRIPTION
## Why

Two gaps remained after the accounts work in #1040:

1. **Saving wasn't unified.** The deckbuilder routed saves by auth, but the **tournament/draft "Save Deck"**, the deck-viewer save, and the **lobby deck picker's** save still always wrote to `localStorage` — even when signed in.
2. **The profile's saved-deck list was a second, plainer copy** of deck UI. The ask was to reuse the deckbuilder's polished deck browser and show which decks are already online.

## What changed

### Saving — one path everywhere
- New **`useSaveDeck`** hook + **`upsertDeckByName`** API helper: when signed in, save to the account (overwriting a same-named deck so re-saves don't duplicate); otherwise `localStorage`.
- Wired into: tournament **Save Deck** dialog, the **deck-viewer** "Save to My Decks", and the lobby **DeckPicker** Paste-tab save. The deckbuilder save and the sign-in migration prompt were refactored onto the same shared helpers (removing duplicated upsert logic).

### Browsing — one unified, polished list
- New **`useUnifiedDecks`** hook merges account decks with browser-only decks, each tagged `online`/local. A local deck whose name matches a cloud deck is treated as the backed-up copy (not shown twice).
- Cloud decks are fetched in full in **one round-trip** via a new `GET /api/account/decks?full` endpoint (avoids an N+1 of per-deck fetches), so they render the same rich metadata as local decks.
- The **deckbuilder's saved-deck browser** now shows an **Online / Browser** badge per deck and routes load/rename/delete to the right store. The lobby **DeckPicker** "My Decks" tab shows the same unified list with badges, so signed-in users can pick their cloud decks to play.
- The **profile** replaces its inline list with a small **"Manage my decks"** launcher that opens the deckbuilder browser (`/deckbuilder?decks=open`) — reuse, not a second implementation.

## Notes
- Built on top of #1040 (now merged into `main`).
- Docs updated: `docs/accounts-and-persistence.md`.

## Verification
- `npm run typecheck` ✅, `npm run build` ✅, `:game-server:compileKotlin` ✅.
- Not exercised against a running stack — the accounts subsystem needs `ACCOUNTS_ENABLED=true` + Postgres + SMTP. Screenshots of the deck browser badges, tournament save, and profile launcher to follow once the accounts stack is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)