### PR TITLE
Add five Final Fantasy cards (Ambrosia Whiteheart, Nibelheim Aflame, Judgment Bolt, Gaius van Baelsar, Retrieve the Esper)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AmbrosiaWhiteheart.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AmbrosiaWhiteheart.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ambrosia Whiteheart
+ * {1}{W}
+ * Legendary Creature — Bird
+ * 2/2
+ *
+ * Flash
+ * When Ambrosia Whiteheart enters, you may return another permanent you control to its owner's hand.
+ * Landfall — Whenever a land you control enters, Ambrosia Whiteheart gets +1/+0 until end of turn.
+ */
+val AmbrosiaWhiteheart = card("Ambrosia Whiteheart") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Flash\n" +
+        "When Ambrosia Whiteheart enters, you may return another permanent you control to its owner's hand.\n" +
+        "Landfall — Whenever a land you control enters, Ambrosia Whiteheart gets +1/+0 until end of turn."
+
+    keywords(Keyword.FLASH)
+
+    // When Ambrosia enters, you may return another permanent you control to its owner's hand.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "another permanent you control",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Permanent.youControl(), excludeSelf = true),
+            ),
+        )
+        effect = Effects.ReturnToHand(t)
+    }
+
+    // Landfall — Whenever a land you control enters, Ambrosia gets +1/+0 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = ModifyStatsEffect(1, 0, EffectTarget.Self)
+        description = "Landfall — Whenever a land you control enters, Ambrosia Whiteheart gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Fajareka Setiawan"
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2596767-7d19-4110-86ed-3cfc93ac7483.jpg?1748705777"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GaiusVanBaelsar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GaiusVanBaelsar.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Gaius van Baelsar
+ * {2}{B}{B}
+ * Legendary Creature — Human Soldier
+ * 3/2
+ *
+ * When Gaius van Baelsar enters, choose one —
+ * • Each player sacrifices a creature token of their choice.
+ * • Each player sacrifices a nontoken creature of their choice.
+ * • Each player sacrifices an enchantment of their choice.
+ *
+ * A modal ETB trigger ([ModalEffect.chooseOne]). Each mode is a symmetric edict over
+ * [Player.Each]: every player sacrifices one matching permanent of their own choosing, so no
+ * targeting is involved (the choice is made by each player as the ability resolves).
+ */
+val GaiusVanBaelsar = card("Gaius van Baelsar") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 3
+    toughness = 2
+    oracleText = "When Gaius van Baelsar enters, choose one —\n" +
+        "• Each player sacrifices a creature token of their choice.\n" +
+        "• Each player sacrifices a nontoken creature of their choice.\n" +
+        "• Each player sacrifices an enchantment of their choice."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(
+                Effects.Sacrifice(
+                    GameObjectFilter.Creature.token(),
+                    count = 1,
+                    target = EffectTarget.PlayerRef(Player.Each),
+                ),
+                "Each player sacrifices a creature token of their choice",
+            ),
+            Mode.noTarget(
+                Effects.Sacrifice(
+                    GameObjectFilter.Creature.nontoken(),
+                    count = 1,
+                    target = EffectTarget.PlayerRef(Player.Each),
+                ),
+                "Each player sacrifices a nontoken creature of their choice",
+            ),
+            Mode.noTarget(
+                Effects.Sacrifice(
+                    GameObjectFilter.Enchantment,
+                    count = 1,
+                    target = EffectTarget.PlayerRef(Player.Each),
+                ),
+                "Each player sacrifices an enchantment of their choice",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "102"
+        artist = "Nino Is"
+        imageUri = "https://cards.scryfall.io/normal/front/a/4/a4ee8ba5-6a79-4652-b2a4-a3dae804bc28.jpg?1748706145"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JudgmentBolt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JudgmentBolt.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Judgment Bolt
+ * {3}{R}
+ * Instant
+ *
+ * Judgment Bolt deals 5 damage to target creature and X damage to that creature's controller,
+ * where X is the number of Equipment you control.
+ *
+ * Two damage clauses share one target: a fixed 5 to the creature, and a dynamic amount equal to
+ * the number of Equipment you control ([DynamicAmount.Count]) to its controller, reached via
+ * [EffectTarget.TargetController].
+ */
+val JudgmentBolt = card("Judgment Bolt") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Judgment Bolt deals 5 damage to target creature and X damage to that creature's controller, " +
+        "where X is the number of Equipment you control."
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.DealDamage(5, t),
+            Effects.DealDamage(
+                DynamicAmount.Count(
+                    Player.You,
+                    Zone.BATTLEFIELD,
+                    GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT),
+                ),
+                EffectTarget.TargetController,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "559"
+        artist = "Billy Christian"
+        flavorText = "\"I'm here to even the odds. Any objections?\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/5/05b04b06-9271-4a28-a60e-287df0d1a4d1.jpg?1748707602"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/NibelheimAflame.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/NibelheimAflame.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Nibelheim Aflame
+ * {2}{R}{R}
+ * Sorcery
+ *
+ * Choose target creature you control. It deals damage equal to its power to each other creature.
+ * If this spell was cast from a graveyard, discard your hand and draw four cards.
+ * Flashback {5}{R}{R}
+ *
+ * The chosen creature deals damage equal to its power to each OTHER creature: a
+ * [Effects.ForEachInGroup] over every creature except the chosen one
+ * (`GroupFilter(...).otherThanTarget()`), each iterated creature ([EffectTarget.Self]) taking
+ * [DynamicAmounts.targetPower] damage *from the chosen creature itself* (`damageSource = chosen`),
+ * so its combat keywords and "dealt damage by" triggers see the correct source. The graveyard-cast
+ * rider is a [ConditionalEffect] gated on [Conditions.WasCastFromGraveyard] — true when the
+ * flashback cast resolves.
+ */
+val NibelheimAflame = card("Nibelheim Aflame") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose target creature you control. It deals damage equal to its power to each other creature. " +
+        "If this spell was cast from a graveyard, discard your hand and draw four cards.\n" +
+        "Flashback {5}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        val chosen = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                filter = GroupFilter(GameObjectFilter.Creature).otherThanTarget(),
+                effect = DealDamageEffect(
+                    amount = DynamicAmounts.targetPower(0),
+                    target = EffectTarget.Self,
+                    damageSource = chosen,
+                ),
+            ),
+            ConditionalEffect(
+                condition = Conditions.WasCastFromGraveyard,
+                effect = Effects.Composite(
+                    Patterns.Hand.discardHand(),
+                    Effects.DrawCards(4),
+                ),
+            ),
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{5}{R}{R}"))
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "146"
+        artist = "Arou"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d3e926a-74af-4996-849f-d31e0fdedeae.jpg?1748706306"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RetrieveTheEsper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RetrieveTheEsper.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Retrieve the Esper
+ * {3}{U}
+ * Sorcery
+ *
+ * Create a 3/3 blue Robot Warrior artifact creature token. Then if this spell was cast from a
+ * graveyard, put two +1/+1 counters on that token.
+ * Flashback {5}{U}
+ *
+ * The token-create atomic publishes its entity id under [CREATED_TOKENS]; the graveyard-cast rider
+ * is a [ConditionalEffect] gated on [Conditions.WasCastFromGraveyard] that addresses that same token
+ * via [Effects.AddCountersToCollection] (the Incubate composition pattern).
+ */
+val RetrieveTheEsper = card("Retrieve the Esper") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Create a 3/3 blue Robot Warrior artifact creature token. " +
+        "Then if this spell was cast from a graveyard, put two +1/+1 counters on that token.\n" +
+        "Flashback {5}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        effect = Effects.Composite(
+            Effects.CreateToken(
+                power = 3,
+                toughness = 3,
+                colors = setOf(Color.BLUE),
+                creatureTypes = setOf("Robot", "Warrior"),
+                artifactToken = true,
+                imageUri = "https://cards.scryfall.io/normal/front/c/2/c2b4e93b-6b27-4dd3-a6dd-a75d6fab14dc.jpg?1748704066",
+            ),
+            ConditionalEffect(
+                condition = Conditions.WasCastFromGraveyard,
+                effect = Effects.AddCountersToCollection(CREATED_TOKENS, Counters.PLUS_ONE_PLUS_ONE, 2),
+            ),
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{5}{U}"))
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "68"
+        artist = "Jake Murray"
+        imageUri = "https://cards.scryfall.io/normal/front/e/b/ebd733f0-8883-434a-b36c-ef76b091fe8e.jpg?1748706008"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -558,6 +558,80 @@
     ]
 }
 
