### PR TITLE
Add a handful of Duskmourn: House of Horror cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3416,6 +3416,16 @@ staticAbility {
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a
   *permanent, player-scoped* "no maximum hand size for the rest of the game" (survives the source
   leaving play), use the effect `Effects.RemoveMaximumHandSize(target)` instead — see §4. (Wisdom of Ages)
+- `GrantCantLoseGame` — controller "can't lose the game" while this permanent is on the battlefield
+  (Lich's Mastery, Platinum Angel). Suppresses *all* loss conditions for that player (0-or-less life,
+  poison, empty-library draw, effect losses); opponents can still win via "you win the game" effects.
+  Projected to `GrantsCantLoseGameComponent`, read by every player-loss SBA via `playerCantLoseGame`.
+- `GrantCantLoseGameFromLife` — the narrow sibling: controller "doesn't lose the game for having 0 or
+  less life" (CR 704.5a) only. Poison, empty-library, and effect-based losses still apply — including a
+  card's own `Effects.LoseGame`. Marina Vendrell's Grimoire ("…and don't lose the game for having 0 or
+  less life" alongside its "if you have no cards in hand, you lose the game" clause, which still fires).
+  Projected to `GrantsCantLoseGameFromLifeComponent`, read only by `PlayerLifeLossCheck` (controller-
+  scoped, not a team-wide grant).
 - `SetMaximumHandSize(player, amount)` — sets the maximum hand size of a `player` scope (`You` /
   `EachOpponent` / `Each`, resolved relative to the source's controller) to a `DynamicAmount`, read at
   cleanup. Most restrictive (smallest) value wins when several apply; a `NoMaximumHandSize` controlled

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5301,6 +5301,13 @@ replacementEffect {
   Martyrs of Korlis uses `Conditions.SourceIsUntapped` for "As long as this creature is untapped, all
   damage that would be dealt to you by artifacts is dealt to this creature instead" (`redirectTo =
   EffectTarget.Self`, `source = SourceFilter.Matching(GameObjectFilter.Artifact)`).
+- `ReplaceDamageWithMill(appliesTo = DamageEvent(recipient = Opponent))` — replace matching damage
+  (CR 615, neither dealt nor prevented): each opponent of the replacement's controller mills that many
+  cards instead. The Mindskinner: `DamageEvent(recipient = RecipientFilter.Opponent, source =
+  SourceFilter.Matching(GameObjectFilter.Any.youControl()))` covers both the unblockable creature's
+  combat damage and noncombat damage from any source you control. Mirrors `ReplaceDamageWithCounters`;
+  wired in both damage paths (`DamageUtils.applyReplaceDamageWithMill` for the general path,
+  `CombatDamageManager` for combat). Damage-type filtering is not applied (matches any type).
 - **DamageEvent filters (gap #7):** `EventPattern.DamageEvent(recipient, source, damageType, amount)`.
   `amount: AmountFilter` (`Any` / `AtMost(n)` / `AtLeast(n)` / `Exactly(n)`) gates on the would-be
   amount (Callous Giant: `AtMost(3)`). `source = SourceFilter.Matching(filter)` can carry relational

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3257,7 +3257,8 @@ staticAbility {
   the battlefield" wording. `TriggerDetector.duplicateETBOrLTBTriggers`; additive across copies.
 - `AdditionalSourceTriggers(sourceFilter, excludeSelf = true)` — Twinflame Travelers: all triggered
   abilities of permanents matching `sourceFilter` you control trigger an additional time (not just ETB).
-  `TriggerDetector.duplicateSourceTriggers`.
+  Set `excludeSelf = false` for "a permanent you control" wording that includes the source itself
+  (Fractured Realm). `TriggerDetector.duplicateSourceTriggers`.
 - `AdditionalAttackTriggers(attackerFilter = GameObjectFilter.Any)` — Windcrag Siege (Mardu): the
   attack-cause analogue of `AdditionalETBOrLTBTriggers`. If a creature matching `attackerFilter`
   being declared as an attacker causes an attack-related triggered ability ("whenever a creature

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
@@ -268,6 +268,22 @@ data object GrantCantLoseGame : StaticAbility {
 }
 
 /**
+ * Grants the controller "you don't lose the game for having 0 or less life" — the *narrow*
+ * sibling of [GrantCantLoseGame].
+ *
+ * Unlike [GrantCantLoseGame], this only suppresses the 0-or-less-life state-based action
+ * (CR 704.5a). The controller can still lose to poison (704.5c), drawing from an empty library
+ * (704.5b/c), and card effects. Marina Vendrell's Grimoire (DSK): "You have no maximum hand size
+ * and don't lose the game for having 0 or less life." — its own "if you have no cards in hand, you
+ * lose the game" clause therefore still functions.
+ */
+@SerialName("GrantCantLoseGameFromLife")
+@Serializable
+data object GrantCantLoseGameFromLife : StaticAbility {
+    override val description: String = "You don't lose the game for having 0 or less life"
+}
+
+/**
  * Creatures matching [filter] can be the targets of spells and abilities as though
  * they didn't have hexproof.
  *

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1300,6 +1300,35 @@ data class ReplaceDamageWithCounters(
     }
 }
 
+/**
+ * Prevent matched damage and, instead, each opponent of this permanent's controller mills that
+ * many cards.
+ *
+ * Models The Mindskinner (DSK): "If a source you control would deal damage to an opponent, prevent
+ * that damage and each opponent mills that many cards." The [appliesTo] pattern scopes which damage
+ * is replaced — typically `DamageEvent(recipient = Opponent, source = Matching(<you control>))`.
+ *
+ * Like [ReplaceDamageWithCounters], the damage is neither dealt nor prevented in the
+ * "prevention shield" sense — it is *replaced* (CR 615): the mill happens instead. The mill goes to
+ * every opponent of the controller, not just the damaged one, matching the printed "each opponent"
+ * wording (identical to a single opponent in a two-player game).
+ */
+@SerialName("ReplaceDamageWithMill")
+@Serializable
+data class ReplaceDamageWithMill(
+    override val appliesTo: EventPattern = EventPattern.DamageEvent(
+        recipient = RecipientFilter.Opponent
+    )
+) : ReplacementEffect {
+    override val description: String =
+        "If ${appliesTo.description}, prevent that damage and each opponent mills that many cards instead"
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        return if (newAppliesTo !== appliesTo) copy(appliesTo = newAppliesTo) else this
+    }
+}
+
 // =============================================================================
 // Extra Turn Replacement Effects
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MarinaVendrellsGrimoire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MarinaVendrellsGrimoire.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantCantLoseGameFromLife
+import com.wingedsheep.sdk.scripting.NoMaximumHandSize
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Marina Vendrell's Grimoire (DSK 64)
+ * {5}{U}
+ * Legendary Artifact — Book
+ *
+ * When Marina Vendrell's Grimoire enters, if you cast it, draw five cards.
+ * You have no maximum hand size and don't lose the game for having 0 or less life.
+ * Whenever you gain life, draw that many cards.
+ * Whenever you lose life, discard that many cards. Then if you have no cards in hand, you lose the game.
+ *
+ * The "don't lose for 0 or less life" clause is the narrow [GrantCantLoseGameFromLife] static, NOT
+ * the broad Platinum-Angel [com.wingedsheep.sdk.scripting.GrantCantLoseGame]: the controller can
+ * still lose to poison, an empty library, or — crucially — this card's own "if you have no cards in
+ * hand, you lose the game" clause (a direct [Effects.LoseGame], not the 704.5a state-based action).
+ */
+val MarinaVendrellsGrimoire = card("Marina Vendrell's Grimoire") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Artifact — Book"
+    oracleText = "When Marina Vendrell's Grimoire enters, if you cast it, draw five cards.\n" +
+        "You have no maximum hand size and don't lose the game for having 0 or less life.\n" +
+        "Whenever you gain life, draw that many cards.\n" +
+        "Whenever you lose life, discard that many cards. Then if you have no cards in hand, you lose the game."
+
+    // When ~ enters, if you cast it, draw five cards.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = Effects.DrawCards(5)
+    }
+
+    // You have no maximum hand size.
+    staticAbility {
+        ability = NoMaximumHandSize
+    }
+
+    // ...and don't lose the game for having 0 or less life.
+    staticAbility {
+        ability = GrantCantLoseGameFromLife
+    }
+
+    // Whenever you gain life, draw that many cards.
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.DrawCards(DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_LIFE_GAINED))
+    }
+
+    // Whenever you lose life, discard that many cards. Then if you have no cards in hand, you lose the game.
+    triggeredAbility {
+        trigger = Triggers.YouLoseLife
+        effect = Effects.Composite(
+            Effects.Discard(DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_LIFE_LOST)),
+            ConditionalEffect(
+                condition = Conditions.EmptyHand,
+                effect = Effects.LoseGame()
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "64"
+        artist = "Denys Tsiperko"
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1ab1aef7-4171-4869-8eb5-fe42e3ca9e45.jpg?1726286094"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MirrorRoomFracturedRealm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/MirrorRoomFracturedRealm.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Mirror Room // Fractured Realm (DSK 67) — split-layout Room (CR 709.5).
+ *
+ * Mirror Room {2}{U} — Enchantment — Room
+ *   When you unlock this door, create a token that's a copy of target creature you control,
+ *   except it's a Reflection in addition to its other creature types.
+ *
+ * Fractured Realm {5}{U}{U} — Enchantment — Room
+ *   If a triggered ability of a permanent you control triggers, that ability triggers an
+ *   additional time.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ *
+ * The back face says "a permanent you control" — not "another" — so Fractured Realm doubles
+ * its own triggered abilities too (excludeSelf = false). It has no triggers of its own, but the
+ * intent is faithful to the literal text.
+ */
+val MirrorRoomFracturedRealm = card("Mirror Room // Fractured Realm") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "U"
+
+    face("Mirror Room") {
+        manaCost = "{2}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, create a token that's a copy of target creature " +
+            "you control, except it's a Reflection in addition to its other creature types."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            val creature = target("target creature you control", Targets.CreatureYouControl)
+            effect = Effects.CreateTokenCopyOfTarget(
+                target = creature,
+                addedSubtypes = setOf(Subtype("Reflection"))
+            )
+        }
+    }
+
+    face("Fractured Realm") {
+        manaCost = "{5}{U}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "If a triggered ability of a permanent you control triggers, that ability " +
+            "triggers an additional time."
+
+        staticAbility {
+            ability = AdditionalSourceTriggers(
+                sourceFilter = GameObjectFilter.Permanent.youControl(),
+                excludeSelf = false
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "67"
+        artist = "Helge C. Balzer"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg?1726867728"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TheMindskinner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/TheMindskinner.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ReplaceDamageWithMill
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * The Mindskinner (DSK 66)
+ * {U}{U}{U}
+ * Legendary Enchantment Creature — Nightmare
+ * 10/1
+ *
+ * The Mindskinner can't be blocked.
+ * If a source you control would deal damage to an opponent, prevent that damage and each opponent
+ * mills that many cards.
+ *
+ * The second ability is a damage replacement ([ReplaceDamageWithMill]): it covers both combat
+ * damage from the unblockable 10/1 and noncombat damage from any other source you control. The
+ * damage is replaced (CR 615) — neither dealt nor "prevented" in the shield sense — and each
+ * opponent mills that many cards instead.
+ */
+val TheMindskinner = card("The Mindskinner") {
+    manaCost = "{U}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Enchantment Creature — Nightmare"
+    power = 10
+    toughness = 1
+    oracleText = "The Mindskinner can't be blocked.\n" +
+        "If a source you control would deal damage to an opponent, prevent that damage and each " +
+        "opponent mills that many cards."
+
+    flags(AbilityFlag.CANT_BE_BLOCKED)
+
+    replacementEffect(
+        ReplaceDamageWithMill(
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.Opponent,
+                source = SourceFilter.Matching(GameObjectFilter.Any.youControl()),
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "66"
+        artist = "Abz J Harding"
+        flavorText = "It slices away the most precious memories first, then the mundane, until all that remains is blank, formless fear."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f1bb4c5-99be-46cc-ad54-7affb5f0144c.jpg?1726286101"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -10289,6 +10289,116 @@
     ]
 }
 
+// Marina Vendrell's Grimoire
+{
+    "name": "Marina Vendrell's Grimoire",
+    "manaCost": "{5}{U}",
+    "typeLine": "Legendary Artifact — Book",
+    "oracleText": "When Marina Vendrell's Grimoire enters, if you cast it, draw five cards.\nYou have no maximum hand size and don't lose the game for having 0 or less life.\nWhenever you gain life, draw that many cards.\nWhenever you lose life, discard that many cards. Then if you have no cards in hand, you lose the game.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                },
+                "triggerCondition": "WasCast"
+            },
+            {
+                "id": "ability_2",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_LIFE_GAINED"
+                    }
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": "LifeLossEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "ContextProperty",
+                                            "key": "TRIGGER_LIFE_LOST"
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose cards to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Exists",
+                                    "player": "You",
+                                    "zone": "Hand",
+                                    "negate": true
+                                }
+                            },
+                            "then": "LoseGame"
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            "NoMaximumHandSize",
+            "GrantCantLoseGameFromLife"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "rarity": "RARE",
+        "artist": "Denys Tsiperko",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1ab1aef7-4171-4869-8eb5-fe42e3ca9e45.jpg?1726286094"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Marvin, Murderous Mimic
 {
     "name": "Marvin, Murderous Mimic",

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -16519,6 +16519,46 @@
     ]
 }
 
+// The Mindskinner
+{
+    "name": "The Mindskinner",
+    "manaCost": "{U}{U}{U}",
+    "typeLine": "Legendary Enchantment Creature — Nightmare",
+    "oracleText": "The Mindskinner can't be blocked.\nIf a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards.",
+    "creatureStats": {
+        "power": 10,
+        "toughness": 1
+    },
+    "flags": [
+        "CANT_BE_BLOCKED"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "ReplaceDamageWithMill",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "RecipientOpponent",
+                    "source": {
+                        "type": "SourceMatching",
+                        "filter": "ctrl:you"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "RARE",
+        "artist": "Abz J Harding",
+        "flavorText": "It slices away the most precious memories first, then the mundane, until all that remains is blank, formless fear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f1bb4c5-99be-46cc-ad54-7affb5f0144c.jpg?1726286101"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // The Rollercrusher Ride
 {
     "name": "The Rollercrusher Ride",

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -10767,6 +10767,72 @@
     ]
 }
 
+// Mirror Room // Fractured Realm
+{
+    "name": "Mirror Room // Fractured Realm",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, create a token that's a copy of target creature you control, except it's a Reflection in addition to its other creature types.\n//\nIf a triggered ability of a permanent you control triggers, that ability triggers an additional time.",
+    "metadata": {
+        "collectorNumber": "67",
+        "rarity": "MYTHIC",
+        "artist": "Helge C. Balzer",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2e085dd-a448-4f5a-9cfa-5c2034234e7c.jpg?1726867728"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Mirror Room",
+            "manaCost": "{2}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, create a token that's a copy of target creature you control, except it's a Reflection in addition to its other creature types.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "CreateTokenCopyOfTarget",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            },
+                            "addedSubtypes": [
+                                "Reflection"
+                            ]
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Fractured Realm",
+            "manaCost": "{5}{U}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "If a triggered ability of a permanent you control triggers, that ability triggers an additional time.",
+            "script": {
+                "staticAbilities": [
+                    {
+                        "type": "AdditionalSourceTriggers",
+                        "sourceFilter": "permanent ctrl:you",
+                        "excludeSelf": false
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Moldering Gym // Weight Room
 {
     "name": "Moldering Gym // Weight Room",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -392,6 +392,7 @@ val engineSerializersModule = SerializersModule {
         subclass(EnteredViaAbilityComponent::class)
         subclass(GrantCantBeBlockedToSmallCreaturesComponent::class)
         subclass(GrantsCantLoseGameComponent::class)
+        subclass(GrantsCantLoseGameFromLifeComponent::class)
         subclass(GrantsControllerHexproofComponent::class)
         subclass(GrantsControllerShroudComponent::class)
         subclass(GrantsStationUsingToughnessComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -33,6 +33,7 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.SuppressEntersTriggers
 import com.wingedsheep.engine.state.components.identity.RoomComponent
 import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.state.components.identity.RoomFaceStatics
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
@@ -2435,8 +2436,9 @@ class TriggerDetector(
             val controllerId = projected.getController(permanentId) ?: continue
             val cardDef = registry.getCard(card.cardDefinitionId) ?: continue
 
-            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-            for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
+            // Route through RoomFaceStatics so a doubler printed on an *unlocked* Room face
+            // (CR 709.5) is honoured, not just one in the card's top-level script.
+            for (ability in RoomFaceStatics.activeStaticAbilities(container, cardDef)) {
                 if (ability is AdditionalETBOrLTBTriggers) {
                     doublers.add(
                         Doubler(
@@ -2688,8 +2690,9 @@ class TriggerDetector(
             if (container.has<FaceDownComponent>()) continue
             val controllerId = projected.getController(permanentId) ?: continue
             val cardDef = registry.getCard(card.cardDefinitionId) ?: continue
-            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-            for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
+            // Route through RoomFaceStatics so a doubler printed on an *unlocked* Room face
+            // (CR 709.5) is honoured, not just one in the card's top-level script.
+            for (ability in RoomFaceStatics.activeStaticAbilities(container, cardDef)) {
                 if (ability is AdditionalSourceTriggers) {
                     doublers.add(
                         SourceDoubler(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -52,6 +52,7 @@ import com.wingedsheep.sdk.scripting.PreventLifeGain
 import com.wingedsheep.sdk.scripting.RedirectDamage
 import com.wingedsheep.sdk.scripting.effects.RedirectScope
 import com.wingedsheep.sdk.scripting.ReplaceDamageWithCounters
+import com.wingedsheep.sdk.scripting.ReplaceDamageWithMill
 import com.wingedsheep.sdk.scripting.ReplacementEffect
 import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.events.DamageType
@@ -213,6 +214,10 @@ object DamageUtils {
         if (isPlayer) {
             val counterResult = applyReplaceDamageWithCounters(newState, targetId, effectiveAmount, sourceId)
             if (counterResult != null) return counterResult
+
+            // Damage-to-an-opponent → prevent + each opponent mills that many (The Mindskinner).
+            val millResult = applyReplaceDamageWithMill(newState, targetId, effectiveAmount, sourceId)
+            if (millResult != null) return millResult
         }
 
         // Events from a reflect shield (Eye for an Eye) that fired but let the damage proceed.
@@ -1719,6 +1724,81 @@ object DamageUtils {
                     events.addAll(transitionResult.events)
                 }
 
+                return EffectResult.success(newState, events)
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * Check for [ReplaceDamageWithMill] replacement effects (The Mindskinner).
+     *
+     * Scans the battlefield for permanents whose replacement effect prevents damage matching its
+     * [ReplaceDamageWithMill.appliesTo] pattern and instead mills that many cards from each opponent
+     * of the replacement's controller. [targetId] is the damage recipient (a player), [sourceId] the
+     * damage source (required — the modelled cards scope to "a source you control"). Returns a
+     * short-circuiting [EffectResult] when a replacement applies (so the original damage is replaced,
+     * not dealt), or null when none matches.
+     *
+     * Mirrors [applyReplaceDamageWithCounters]; like it, damage-type filtering is not applied
+     * (the modelled card replaces damage of any type).
+     */
+    fun applyReplaceDamageWithMill(
+        state: GameState,
+        targetId: EntityId,
+        amount: Int,
+        sourceId: EntityId?
+    ): EffectResult? {
+        if (amount <= 0 || sourceId == null) return null
+        val projected = state.projectedState
+
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacementComponent = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = replacementHostController(state, entityId) ?: continue
+
+            for (effect in replacementComponent.replacementEffects) {
+                if (effect !is ReplaceDamageWithMill) continue
+
+                val damageEvent = effect.appliesTo
+                if (damageEvent !is EventPattern.DamageEvent) continue
+                if (!damageEvent.amount.matches(amount)) continue
+
+                val sourceMatches = when (val source = damageEvent.source) {
+                    is SourceFilter.Any -> true
+                    is SourceFilter.Matching -> {
+                        val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId, recipientId = targetId)
+                        predicateEvaluator.matches(state, projected, sourceId, source.filter, context)
+                    }
+                    else -> false
+                }
+                if (!sourceMatches) continue
+
+                val recipientMatches = when (val recipient = damageEvent.recipient) {
+                    is RecipientFilter.Any -> true
+                    is RecipientFilter.Opponent -> targetId in state.turnOrder && targetId != sourceControllerId
+                    is RecipientFilter.You -> targetId == sourceControllerId
+                    is RecipientFilter.Matching -> {
+                        val context = PredicateContext(controllerId = sourceControllerId, sourceId = entityId)
+                        predicateEvaluator.matches(state, projected, targetId, recipient.filter, context)
+                    }
+                    else -> false
+                }
+                if (!recipientMatches) continue
+
+                // Replace the damage: each opponent of the controller mills `amount` cards. Snapshot
+                // the top cards before moving so a shrinking library doesn't re-read shifted slots.
+                var newState = state
+                val events = mutableListOf<EngineGameEvent>()
+                for (opponentId in state.getOpponents(sourceControllerId)) {
+                    val topCards = newState.getLibrary(opponentId).take(amount)
+                    for (cardId in topCards) {
+                        val result = ZoneTransitionService.moveToZone(newState, cardId, Zone.GRAVEYARD)
+                        newState = result.state
+                        events.addAll(result.events)
+                    }
+                }
                 return EffectResult.success(newState, events)
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -824,6 +824,15 @@ internal class CombatDamageManager(
             return newState
         }
 
+        // Replace combat damage to an opponent → prevent + each opponent mills that many
+        // (The Mindskinner: an unblockable attacker's combat damage routes through here).
+        val millResult = DamageUtils.applyReplaceDamageWithMill(newState, targetId, amplifiedAmount, sourceId)
+        if (millResult != null) {
+            newState = millResult.state
+            events.addAll(millResult.events)
+            return newState
+        }
+
         // Deflection / reflection shields (Deflecting Palm prevents; Eye for an Eye reflects but
         // lets the damage proceed).
         when (val deflect = DamageUtils.checkDeflectDamageShield(newState, targetId, amplifiedAmount, sourceId)) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.engine.state.components.battlefield.CantBeTargetedByOpponentAbilitiesComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantCantBeBlockedToSmallCreaturesComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameFromLifeComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexproofComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsStationUsingToughnessComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
@@ -232,6 +233,11 @@ class StaticAbilityHandler(
         // Add tag component for "you can't lose the game"
         if (allStaticAbilities.any { it is com.wingedsheep.sdk.scripting.GrantCantLoseGame }) {
             result = result.with(GrantsCantLoseGameComponent)
+        }
+
+        // Add tag component for the narrow "you don't lose for 0 or less life" (Marina's Grimoire)
+        if (allStaticAbilities.any { it is com.wingedsheep.sdk.scripting.GrantCantLoseGameFromLife }) {
+            result = result.with(GrantsCantLoseGameFromLifeComponent)
         }
 
         // Add tag component for "station using toughness"
@@ -820,6 +826,7 @@ class StaticAbilityHandler(
             is CantBeTargetedByOpponentAbilities,
             is GrantCantBeBlockedToSmallCreatures,
             is GrantCantLoseGame,
+            is com.wingedsheep.sdk.scripting.GrantCantLoseGameFromLife,
             is GrantHexproofToController,
             is GrantShroudToController,
             is StationUsingToughness,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -896,6 +896,7 @@ class StaticAbilityHandler(
             is com.wingedsheep.sdk.scripting.RedirectDamage,
             is com.wingedsheep.sdk.scripting.DamageCantBePrevented,
             is ReplaceDamageWithCounters,
+            is com.wingedsheep.sdk.scripting.ReplaceDamageWithMill,
             // Life gain/loss:
             is PreventLifeGain,
             is com.wingedsheep.sdk.scripting.ModifyLifeGain,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/player/PlayerLifeLossCheck.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.mechanics.sba.SbaOrder
 import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameFromLifeComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
 import com.wingedsheep.engine.state.components.player.LossReason
@@ -30,6 +31,8 @@ class PlayerLifeLossCheck : StateBasedActionCheck {
             val container = state.getEntity(playerId) ?: continue
             if (container.has<PlayerLostComponent>()) continue
             if (playerCantLoseGame(state, playerId)) continue
+            // Narrow "don't lose for 0 or less life" (Marina Vendrell's Grimoire) — 704.5a only.
+            if (playerCantLoseGameFromLife(state, playerId)) continue
 
             // Presence guard stays per-player; the value is the team's shared total (CR 810.9c).
             // Reading through the resolver means every member of a 0-life team is marked in this
@@ -60,3 +63,16 @@ internal fun playerCantLoseGame(state: GameState, playerId: EntityId): Boolean {
             container.get<ControllerComponent>()?.playerId in team
     }
 }
+
+/**
+ * Narrow sibling of [playerCantLoseGame]: true when [playerId] controls a permanent granting
+ * "you don't lose the game for having 0 or less life" (Marina Vendrell's Grimoire). Consulted only
+ * by the 704.5a life-loss check, so poison / empty-library / effect losses are unaffected. Scoped
+ * to the controller itself — it is not a team-wide "can't lose" grant.
+ */
+internal fun playerCantLoseGameFromLife(state: GameState, playerId: EntityId): Boolean =
+    state.getBattlefield().any { entityId ->
+        val container = state.getEntity(entityId) ?: return@any false
+        container.has<GrantsCantLoseGameFromLifeComponent>() &&
+            container.get<ControllerComponent>()?.playerId == playerId
+    }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -700,6 +700,15 @@ data object GrantsControllerHexproofComponent : Component
 data object GrantsCantLoseGameComponent : Component
 
 /**
+ * Marks a permanent as granting "you don't lose the game for having 0 or less life" to its
+ * controller — the narrow sibling of [GrantsCantLoseGameComponent]. Read only by the 704.5a
+ * life-loss state-based action (Marina Vendrell's Grimoire); poison / empty-library / effect
+ * losses are unaffected. Leaves with the permanent — no cleanup needed.
+ */
+@Serializable
+data object GrantsCantLoseGameFromLifeComponent : Component
+
+/**
  * Marks a permanent as granting the Station-using-toughness effect to creatures its
  * controller controls. When a creature with this component's controller taps for a
  * Station ability and its toughness > power, it contributes toughness instead of power.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarinaVendrellsGrimoireTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarinaVendrellsGrimoireTest.kt
@@ -1,0 +1,181 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.MarinaVendrellsGrimoire
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Marina Vendrell's Grimoire (DSK 64).
+ *
+ *  - When it enters, if you cast it, draw five cards.
+ *  - You have no maximum hand size and don't lose the game for having 0 or less life.
+ *  - Whenever you gain life, draw that many cards.
+ *  - Whenever you lose life, discard that many cards. Then if you have no cards in hand, you lose.
+ */
+class MarinaVendrellsGrimoireTest : FunSpec({
+
+    val gainThree = card("Test Lifegain") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        oracleText = "You gain 3 life."
+        spell { effect = Effects.GainLife(3) }
+    }
+
+    val loseThree = card("Test Lifeloss") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        oracleText = "You lose 3 life."
+        spell { effect = Effects.LoseLife(3, EffectTarget.Controller) }
+    }
+
+    fun driver(startingLife: Int = 20): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(MarinaVendrellsGrimoire, gainThree, loseThree))
+        d.initMirrorMatch(
+            deck = Deck.of("Island" to 30, "Grizzly Bears" to 10),
+            skipMulligans = true,
+            startingLife = startingLife,
+        )
+        return d
+    }
+
+    // Resolve the stack, auto-picking the required cards for any forced discard along the way.
+    fun GameTestDriver.settle(player: EntityId) {
+        var guard = 0
+        while (!state.gameOver && guard++ < 40) {
+            val pd = pendingDecision
+            when {
+                pd is SelectCardsDecision && pd.playerId == player -> {
+                    val pick = getHand(player).take(pd.minSelections)
+                    submitCardSelection(player, pick)
+                }
+                state.stack.isNotEmpty() || state.priorityPlayerId != null -> bothPass()
+                else -> break
+            }
+        }
+    }
+
+    test("cast: ETB draws five cards (the 'if you cast it' clause)") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val grimoire = d.putCardInHand(p1, MarinaVendrellsGrimoire.name)
+        d.giveMana(p1, Color.BLUE, 1)
+        d.giveColorlessMana(p1, 5)
+        val before = d.getHandSize(p1)
+        d.castSpell(p1, grimoire).isSuccess shouldBe true
+        var guard = 0
+        while (d.state.stack.isNotEmpty() && guard++ < 20) d.bothPass()
+
+        // -1 (Grimoire leaves hand) + 5 (ETB draw) = +4.
+        (d.getHandSize(p1) - before) shouldBe 4
+        d.state.getBattlefield().any { d.getCardName(it) == MarinaVendrellsGrimoire.name } shouldBe true
+    }
+
+    test("put onto battlefield without casting does NOT draw five") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val before = d.getHandSize(p1)
+        d.putPermanentOnBattlefield(p1, MarinaVendrellsGrimoire.name)
+        var guard = 0
+        while (d.state.stack.isNotEmpty() && guard++ < 20) d.bothPass()
+
+        // No "if you cast it" → no draw.
+        d.getHandSize(p1) shouldBe before
+    }
+
+    test("whenever you gain life, draw that many cards") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putPermanentOnBattlefield(p1, MarinaVendrellsGrimoire.name)
+
+        val spell = d.putCardInHand(p1, "Test Lifegain")
+        d.giveColorlessMana(p1, 1)
+        val before = d.getHandSize(p1)
+        d.castSpell(p1, spell).isSuccess shouldBe true
+        d.settle(p1)
+
+        // -1 (cast) + 3 (gained 3 life → draw 3) = +2, and life went up by 3.
+        (d.getHandSize(p1) - before) shouldBe 2
+        d.getLifeTotal(p1) shouldBe 23
+    }
+
+    test("whenever you lose life, discard that many cards") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putPermanentOnBattlefield(p1, MarinaVendrellsGrimoire.name)
+
+        val spell = d.putCardInHand(p1, "Test Lifeloss")
+        d.giveColorlessMana(p1, 1)
+        val before = d.getHandSize(p1)
+        d.castSpell(p1, spell).isSuccess shouldBe true
+        d.settle(p1)
+
+        // -1 (cast) - 3 (discard 3 for losing 3 life) = -4; hand still non-empty so no loss.
+        (d.getHandSize(p1) - before) shouldBe -4
+        d.state.gameOver.shouldBeFalse()
+    }
+
+    test("don't lose the game for having 0 or less life (704.5a suppressed)") {
+        val d = driver(startingLife = 3)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putPermanentOnBattlefield(p1, MarinaVendrellsGrimoire.name)
+
+        // Lose exactly to 0. The lose-life trigger discards 3 cards, but the opening hand is large
+        // enough that it isn't emptied, so the only thing that could kill p1 is the 0-life SBA.
+        val spell = d.putCardInHand(p1, "Test Lifeloss")
+        d.giveColorlessMana(p1, 1)
+        d.castSpell(p1, spell).isSuccess shouldBe true
+        d.settle(p1)
+
+        d.getLifeTotal(p1) shouldBe 0
+        d.state.gameOver.shouldBeFalse()
+    }
+
+    test("losing life that empties your hand makes you lose the game") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putPermanentOnBattlefield(p1, MarinaVendrellsGrimoire.name)
+
+        // Reduce the hand to only the lifeloss spell, so after casting it the hand is empty; the
+        // life loss then discards nothing and the "no cards in hand → you lose the game" clause fires.
+        val spell = d.putCardInHand(p1, "Test Lifeloss")
+        var st = d.state
+        for (cardId in d.getHand(p1)) {
+            if (cardId != spell) {
+                st = st.removeFromZone(ZoneKey(p1, Zone.HAND), cardId)
+                st = st.withoutEntity(cardId)
+            }
+        }
+        val stateField = d::class.java.getDeclaredField("_state")
+        stateField.isAccessible = true
+        stateField.set(d, st)
+
+        d.giveColorlessMana(p1, 1)
+        d.castSpell(p1, spell).isSuccess shouldBe true
+        d.settle(p1)
+
+        d.state.gameOver.shouldBeTrue()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MirrorRoomFracturedRealmTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MirrorRoomFracturedRealmTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.RoomComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.MirrorRoomFracturedRealm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario for `Mirror Room // Fractured Realm` (DSK 67), a split-layout Room (CR 709.5).
+ *
+ * Mirror Room {2}{U}    — "When you unlock this door, create a token that's a copy of target
+ *                          creature you control, except it's a Reflection in addition to its
+ *                          other creature types." Casting the half enters it unlocked, firing
+ *                          the trigger.
+ * Fractured Realm {5}{U}{U} — "If a triggered ability of a permanent you control triggers, that
+ *                          ability triggers an additional time." (any permanent you control,
+ *                          including Fractured Realm itself — excludeSelf = false).
+ */
+class MirrorRoomFracturedRealmTest : FunSpec({
+
+    // A creature with an ETB draw trigger, used to observe Fractured Realm's doubling.
+    val drawer = card("Test ETB Drawer") {
+        manaCost = "{2}"
+        typeLine = "Creature — Human"
+        power = 2
+        toughness = 2
+        oracleText = "When Test ETB Drawer enters, draw a card."
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(MirrorRoomFracturedRealm, drawer))
+        d.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("Mirror Room unlocks its door and tokens a Reflection copy of a creature you control") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A creature to copy.
+        val bear = d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+
+        // Cast Mirror Room ({2}{U}, face 0). The cast face enters unlocked, firing the trigger.
+        val roomId = d.putCardInHand(p1, MirrorRoomFracturedRealm.name)
+        d.giveMana(p1, Color.BLUE, 1)
+        d.giveColorlessMana(p1, 2)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+
+        val room = d.state.getEntity(roomId)?.get<RoomComponent>()
+        room shouldNotBe null
+        room!!.unlocked shouldBe setOf(RoomFaceId("Mirror Room"))
+
+        // The "When you unlock this door" trigger asks for its target creature.
+        d.submitTargetSelection(p1, listOf(bear))
+        d.bothPass()
+
+        // Two Grizzly Bears now: the original plus a token copy.
+        val bears = d.state.getBattlefield().filter {
+            d.getController(it) == p1 && d.getCardName(it) == "Grizzly Bears"
+        }
+        bears.size shouldBe 2
+
+        // The token is the new entity and is a Reflection in addition to its other types.
+        val token = bears.first { it != bear }
+        val projected = d.state.projectedState
+        projected.hasSubtype(token, "Reflection") shouldBe true
+        projected.hasSubtype(token, "Bear") shouldBe true
+    }
+
+    test("Fractured Realm doubles a creature's ETB trigger — controller draws twice") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast Fractured Realm ({5}{U}{U}, face 1) so its static doubler is installed.
+        val roomId = d.putCardInHand(p1, MirrorRoomFracturedRealm.name)
+        d.giveMana(p1, Color.BLUE, 2)
+        d.giveColorlessMana(p1, 5)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+        d.bothPass()
+        d.state.getEntity(roomId)!!.get<RoomComponent>()!!.unlocked shouldBe setOf(RoomFaceId("Fractured Realm"))
+
+        // A creature with an ETB draw trigger: the trigger should fire an additional time.
+        val creature = d.putCardInHand(p1, "Test ETB Drawer")
+        d.giveColorlessMana(p1, 2)
+        val before = d.getHandSize(p1)
+        d.castSpell(p1, creature).isSuccess shouldBe true
+        var guard = 0
+        while (d.state.stack.isNotEmpty() && guard++ < 20) {
+            d.bothPass()
+        }
+
+        // Casting moved the card from hand, then two ETB draws (original + additional firing):
+        // net delta = -1 (cast) + 2 (draws) = +1.
+        (d.getHandSize(p1) - before) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMindskinnerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMindskinnerTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.TheMindskinner
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Mindskinner (DSK 66).
+ *
+ * 1. "The Mindskinner can't be blocked." — combat damage path: an unblocked 10/1 deals 10 combat
+ *    damage to an opponent, which is replaced — the opponent loses no life and mills 10 instead.
+ * 2. "If a source you control would deal damage to an opponent, prevent that damage and each
+ *    opponent mills that many cards." — noncombat damage from a source you control is likewise
+ *    replaced with milling.
+ */
+class TheMindskinnerTest : FunSpec({
+
+    // A 0/1 with an ETB "deal 3 damage to target opponent" — a noncombat source you control.
+    val zapper = card("Test Zapper") {
+        manaCost = "{1}"
+        typeLine = "Creature — Wizard"
+        power = 0
+        toughness = 1
+        oracleText = "When Test Zapper enters, it deals 3 damage to target opponent."
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            val foe = target("target opponent", Targets.Opponent)
+            effect = Effects.DealDamage(3, foe)
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(TheMindskinner, zapper))
+        d.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+            startingLife = 20,
+        )
+        return d
+    }
+
+    test("unblocked combat damage to an opponent is replaced — no life lost, opponent mills that many") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val skinner = d.putPermanentOnBattlefield(p1, "The Mindskinner")
+        d.removeSummoningSickness(skinner)
+
+        val libBefore = d.state.getLibrary(p2).size
+        val gyBefore = d.getGraveyard(p2).size
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(p1, listOf(skinner), p2)
+        d.bothPass()
+        // The Mindskinner can't be blocked — no blocker can be declared.
+        d.declareNoBlockers(p2)
+        d.bothPass()
+        d.bothPass()
+
+        // Combat damage (10) was replaced: the opponent loses no life and mills 10.
+        d.assertLifeTotal(p2, 20)
+        (libBefore - d.state.getLibrary(p2).size) shouldBe 10
+        (d.getGraveyard(p2).size - gyBefore) shouldBe 10
+    }
+
+    test("noncombat damage from a source you control is replaced with milling") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(p1, "The Mindskinner")
+
+        val libBefore = d.state.getLibrary(p2).size
+        val gyBefore = d.getGraveyard(p2).size
+
+        // Cast the zapper; its ETB deals 3 to the opponent — a source p1 controls.
+        val zap = d.putCardInHand(p1, "Test Zapper")
+        d.giveColorlessMana(p1, 1)
+        d.castSpell(p1, zap).isSuccess shouldBe true
+        var guard = 0
+        while ((d.state.stack.isNotEmpty() || d.state.pendingDecision is ChooseTargetsDecision) && guard++ < 20) {
+            if (d.state.pendingDecision is ChooseTargetsDecision) {
+                d.submitTargetSelection(p1, listOf(p2))
+            } else {
+                d.bothPass()
+            }
+        }
+
+        // The 3 damage was replaced: opponent loses no life and mills 3.
+        d.assertLifeTotal(p2, 20)
+        (libBefore - d.state.getLibrary(p2).size) shouldBe 3
+        (d.getGraveyard(p2).size - gyBefore) shouldBe 3
+    }
+})


