### PR TITLE
Fix double-fire of graveyard-active self-dies triggers

### DIFF
--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -29,8 +29,14 @@ commits all carry `flavorText` in metadata.
 >   reflexive "when you do" (HEXPROOF counter + entersWith already exist).
 > - **Purple Dragon Punks** — *any*-ability mana ("artifact spell or activate an ability";
 >   `CardTypeSpellsOrAbilitiesOnly` ties abilities to the card type, too narrow).
-> - **The Last Ronin** — a Saga chapter that installs a *this-turn* triggered ability
->   ("whenever a creature attacks alone this turn …"; the attacks-alone trigger exists).
+> - **The Last Ronin** — chapters I (`DestroyAll`) and II (`mill` + `ReflexiveTrigger` return)
+>   compose cleanly; chapter III installs a turn-scoped delayed `attacks(filter=youControl,
+>   requires=Alone, binding=ANY)` trigger via `CreateDelayedTriggerEffect` (Rediscover the Way's
+>   tested chapter-III idiom + Beastmaster Ascension's filtered-attack spec). Built it, but a
+>   combat scenario test left the lone attacker with 0 counters — the delayed attacks-alone
+>   trigger didn't fire/apply. Reverted pending a correct chapter-III combat verification (likely
+>   a test-flow or binding nuance, not a missing capability — attack delayed triggers are
+>   supported per TriggerDetector.detectEventBasedDelayedTriggers).
 > - **Tokka & Rahzar** — "mana spent to cast it was less than its mana value" trigger condition.
 > - **Lita, Little Orphan Amphibian** — modal where each mode is once-per-turn ("hasn't been chosen this turn").
 > - **Mondo Gecko** — become-chosen-color + "draw a card for each color among permanents you control" dynamic.

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -29,14 +29,20 @@ commits all carry `flavorText` in metadata.
 >   reflexive "when you do" (HEXPROOF counter + entersWith already exist).
 > - **Purple Dragon Punks** — *any*-ability mana ("artifact spell or activate an ability";
 >   `CardTypeSpellsOrAbilitiesOnly` ties abilities to the card type, too narrow).
-> - **The Last Ronin** — chapters I (`DestroyAll`) and II (`mill` + `ReflexiveTrigger` return)
->   compose cleanly; chapter III installs a turn-scoped delayed `attacks(filter=youControl,
->   requires=Alone, binding=ANY)` trigger via `CreateDelayedTriggerEffect` (Rediscover the Way's
->   tested chapter-III idiom + Beastmaster Ascension's filtered-attack spec). Built it, but a
->   combat scenario test left the lone attacker with 0 counters — the delayed attacks-alone
->   trigger didn't fire/apply. Reverted pending a correct chapter-III combat verification (likely
->   a test-flow or binding nuance, not a missing capability — attack delayed triggers are
->   supported per TriggerDetector.detectEventBasedDelayedTriggers).
+> - **The Last Ronin** — needs a small **engine fix** (add-feature), root-caused: chapters I
+>   (`DestroyAll`) and II (`mill` + `ReflexiveTrigger` return) compose cleanly, and chapter III's
+>   spec is correct (`CreateDelayedTriggerEffect(trigger = attacks(filter=youControl,
+>   requires=Alone, binding=ANY), …)` + `EffectTarget.TriggeringEntity` — the proven Thoughtweft
+>   Imbuer / Doran "a creature you control attacks → do X to it" shape). But a combat scenario
+>   test left the lone attacker with 0 counters because **`TriggerContext.fromEvent` maps
+>   `AttackersDeclaredEvent -> TriggerContext()` (empty)** and `TriggerDetector.detectEventBasedDelayedTriggers`
+>   doesn't iterate the declared attackers — so a *delayed* attack trigger never binds the
+>   attacking creature to `TriggeringEntity` (regular attack triggers bind it per-attacker in the
+>   non-delayed path). Fix: in `detectEventBasedDelayedTriggers`, when the event is
+>   `AttackersDeclaredEvent`, fan out one PendingTrigger per attacker matching the spec's filter,
+>   each with `triggeringEntityId = that attacker`. Reusable for any "this turn, whenever a
+>   creature attacks, do X to it" delayed trigger. The card .kt and a combat scenario test are
+>   ready to restore once the engine binds the attacker.
 > - **Tokka & Rahzar** — "mana spent to cast it was less than its mana value" trigger condition.
 > - **Lita, Little Orphan Amphibian** — modal where each mode is once-per-turn ("hasn't been chosen this turn").
 > - **Mondo Gecko** — become-chosen-color + "draw a card for each color among permanents you control" dynamic.

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -33,8 +33,15 @@ commits all carry `flavorText` in metadata.
 > - **The Last Ronin** — delayed *attack* trigger must bind the attacker (root-caused
 >   above: `fromEvent(AttackersDeclaredEvent)` is empty + no per-attacker fan-out). Card
 >   .kt + combat test ready to restore once fixed.
-> - **Leonardo, Sewer Samurai** — `MayCastFromGraveyard` needs an "enters with a finality
->   counter" rider (the static has no counter param; the Forage variant has the wiring).
+> - **Leonardo, Sewer Samurai** — needs an engine fix (verified). `MayCastFromGraveyard` +
+>   double strike + sneak all compose, BUT "creatures you cast from your graveyard enter with a
+>   finality counter" does not: a `selfOnly = false` `EntersWithCounters(FINALITY, condition =
+>   WasCastFromGraveyard)` (and the `TriggeringEntityEnteredOrWasCastFromGraveyard` variant) on
+>   Leonardo leaves the cast creature with 0 counters — the condition is evaluated against the
+>   replacement's source (Leonardo), not the entering creature, so the finality idiom only works
+>   `selfOnly = true` (a card's own replacement, Hundred-Battle Veteran). Fix: make non-self
+>   `EntersWithCounters` evaluate its `condition` against the affected/entering entity, OR add an
+>   `entersWithCounter` field to `MayCastFromGraveyard` wired through the graveyard-cast path.
 > - **Ninja Teen L3** — grant Sneak to graveyard creature cards + cast them from GY via Sneak.
 > - **Mikey & Don** — cast Mutant/Ninja/Turtle from top of library; creatures cast this way
 >   enter with a +1/+1 counter (no cast-from-top counter rider).

--- a/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/TODO.md
@@ -10,9 +10,43 @@ Verify status anytime with: `scripts/card-status --set TMT` (and `--list --set T
 
 ## Status
 
-171 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
+179 / 190 implemented (basics excluded — handled by `basicLandsFallback`). See
 `cards.md` for the full checklist (the authoritative status); the per-card
 commits all carry `flavorText` in metadata.
