### PR TITLE
Add Central Elevator // Promising Stairs and Charred Foyer // Warped Space (DSK)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2006,6 +2006,14 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
   reprints still match their original set, regardless of the printing in play. Reads the entity's
   `CardComponent.originalSetCode` (populated from the canonical `CardDefinition.setCode`); tokens never
   match. Used by Golgothian Sylex (`"ATQ"`) and ARN City in a Bottle (`"ARN"`).
+- `.nameNotSharedWithControlledRoom()` — `CardPredicate.NameNotSharedWithControlledRoom`: matches a Room card
+  whose name isn't shared with any Room the evaluating player controls (CR 709). Per the Central Elevator
+  ruling, only the names of a controlled Room's **unlocked** doors count (a Room with no unlocked doors
+  contributes neither name), and a split Room card is excluded if **either** of its door names matches. Keyed
+  off the predicate context's `controllerId`; fails **open** (matches) with no controller in scope and matches
+  every Room card when the controller has no unlocked doors. Pair with `.withSubtype(Subtype.ROOM)` at a search
+  site. Used by Central Elevator ("search your library for a Room card that doesn't have the same name as a
+  Room you control").
 - `.power(n)` / `.minPower(n)` / `.maxPower(n)` — P/T comparator.
 - `.manaValue(n)` / `.manaValueAtMost(n)` / `.manaValueAtLeast(n)` — mana-value comparator.
 - `.manaValueAtMostX()` — mana value ≤ the X chosen for the source spell/ability.
@@ -3039,6 +3047,14 @@ creature"), and similar "static cleanup" wording in early sets. Differs from an
 intervening-if triggered ability — there is no event to gate on; the engine watches the
 condition itself.
 
+`stateTriggeredAbility { }` is also available **inside a `face { }` block** of a split/Room
+card. The poller folds in the state triggers of every currently-**unlocked** Room face
+(`RoomFaceStatics.activeStateTriggeredAbilities`), so a locked door's state trigger stays inert
+until its door is unlocked — Promising Stairs (Central Elevator // Promising Stairs): "You win the
+game if there are eight or more different names among unlocked doors of Rooms you control"
+(`condition = Compare(DynamicAmount.UnlockedDoors(Player.You, distinctNames = true),
+ComparisonOperator.GTE, DynamicAmount.Fixed(8))`, `effect = Effects.WinGame(...)`).
+
 ---
 
 ## 9. Static abilities
@@ -3580,7 +3596,7 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
     grant. (Cascade-style granted keywords are instead modelled as a `youCastSpell(...)`-triggered `Effects.Cascade`
     on the granter — see **Quandrix, the Proof** / Wildsear, Scouring Maw — since cascade is a cast trigger, not a
     cost keyword.)
-- `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false, spellFilter = Any, oncePerTurn = false)` — a
+- `MayCastWithoutPayingManaCost(controllerOnly = false, firstSpellOfTurnOnly = false, spellFilter = Any, oncePerTurn = false, fromExileOnly = false)` — a
   battlefield permission to cast a spell without paying its mana cost (CR 118.9). Composable
   gates: `controllerOnly = true` restricts the benefit to the source's controller ("you" wording);
   `firstSpellOfTurnOnly = true` requires the caster to be the active player and to have cast
@@ -3589,16 +3605,23 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   `firstSpellOfTurnOnly`, the caster may cast other spells before using it; each source tracks its
   own use via `MayCastWithoutPayingCostUsedThisTurnComponent`, cleared at end of turn; `spellFilter`
   restricts *which* spells may be cast for free (card predicates, matched in any zone — default
-  `GameObjectFilter.Any` = every spell). The free-cast permission is only ever offered for cards in
-  hand. Weftwalking is `MayCastWithoutPayingManaCost(firstSpellOfTurnOnly = true)`; Zaffai and the
+  `GameObjectFilter.Any` = every spell). `fromExileOnly = true` restricts the permission to spells
+  cast **from exile** (offered on the cast-from-exile path, withheld from hand/graveyard casts) —
+  Warped Space (Charred Foyer // Warped Space): "Once each turn, you may pay {0} rather than pay the
+  mana cost for a spell you cast from exile" → `MayCastWithoutPayingManaCost(controllerOnly = true,
+  oncePerTurn = true, fromExileOnly = true)`. The free-cast permission is offered for cards in hand
+  (default) and, when `fromExileOnly = true`, for cards being cast from exile. Weftwalking is
+  `MayCastWithoutPayingManaCost(firstSpellOfTurnOnly = true)`; Zaffai and the
   Tempests is `MayCastWithoutPayingManaCost(controllerOnly = true, oncePerTurn = true, spellFilter =
   GameObjectFilter.InstantOrSorcery)` ("Once during each of your turns, you may cast an instant or
   sorcery spell from your hand without paying its mana cost"); Dracogenesis is
   `MayCastWithoutPayingManaCost(controllerOnly = true, spellFilter = GameObjectFilter.Any.withSubtype("Dragon"))`
   ("You may cast Dragon spells without paying their mana costs"); a future "you may cast the first
-  spell you cast each turn …" composes via both gates true. The filter is enforced per-spell in
-  `CostCalculator.hasFreeCastPermission(state, casterId, spellCardDef)` (the enumerator threads the
-  card being cast through `EnumerationContext.freeCastPermissionFor(cardId)`).
+  spell you cast each turn …" composes via both gates true. The filter and zone gate are enforced
+  per-spell in `CostCalculator.hasFreeCastPermission(state, casterId, spellCardDef, castFromZone)`
+  (the enumerator threads the card being cast and its zone through
+  `EnumerationContext.freeCastPermissionFor(cardId, castFromZone)` — `Zone.HAND` on the hand path,
+  `Zone.EXILE` on the cast-from-exile path).
   Cast-legality is checked by `CostCalculator.hasFreeCastPermission`. Surfaced as a dedicated
   `CastWithoutPayingManaCost` `LegalAction` variant routed through
   `CastSpell.useWithoutPayingManaCost = true` — emitted **alongside** Jodah-style

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1615,6 +1615,7 @@ class CardFaceBuilder(private val name: String) {
 
     private val keywordSet: MutableSet<Keyword> = mutableSetOf()
     private val triggeredAbilities: MutableList<TriggeredAbility> = mutableListOf()
+    private val stateTriggeredAbilities: MutableList<StateTriggeredAbility> = mutableListOf()
     private val activatedAbilities: MutableList<ActivatedAbility> = mutableListOf()
     private val staticAbilities: MutableList<StaticAbility> = mutableListOf()
     private val additionalCostsList: MutableList<AdditionalCost> = mutableListOf()
@@ -1628,6 +1629,18 @@ class CardFaceBuilder(private val name: String) {
         val builder = TriggeredAbilityBuilder()
         builder.init()
         triggeredAbilities.add(builder.build())
+    }
+
+    /**
+     * A state-triggered ability (CR 603.8) on this face. For a Room face it functions only while
+     * the door is unlocked (the engine folds unlocked-face state triggers via `RoomFaceStatics`).
+     * Promising Stairs: "You win the game if there are eight or more different names among unlocked
+     * doors of Rooms you control."
+     */
+    fun stateTriggeredAbility(init: StateTriggeredAbilityBuilder.() -> Unit) {
+        val builder = StateTriggeredAbilityBuilder()
+        builder.init()
+        stateTriggeredAbilities.add(builder.build())
     }
 
     fun activatedAbility(init: ActivatedAbilityBuilder.() -> Unit) {
@@ -1669,6 +1682,7 @@ class CardFaceBuilder(private val name: String) {
             spellEffect = spellEffect,
             targetRequirements = spellBuilder?.targetRequirements ?: emptyList(),
             triggeredAbilities = triggeredAbilities.toList(),
+            stateTriggeredAbilities = stateTriggeredAbilities.toList(),
             activatedAbilities = activatedAbilities.toList(),
             staticAbilities = staticAbilities.toList(),
             additionalCosts = additionalCostsList.toList(),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -396,13 +396,23 @@ data class MayCastWithoutPayingManaCost(
      * `MayCastWithoutPayingManaCost(controllerOnly = true, oncePerTurn = true,
      * spellFilter = GameObjectFilter.InstantOrSorcery)`.
      */
-    val oncePerTurn: Boolean = false
+    val oncePerTurn: Boolean = false,
+    /**
+     * When true, the permission applies only to spells **cast from exile** — the free cast is
+     * offered on the cast-from-exile path and withheld from hand / graveyard / other casts. Warped
+     * Space (Charred Foyer // Warped Space): "Once each turn, you may pay {0} rather than pay the
+     * mana cost for a spell you cast from exile" → `MayCastWithoutPayingManaCost(controllerOnly =
+     * true, oncePerTurn = true, fromExileOnly = true)`. The engine gates this on the cast's source
+     * zone in `CostCalculator.hasFreeCastPermission` / `oncePerTurnFreeCastSourceToConsume`.
+     */
+    val fromExileOnly: Boolean = false
 ) : StaticAbility {
     override val description: String = buildString {
         val noun = if (spellFilter == GameObjectFilter.Any) "spells" else "${spellFilter.description} spells"
         val singular = if (spellFilter == GameObjectFilter.Any) "spell" else "${spellFilter.description} spell"
+        val fromExile = if (fromExileOnly) " from exile" else ""
         if (oncePerTurn) {
-            append("Once during each of your turns, you may cast a $singular without paying its mana cost")
+            append("Once during each of your turns, you may cast a $singular$fromExile without paying its mana cost")
         } else if (firstSpellOfTurnOnly) {
             if (controllerOnly) append("The first spell you cast each turn may be cast without paying its mana cost")
             else append("The first spell each player casts during each of their turns may be cast without paying its mana cost")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -281,6 +281,15 @@ data class GameObjectFilter(
     )
 
     /**
+     * Match Room cards whose name isn't shared with a Room the evaluating player controls
+     * (CR 709, by unlocked door names) — "a Room card that doesn't have the same name as a
+     * Room you control" (Central Elevator).
+     */
+    fun nameNotSharedWithControlledRoom() = copy(
+        cardPredicates = cardPredicates + CardPredicate.NameNotSharedWithControlledRoom
+    )
+
+    /**
      * Match cards whose name equals the name durably chosen by the *source permanent* as it
      * entered (its [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under
      * [slot]). Static-projection / activation-legality safe — use this in static-ability filters

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/CardPredicate.kt
@@ -283,6 +283,23 @@ sealed interface CardPredicate : TextReplaceable<CardPredicate> {
     }
 
     /**
+     * Matches a card whose name is **not** shared with any Room the evaluating player controls
+     * (CR 709). Per the Central Elevator ruling, only the names of a Room's *unlocked* doors
+     * count: a Room with no unlocked doors contributes neither of its names, and a split Room
+     * card shares a name if **either** of its door names matches a controlled Room's unlocked
+     * door name. Models "a Room card that doesn't have the same name as a Room you control".
+     *
+     * Evaluated against the evaluating player ([com.wingedsheep.engine.handlers.PredicateContext.controllerId]).
+     * Fails open (matches) when no controller is in scope, and matches every Room card when the
+     * controller has no unlocked doors. Pair with a `Room` subtype filter at the search site.
+     */
+    @SerialName("NameNotSharedWithControlledRoom")
+    @Serializable
+    data object NameNotSharedWithControlledRoom : CardPredicate {
+        override val description: String = "that doesn't have the same name as a Room you control"
+    }
+
+    /**
      * Matches cards *originally printed* in the given set — i.e. whose canonical
      * [com.wingedsheep.sdk.model.CardDefinition.setCode] equals [setCode] (case-insensitive),
      * regardless of which printing is actually in play. This is the card's first/canonical set, so

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CentralElevatorPromisingStairs.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CentralElevatorPromisingStairs.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Central Elevator // Promising Stairs (DSK 44) — split-layout Room (CR 709.5).
+ *
+ * Central Elevator {3}{U} — Enchantment — Room
+ *   When you unlock this door, search your library for a Room card that doesn't have the same
+ *   name as a Room you control, reveal it, put it into your hand, then shuffle.
+ *
+ * Promising Stairs {2}{U} — Enchantment — Room
+ *   At the beginning of your upkeep, surveil 1. You win the game if there are eight or more
+ *   different names among unlocked doors of Rooms you control.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ *
+ * Notes:
+ * - Central Elevator's search restriction is the new [GameObjectFilter.nameNotSharedWithControlledRoom]
+ *   predicate. Per the 2024-09-20 ruling, only the names of *unlocked* doors of Rooms you control
+ *   count; a split Room card in the library shares a name if either of its door names matches.
+ * - Promising Stairs's win is a state-triggered ability (CR 603.8), checked continuously rather
+ *   than only at upkeep — it triggers the moment you reach eight or more different unlocked-door
+ *   names. The ruling clarifies it counts names, not permanents (a Room with two unlocked doors
+ *   contributes two), which is exactly [DynamicAmount.UnlockedDoors] with `distinctNames = true`.
+ */
+val CentralElevatorPromisingStairs = card("Central Elevator // Promising Stairs") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "U"
+
+    face("Central Elevator") {
+        manaCost = "{3}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "When you unlock this door, search your library for a Room card that doesn't " +
+            "have the same name as a Room you control, reveal it, put it into your hand, then shuffle."
+
+        triggeredAbility {
+            trigger = Triggers.OnDoorUnlocked
+            effect = Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.Any
+                    .withSubtype(Subtype.ROOM)
+                    .nameNotSharedWithControlledRoom(),
+                count = 1,
+                destination = SearchDestination.HAND,
+                reveal = true,
+                shuffleAfter = true,
+            )
+            description = "When you unlock this door, search your library for a Room card that " +
+                "doesn't have the same name as a Room you control, reveal it, put it into your " +
+                "hand, then shuffle."
+        }
+    }
+
+    face("Promising Stairs") {
+        manaCost = "{2}{U}"
+        typeLine = "Enchantment — Room"
+        oracleText = "At the beginning of your upkeep, surveil 1. You win the game if there are " +
+            "eight or more different names among unlocked doors of Rooms you control."
+
+        triggeredAbility {
+            trigger = Triggers.YourUpkeep
+            effect = Effects.Surveil(1)
+            description = "At the beginning of your upkeep, surveil 1."
+        }
+
+        stateTriggeredAbility {
+            condition = Compare(
+                DynamicAmount.UnlockedDoors(Player.You, distinctNames = true),
+                ComparisonOperator.GTE,
+                DynamicAmount.Fixed(8),
+            )
+            effect = Effects.WinGame(message = "Eight doors stood open — the stairs led out.")
+            description = "You win the game if there are eight or more different names among " +
+                "unlocked doors of Rooms you control."
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "44"
+        artist = "Cristi Balanescu"
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg?1726867824"
+        ruling("2024-09-20", "Two or more objects have the same name if they have at least one name in common, even if one or more of those objects have additional names. Central Elevator's ability lets you search your library for any Room card that doesn't share a name with a Room you control on the battlefield, checking only the names of unlocked doors. If a Room on the battlefield has no unlocked doors, it doesn't have either of its names.")
+        ruling("2024-09-20", "Promising Stairs's ability counts names, not permanents. A Room with two unlocked doors has two names.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CharredFoyerWarpedSpace.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/CharredFoyerWarpedSpace.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.MayCastWithoutPayingManaCost
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+
+/**
+ * Charred Foyer // Warped Space (DSK 129) — split-layout Room (CR 709.5).
+ *
+ * Charred Foyer {3}{R} — Enchantment — Room
+ *   At the beginning of your upkeep, exile the top card of your library. You may play it this turn.
+ *
+ * Warped Space {4}{R}{R} — Enchantment — Room
+ *   Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile.
+ *
+ * Cast each half separately; the cast face enters unlocked, the other locked. Pay the locked
+ * face's printed mana cost as a sorcery-speed special action to unlock it (CR 709.5e).
+ *
+ * Notes:
+ * - Charred Foyer's upkeep ability is the standard "impulse draw" ([Patterns.Exile.impulse]) with
+ *   an end-of-turn play window.
+ * - Warped Space is the [MayCastWithoutPayingManaCost] free-cast static, gated to spells cast from
+ *   exile (`fromExileOnly`) and to once per turn (`oncePerTurn`). "Pay {0}" is an alternative cost
+ *   of nothing, i.e. casting without paying the mana cost (CR 118.9 — additional/mandatory costs
+ *   still apply, X is 0). It pairs naturally with Charred Foyer's impulse-exiled cards but applies
+ *   to any spell cast from exile (foretell, adventure-in-exile, etc.).
+ */
+val CharredFoyerWarpedSpace = card("Charred Foyer // Warped Space") {
+    layout = CardLayout.SPLIT
+    colorIdentity = "R"
+
+    face("Charred Foyer") {
+        manaCost = "{3}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "At the beginning of your upkeep, exile the top card of your library. You may play it this turn."
+
+        triggeredAbility {
+            trigger = Triggers.YourUpkeep
+            effect = Patterns.Exile.impulse(count = 1, expiry = MayPlayExpiry.EndOfTurn)
+            description = "At the beginning of your upkeep, exile the top card of your library. You may play it this turn."
+        }
+    }
+
+    face("Warped Space") {
+        manaCost = "{4}{R}{R}"
+        typeLine = "Enchantment — Room"
+        oracleText = "Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile."
+
+        staticAbility {
+            ability = MayCastWithoutPayingManaCost(
+                controllerOnly = true,
+                oncePerTurn = true,
+                fromExileOnly = true,
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "129"
+        artist = "Andrew Mar"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg?1726867813"
+        ruling("2024-09-20", "You pay all costs and follow all timing rules for cards played with the permission granted by Charred Foyer's ability. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty.")
+        ruling("2024-09-20", "If you cast a spell for an alternative cost of {0}, you can't pay any other alternative costs. You can, however, pay additional costs, such as kicker. If the card has any mandatory additional costs, you must pay those.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -1781,6 +1781,140 @@
     ]
 }
 
+// Central Elevator // Promising Stairs
+{
+    "name": "Central Elevator // Promising Stairs",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "When you unlock this door, search your library for a Room card that doesn't have the same name as a Room you control, reveal it, put it into your hand, then shuffle.\n//\nAt the beginning of your upkeep, surveil 1. You win the game if there are eight or more different names among unlocked doors of Rooms you control.",
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "RARE",
+        "artist": "Cristi Balanescu",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e548befc-4cd4-46be-951f-045452261cda.jpg?1726867824",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "Two or more objects have the same name if they have at least one name in common, even if one or more of those objects have additional names. Central Elevator's ability lets you search your library for any Room card that doesn't share a name with a Room you control on the battlefield, checking only the names of unlocked doors. If a Room on the battlefield has no unlocked doors, it doesn't have either of its names."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "Promising Stairs's ability counts names, not permanents. A Room with two unlocked doors has two names."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Central Elevator",
+            "manaCost": "{3}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "When you unlock this door, search your library for a Room card that doesn't have the same name as a Room you control, reveal it, put it into your hand, then shuffle.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": "DoorUnlockedEvent",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Room"
+                                                },
+                                                "NameNotSharedWithControlledRoom"
+                                            ]
+                                        }
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    },
+                                    "revealed": true
+                                },
+                                "ShuffleLibrary"
+                            ]
+                        },
+                        "descriptionOverride": "When you unlock this door, search your library for a Room card that doesn't have the same name as a Room you control, reveal it, put it into your hand, then shuffle."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Promising Stairs",
+            "manaCost": "{2}{U}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "At the beginning of your upkeep, surveil 1. You win the game if there are eight or more different names among unlocked doors of Rooms you control.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_2",
+                        "trigger": {
+                            "type": "StepEvent",
+                            "step": "UPKEEP"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "Surveil",
+                            "count": 1
+                        },
+                        "descriptionOverride": "At the beginning of your upkeep, surveil 1."
+                    }
+                ],
+                "stateTriggeredAbilities": [
+                    {
+                        "id": "ability_3",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "UnlockedDoors",
+                                "distinctNames": true
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 8
+                            }
+                        },
+                        "effect": {
+                            "type": "WinGame",
+                            "message": "Eight doors stood open — the stairs led out."
+                        },
+                        "descriptionOverride": "You win the game if there are eight or more different names among unlocked doors of Rooms you control."
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Chainsaw
 {
     "name": "Chainsaw",
@@ -1894,6 +2028,99 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Charred Foyer // Warped Space
+{
+    "name": "Charred Foyer // Warped Space",
+    "manaCost": "",
+    "typeLine": "Enchantment — Room",
+    "oracleText": "At the beginning of your upkeep, exile the top card of your library. You may play it this turn.\n//\nOnce each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile.",
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "MYTHIC",
+        "artist": "Andrew Mar",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a128e6d1-b90f-45a1-b587-f8c29bd0ec8c.jpg?1726867813",
+        "rulings": [
+            {
+                "date": "2024-09-20",
+                "text": "You pay all costs and follow all timing rules for cards played with the permission granted by Charred Foyer's ability. For example, if the exiled card is a land card, you may play it only during your main phase while the stack is empty."
+            },
+            {
+                "date": "2024-09-20",
+                "text": "If you cast a spell for an alternative cost of {0}, you can't pay any other alternative costs. You can, however, pay additional costs, such as kicker. If the card has any mandatory additional costs, you must pay those."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "SPLIT",
+    "cardFaces": [
+        {
+            "name": "Charred Foyer",
+            "manaCost": "{3}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "At the beginning of your upkeep, exile the top card of your library. You may play it this turn.",
+            "script": {
+                "triggeredAbilities": [
+                    {
+                        "id": "ability_1",
+                        "trigger": {
+                            "type": "StepEvent",
+                            "step": "UPKEEP"
+                        },
+                        "binding": "ANY",
+                        "effect": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeAs": "impulseExiled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "impulseExiled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    }
+                                },
+                                {
+                                    "type": "GrantMayPlayFromExile",
+                                    "from": "impulseExiled"
+                                }
+                            ]
+                        },
+                        "descriptionOverride": "At the beginning of your upkeep, exile the top card of your library. You may play it this turn."
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Warped Space",
+            "manaCost": "{4}{R}{R}",
+            "typeLine": "Enchantment — Room",
+            "oracleText": "Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile.",
+            "script": {
+                "staticAbilities": [
+                    {
+                        "type": "MayCastWithoutPayingManaCost",
+                        "controllerOnly": true,
+                        "oncePerTurn": true,
+                        "fromExileOnly": true
+                    }
+                ]
+            }
+        }
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/StateTriggerPoller.kt
@@ -57,7 +57,10 @@ class StateTriggerPoller(
             if (container.has<FaceDownComponent>()) continue
             val controllerId = projected.getController(permanentId) ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            val abilities = cardDef.script.stateTriggeredAbilities
+            // Fold in unlocked Room-face state triggers (CR 709.5) so a locked door's state
+            // trigger stays inert until its door is unlocked (Promising Stairs).
+            val abilities = com.wingedsheep.engine.state.components.identity.RoomFaceStatics
+                .activeStateTriggeredAbilities(container, cardDef)
             if (abilities.isEmpty()) continue
 
             val effectContext = EffectContext(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -270,6 +270,27 @@ class PredicateEvaluator {
             // Name predicates
             is CardPredicate.NameEquals -> card.name == predicate.name
 
+            // CR 709 + Central Elevator ruling: a Room card may be found only if none of its
+            // door names matches an *unlocked* door name of a Room the searcher controls. A Room
+            // with no unlocked doors contributes neither of its names; a split Room card carries
+            // both door names and is excluded if either matches. Fails open with no controller.
+            is CardPredicate.NameNotSharedWithControlledRoom -> {
+                val controllerId = context?.controllerId
+                if (controllerId == null) {
+                    true
+                } else {
+                    val controlledDoorNames = state.getBattlefield().flatMapTo(mutableSetOf<String>()) { id ->
+                        val room = state.getEntity(id)?.get<RoomComponent>()
+                        if (room == null || projected.getController(id) != controllerId) {
+                            emptyList()
+                        } else {
+                            room.faces.filter { it.id in room.unlocked }.map { it.name }
+                        }
+                    }
+                    card.name.split(" // ").map { it.trim() }.none { it in controlledDoorNames }
+                }
+            }
+
             // Keyword predicates - use projected keywords
             is CardPredicate.HasKeyword -> predicate.keyword.name in keywords
             is CardPredicate.NotKeyword -> predicate.keyword.name !in keywords
@@ -1213,6 +1234,7 @@ class PredicateEvaluator {
             // Name / printing predicates — not stored in record
             is CardPredicate.NameEquals -> false
             is CardPredicate.NameEqualsChosen -> false
+            CardPredicate.NameNotSharedWithControlledRoom -> false
             is CardPredicate.OriginallyPrintedInSet -> false
 
             // Keyword predicates — not stored in record

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -390,7 +390,9 @@ class CastSpellHandler(
             if (action.useAlternativeCost) {
                 return "Cannot combine 'without paying its mana cost' with another alternative cost"
             }
-            if (!costCalculator.hasFreeCastPermission(state, action.playerId, cardDef)) {
+            // Pass the spell's origin zone so a `fromExileOnly` source (Warped Space) validates an
+            // exile cast while staying withheld from hand casts.
+            if (!costCalculator.hasFreeCastPermission(state, action.playerId, cardDef, castSourceZone(state, action.cardId))) {
                 return "'Without paying its mana cost' is not available (gate closed or no source on the battlefield)"
             }
         }
@@ -2653,7 +2655,11 @@ class CastSpellHandler(
         // `MayCastWithoutPayingManaCost(oncePerTurn = true)` source consumes a use, and only when
         // no unlimited free-cast source could have paid instead.
         if (action.useWithoutPayingManaCost) {
-            val onceSource = costCalculator.oncePerTurnFreeCastSourceToConsume(currentCastState, action.playerId, cardDef)
+            // Use the pre-cast `state` to recover the spell's origin zone — by now the card has
+            // left it for the stack — so a `fromExileOnly` source (Warped Space) is only consumed
+            // for an actual exile cast.
+            val castFromZone = castSourceZone(state, action.cardId)
+            val onceSource = costCalculator.oncePerTurnFreeCastSourceToConsume(currentCastState, action.playerId, cardDef, castFromZone)
             if (onceSource != null) {
                 currentCastState = currentCastState.updateEntity(onceSource) { c ->
                     c.with(com.wingedsheep.engine.state.components.battlefield.MayCastWithoutPayingCostUsedThisTurnComponent)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/EnumerationContext.kt
@@ -143,12 +143,15 @@ class EnumerationContext(
      * "any free-cast source exists?" probe), this honors a source's spell filter — e.g.
      * Dracogenesis only frees Dragon spells.
      */
-    fun freeCastPermissionFor(cardId: EntityId): Boolean {
+    fun freeCastPermissionFor(
+        cardId: EntityId,
+        castFromZone: com.wingedsheep.sdk.core.Zone = com.wingedsheep.sdk.core.Zone.HAND
+    ): Boolean {
         val cardDef = state.getEntity(cardId)
             ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
             ?.let { cardRegistry.getCard(it.cardDefinitionId) }
-            ?: return freeCastPermissionAvailable
-        return costCalculator.hasFreeCastPermission(state, playerId, cardDef)
+            ?: return costCalculator.hasFreeCastPermission(state, playerId, null, castFromZone)
+        return costCalculator.hasFreeCastPermission(state, playerId, cardDef, castFromZone)
     }
 
     // Alternative casting costs from battlefield permanents (e.g., Jodah's WUBRG).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -452,6 +452,15 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         blightCreatures.isNotEmpty() &&
                         !playForFree
 
+                    // A battlefield `MayCastWithoutPayingManaCost(fromExileOnly = true)` source
+                    // (Warped Space) lets this exile spell be cast for {0}. Offered as its own
+                    // variant (CR 118.9a) alongside the pay path; X is treated as 0 (CR 107.3b).
+                    // Excludes prepare-spell copies and cards already granted a free play.
+                    val freeCastFromExile = !playForFree &&
+                        prepareCopyFaceIndex == null &&
+                        hasCorrectTiming && meetsRestrictions && canPayAdditionalCost &&
+                        context.freeCastPermissionFor(cardId, Zone.EXILE)
+
                     if (hasCorrectTiming && meetsRestrictions && canAfford && canPayAdditionalCost) {
                         val targetReqs = buildList {
                             addAll(effectiveScript?.targetRequirements ?: emptyList())
@@ -546,8 +555,9 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                 )
                             }
                         }
-                    } else {
-                        // Can't cast right now — show as unaffordable
+                    } else if (!freeCastFromExile) {
+                        // Can't cast right now — show as unaffordable (unless a free-from-exile
+                        // cast is available below, which is the affordable path the player wants).
                         result.add(
                             LegalAction(
                                 actionType = "CastSpell",
@@ -560,6 +570,47 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                 sourceZone = sourceZoneLabel
                             )
                         )
+                    }
+
+                    // Warped Space: emit the {0} free-from-exile variant (its own action so the
+                    // player chooses it over the pay path — CR 118.9a).
+                    if (freeCastFromExile) {
+                        val freeTargetReqs = buildList {
+                            addAll(effectiveScript?.targetRequirements ?: emptyList())
+                            effectiveScript?.auraTarget?.let { add(it) }
+                        }
+                        if (freeTargetReqs.isNotEmpty()) {
+                            val freeTargetInfos = context.targetUtils.buildTargetInfos(state, playerId, freeTargetReqs)
+                            if (context.targetUtils.allRequirementsSatisfied(freeTargetInfos)) {
+                                val firstReq = freeTargetReqs.first()
+                                val firstInfo = freeTargetInfos.first()
+                                result.add(
+                                    LegalAction(
+                                        actionType = "CastSpell",
+                                        description = "Cast ${cardComponent.name} (Free)",
+                                        action = CastSpell(playerId, cardId, faceIndex = prepareCopyFaceIndex, useWithoutPayingManaCost = true),
+                                        validTargets = firstInfo.validTargets,
+                                        requiresTargets = true,
+                                        targetCount = firstReq.count,
+                                        minTargets = firstReq.effectiveMinCount,
+                                        targetDescription = firstReq.description,
+                                        targetRequirements = if (freeTargetInfos.size > 1) freeTargetInfos else null,
+                                        manaCostString = "{0}",
+                                        sourceZone = sourceZoneLabel
+                                    )
+                                )
+                            }
+                        } else {
+                            result.add(
+                                LegalAction(
+                                    actionType = "CastSpell",
+                                    description = "Cast ${cardComponent.name} (Free)",
+                                    action = CastSpell(playerId, cardId, faceIndex = prepareCopyFaceIndex, useWithoutPayingManaCost = true),
+                                    manaCostString = "{0}",
+                                    sourceZone = sourceZoneLabel
+                                )
+                            )
+                        }
                     }
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -633,6 +633,9 @@ internal class AffectsFilterResolver {
         CardPredicate.ManaValueIsOdd -> card.manaValue % 2 != 0
         CardPredicate.HasXInManaCost -> if (isFaceDown) false else card.manaCost.hasX
         is CardPredicate.NameEquals -> card.name == predicate.name
+        // Room-name distinctness is a resolution-time search filter, not a continuous/static
+        // affects-filter concern.
+        CardPredicate.NameNotSharedWithControlledRoom -> false
         is CardPredicate.OriginallyPrintedInSet ->
             card.originalSetCode?.equals(predicate.setCode, ignoreCase = true) == true
         is CardPredicate.HasBasicLandType -> if (isFaceDown) false else subtypes.any { it.equals(predicate.landType, ignoreCase = true) }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/CostCalculator.kt
@@ -915,6 +915,8 @@ class CostCalculator(
             is CardPredicate.HasAnyOfSubtypes -> predicate.subtypes.any { typeLine.hasSubtype(it) }
             is CardPredicate.HasBasicLandType -> typeLine.hasSubtype(Subtype(predicate.landType))
             is CardPredicate.NameEquals -> cardDef.name == predicate.name
+            // Room-name distinctness is a resolution-time search filter, not a cost concern.
+            CardPredicate.NameNotSharedWithControlledRoom -> false
 
             is CardPredicate.OriginallyPrintedInSet ->
                 cardDef.setCode?.equals(predicate.setCode, ignoreCase = true) == true
@@ -1144,15 +1146,20 @@ class CostCalculator(
     fun hasFreeCastPermission(
         state: GameState,
         casterId: EntityId,
-        spellCardDef: CardDefinition? = null
+        spellCardDef: CardDefinition? = null,
+        castFromZone: com.wingedsheep.sdk.core.Zone? = null
     ): Boolean {
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val card = container.get<CardComponent>() ?: continue
             val permanentDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-            for (ability in permanentDef.script.effectiveStaticAbilities(classLevel)) {
+            // Fold in unlocked Room-face statics (CR 709.5) so a face-level Warped Space is seen.
+            for (ability in com.wingedsheep.engine.state.components.identity.RoomFaceStatics.activeStaticAbilities(container, permanentDef)) {
                 if (ability !is MayCastWithoutPayingManaCost) continue
+                // `fromExileOnly` (Warped Space) frees only spells cast from exile. When the cast
+                // zone is unknown (a coarse "any free-cast source?" probe), such a source doesn't
+                // count toward a hand cast — require an explicit EXILE zone.
+                if (ability.fromExileOnly && castFromZone != com.wingedsheep.sdk.core.Zone.EXILE) continue
                 if (ability.controllerOnly) {
                     val controllerId = state.projectedState.getController(entityId) ?: continue
                     if (controllerId != casterId) continue
@@ -1190,16 +1197,20 @@ class CostCalculator(
     fun oncePerTurnFreeCastSourceToConsume(
         state: GameState,
         casterId: EntityId,
-        spellCardDef: CardDefinition?
+        spellCardDef: CardDefinition?,
+        castFromZone: com.wingedsheep.sdk.core.Zone? = null
     ): EntityId? {
         var oncePerTurnCandidate: EntityId? = null
         for (entityId in state.getBattlefield()) {
             val container = state.getEntity(entityId) ?: continue
             val card = container.get<CardComponent>() ?: continue
             val permanentDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
-            for (ability in permanentDef.script.effectiveStaticAbilities(classLevel)) {
+            // Fold in unlocked Room-face statics (CR 709.5) so a face-level Warped Space is seen.
+            for (ability in com.wingedsheep.engine.state.components.identity.RoomFaceStatics.activeStaticAbilities(container, permanentDef)) {
                 if (ability !is MayCastWithoutPayingManaCost) continue
+                // A `fromExileOnly` source (Warped Space) is only a candidate for an exile cast, so
+                // it isn't burned by a free hand cast granted by a different source.
+                if (ability.fromExileOnly && castFromZone != com.wingedsheep.sdk.core.Zone.EXILE) continue
                 if (ability.controllerOnly) {
                     val controllerId = state.projectedState.getController(entityId) ?: continue
                     if (controllerId != casterId) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/RoomFaceStatics.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/identity/RoomFaceStatics.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.engine.state.components.identity
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent
 import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.scripting.StateTriggeredAbility
 import com.wingedsheep.sdk.scripting.StaticAbility
 
 /**
@@ -53,5 +54,26 @@ object RoomFaceStatics {
             .filter { RoomFaceId(it.name) in room.unlocked }
             .flatMap { it.script.effectiveStaticAbilities() }
         return if (faceStatics.isEmpty()) base else base + faceStatics
+    }
+
+    /**
+     * State-triggered abilities (CR 603.8) functioning on [container]'s permanent given its
+     * [cardDef]: its top-level script's state triggers, plus those of every currently-unlocked
+     * Room face. Mirrors [activeStaticAbilities] so a locked door's state trigger stays inert and
+     * unlocking it turns the trigger on (Promising Stairs' "you win the game if …").
+     */
+    fun activeStateTriggeredAbilities(
+        container: ComponentContainer,
+        cardDef: CardDefinition,
+    ): List<StateTriggeredAbility> {
+        val base = cardDef.script.stateTriggeredAbilities
+
+        val room = container.get<RoomComponent>() ?: return base
+        if (room.unlocked.isEmpty() || cardDef.cardFaces.isEmpty()) return base
+
+        val faceAbilities = cardDef.cardFaces
+            .filter { RoomFaceId(it.name) in room.unlocked }
+            .flatMap { it.script.stateTriggeredAbilities }
+        return if (faceAbilities.isEmpty()) base else base + faceAbilities
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CentralElevatorPromisingStairsTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CentralElevatorPromisingStairsTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.BottomlessPoolLockerRoom
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.CentralElevatorPromisingStairs
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardLayout
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario for `Central Elevator // Promising Stairs` (DSK 44), a split-layout Room (CR 709.5).
+ *
+ * Central Elevator {3}{U} — "When you unlock this door, search your library for a Room card that
+ *   doesn't have the same name as a Room you control, reveal it, put it into your hand, then
+ *   shuffle." — exercises [com.wingedsheep.sdk.scripting.predicates.CardPredicate.NameNotSharedWithControlledRoom].
+ * Promising Stairs {2}{U} — "At the beginning of your upkeep, surveil 1. You win the game if there
+ *   are eight or more different names among unlocked doors of Rooms you control." — a state-triggered
+ *   ability (CR 603.8) over `DynamicAmount.UnlockedDoors(distinctNames = true)`.
+ */
+class CentralElevatorPromisingStairsTest : FunSpec({
+
+    // Ability-less two-door helper Rooms, each contributing two distinct door names when fully
+    // unlocked — used to drive Promising Stairs' "different names" win threshold.
+    fun roomWith(a: String, b: String) = card("$a // $b") {
+        layout = CardLayout.SPLIT
+        colorIdentity = "W"
+        face(a) { manaCost = "{W}"; typeLine = "Enchantment — Room"; oracleText = "" }
+        face(b) { manaCost = "{W}"; typeLine = "Enchantment — Room"; oracleText = "" }
+    }
+
+    val room1 = roomWith("Alpha", "Beta")
+    val room2 = roomWith("Gamma", "Delta")
+    val room3 = roomWith("Epsilon", "Zeta")
+    val room4 = roomWith("Eta", "Theta")
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(CentralElevatorPromisingStairs)
+        d.registerCard(BottomlessPoolLockerRoom)
+        listOf(room1, room2, room3, room4).forEach { d.registerCard(it) }
+        d.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("Central Elevator's search offers only Room cards not sharing a name with a Room you control") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Library candidates: a copy of this card (shares the unlocked "Central Elevator" door name)
+        // and a Bottomless Pool // Locker Room (shares neither name).
+        val sharingCopy = d.putCardOnTopOfLibrary(p1, CentralElevatorPromisingStairs.name)
+        val nonSharing = d.putCardOnTopOfLibrary(p1, BottomlessPoolLockerRoom.name)
+
+        // Cast Central Elevator (face 0). It enters with "Central Elevator" unlocked, firing the
+        // search trigger; "Promising Stairs" stays locked, so only "Central Elevator" is controlled.
+        val roomId = d.putCardInHand(p1, CentralElevatorPromisingStairs.name)
+        d.giveMana(p1, Color.BLUE, 4)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass() // resolve the Room spell → door unlocks → trigger goes on the stack
+        d.bothPass() // resolve the trigger → search → SelectCardsDecision
+
+        val decision = d.pendingDecision as SelectCardsDecision
+        decision.options shouldContain nonSharing
+        decision.options shouldNotContain sharingCopy
+
+        // Find the legal (non-sharing) Room → it goes to hand revealed.
+        d.submitCardSelection(p1, listOf(nonSharing))
+        d.getHand(p1) shouldContain nonSharing
+    }
+
+    test("Promising Stairs wins the game at eight different unlocked door names, but not at seven") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Promising Stairs in play (its state-triggered ability now watches the door count).
+        // Casting face 1 unlocks "Promising Stairs" → 1 distinct name.
+        val stairs = d.putCardInHand(p1, CentralElevatorPromisingStairs.name)
+        d.giveMana(p1, Color.BLUE, 3)
+        d.submitSuccess(CastSpell(p1, stairs, faceIndex = 1))
+        d.bothPass()
+
+        // Fully unlock room1..room3 → +6 names (Alpha,Beta,Gamma,Delta,Epsilon,Zeta) → 7 total.
+        // Casting each Room (face 0) unlocks its first door; UnlockRoomDoor unlocks the second.
+        // The unlock is a special action that resolves immediately, so we must NOT pass priority
+        // after it (an empty-stack pass would advance out of the main phase).
+        for (room in listOf(room1, room2, room3)) {
+            val id = d.putCardInHand(p1, room.name)
+            d.giveMana(p1, Color.WHITE, 1)
+            d.submitSuccess(CastSpell(p1, id, faceIndex = 0))
+            d.bothPass()
+            d.giveMana(p1, Color.WHITE, 1)
+            d.submitSuccess(UnlockRoomDoor(p1, id, RoomFaceId(room.cardFaces[1].name)))
+        }
+        d.state.gameOver shouldBe false
+
+        // Cast room4 (face 0) → "Eta" is the eighth distinct name → the win ability triggers.
+        val r4 = d.putCardInHand(p1, room4.name)
+        d.giveMana(p1, Color.WHITE, 1)
+        d.submitSuccess(CastSpell(p1, r4, faceIndex = 0))
+
+        // The state-triggered ability goes on the stack at the next priority check; step through
+        // priority/decisions until the win resolves and the opponent loses.
+        var guard = 0
+        while (!d.state.gameOver && guard++ < 50) {
+            if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass()
+        }
+
+        d.assertGameOver(expectedWinner = p1)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CharredFoyerWarpedSpaceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CharredFoyerWarpedSpaceTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.UnlockRoomDoor
+import com.wingedsheep.engine.state.components.battlefield.MayCastWithoutPayingCostUsedThisTurnComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceId
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.CharredFoyerWarpedSpace
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario for `Charred Foyer // Warped Space` (DSK 129), a split-layout Room (CR 709.5).
+ *
+ * Charred Foyer {3}{R} — "At the beginning of your upkeep, exile the top card of your library. You
+ *   may play it this turn." — standard impulse draw.
+ * Warped Space {4}{R}{R} — "Once each turn, you may pay {0} rather than pay the mana cost for a
+ *   spell you cast from exile." — the `MayCastWithoutPayingManaCost(fromExileOnly = true,
+ *   oncePerTurn = true)` free-cast static.
+ *
+ * The deck is all Grizzly Bears so the impulse always exiles a castable creature; p1 is never given
+ * mana for the impulse-exiled spell, so it can only resolve via Warped Space's {0} cost.
+ */
+class CharredFoyerWarpedSpaceTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(CharredFoyerWarpedSpace)
+        d.initMirrorMatch(
+            deck = Deck.of("Grizzly Bears" to 40),
+            skipMulligans = true,
+        )
+        return d
+    }
+
+    test("Warped Space lets a Charred Foyer impulse-exiled spell be cast from exile for free") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cast Charred Foyer (face 0) and unlock Warped Space too, so both doors function.
+        val roomId = d.putCardInHand(p1, CharredFoyerWarpedSpace.name)
+        d.giveMana(p1, Color.RED, 4)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 0))
+        d.bothPass()
+        d.giveMana(p1, Color.RED, 6)
+        d.submitSuccess(UnlockRoomDoor(p1, roomId, RoomFaceId("Warped Space")))
+
+        // Advance to p1's next turn; the Charred Foyer upkeep impulse fires along the way, exiling
+        // the top card (a Grizzly Bears) and granting permission to play it this turn.
+        d.passPriorityUntil(Step.END)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN) // opponent's turn
+        d.passPriorityUntil(Step.END)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN) // p1's next turn — impulse already resolved at upkeep
+
+        val exiledBears = d.getExile(p1).firstOrNull { id ->
+            d.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+        }
+        exiledBears shouldNotBe null
+
+        // p1 has no mana — the only way to cast the exiled spell is Warped Space's {0} cost.
+        val creaturesBefore = d.getCreatures(p1).size
+        d.submitSuccess(CastSpell(p1, exiledBears!!, useWithoutPayingManaCost = true))
+        d.bothPass()
+
+        d.getCreatures(p1).size shouldBe creaturesBefore + 1
+        // Warped Space's once-per-turn permission is now spent.
+        d.state.getEntity(roomId)?.get<MayCastWithoutPayingCostUsedThisTurnComponent>() shouldNotBe null
+    }
+
+    test("Warped Space does not make a spell cast from hand free (fromExileOnly gate)") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Unlock Warped Space.
+        val roomId = d.putCardInHand(p1, CharredFoyerWarpedSpace.name)
+        d.giveMana(p1, Color.RED, 6)
+        d.submitSuccess(CastSpell(p1, roomId, faceIndex = 1))
+        d.bothPass()
+
+        // A free cast of a hand spell is refused — Warped Space only frees spells cast from exile.
+        val handBears = d.putCardInHand(p1, "Grizzly Bears")
+        val result = d.submit(CastSpell(p1, handBears, useWithoutPayingManaCost = true))
+        result.isSuccess shouldBe false
+    }
+})


### PR DESCRIPTION
Implements two of Duskmourn's last few unimplemented Room cards, each via a small, reusable engine addition.

## Cards

### Central Elevator // Promising Stairs (DSK 44)
- **Central Elevator** — *When you unlock this door, search your library for a Room card that doesn't have the same name as a Room you control, reveal it, put it into your hand, then shuffle.*
  New `CardPredicate.NameNotSharedWithControlledRoom` (+ `GameObjectFilter.nameNotSharedWithControlledRoom()`). Per the official ruling, only the names of a controlled Room's **unlocked** doors count, and a split Room card is excluded if **either** of its door names matches.
- **Promising Stairs** — *At the beginning of your upkeep, surveil 1. You win the game if there are eight or more different names among unlocked doors of Rooms you control.*
  Modeled as a state-triggered ability (CR 603.8) over the existing `DynamicAmount.UnlockedDoors(distinctNames = true)`. Added `stateTriggeredAbility {}` to `CardFaceBuilder` and folded unlocked Room-face state triggers into `StateTriggerPoller` (`RoomFaceStatics.activeStateTriggeredAbilities`), mirroring the existing static-ability folding — a locked door's state trigger stays inert.

### Charred Foyer // Warped Space (DSK 129)
- **Charred Foyer** — upkeep impulse draw (`Patterns.Exile.impulse`).
- **Warped Space** — *Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile.*
  Added a `fromExileOnly` gate to `MayCastWithoutPayingManaCost` and wired the free-cast variant into the cast-from-exile enumeration path, threading the cast-from zone through `CostCalculator.hasFreeCastPermission` / `oncePerTurnFreeCastSourceToConsume` and the `CastSpellHandler` validation + once-per-turn consume. The permission frees exile casts but not hand casts.

## Tests
- `CentralElevatorPromisingStairsTest` — search offers only non-name-sharing Room cards; the alt-win fires at eight distinct unlocked door names and not at seven.
- `CharredFoyerWarpedSpaceTest` — a Charred Foyer impulse-exiled spell is cast from exile for {0} via Warped Space (once-per-turn consume verified); a hand spell is *not* freed (the `fromExileOnly` gate).
- SDK reference updated; DSK card snapshot re-blessed (diff is only the two new cards). Full `just test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)