### PR DESCRIPTION
Implements three of the remaining Duskmourn: House of Horror cards (DSK now 269/276), each via the `add-card` skill, with the supporting engine/SDK work done properly rather than approximated. Each card has a rules-faithful scenario test; the full `rules-engine` and `mtg-sets` suites and `just build` all pass.

## Cards

### Mirror Room // Fractured Realm (DSK 67) — Room
- **Mirror Room** `{2}{U}`: on unlock, token a Reflection copy of a target creature you control (`CreateTokenCopyOfTarget` + `addedSubtypes`).
- **Fractured Realm** `{5}{U}{U}`: `AdditionalSourceTriggers` over permanents you control with `excludeSelf = false` ("a permanent you control" includes itself).
- **Engine fix:** `TriggerDetector` gathered the `AdditionalSourceTriggers` / `AdditionalETBOrLTBTriggers` doublers from a card's *top-level* script only, so a doubler printed on an unlocked **Room face** (CR 709.5) was silently inert. Both doubler sites now route through `RoomFaceStatics.activeStaticAbilities` — the documented single source of truth for an unlocked face's functioning statics — matching the layer-projection path. Drop-in for non-Rooms.

### The Mindskinner (DSK 66) — `{U}{U}{U}` 10/1 Legendary Enchantment Creature
- Can't be blocked, plus "if a source you control would deal damage to an opponent, prevent that damage and each opponent mills that many cards."
- **New SDK `ReplaceDamageWithMill`** (modelled on `ReplaceDamageWithCounters`): the matched damage is *replaced* (CR 615) and each opponent mills that many cards instead. Scoped via `DamageEvent(recipient = Opponent, source = Matching(Any.youControl()))`, so it covers both the unblockable creature's combat damage and noncombat damage from any source you control. Wired into **both** damage paths (`DamageUtils` general + `CombatDamageManager` combat) and classified runtime-relevant in `StaticAbilityHandler`'s exhaustive replacement-effect `when`.

### Marina Vendrell's Grimoire (DSK 64) — `{5}{U}` Legendary Artifact — Book
- ETB "if you cast it, draw five"; no maximum hand size; "don't lose for 0 or less life"; lifegain → draw that many; lifeloss → discard that many, then lose if hand empty.
- **New SDK `GrantCantLoseGameFromLife`** — the *narrow* sibling of the Platinum-Angel `GrantCantLoseGame`. It suppresses only the 0-or-less-life state-based action (CR 704.5a); poison, empty-library, and effect losses still apply — including the Grimoire's own "no cards in hand → you lose the game" clause (a direct `Effects.LoseGame`). New `GrantsCantLoseGameFromLifeComponent`, read controller-scoped only by `PlayerLifeLossCheck`, classified + serialization-registered.

## Tests
- `MirrorRoomFracturedRealmTest`, `TheMindskinnerTest`, `MarinaVendrellsGrimoireTest` — cover both faces / combat + noncombat / all four Grimoire abilities incl. the 0-life suppression and empty-hand loss.
- Per-card golden snapshots re-blessed (diffs scoped to the new cards only).
- SDK reference (`docs/card-sdk-language-reference.md`) updated for every new/changed building block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)