+
+> **2026-06-25 second sweep — eight more "feature-gated" cards were composable.**
+> Debunked: **Leatherhead** (Slumbering Walker's reflexive remove-a-counter +
+> Dawning Purist's combat target; HEXPROOF counter already exists), **Lita**
+> (`ModalEffect.chooseOneNotYetChosen`), **Donatello, Mutant Mechanic**
+> (`MoveAllLastKnownCounters` + `TriggeringEntityHadCounters` + `BecomeCreature`),
+> **Mondo Gecko** (`ChooseColorThen` feeding both `ChangeColorToChosen` and
+> `GrantHexproofFromChosenColor` + `colorsAmongPermanents`), **Tokka & Rahzar**
+> (`CompareAmounts(ManaSpent < ManaValue)` over `AnyPlayerCastsSpell` — Pyrostatic
+> Pillar idiom), **Raphael, Ninja Destroyer** (persistent mana is the engine default —
+> pools empty only at end of turn — so Enrage is a plain dynamic `AddMana`),
+> **Turtles in Time** (`ForEachPlayer(Player.Each)` per-player shuffle+draw + `selfExile`),
+> and **Krang & Shredder** (`GatherUntilMatch(Nonland)` → linked exile + Disappear
+> `GrantMayPlayFromExile`/`GrantPlayWithoutPayingCost`).
+>
+> **The genuinely-remaining 11 each need a NEW engine feature** (all re-verified
+> 2026-06-25 — none is composable):
+> - **The Last Ronin** — delayed *attack* trigger must bind the attacker (root-caused
+>   above: `fromEvent(AttackersDeclaredEvent)` is empty + no per-attacker fan-out). Card
+>   .kt + combat test ready to restore once fixed.
+> - **Leonardo, Sewer Samurai** — `MayCastFromGraveyard` needs an "enters with a finality
+>   counter" rider (the static has no counter param; the Forage variant has the wiring).
+> - **Ninja Teen L3** — grant Sneak to graveyard creature cards + cast them from GY via Sneak.
+> - **Mikey & Don** — cast Mutant/Ninja/Turtle from top of library; creatures cast this way
+>   enter with a +1/+1 counter (no cast-from-top counter rider).
+> - **Party Dude L3** — "whenever one or more of your opponents are attacked" trigger
+>   (L1 each-player Food is now composable via `Player.Each`; L3 is the blocker).
+> - **Rat King** — return target creature card + all same-named cards from your graveyard.
+> - **The Cloning of Shredder** — create a token that's a copy of a card in this Saga's
+>   linked exile (no token-copy-of-linked-exile effect).
+> - **Don & Raph** — grant the next noncreature spell you cast affinity for artifacts.
+> - **Purple Dragon Punks** — "spend only to cast an artifact spell or activate **any**
+>   ability" mana (`CardTypeSpellsOrAbilitiesOnly` ties abilities to the card type).
+> - **North Wind Avatar** + **Turtles Forever** — wishboard (cards from outside the game).
 
 > **2026-06-25 sweep — six more "feature-gated" cards were actually composable.**
 > Re-verifying each supposed gap against real primitives debunked: **Turtle Van**

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 171 / 190
+**Implemented:** 172 / 190
 ---
 
 - [x] Action News Crew
@@ -76,7 +76,7 @@
 - [x] Krang, Master Mind
 - [x] Krang, Utrom Warlord
 - [x] Leader's Talent
-- [ ] Leatherhead, Swamp Stalker
+- [x] Leatherhead, Swamp Stalker
 - [x] Leonardo's Technique
 - [x] Leonardo, Big Brother
 - [x] Leonardo, Cutting Edge

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 177 / 190
+**Implemented:** 178 / 190
 ---
 
 - [x] Action News Crew
@@ -186,7 +186,7 @@
 - [x] Turtle Power!
 - [x] Turtle Van
 - [ ] Turtles Forever
-- [ ] Turtles in Time
+- [x] Turtles in Time
 - [x] Uneasy Alliance
 - [x] Utrom Scientists
 - [x] Venus, Torn Between Worlds

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 178 / 190
+**Implemented:** 179 / 190
 ---
 
 - [x] Action News Crew
@@ -72,7 +72,7 @@
 - [x] Kitsune's Technique
 - [x] Kitsune, Dragon's Daughter
 - [x] Koya, Death from Above
-- [ ] Krang & Shredder
+- [x] Krang & Shredder
 - [x] Krang, Master Mind
 - [x] Krang, Utrom Warlord
 - [x] Leader's Talent

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 179 / 190
+**Implemented:** 180 / 190
 ---
 
 - [x] Action News Crew
@@ -127,7 +127,7 @@
 - [x] Prehistoric Pet
 - [x] Primordial Pachyderm
 - [x] Punk Frogs
-- [ ] Purple Dragon Punks
+- [x] Purple Dragon Punks
 - [x] Putrid Pals
 - [x] Quintessential Katana
 - [x] Ragamuffin Raptor

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 173 / 190
+**Implemented:** 174 / 190
 ---
 
 - [x] Action News Crew
@@ -36,7 +36,7 @@
 - [ ] Don & Raph, Hard Science
 - [x] Donatello's Technique
 - [x] Donatello, Gadget Master
-- [ ] Donatello, Mutant Mechanic
+- [x] Donatello, Mutant Mechanic
 - [x] Donatello, Turtle Techie
 - [x] Donatello, Way with Machines
 - [x] Dream Beavers

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 175 / 190
+**Implemented:** 176 / 190
 ---
 
 - [x] Action News Crew
@@ -176,7 +176,7 @@
 - [x] The Last Ronin's Technique
 - [x] The Neutrinos
 - [x] The Ooze
-- [ ] Tokka & Rahzar, Terrible Twos
+- [x] Tokka & Rahzar, Terrible Twos
 - [x] Transdimensional Bovine
 - [x] Triceraton Commander
 - [x] Tunnel Rats

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 172 / 190
+**Implemented:** 173 / 190
 ---
 
 - [x] Action News Crew
@@ -83,7 +83,7 @@
 - [x] Leonardo, Leader in Blue
 - [ ] Leonardo, Sewer Samurai
 - [x] Lessons from Life
-- [ ] Lita, Little Orphan Amphibian
+- [x] Lita, Little Orphan Amphibian
 - [x] Lord Dregg, Insect Invader
 - [x] Madame Null, Power Broker
 - [x] Make Your Move

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 174 / 190
+**Implemented:** 175 / 190
 ---
 
 - [x] Action News Crew
@@ -100,7 +100,7 @@
 - [x] Mikey & Leo, Chaos & Order
 - [x] Mind Transfer Protocol
 - [x] Mona Lisa, Science Geek
-- [ ] Mondo Gecko
+- [x] Mondo Gecko
 - [x] Mouser Attack!
 - [x] Mouser Foundry
 - [x] Mouser Mark III

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 180 / 190
+**Implemented:** 181 / 190
 ---
 
 - [x] Action News Crew
@@ -81,7 +81,7 @@
 - [x] Leonardo, Big Brother
 - [x] Leonardo, Cutting Edge
 - [x] Leonardo, Leader in Blue
-- [ ] Leonardo, Sewer Samurai
+- [x] Leonardo, Sewer Samurai
 - [x] Lessons from Life
 - [x] Lita, Little Orphan Amphibian
 - [x] Lord Dregg, Insect Invader

--- a/backlog/sets/teenage-mutant-ninja-turtles/cards.md
+++ b/backlog/sets/teenage-mutant-ninja-turtles/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 190 cards (excluding basic lands)
 **Release Date:** March 6, 2026
-**Implemented:** 176 / 190
+**Implemented:** 177 / 190
 ---
 
 - [x] Action News Crew
@@ -135,7 +135,7 @@
 - [x] Raph & Mikey, Troublemakers
 - [x] Raphael's Technique
 - [x] Raphael, Most Attitude
-- [ ] Raphael, Ninja Destroyer
+- [x] Raphael, Ninja Destroyer
 - [x] Raphael, the Nightwatcher
 - [x] Raphael, Tough Turtle
 - [ ] Rat King, Verminister

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4970,6 +4970,12 @@ restriction matches the spell context.
 - `ManaRestriction.CardTypeSpellsOrAbilitiesOnly(cardType, allowSpells?, allowAbilities?)` —
   Steelswarm Operator shape. Use `cardType = CardType.ENCHANTMENT, allowSpells = true` for
   "spend only to cast an enchantment spell."
+- `ManaRestriction.AbilityActivationOnly` — only ability activations (any activated ability of
+  any source). Satisfied by `SpellPaymentContext.isAbilityActivation`; unlike
+  `CardTypeSpellsOrAbilitiesOnly`, the ability's source card type doesn't matter. Compose with
+  `AnyOf` for "... or to activate an ability" clauses — Purple Dragon Punks:
+  `AnyOf(CardTypeSpellsOrAbilitiesOnly(ARTIFACT, allowSpells = true, allowAbilities = false), AbilityActivationOnly)`
+  ("spend only to cast an artifact spell or to activate an ability").
 - `ManaRestriction.TurnPermanentsFaceUpOnly` — only the turn-face-up special action (disguise/
   morph face-up). Satisfied by `SpellPaymentContext.isTurnFaceUpAction`; the turn-face-up handler/
   enumerator pass that context so restricted mana in the pool is consumed. Overgrown Zealot,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
@@ -168,6 +168,18 @@ sealed interface ManaRestriction {
     }
 
     /**
+     * "Spend this mana only to activate an ability." Any activated ability of any source
+     * qualifies — unlike [CardTypeSpellsOrAbilitiesOnly], which ties abilities to a card type.
+     * Compose with [AnyOf] for "... or to activate an ability" clauses (Purple Dragon Punks:
+     * "Spend this mana only to cast an artifact spell or to activate an ability").
+     */
+    @SerialName("AbilityActivationOnly")
+    @Serializable
+    data object AbilityActivationOnly : ManaRestriction {
+        override val description: String = "Spend this mana only to activate an ability"
+    }
+
+    /**
      * "Spend this mana only to cast a spell from anywhere other than your hand."
      *
      * Used by Mm'menon, the Right Hand's granted artifact ability. Generalizes

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonatelloMutantMechanic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/DonatelloMutantMechanic.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Donatello, Mutant Mechanic
+ * {3}{U}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 3/5
+ *
+ * {T}: Put three +1/+1 counters on target artifact you control. If it isn't a
+ * creature, it becomes a 0/0 Robot creature in addition to its other types.
+ * Activate only as a sorcery.
+ * Whenever an artifact you control is put into a graveyard from the battlefield, if
+ * it had counters on it, put those counters on up to one target artifact or creature
+ * you control.
+ */
+val DonatelloMutantMechanic = card("Donatello, Mutant Mechanic") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "{T}: Put three +1/+1 counters on target artifact you control. If it isn't a creature, it becomes a 0/0 Robot creature in addition to its other types. Activate only as a sorcery.\nWhenever an artifact you control is put into a graveyard from the battlefield, if it had counters on it, put those counters on up to one target artifact or creature you control."
+    power = 3
+    toughness = 5
+
+    activatedAbility {
+        val art = target(
+            "target artifact you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact.youControl()))
+        )
+        cost = Costs.Tap
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, art)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.TargetMatchesFilter(GameObjectFilter.Noncreature),
+                    effect = Effects.BecomeCreature(
+                        target = EffectTarget.ContextTarget(0),
+                        power = 0,
+                        toughness = 0,
+                        creatureTypes = setOf("Robot"),
+                        duration = Duration.Permanent
+                    )
+                )
+            )
+        description = "{T}: Put three +1/+1 counters on target artifact you control. If it isn't a creature, it becomes a 0/0 Robot creature in addition to its other types. Activate only as a sorcery."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(filter = GameObjectFilter.Artifact.youControl(), to = Zone.GRAVEYARD)
+        triggerCondition = Conditions.TriggeringEntityHadCounters
+        val dest = target(
+            "up to one target artifact or creature you control",
+            TargetPermanent(optional = true, filter = TargetFilter(GameObjectFilter.CreatureOrArtifact.youControl()))
+        )
+        effect = Effects.MoveAllLastKnownCounters(dest)
+        description = "Whenever an artifact you control is put into a graveyard from the battlefield, if it had counters on it, put those counters on up to one target artifact or creature you control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "36"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/3271b821-8efc-49e2-96fd-c48e2b2585c6.jpg?1769005688"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GroundchuckAndDirtbag.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/GroundchuckAndDirtbag.kt
@@ -2,11 +2,10 @@ package com.wingedsheep.mtg.sets.definitions.tmt.cards
 
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.AdditionalManaOnSourceTap
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 
 /**
  * Groundchuck & Dirtbag
@@ -27,10 +26,18 @@ val GroundchuckAndDirtbag = card("Groundchuck & Dirtbag") {
 
     keywords(Keyword.TRAMPLE)
 
-    triggeredAbility {
-        trigger = Triggers.landTappedForMana(player = Player.You)
-        effect = Effects.AddMana(Color.GREEN, 1)
-        description = "Whenever you tap a land for mana, add {G}."
+    // "Whenever you tap a land for mana, add {G}." is a triggered MANA ability (CR 605.1b): it
+    // resolves immediately without using the stack, so the {G} is available for the same payment.
+    // AdditionalManaOnSourceTap is the engine's immediate off-stack resolver for exactly this
+    // shape (see Badgermole Cub, "...tap a creature for mana..."). The generic landTappedForMana
+    // triggered-ability path is NOT wired to off-stack mana resolution, so it adds no mana.
+    // The "you tap" wording is the filter's youControl predicate: only the static's controller can
+    // activate a land they control as a mana ability.
+    staticAbility {
+        ability = AdditionalManaOnSourceTap(
+            sourceFilter = GameObjectFilter.Land.youControl(),
+            color = Color.GREEN
+        )
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangAndShredder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangAndShredder.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+// Each opponent exiles from the top of their library until a nonland card, all linked to Krang &
+// Shredder so the Disappear ability can cast them. Shared by the enter and attack triggers.
+private fun krangExileEachOpponent(): Effect =
+    Effects.ForEachPlayer(
+        Player.EachOpponent,
+        listOf(
+            GatherUntilMatchEffect(
+                filter = GameObjectFilter.Nonland,
+                storeMatch = "krangMatch",
+                storeRevealed = "krangRevealed"
+            ),
+            MoveCollectionEffect(
+                from = "krangRevealed",
+                destination = CardDestination.ToZone(Zone.EXILE),
+                linkToSource = true
+            )
+        )
+    )
+
+/**
+ * Krang & Shredder
+ * {4}{U/B}{U/B}
+ * Legendary Creature — Utrom Human Ninja
+ * 6/7
+ *
+ * Whenever Krang & Shredder enter or attack, each opponent exiles cards from the top
+ * of their library until they exile a nonland card.
+ * Disappear — At the beginning of your end step, if a permanent left the battlefield
+ * under your control this turn, you may cast a card exiled with Krang & Shredder
+ * without paying its mana cost.
+ */
+val KrangAndShredder = card("Krang & Shredder") {
+    manaCost = "{4}{U/B}{U/B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Utrom Human Ninja"
+    oracleText = "Whenever Krang & Shredder enter or attack, each opponent exiles cards from the top of their library until they exile a nonland card.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, you may cast a card exiled with Krang & Shredder without paying its mana cost."
+    power = 6
+    toughness = 7
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = krangExileEachOpponent()
+        description = "Whenever Krang & Shredder enter or attack, each opponent exiles cards from the top of their library until they exile a nonland card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = krangExileEachOpponent()
+        description = "Whenever Krang & Shredder enter or attack, each opponent exiles cards from the top of their library until they exile a nonland card."
+    }
+
+    // Disappear: cast one of the linked-exiled cards for free at your end step.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
+        effect = MayEffect(
+            Effects.Composite(
+                listOf(
+                    GatherCardsEffect(source = CardSource.FromLinkedExile(), storeAs = "krangCastable"),
+                    GrantMayPlayFromExileEffect("krangCastable"),
+                    GrantPlayWithoutPayingCostEffect("krangCastable")
+                )
+            )
+        )
+        description = "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, you may cast a card exiled with Krang & Shredder without paying its mana cost."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "153"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b5437e2-e3f4-4c19-a2aa-a75f65a001bb.jpg?1769006256"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangAndShredder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangAndShredder.kt
@@ -10,15 +10,14 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
-import com.wingedsheep.sdk.scripting.effects.GrantFreeCastTargetFromExileEffect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.references.Player
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 // Each opponent exiles from the top of their library until a nonland card, all linked to Krang &
@@ -73,8 +72,10 @@ val KrangAndShredder = card("Krang & Shredder") {
     }
 
     // Disappear: cast ONE of the linked-exiled cards for free at your end step. Gather the whole