+// Ambrosia Whiteheart
+{
+    "name": "Ambrosia Whiteheart",
+    "manaCost": "{1}{W}",
+    "typeLine": "Legendary Creature — Bird",
+    "oracleText": "Flash\nWhen Ambrosia Whiteheart enters, you may return another permanent you control to its owner's hand.\nLandfall — Whenever a land you control enters, Ambrosia Whiteheart gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another permanent you control"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "permanent ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "another permanent you control"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, Ambrosia Whiteheart gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Fajareka Setiawan",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2596767-7d19-4110-86ed-3cfc93ac7483.jpg?1748705777"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ardyn, the Usurper
 {
     "name": "Ardyn, the Usurper",
@@ -4596,6 +4670,76 @@
     ]
 }
 
+// Gaius van Baelsar
+{
+    "name": "Gaius van Baelsar",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "When Gaius van Baelsar enters, choose one —\n• Each player sacrifices a creature token of their choice.\n• Each player sacrifices a nontoken creature of their choice.\n• Each player sacrifices an enchantment of their choice.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "ForceSacrifice",
+                                "filter": "creature token",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "Each"
+                                }
+                            },
+                            "description": "Each player sacrifices a creature token of their choice"
+                        },
+                        {
+                            "effect": {
+                                "type": "ForceSacrifice",
+                                "filter": "creature nontoken",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "Each"
+                                }
+                            },
+                            "description": "Each player sacrifices a nontoken creature of their choice"
+                        },
+                        {
+                            "effect": {
+                                "type": "ForceSacrifice",
+                                "filter": "enchantment",
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "Each"
+                                }
+                            },
+                            "description": "Each player sacrifices an enchantment of their choice"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Is",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/4/a4ee8ba5-6a79-4652-b2a4-a3dae804bc28.jpg?1748706145"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Genji Glove
 {
     "name": "Genji Glove",
@@ -6564,6 +6708,61 @@
     ]
 }
 