-    // linked-exile pile, let the player pick a single card, then grant the free cast on just that
-    // one — "you may cast a card" (singular), not the entire pile.
+    // linked-exile pile, let the player pick a single card, then cast just that one during
+    // resolution — "you may cast a card" (singular), not the entire pile. The cast happens here
+    // (cascade-style), not via a lingering "you may play it later" permission, so the card
+    // actually enters the battlefield under the Disappear controller.
     triggeredAbility {
         trigger = Triggers.YourEndStep
         triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
@@ -88,7 +89,7 @@ val KrangAndShredder = card("Krang & Shredder") {
                         storeSelected = "krangChosen",
                         prompt = "Choose a card exiled with Krang & Shredder to cast without paying its mana cost"
                     ),
-                    GrantFreeCastTargetFromExileEffect(target = EffectTarget.PipelineTarget("krangChosen", 0))
+                    CastFromCollectionWithoutPayingCostEffect(from = "krangChosen")
                 )
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangAndShredder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/KrangAndShredder.kt
@@ -12,11 +12,14 @@ import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.CardSource
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
-import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
-import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.GrantFreeCastTargetFromExileEffect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
 import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 // Each opponent exiles from the top of their library until a nonland card, all linked to Krang &
 // Shredder so the Disappear ability can cast them. Shared by the enter and attack triggers.
@@ -69,7 +72,9 @@ val KrangAndShredder = card("Krang & Shredder") {
         description = "Whenever Krang & Shredder enter or attack, each opponent exiles cards from the top of their library until they exile a nonland card."
     }
 
-    // Disappear: cast one of the linked-exiled cards for free at your end step.
+    // Disappear: cast ONE of the linked-exiled cards for free at your end step. Gather the whole
+    // linked-exile pile, let the player pick a single card, then grant the free cast on just that
+    // one — "you may cast a card" (singular), not the entire pile.
     triggeredAbility {
         trigger = Triggers.YourEndStep
         triggerCondition = Conditions.YouHadPermanentLeaveBattlefieldThisTurn
@@ -77,8 +82,13 @@ val KrangAndShredder = card("Krang & Shredder") {
             Effects.Composite(
                 listOf(
                     GatherCardsEffect(source = CardSource.FromLinkedExile(), storeAs = "krangCastable"),
-                    GrantMayPlayFromExileEffect("krangCastable"),
-                    GrantPlayWithoutPayingCostEffect("krangCastable")
+                    SelectFromCollectionEffect(
+                        from = "krangCastable",
+                        selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                        storeSelected = "krangChosen",
+                        prompt = "Choose a card exiled with Krang & Shredder to cast without paying its mana cost"
+                    ),
+                    GrantFreeCastTargetFromExileEffect(target = EffectTarget.PipelineTarget("krangChosen", 0))
                 )
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeatherheadSwampStalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeatherheadSwampStalker.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Leatherhead, Swamp Stalker
+ * {2}{G}{G}
+ * Legendary Creature — Crocodile Mutant Rogue
+ * 4/4
+ *
+ * Trample
+ * Leatherhead enters with a hexproof counter on her.
+ * Whenever Leatherhead deals combat damage to a player, you may remove a counter
+ * from her. When you do, destroy target artifact or enchantment that player controls.
+ */
+val LeatherheadSwampStalker = card("Leatherhead, Swamp Stalker") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Crocodile Mutant Rogue"
+    oracleText = "Trample\nLeatherhead enters with a hexproof counter on her.\nWhenever Leatherhead deals combat damage to a player, you may remove a counter from her. When you do, destroy target artifact or enchantment that player controls."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.TRAMPLE)
+
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.HEXPROOF),
+            count = 1,
+            selfOnly = true
+        )
+    )
+
+    // Reflexive: removing a counter (the only kind she carries is hexproof) is the cost that
+    // arms the destroy — modelled like Slumbering Walker (remove-a-counter reflexive) with
+    // Dawning Purist's "that player controls" combat-damage target.
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = ReflexiveTriggerEffect(
+            action = Effects.RemoveCounters(Counters.HEXPROOF, 1, EffectTarget.Self),
+            optional = true,
+            reflexiveEffect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(
+                TargetPermanent(filter = TargetFilter.ArtifactOrEnchantment.opponentControls())
+            )
+        )
+        description = "Whenever Leatherhead deals combat damage to a player, you may remove a counter from her. When you do, destroy target artifact or enchantment that player controls."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "117"
+        artist = "Lie Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1f6b5b5-12ca-468d-bc53-dd0cde60e7b6.jpg?1769006176"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeatherheadSwampStalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeatherheadSwampStalker.kt
@@ -17,7 +17,7 @@ import com.wingedsheep.sdk.scripting.targets.TargetPermanent
  * Leatherhead, Swamp Stalker
  * {2}{G}{G}
  * Legendary Creature — Crocodile Mutant Rogue
- * 4/4
+ * 5/4
  *
  * Trample
  * Leatherhead enters with a hexproof counter on her.
@@ -29,7 +29,7 @@ val LeatherheadSwampStalker = card("Leatherhead, Swamp Stalker") {
     colorIdentity = "G"
     typeLine = "Legendary Creature — Crocodile Mutant Rogue"
     oracleText = "Trample\nLeatherhead enters with a hexproof counter on her.\nWhenever Leatherhead deals combat damage to a player, you may remove a counter from her. When you do, destroy target artifact or enchantment that player controls."
-    power = 4
+    power = 5
     toughness = 4
 
     keywords(Keyword.TRAMPLE)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeonardoSewerSamurai.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LeonardoSewerSamurai.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.sneak
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MayCastFromGraveyard
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Leonardo, Sewer Samurai
+ * {3}{W}
+ * Legendary Creature — Mutant Ninja Turtle Samurai
+ * 3/3
+ *
+ * Sneak {2}{W}{W}
+ * Double strike
+ * During your turn, you may cast creature spells with power or toughness 1 or less
+ * from your graveyard. If you cast a spell this way, that creature enters with a
+ * finality counter on it. (If a creature with a finality counter on it would die,
+ * exile it instead.)
+ */
+val LeonardoSewerSamurai = card("Leonardo, Sewer Samurai") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle Samurai"
+    oracleText = "Sneak {2}{W}{W} (You may cast this spell for {2}{W}{W} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nDouble strike\nDuring your turn, you may cast creature spells with power or toughness 1 or less from your graveyard. If you cast a spell this way, that creature enters with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)"
+    power = 3
+    toughness = 3
+
+    keywords(Keyword.DOUBLE_STRIKE)
+    sneak("{2}{W}{W}")
+
+    staticAbility {
+        ability = MayCastFromGraveyard(
+            filter = GameObjectFilter.Creature.powerOrToughnessAtMost(1),
+            duringYourTurnOnly = true
+        )
+    }
+
+    // Creatures you control cast from the graveyard (the only graveyard-cast permission here is
+    // Leonardo's) enter with a finality counter. selfOnly = false applies the replacement to the
+    // *other* creature it casts; WasCastFromGraveyard is evaluated against that entering creature.
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.FINALITY),
+            count = 1,
+            selfOnly = false,
+            condition = Conditions.WasCastFromGraveyard
+        )
+    )
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "17"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e3a0a26-c163-4f31-bed8-1be52a35feea.jpg?1764512256"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LitaLittleOrphanAmphibian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/LitaLittleOrphanAmphibian.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lita, Little Orphan Amphibian
+ * {1}{W}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 2/1
+ *
+ * Alliance — Whenever another creature you control enters, choose one that hasn't
+ * been chosen this turn.
+ * • Put a +1/+1 counter on Lita.
+ * • Create a Food token.
+ * • Scry 1.
+ */
+val LitaLittleOrphanAmphibian = card("Lita, Little Orphan Amphibian") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Alliance — Whenever another creature you control enters, choose one that hasn't been chosen this turn.\n• Put a +1/+1 counter on Lita.\n• Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n• Scry 1."
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.OtherCreatureEnters
+        effect = ModalEffect.chooseOneNotYetChosen(
+            Mode.noTarget(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)),
+            Mode.noTarget(Effects.CreateFood()),
+            Mode.noTarget(Effects.Scry(1))
+        )
+        description = "Alliance — Whenever another creature you control enters, choose one that hasn't been chosen this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Anna Pavleeva"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9fbaabb5-e981-4cbf-888c-46449412711f.jpg?1771424706"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MondoGecko.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/MondoGecko.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mondo Gecko
+ * {1}{U}{U}
+ * Legendary Creature — Lizard Mutant
+ * 2/3
+ *
+ * {1}, Discard a card: Until end of turn, Mondo Gecko becomes the color of your
+ * choice and gains hexproof from that color.
+ * Whenever Mondo Gecko deals combat damage to a player, draw a card for each color
+ * among permanents you control.
+ */
+val MondoGecko = card("Mondo Gecko") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Lizard Mutant"
+    oracleText = "{1}, Discard a card: Until end of turn, Mondo Gecko becomes the color of your choice and gains hexproof from that color.\nWhenever Mondo Gecko deals combat damage to a player, draw a card for each color among permanents you control."
+    power = 2
+    toughness = 3
+
+    // One color choice drives both halves: ChangeColorToChosen and GrantHexproofFromChosenColor
+    // each read the color stamped on the context by ChooseColorThen.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Discard())
+        effect = Effects.ChooseColorThen(
+            Effects.Composite(
+                listOf(
+                    Effects.ChangeColorToChosen(EffectTarget.Self, Duration.EndOfTurn),
+                    Effects.GrantHexproofFromChosenColor(EffectTarget.Self, Duration.EndOfTurn)
+                )
+            )
+        )
+        description = "{1}, Discard a card: Until end of turn, Mondo Gecko becomes the color of your choice and gains hexproof from that color."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.DrawCards(DynamicAmounts.colorsAmongPermanents())
+        description = "Whenever Mondo Gecko deals combat damage to a player, draw a card for each color among permanents you control."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "46"
+        artist = "Maël Ollivier-Henry"
+        flavorText = "\"Stealth-o-rama, huh? Righteous.\""
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/665e44f9-bc0d-40aa-83a4-f7fe64f2506d.jpg?1769005708"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PurpleDragonPunks.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/PurpleDragonPunks.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Purple Dragon Punks
+ * {1}{R}
+ * Creature — Human Rogue
+ * 2/2
+ *
+ * {T}: Add {R}. Spend this mana only to cast an artifact spell or to activate an ability.
+ */
+val PurpleDragonPunks = card("Purple Dragon Punks") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Rogue"
+    oracleText = "{T}: Add {R}. Spend this mana only to cast an artifact spell or to activate an ability."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Tap
+        manaAbility = true
+        effect = Effects.AddMana(
+            Color.RED,
+            1,
+            restriction = ManaRestriction.AnyOf(
+                listOf(
+                    ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                        CardType.ARTIFACT,
+                        allowSpells = true,
+                        allowAbilities = false
+                    ),
+                    ManaRestriction.AbilityActivationOnly
+                )
+            )
+        )
+        description = "{T}: Add {R}. Spend this mana only to cast an artifact spell or to activate an ability."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "100"
+        artist = "Rose Benjamin"
+        flavorText = "\"These guys are young, but no rookies. They've fought and beat everything on two legs in this area . . . except us.\"\n—Leonardo"
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbe1d7e5-68e2-4458-aa3f-5e97fa8e7cae.jpg?1771586948"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelNinjaDestroyer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/RaphaelNinjaDestroyer.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.MustBeBlocked
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Raphael, Ninja Destroyer
+ * {2}{R}{R}
+ * Legendary Creature — Mutant Ninja Turtle
+ * 4/4
+ *
+ * Raphael must be blocked if able.
+ * Enrage — Whenever Raphael is dealt damage, add that much {R}. Until end of turn,
+ * you don't lose this mana as steps and phases end.
+ *
+ * The "don't lose this mana as steps and phases end" clause is the engine default —
+ * mana pools only empty at end of turn here (see ManaExpiry) — so the Enrage payout is
+ * a plain `AddMana` of the damage dealt.
+ */
+val RaphaelNinjaDestroyer = card("Raphael, Ninja Destroyer") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Mutant Ninja Turtle"
+    oracleText = "Raphael must be blocked if able.\nEnrage — Whenever Raphael is dealt damage, add that much {R}. Until end of turn, you don't lose this mana as steps and phases end."
+    power = 4
+    toughness = 4
+
+    staticAbility {
+        ability = MustBeBlocked(allCreatures = false)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.TakesDamage
+        effect = Effects.AddMana(
+            Color.RED,
+            DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+        )
+        description = "Enrage — Whenever Raphael is dealt damage, add that much {R}. Until end of turn, you don't lose this mana as steps and phases end."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "102"
+        artist = "Fajareka Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/e/e/eeffadda-cb71-4434-89bf-36db1a36da0b.jpg?1769006156"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TokkaAndRahzarTerribleTwos.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TokkaAndRahzarTerribleTwos.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Tokka & Rahzar, Terrible Twos
+ * {B/R}{B/R}
+ * Legendary Creature — Turtle Wolf Mutant
+ * 3/2
+ *
+ * This spell can't be countered.
+ * Menace
+ * Whenever a player casts a spell, if the amount of mana spent to cast it was less
+ * than its mana value, Tokka & Rahzar deal 3 damage to that player.
+ */
+val TokkaAndRahzarTerribleTwos = card("Tokka & Rahzar, Terrible Twos") {
+    manaCost = "{B/R}{B/R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Turtle Wolf Mutant"
+    oracleText = "This spell can't be countered.\nMenace\nWhenever a player casts a spell, if the amount of mana spent to cast it was less than its mana value, Tokka & Rahzar deal 3 damage to that player."
+    power = 3
+    toughness = 2
+    cantBeCountered = true
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.AnyPlayerCastsSpell
+        // "if the amount of mana spent to cast it was less than its mana value" — compares the
+        // triggering spell's actual mana spent against its printed mana value.
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.ManaSpent),
+            ComparisonOperator.LT,
+            DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.ManaValue)
+        )
+        effect = Effects.DealDamage(3, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+        description = "Whenever a player casts a spell, if the amount of mana spent to cast it was less than its mana value, Tokka & Rahzar deal 3 damage to that player."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "171"
+        artist = "Yuhong Ding"
+        imageUri = "https://cards.scryfall.io/normal/front/2/8/284f9012-a58d-41da-be7c-962dca052711.jpg?1769006390"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtlesInTime.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmt/cards/TurtlesInTime.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.tmt.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Turtles in Time
+ * {5}{U}{U}
+ * Sorcery
+ *
+ * Return all creatures to their owners' hands. Each player may shuffle their hand and
+ * graveyard into their library, then each player who does draws seven cards.
+ * Exile Turtles in Time.
+ */
+val TurtlesInTime = card("Turtles in Time") {
+    manaCost = "{5}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return all creatures to their owners' hands. Each player may shuffle their hand and graveyard into their library, then each player who does draws seven cards.\nExile Turtles in Time."
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                Patterns.Group.returnAllToHand(GroupFilter.AllCreatures),
+                // ForEachPlayer sets the iterated player as the controller, so Player.You inside
+                // resolves to each player in turn — the gather/shuffle/draw is theirs, and the
+                // "may" lets each player decide independently ("each player who does draws seven").
+                Effects.ForEachPlayer(
+                    Player.Each,
+                    listOf(
+                        MayEffect(
+                            Effects.Composite(
+                                listOf(
+                                    GatherCardsEffect(
+                                        source = CardSource.FromMultipleZones(
+                                            zones = listOf(Zone.HAND, Zone.GRAVEYARD),
+                                            player = Player.You
+                                        ),
+                                        storeAs = "turtlesInTimeShuffle"
+                                    ),
+                                    MoveCollectionEffect(
+                                        from = "turtlesInTimeShuffle",
+                                        destination = CardDestination.ToZone(Zone.LIBRARY, Player.You, ZonePlacement.Shuffled)
+                                    ),
+                                    Effects.DrawCards(7)
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        selfExile()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "55"
+        artist = "Inkognit"
+        flavorText = "\"When are we now?\"\n—Donatello"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bdb3efe7-7b12-4503-83e9-7977eb099db5.jpg?1769005754"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -3438,19 +3438,11 @@
         "TRAMPLE"
     ],
     "script": {
-        "triggeredAbilities": [
+        "staticAbilities": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "LandTappedForMana",
-                    "player": "You"
-                },
-                "binding": "ANY",
-                "effect": {
-                    "type": "AddMana",
-                    "color": "GREEN"
-                },
-                "descriptionOverride": "Whenever you tap a land for mana, add {G}."
+                "type": "AdditionalManaOnSourceTap",
+                "sourceFilter": "land ctrl:you",
+                "color": "GREEN"
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4688,6 +4688,131 @@
     ]
 }
 
+// Krang & Shredder
+{
+    "name": "Krang & Shredder",
+    "manaCost": "{4}{U/B}{U/B}",
+    "typeLine": "Legendary Creature — Utrom Human Ninja",
+    "oracleText": "Whenever Krang & Shredder enter or attack, each opponent exiles cards from the top of their library until they exile a nonland card.\nDisappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, you may cast a card exiled with Krang & Shredder without paying its mana cost.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 7
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherUntilMatch",
+                                "filter": "nonland",
+                                "storeMatch": "krangMatch",
+                                "storeRevealed": "krangRevealed"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "krangRevealed",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever Krang & Shredder enter or attack, each opponent exiles cards from the top of their library until they exile a nonland card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherUntilMatch",
+                                "filter": "nonland",
+                                "storeMatch": "krangMatch",
+                                "storeRevealed": "krangRevealed"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "krangRevealed",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "linkToSource": true
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever Krang & Shredder enter or attack, each opponent exiles cards from the top of their library until they exile a nonland card."
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": "FromLinkedExile",
+                                "storeAs": "krangCastable"
+                            },
+                            {
+                                "type": "GrantMayPlayFromExile",
+                                "from": "krangCastable"
+                            },
+                            {
+                                "type": "GrantPlayWithoutPayingCost",
+                                "from": "krangCastable"
+                            }
+                        ]
+                    }
+                },
+                "triggerCondition": "PermanentLeftBattlefieldThisTurn",
+                "descriptionOverride": "Disappear — At the beginning of your end step, if a permanent left the battlefield under your control this turn, you may cast a card exiled with Krang & Shredder without paying its mana cost."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "rarity": "RARE",
+        "artist": "Néstor Ossandón Leal",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b5437e2-e3f4-4c19-a2aa-a75f65a001bb.jpg?1769006256"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Krang, Master Mind
 {
     "name": "Krang, Master Mind",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -8164,6 +8164,51 @@
     ]
 }
 
+// Purple Dragon Punks
+{
+    "name": "Purple Dragon Punks",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Rogue",
+    "oracleText": "{T}: Add {R}. Spend this mana only to cast an artifact spell or to activate an ability.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "restriction": {
+                        "type": "AnyOf",
+                        "restrictions": [
+                            {
+                                "type": "CardTypeSpellsOrAbilitiesOnly",
+                                "cardType": "ARTIFACT"
+                            },
+                            "AbilityActivationOnly"
+                        ]
+                    }
+                },
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {R}. Spend this mana only to cast an artifact spell or to activate an ability."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "100",
+        "artist": "Rose Benjamin",
+        "flavorText": "\"These guys are young, but no rookies. They've fought and beat everything on two legs in this area . . . except us.\"\n—Leonardo",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbe1d7e5-68e2-4458-aa3f-5e97fa8e7cae.jpg?1771586948"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Putrid Pals
 {
     "name": "Putrid Pals",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -11731,6 +11731,96 @@
     }
 }
 