+// Judgment Bolt
+{
+    "name": "Judgment Bolt",
+    "manaCost": "{3}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Judgment Bolt deals 5 damage to target creature and X damage to that creature's controller, where X is the number of Equipment you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "artifact Equipment"
+                    },
+                    "target": "TargetController"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "559",
+        "rarity": "RARE",
+        "artist": "Billy Christian",
+        "flavorText": "\"I'm here to even the odds. Any objections?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/5/05b04b06-9271-4a28-a60e-287df0d1a4d1.jpg?1748707602"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Jumbo Cactuar
 {
     "name": "Jumbo Cactuar",
@@ -8060,6 +8259,115 @@
     ]
 }
 
+// Nibelheim Aflame
+{
+    "name": "Nibelheim Aflame",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose target creature you control. It deals damage equal to its power to each other creature. If this spell was cast from a graveyard, discard your hand and draw four cards.\nFlashback {5}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{5}{R}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature",
+                            "excludeTarget": true
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Power"
+                        },
+                        "target": "Self",
+                        "damageSource": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "WasCastFromZone",
+                            "zone": "Graveyard"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "discardedHand"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discardedHand",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "MYTHIC",
+        "artist": "Arou",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d3e926a-74af-4996-849f-d31e0fdedeae.jpg?1748706306"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Overkill
 {
     "name": "Overkill",
@@ -9398,6 +9706,68 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Retrieve the Esper
+{
+    "name": "Retrieve the Esper",
+    "manaCost": "{3}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a 3/3 blue Robot Warrior artifact creature token. Then if this spell was cast from a graveyard, put two +1/+1 counters on that token.\nFlashback {5}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{5}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 3,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Robot",
+                        "Warrior"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2b4e93b-6b27-4dd3-a6dd-a75d6fab14dc.jpg?1748704066",
+                    "artifactToken": true
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "WasCastFromZone",
+                            "zone": "Graveyard"
+                        }
+                    },
+                    "then": {
+                        "type": "AddCountersToCollection",
+                        "collectionName": "createdTokens",
+                        "counterType": "+1/+1",
+                        "count": 2
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "68",
+        "artist": "Jake Murray",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/b/ebd733f0-8883-434a-b36c-ef76b091fe8e.jpg?1748706008"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
Implements five more **Final Fantasy (FIN)** cards. Each composes existing SDK primitives — **no new effects, triggers, conditions, or keywords** — so the only test artifact is the re-blessed FIN snapshot golden.

## Cards

| Card | Cost | What it does | Key primitives reused |
|------|------|--------------|------------------------|
| **Ambrosia Whiteheart** | `{1}{W}` | Flash; ETB may return another permanent you control; landfall +1/+0 EOT | `Keyword.FLASH`, `Effects.ReturnToHand` (optional target, `excludeSelf`), `Triggers.LandYouControlEnters` + `ModifyStatsEffect` |
| **Nibelheim Aflame** | `{2}{R}{R}` | Chosen creature deals damage equal to its power to each *other* creature; if cast from a graveyard, discard hand + draw four; Flashback `{5}{R}{R}` | `ForEachInGroup` + `GroupFilter(...).otherThanTarget()`, `DealDamageEffect(damageSource=…)`, `DynamicAmounts.targetPower`, `ConditionalEffect(Conditions.WasCastFromGraveyard)`, `Patterns.Hand.discardHand`, `KeywordAbility.flashback` |
| **Judgment Bolt** | `{3}{R}` | 5 damage to target creature + X damage to its controller (X = Equipment you control) | `Effects.DealDamage`, `DynamicAmount.Count(Equipment)`, `EffectTarget.TargetController` |
| **Gaius van Baelsar** | `{2}{B}{B}` | Modal ETB edict: each player sacrifices a token creature / nontoken creature / enchantment of their choice | `ModalEffect.chooseOne` + `Mode.noTarget`, `Effects.Sacrifice(target=Player.Each)`, `.token()`/`.nontoken()` filters |
| **Retrieve the Esper** | `{3}{U}` | Create a 3/3 blue Robot Warrior artifact token; if cast from a graveyard, two +1/+1 counters on it; Flashback `{5}{U}` | `Effects.CreateToken`, `CREATED_TOKENS` pipeline + `AddCountersToCollection`, `ConditionalEffect(Conditions.WasCastFromGraveyard)` |

## Verification

- `just build` — all modules compile; full rules-engine/server/etc. test suites pass.
- The only build delta was the expected `CardDefinitionSnapshotTest` FIN golden mismatch; diff confirms **only these five cards added, no other card changed**. Re-blessed with `-DupdateSnapshots=true`.
- `CardLintTest` passes (dataflow / target / slot hygiene clean).
- All card + token image URIs verified `HTTP 200` against Scryfall (`set=fin`).
- No new SDK building blocks, so no scenario tests required (Step 5 gate); behavior is pure composition of already-tested primitives.

FIN coverage: 195 → 199 implemented (Draft) + Judgment Bolt as an extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)