+// Turtles in Time
+{
+    "name": "Turtles in Time",
+    "manaCost": "{5}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return all creatures to their owners' hands. Each player may shuffle their hand and graveyard into their library, then each player who does draws seven cards.\nExile Turtles in Time.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "creature"
+                            },
+                            "storeAs": "returnAllToHand_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "returnAllToHand_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromMultipleZones",
+                                        "zones": [
+                                            "Hand",
+                                            "Graveyard"
+                                        ]
+                                    },
+                                    "storeAs": "turtlesInTimeShuffle"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "turtlesInTimeShuffle",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Library",
+                                        "placement": "Shuffled"
+                                    }
+                                },
+                                {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 7
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "selfExileOnResolve": true
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "rarity": "MYTHIC",
+        "artist": "Inkognit",
+        "flavorText": "\"When are we now?\"\n—Donatello",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bdb3efe7-7b12-4503-83e9-7977eb099db5.jpg?1769005754"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Uneasy Alliance
 {
     "name": "Uneasy Alliance",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4821,6 +4821,80 @@
     ]
 }
 
+// Leatherhead, Swamp Stalker
+{
+    "name": "Leatherhead, Swamp Stalker",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Creature — Crocodile Mutant Rogue",
+    "oracleText": "Trample\nLeatherhead enters with a hexproof counter on her.\nWhenever Leatherhead deals combat damage to a player, you may remove a counter from her. When you do, destroy target artifact or enchantment that player controls.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "RemoveCounters",
+                        "counterType": "hexproof",
+                        "count": 1,
+                        "target": "Self"
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact|enchantment ctrl:opponent"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Leatherhead deals combat damage to a player, you may remove a counter from her. When you do, destroy target artifact or enchantment that player controls."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "hexproof"
+                },
+                "count": 1,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "117",
+        "rarity": "RARE",
+        "artist": "Lie Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1f6b5b5-12ca-468d-bc53-dd0cde60e7b6.jpg?1769006176"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Leonardo's Technique
 {
     "name": "Leonardo's Technique",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -2285,6 +2285,121 @@
     ]
 }
 
+// Donatello, Mutant Mechanic
+{
+    "name": "Donatello, Mutant Mechanic",
+    "manaCost": "{3}{U}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "{T}: Put three +1/+1 counters on target artifact you control. If it isn't a creature, it becomes a 0/0 Robot creature in addition to its other types. Activate only as a sorcery.\nWhenever an artifact you control is put into a graveyard from the battlefield, if it had counters on it, put those counters on up to one target artifact or creature you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "MoveAllLastKnownCounters",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target artifact or creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|artifact ctrl:you"
+                    },
+                    "id": "up to one target artifact or creature you control"
+                },
+                "triggerCondition": "TriggeringEntityHadCounters",
+                "descriptionOverride": "Whenever an artifact you control is put into a graveyard from the battlefield, if it had counters on it, put those counters on up to one target artifact or creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 3,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target artifact you control"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "noncreature"
+                                }
+                            },
+                            "then": {
+                                "type": "BecomeCreature",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "power": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "toughness": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "creatureTypes": [
+                                    "Robot"
+                                ],
+                                "duration": "Permanent"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "artifact ctrl:you"
+                        },
+                        "id": "target artifact you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "{T}: Put three +1/+1 counters on target artifact you control. If it isn't a creature, it becomes a 0/0 Robot creature in addition to its other types. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "MYTHIC",
+        "artist": "Zoltan Boros",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/3271b821-8efc-49e2-96fd-c48e2b2585c6.jpg?1769005688"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Donatello, Turtle Techie
 {
     "name": "Donatello, Turtle Techie",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -11087,6 +11087,70 @@
     }
 }
 
+// Tokka & Rahzar, Terrible Twos
+{
+    "name": "Tokka & Rahzar, Terrible Twos",
+    "manaCost": "{B/R}{B/R}",
+    "typeLine": "Legendary Creature — Turtle Wolf Mutant",
+    "oracleText": "This spell can't be countered.\nMenace\nWhenever a player casts a spell, if the amount of mana spent to cast it was less than its mana value, Tokka & Rahzar deal 3 damage to that player.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": "ManaSpent"
+                    },
+                    "operator": "LT",
+                    "right": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": "ManaValue"
+                    }
+                },
+                "descriptionOverride": "Whenever a player casts a spell, if the amount of mana spent to cast it was less than its mana value, Tokka & Rahzar deal 3 damage to that player."
+            }
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "RARE",
+        "artist": "Yuhong Ding",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/8/284f9012-a58d-41da-be7c-962dca052711.jpg?1769006390"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Transdimensional Bovine
 {
     "name": "Transdimensional Bovine",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5193,6 +5193,68 @@
     ]
 }
 
+// Lita, Little Orphan Amphibian
+{
+    "name": "Lita, Little Orphan Amphibian",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "Alliance — Whenever another creature you control enters, choose one that hasn't been chosen this turn.\n• Put a +1/+1 counter on Lita.\n• Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n• Scry 1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Food"
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "Scry",
+                                "count": 1
+                            }
+                        }
+                    ],
+                    "excludePreviouslyChosenModes": true,
+                    "countsAsModalSpell": false
+                },
+                "descriptionOverride": "Alliance — Whenever another creature you control enters, choose one that hasn't been chosen this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Anna Pavleeva",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fbaabb5-e981-4cbf-888c-46449412711f.jpg?1771424706"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Lord Dregg, Insect Invader
 {
     "name": "Lord Dregg, Insect Invader",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4791,11 +4791,8 @@
                                 "prompt": "Choose a card exiled with Krang & Shredder to cast without paying its mana cost"
                             },
                             {
-                                "type": "GrantFreeCastTargetFromExile",
-                                "target": {
-                                    "type": "PipelineTarget",
-                                    "collectionName": "krangChosen"
-                                }
+                                "type": "CastFromCollectionWithoutPayingCost",
+                                "from": "krangChosen"
                             }
                         ]
                     }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -6348,6 +6348,88 @@
     ]
 }
 
+// Mondo Gecko
+{
+    "name": "Mondo Gecko",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Legendary Creature — Lizard Mutant",
+    "oracleText": "{1}, Discard a card: Until end of turn, Mondo Gecko becomes the color of your choice and gains hexproof from that color.\nWhenever Mondo Gecko deals combat damage to a player, draw a card for each color among permanents you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "permanent",
+                        "aggregation": "DISTINCT_COLORS"
+                    }
+                },
+                "descriptionOverride": "Whenever Mondo Gecko deals combat damage to a player, draw a card for each color among permanents you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": "AtomDiscard"
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "ChooseColorThen",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ChangeColorToChosen",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "GrantHexproofFromChosenColor",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "{1}, Discard a card: Until end of turn, Mondo Gecko becomes the color of your choice and gains hexproof from that color."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "MYTHIC",
+        "artist": "Maël Ollivier-Henry",
+        "flavorText": "\"Stealth-o-rama, huh? Righteous.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/665e44f9-bc0d-40aa-83a4-f7fe64f2506d.jpg?1769005708"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Mouser Attack!
 {
     "name": "Mouser Attack!",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5365,6 +5365,68 @@
     ]
 }
 
+// Leonardo, Sewer Samurai
+{
+    "name": "Leonardo, Sewer Samurai",
+    "manaCost": "{3}{W}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle Samurai",
+    "oracleText": "Sneak {2}{W}{W} (You may cast this spell for {2}{W}{W} if you also return an unblocked attacker you control to hand during the declare blockers step.)\nDouble strike\nDuring your turn, you may cast creature spells with power or toughness 1 or less from your graveyard. If you cast a spell this way, that creature enters with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DOUBLE_STRIKE",
+        "SNEAK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Sneak",
+            "cost": "{2}{W}{W}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "MayCastFromGraveyard",
+                "filter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "PowerOrToughnessAtMost",
+                            "max": 1
+                        }
+                    ]
+                },
+                "duringYourTurnOnly": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "finality"
+                },
+                "count": 1,
+                "condition": {
+                    "type": "WasCastFromZone",
+                    "zone": "Graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "MYTHIC",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e3a0a26-c163-4f31-bed8-1be52a35feea.jpg?1764512256"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Lessons from Life
 {
     "name": "Lessons from Life",

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -4786,12 +4786,24 @@
                                 "storeAs": "krangCastable"
                             },
                             {
-                                "type": "GrantMayPlayFromExile",
-                                "from": "krangCastable"
+                                "type": "SelectFromCollection",
+                                "from": "krangCastable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "krangChosen",
+                                "prompt": "Choose a card exiled with Krang & Shredder to cast without paying its mana cost"
                             },
                             {
-                                "type": "GrantPlayWithoutPayingCost",
-                                "from": "krangCastable"
+                                "type": "GrantFreeCastTargetFromExile",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "krangChosen"
+                                }
                             }
                         ]
                     }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -5069,7 +5069,7 @@
     "typeLine": "Legendary Creature — Crocodile Mutant Rogue",
     "oracleText": "Trample\nLeatherhead enters with a hexproof counter on her.\nWhenever Leatherhead deals combat damage to a player, you may remove a counter from her. When you do, destroy target artifact or enchantment that player controls.",
     "creatureStats": {
-        "power": 4,
+        "power": 5,
         "toughness": 4
     },
     "keywords": [

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -8532,6 +8532,47 @@
     ]
 }
 
+// Raphael, Ninja Destroyer
+{
+    "name": "Raphael, Ninja Destroyer",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Legendary Creature — Mutant Ninja Turtle",
+    "oracleText": "Raphael must be blocked if able.\nEnrage — Whenever Raphael is dealt damage, add that much {R}. Until end of turn, you don't lose this mana as steps and phases end.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DamageReceivedEvent",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    }
+                },
+                "descriptionOverride": "Enrage — Whenever Raphael is dealt damage, add that much {R}. Until end of turn, you don't lose this mana as steps and phases end."
+            }
+        ],
+        "staticAbilities": [
+            "MustBeBlockedStatic"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "MYTHIC",
+        "artist": "Fajareka Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/e/eeffadda-cb71-4434-89bf-36db1a36da0b.jpg?1769006156"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Raphael, Tough Turtle
 {
     "name": "Raphael, Tough Turtle",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1236,6 +1236,17 @@ class TriggerDetector(
                 val container = state.getEntity(entityId) ?: continue
                 val cardComponent = container.get<CardComponent>() ?: continue
 
+                // The card's OWN battlefield-exit (its death / leaving) is owned by the dedicated
+                // death and leaves-battlefield detectors below, which resolve the dying entity's
+                // abilities regardless of activeZone. Skipping it here prevents a graveyard-active
+                // dies trigger (triggerZone = GRAVEYARD, e.g. Paramecia Coloniex) from being
+                // detected twice — once here, because the dead card already sits in the graveyard
+                // and its trigger pattern matches its own death event, and once in
+                // detectDeathTriggers. Other graveyard-resident reactions (another creature dying,
+                // entering, etc.) still fall through to the matcher below.
+                if (event is ZoneChangeEvent && event.fromZone == Zone.BATTLEFIELD &&
+                    event.entityId == entityId) continue
+
                 val abilities = abilityResolver.getTriggeredAbilities(entityId, cardComponent.cardDefinitionId, state)
 
                 for (ability in abilities) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
@@ -80,6 +80,7 @@ fun ManaRestriction.isSatisfiedBy(context: SpellPaymentContext): Boolean = when 
     is ManaRestriction.CastFromNonHandOnly -> !context.isAbilityActivation && !context.isFromHand
     is ManaRestriction.TurnPermanentsFaceUpOnly -> context.isTurnFaceUpAction
     is ManaRestriction.UnlockDoorOnly -> context.isUnlockDoorAction
+    is ManaRestriction.AbilityActivationOnly -> context.isAbilityActivation
     is ManaRestriction.AnyOf -> restrictions.any { it.isSatisfiedBy(context) }
     is ManaRestriction.SubtypeSpellsOnly ->
         !context.isAbilityActivation &&

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerDetectorBatchTriggerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerDetectorBatchTriggerTest.kt
@@ -92,6 +92,23 @@ class TriggerDetectorBatchTriggerTest : FunSpec({
         }
     }
 
+    // A dies trigger that functions from the graveyard (triggerZone = GRAVEYARD), the shape
+    // Paramecia Coloniex uses so its effect can reference Self after the creature has died and
+    // is sitting in the graveyard. Its activeZone is GRAVEYARD, which made the graveyard-resident
+    // trigger scan match its own death event in addition to the dedicated death detector — the
+    // double-fire this test guards against.
+    val graveyardActiveDiesWatcher = card("Graveyard Active Dies Watcher") {
+        manaCost = "{1}{B}"
+        typeLine = "Creature — Zombie"
+        power = 2
+        toughness = 2
+        triggeredAbility {
+            trigger = Triggers.Dies
+            triggerZone = Zone.GRAVEYARD
+            effect = LoseLifeEffect(1, EffectTarget.PlayerRef(Player.You))
+        }
+    }
+
     fun createDriver(vararg extras: CardDefinition): GameTestDriver {
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all + extras.toList())
@@ -600,6 +617,51 @@ class TriggerDetectorBatchTriggerTest : FunSpec({
             // Grizzly Bears has no GainControlOfSelf trigger either way; this just
             // exercises the early-exit branch in detectControlChangeTriggers.
             triggers.shouldBeEmpty()
+        }
+    }
+
+    // --- graveyard-active dies trigger dedupe (Paramecia Coloniex shape) ---------
+
+    context("graveyard-active dies trigger (Paramecia Coloniex shape)") {
+
+        test("a dies trigger with triggerZone = GRAVEYARD fires exactly once on its own death") {
+            val driver = createDriver(graveyardActiveDiesWatcher)
+            // The creature has already moved to the graveyard by the time triggers are detected,
+            // which is exactly the condition that made the graveyard-resident scan match its own
+            // death event a second time.
+            val died = driver.putCardInGraveyard(driver.player1, "Graveyard Active Dies Watcher")
+            val event = ZoneChangeEvent(
+                entityId = died,
+                entityName = "Graveyard Active Dies Watcher",
+                fromZone = Zone.BATTLEFIELD,
+                toZone = Zone.GRAVEYARD,
+                ownerId = driver.player1
+            )
+
+            val triggers = detectorFor(driver).detectTriggers(driver.state, listOf(event))
+
+            // Exactly one — not two (graveyard-resident scan + dedicated death detector).
+            val own = triggers.filter { it.sourceId == died }
+            own shouldHaveSize 1
+            own[0].ability.trigger.shouldBeInstanceOf<EventPattern.ZoneChangeEvent>()
+            own[0].controllerId shouldBe driver.player1
+        }
+
+        test("a dies trigger with triggerZone = GRAVEYARD still fires on its own death") {
+            // Companion to the dedupe test: the guard removes the duplicate, not the trigger.
+            val driver = createDriver(graveyardActiveDiesWatcher)
+            val died = driver.putCardInGraveyard(driver.player1, "Graveyard Active Dies Watcher")
+            val event = ZoneChangeEvent(
+                entityId = died,
+                entityName = "Graveyard Active Dies Watcher",
+                fromZone = Zone.BATTLEFIELD,
+                toZone = Zone.GRAVEYARD,
+                ownerId = driver.player1
+            )
+
+            val triggers = detectorFor(driver).detectTriggers(driver.state, listOf(event))
+
+            triggers.filter { it.sourceId == died }.shouldHaveSize(1)
         }
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/mana/ManaSpendRestrictionAnyAbilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/mana/ManaSpendRestrictionAnyAbilityTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.handlers.mana
+
+import com.wingedsheep.engine.mechanics.mana.ManaPool
+import com.wingedsheep.engine.mechanics.mana.SpellPaymentContext
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for [ManaRestriction.AbilityActivationOnly] — "spend this mana only to activate an
+ * ability" (any ability of any source) — and the Purple Dragon Punks composition
+ * (`AnyOf(artifact spells, any ability)` for "cast an artifact spell or activate an ability").
+ */
+class ManaSpendRestrictionAnyAbilityTest : FunSpec({
+
+    val cost = ManaCost.parse("{R}")
+
+    // Purple Dragon Punks: "Spend this mana only to cast an artifact spell or to activate an ability."
+    val punks = ManaRestriction.AnyOf(
+        listOf(
+            ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                cardType = CardType.ARTIFACT, allowSpells = true, allowAbilities = false,
+            ),
+            ManaRestriction.AbilityActivationOnly,
+        ),
+    )
+
+    test("any-ability mana pays for an ability of a NON-artifact source") {
+        val pool = ManaPool().addRestricted(Color.RED, 1, ManaRestriction.AbilityActivationOnly)
+        // A creature's activated ability — CardTypeSpellsOrAbilitiesOnly(ARTIFACT) would reject this.
+        pool.canPay(
+            cost,
+            SpellPaymentContext(isAbilityActivation = true, abilitySourceCardTypes = setOf(CardType.CREATURE)),
+        ) shouldBe true
+    }
+
+    test("any-ability mana is rejected for a spell cast") {
+        val pool = ManaPool().addRestricted(Color.RED, 1, ManaRestriction.AbilityActivationOnly)
+        pool.canPay(cost, SpellPaymentContext(cardTypes = setOf(CardType.ARTIFACT))) shouldBe false
+    }
+
+    test("Purple Dragon Punks mana pays for an artifact spell") {
+        val pool = ManaPool().addRestricted(Color.RED, 1, punks)
+        pool.canPay(cost, SpellPaymentContext(cardTypes = setOf(CardType.ARTIFACT))) shouldBe true
+    }
+
+    test("Purple Dragon Punks mana pays for any ability activation") {
+        val pool = ManaPool().addRestricted(Color.RED, 1, punks)
+        pool.canPay(
+            cost,
+            SpellPaymentContext(isAbilityActivation = true, abilitySourceCardTypes = setOf(CardType.CREATURE)),
+        ) shouldBe true
+    }
+
+    test("Purple Dragon Punks mana does NOT pay for a non-artifact spell") {
+        val pool = ManaPool().addRestricted(Color.RED, 1, punks)
+        pool.canPay(cost, SpellPaymentContext(isCreature = true, cardTypes = setOf(CardType.CREATURE))) shouldBe false
+        pool.canPay(cost, SpellPaymentContext(isInstantOrSorcery = true, cardTypes = setOf(CardType.INSTANT))) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DonAndLeoProblemSolversScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DonAndLeoProblemSolversScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Don & Leo, Problem Solvers (TMT).
+ *
+ * "At the beginning of your end step, exile up to one target artifact you control and up to one
+ *  target creature you control. Then return them to the battlefield under their owners' control."
+ *
+ * Regression guard for the two-optional-target fizzle: declining the (slot 0) artifact target and
+ * choosing only the (slot 1) creature target must NOT fizzle the ability. Before the fix, the
+ * resumer compacted the chosen-targets list to `[creature]` while keeping the full
+ * `[artifact, creature]` requirement list, so resolution-time validation (CR 608.2b) checked the
+ * creature against the *artifact* requirement, found it illegal, and fizzled with "all targets
+ * invalid" — the creature was never blinked.
+ */
+class DonAndLeoProblemSolversScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Don & Leo, Problem Solvers end-step blink") {
+
+            test("exiling only a creature (declining the artifact) blinks the creature instead of fizzling") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Don & Leo, Problem Solvers")
+                    .withCardOnBattlefield(1, "Centaur Courser") // p1's creature; no artifact in play
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val creatureBefore = game.findPermanent("Centaur Courser")
+                    ?: error("Centaur Courser should start on the battlefield")
+
+                // Advance to the end step; the trigger pauses for target selection.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+
+                val decision = game.getPendingDecision() as? ChooseTargetsDecision
+                    ?: error("Don & Leo's end-step trigger should prompt for targets")
+
+                // Choose ONLY the creature slot (the artifact slot is left declined). Find the slot
+                // whose legal targets include the creature so we don't depend on requirement ordering.
+                val creatureSlot = decision.legalTargets.entries.first { creatureBefore in it.value }.key
+                val result = game.submitDecision(
+                    TargetsResponse(decision.id, mapOf(creatureSlot to listOf(creatureBefore)))
+                )
+                withClue("Choosing only a creature must not error: ${result.error}") {
+                    result.error shouldBe null
+                }
+                val resolveResults = game.resolveStack()
+                val events = resolveResults.flatMap { it.events }.map { it::class.simpleName }
+
+                // The ability must RESOLVE (exile + return), not fizzle. Before the fix it fizzled with
+                // "all targets invalid": the creature was validated against the artifact requirement.
+                // A successful resolution emits the exile/return ZoneChangeEvents; a fizzle emits an
+                // AbilityFizzledEvent and no zone changes.
+                withClue("Don & Leo's ability must not fizzle when only a creature is chosen (events=$events)") {
+                    events shouldNotContain "AbilityFizzledEvent"
+                }
+                withClue("The exile-and-return should have moved the creature (events=$events)") {
+                    events shouldContain "ZoneChangeEvent"
+                }
+                withClue("Centaur Courser is on the battlefield after the blink (events=$events)") {
+                    (game.findPermanent("Centaur Courser") != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GroundchuckAndDirtbagTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GroundchuckAndDirtbagTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tmt.cards.GroundchuckAndDirtbag
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Groundchuck & Dirtbag ({4}{G}{G}, 8/8 Ox Mole Mutant).
+ *
+ *   Trample
+ *   Whenever you tap a land for mana, add {G}.
+ *
+ * This is a triggered MANA ability (CR 605.1b): it adds mana and triggers off a mana ability,
+ * so it must resolve immediately without using the stack — the {G} has to be in the pool for the
+ * same payment. The card is built on [com.wingedsheep.sdk.scripting.AdditionalManaOnSourceTap]
+ * (the engine's off-stack resolver, shared with Badgermole Cub's "...tap a creature for mana..."),
+ * not a generic `landTappedForMana` triggered ability — which is not wired to off-stack mana
+ * resolution and so adds no mana (the reported bug).
+ */
+class GroundchuckAndDirtbagTest : FunSpec({
+
+    // A nonbasic Land with an explicit "{T}: Add {G}" mana ability, so the test can drive the
+    // manual mana-ability activation path directly (no intrinsic-ability id plumbing).
+    val tapForGreenLand = card("Tap-for-Green Land") {
+        typeLine = "Land"
+        oracleText = "{T}: Add {G}."
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddMana(Color.GREEN, 1)
+            manaAbility = true
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GroundchuckAndDirtbag, tapForGreenLand))
+        return driver
+    }
+
+    fun createRegistry(): CardRegistry {
+        val registry = CardRegistry()
+        registry.register(TestCards.all + listOf(GroundchuckAndDirtbag, tapForGreenLand))
+        return registry
+    }
+
+    test("tapping a land for mana adds the extra {G} to the pool immediately") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Forest" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(activePlayer, "Groundchuck & Dirtbag")
+        val land = driver.putLandOnBattlefield(activePlayer, "Tap-for-Green Land")
+
+        val manaAbilityId = tapForGreenLand.activatedAbilities[0].id
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = land, abilityId = manaAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        // 1 from the land + 1 bonus from Groundchuck = 2 green, available right now.
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()!!
+        pool.green shouldBe 2
+    }
+
+    test("ManaSolver counts the Groundchuck bonus when costing land mana") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Forest" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(activePlayer, "Groundchuck & Dirtbag")
+        driver.putLandOnBattlefield(activePlayer, "Tap-for-Green Land")
+
+        val solver = ManaSolver(createRegistry())
+        // 1 from the land + 1 bonus from Groundchuck = 2 green available
+        solver.canPay(driver.state, activePlayer, ManaCost.parse("{G}{G}")) shouldBe true
+        solver.canPay(driver.state, activePlayer, ManaCost.parse("{G}{G}{G}")) shouldBe false
+    }
+
+    test("bonus does not fire when an opponent controls Groundchuck") {
+        // "Whenever you tap a land for mana" — the bonus belongs to Groundchuck's controller. If P2
+        // controls Groundchuck but P1 taps their own land, neither player gets the extra {G}.
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Forest" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(opponent, "Groundchuck & Dirtbag")
+        val land = driver.putLandOnBattlefield(activePlayer, "Tap-for-Green Land")
+
+        val manaAbilityId = tapForGreenLand.activatedAbilities[0].id
+        val result = driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = land, abilityId = manaAbilityId)
+        )
+        result.isSuccess shouldBe true
+
+        val activePool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()!!
+        val opponentPool = driver.state.getEntity(opponent)?.get<ManaPoolComponent>()!!
+        activePool.green shouldBe 1   // just the land — no Groundchuck bonus
+        opponentPool.green shouldBe 0 // opponent controls Groundchuck but didn't tap anything
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KrangAndShredderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KrangAndShredderScenarioTest.kt
@@ -9,9 +9,8 @@ import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
-import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Scenario test for Krang & Shredder's "Disappear" end-step ability (TMT).
@@ -70,17 +69,25 @@ class KrangAndShredderScenarioTest : ScenarioTestBase() {
                 game.selectCards(listOf(centaur))
                 game.resolveStack()
 
-                // Disappear grants a free-cast (MayPlayPermission) on ONLY the chosen card. The earlier
-                // implementation granted the permission over the whole linked-exile pile.
-                val freeCastable = game.state.mayPlayPermissions
-                    .filter { it.controllerId == game.player1Id }
-                    .flatMap { it.cardIds }
-                    .toSet()
-                withClue("The chosen card is granted a free cast (permissions=$freeCastable)") {
-                    freeCastable shouldContain centaur
+                // The chosen card is actually CAST during resolution (cascade-style) and enters the
+                // battlefield under the Disappear controller — not merely granted a "play it later"
+                // permission, which the earlier implementation left to expire unused at end of turn.
+                val centaurOnBattlefield = game.findPermanent("Centaur Courser")
+                withClue("The chosen card (Centaur Courser) entered the battlefield") {
+                    centaurOnBattlefield shouldNotBe null
                 }
-                withClue("The other exiled card is NOT granted a free cast — not the whole pile (permissions=$freeCastable)") {
-                    freeCastable shouldNotContain grizzly
+                withClue("...under the Disappear controller's control, even though the opponent owns it") {
+                    game.state.projectedState.getController(centaurOnBattlefield!!) shouldBe game.player1Id
+                }
+
+                // The other exiled card was NOT cast — only the one card the player chose, not the
+                // whole linked-exile pile.
+                withClue("The other card (Grizzly Bears) stays exiled") {
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                }
+                withClue("The chosen card is no longer in exile") {
+                    game.isInExile(2, "Centaur Courser") shouldBe false
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KrangAndShredderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KrangAndShredderScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.PermanentLeftBattlefieldThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Krang & Shredder's "Disappear" end-step ability (TMT).
+ *
+ * "At the beginning of your end step, if a permanent left the battlefield under your control this
+ *  turn, you may cast a card exiled with Krang & Shredder without paying its mana cost."
+ *
+ * Regression guard: the ability casts exactly ONE card (the player chooses), not the entire
+ * accumulated linked-exile pile. The earlier implementation granted a blanket
+ * play-from-exile-without-paying permission over the whole pile, letting the controller cast every
+ * card exiled with Krang for free that turn. The fix gathers the pile, asks the player to pick one,
+ * and grants the free cast on just that card.
+ */
+class KrangAndShredderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Krang & Shredder Disappear") {
+
+            test("casts only the chosen card from the linked-exile pile, leaving the rest exiled") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Krang & Shredder")
+                    .withCardInExile(2, "Centaur Courser") // two opponent cards "exiled with Krang"
+                    .withCardInExile(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val krang = game.findPermanent("Krang & Shredder")!!
+                fun exiledId(name: String) = game.state.getExile(game.player2Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == name
+                }
+                val centaur = exiledId("Centaur Courser")
+                val grizzly = exiledId("Grizzly Bears")
+
+                // Seed the linked-exile pile (as if Krang's enter/attack triggers had exiled both) and
+                // satisfy "a permanent left the battlefield under your control this turn".
+                game.state = game.state
+                    .updateEntity(krang) { it.with(LinkedExileComponent(listOf(centaur, grizzly))) }
+                    .updateEntity(game.player1Id) { it.with(PermanentLeftBattlefieldThisTurnComponent(count = 1)) }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                // Disappear is a "you may" — accept it.
+                withClue("Disappear asks whether to cast a card") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe true
+                }
+                game.answerYesNo(true)
+
+                // The player picks ONE card from the exiled pile (not the whole pile).
+                val select = game.getPendingDecision()
+                withClue("Disappear presents a single-card selection over the exiled pile") {
+                    (select is SelectCardsDecision) shouldBe true
+                }
+                game.selectCards(listOf(centaur))
+                game.resolveStack()
+
+                // Disappear grants a free-cast (MayPlayPermission) on ONLY the chosen card. The earlier
+                // implementation granted the permission over the whole linked-exile pile.
+                val freeCastable = game.state.mayPlayPermissions
+                    .filter { it.controllerId == game.player1Id }
+                    .flatMap { it.cardIds }
+                    .toSet()
+                withClue("The chosen card is granted a free cast (permissions=$freeCastable)") {
+                    freeCastable shouldContain centaur
+                }
+                withClue("The other exiled card is NOT granted a free cast — not the whole pile (permissions=$freeCastable)") {
+                    freeCastable shouldNotContain grizzly
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeonardoSewerSamuraiScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeonardoSewerSamuraiScenarioTest.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Leonardo, Sewer Samurai (TMT) — casting a small creature from your graveyard
+ * via Leonardo's permission makes it enter with a finality counter.
+ *
+ * Exercises the non-self `EntersWithCounters(FINALITY, condition = WasCastFromGraveyard)`:
+ * Leonardo's `selfOnly = false` replacement must evaluate the cast-from-graveyard status of the
+ * *entering* creature (the fix in EntersWithCountersHelper.applyGlobalEntersWithCounters).
+ */
+class LeonardoSewerSamuraiScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Leonardo, Sewer Samurai") {
+
+            test("a creature cast from the graveyard via Leonardo enters with a finality counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Leonardo, Sewer Samurai")
+                    .withCardInGraveyard(1, "Mons's Goblin Raiders") // {R} 1/1 — power/toughness <= 1
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpellFromGraveyard(1, "Mons's Goblin Raiders")
+                withClue("Casting from the graveyard via Leonardo should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val raider = game.findPermanent("Mons's Goblin Raiders")!!
+                val counters = game.state.getEntity(raider)?.get<CountersComponent>()
+                withClue("Cast from graveyard via Leonardo → enters with one finality counter") {
+                    (counters?.getCount(CounterType.FINALITY) ?: 0) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/wingedsheep/argentum-engine/pull/1046

A dies trigger declared with triggerZone = GRAVEYARD (activeZone == GRAVEYARD,
e.g. Paramecia Coloniex, so its effect can reference Self after death) was
detected twice for a single battlefield->graveyard zone change: once by the
graveyard-resident trigger scan (the dead card already sits in the graveyard
and its trigger pattern matches its own death event) and once by the dedicated
detectDeathTriggers pass.

Guard the graveyard-resident scan so it skips a card's own battlefield-exit
event; that case is owned by detectDeathTriggers / detectLeavesBattlefieldTriggers,
which fire regardless of activeZone. Other graveyard-resident reactions (another
creature dying/entering) still fall through to the matcher.

Add regression tests covering a triggerZone = GRAVEYARD dies trigger firing
exactly once on its own death.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>