### PR TITLE
Add four Final Fantasy cards (Wastes, Aerith Rescue Mission, Ride the Shoopuf, Galuf's Final Act)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -19,9 +19,11 @@ section; do not let SDK additions land without a corresponding doc update.
 **Entry points**
 
 - `card("Name") { ... }` — open the builder for a standard card.
-- `basicLand("Plains" | "Island" | "Swamp" | "Mountain" | "Forest")` — shortcut for basic lands (sets type line,
-  intrinsic mana ability, supertype). Supports `collectorNumber`, `artist`, `flavorText`, `imageUri`, `rarity`, and
-  `inBooster` (set `false` to keep an art variant defined but exclude it from the draft/sealed deck-building basic pool).
+- `basicLand("Plains" | "Island" | "Swamp" | "Mountain" | "Forest" | "Wastes")` — shortcut for basic lands (sets
+  type line, intrinsic mana ability, supertype). The five colored types get a subtype after the dash and tap for
+  their color; `"Wastes"` is the colorless basic — type line `Basic Land` with no subtype, intrinsic `{T}: Add {C}`.
+  Supports `collectorNumber`, `artist`, `flavorText`, `imageUri`, `rarity`, and `inBooster` (set `false` to keep an
+  art variant defined but exclude it from the draft/sealed deck-building basic pool).
 
 **Card builder properties**
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.sdk.scripting.conditions.Condition
 import com.wingedsheep.sdk.scripting.conditions.SourceCastForImpending
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
@@ -68,7 +69,8 @@ fun card(name: String, init: CardBuilder.() -> Unit): CardDefinition {
  * }
  * ```
  *
- * @param landType The basic land type: "Plains", "Island", "Swamp", "Mountain", or "Forest"
+ * @param landType The basic land type: "Plains", "Island", "Swamp", "Mountain", "Forest",
+ *   or "Wastes" (the colorless basic land — type line "Basic Land" with no subtype, taps for {C})
  * @param init Metadata configuration for this art variant
  */
 fun basicLand(landType: String, init: BasicLandBuilder.() -> Unit): CardDefinition {
@@ -94,24 +96,30 @@ class BasicLandBuilder(private val landType: String) {
      */
     var inBooster: Boolean = true
 
-    private val manaColor: Color = when (landType) {
+    // Wastes is the colorless basic land: type line "Basic Land" with no subtype, taps for {C}.
+    private val isWastes: Boolean = landType == "Wastes"
+
+    private val manaColor: Color? = when (landType) {
         "Plains" -> Color.WHITE
         "Island" -> Color.BLUE
         "Swamp" -> Color.BLACK
         "Mountain" -> Color.RED
         "Forest" -> Color.GREEN
+        "Wastes" -> null
         else -> throw IllegalArgumentException("Unknown basic land type: $landType")
     }
 
     fun build(): CardDefinition {
-        val typeLine = TypeLine.parse("Basic Land — $landType")
+        // Wastes has no land subtype; the colored basics carry a subtype after the dash.
+        val typeLine = if (isWastes) TypeLine.parse("Basic Land") else TypeLine.parse("Basic Land — $landType")
+        val manaSymbol = manaColor?.symbol ?: 'C'
 
-        // Basic lands have an intrinsic mana ability: "{T}: Add {color}."
+        // Basic lands have an intrinsic mana ability: "{T}: Add {color}." (Wastes adds {C}.)
         // Mana abilities don't use the stack and resolve immediately.
         val manaAbility = ActivatedAbility(
             id = AbilityId.generate(),
             cost = AbilityCost.Tap,
-            effect = AddManaEffect(manaColor),
+            effect = if (manaColor != null) AddManaEffect(manaColor) else AddColorlessManaEffect(1),
             isManaAbility = true,
             timing = TimingRule.ManaAbility
         )
@@ -133,7 +141,7 @@ class BasicLandBuilder(private val landType: String) {
             name = landType,
             manaCost = ManaCost.ZERO,
             typeLine = typeLine,
-            oracleText = "({T}: Add {${manaColor.symbol}}.)",
+            oracleText = "({T}: Add {$manaSymbol}.)",
             script = script,
             metadata = metadata
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AerithRescueMission.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AerithRescueMission.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersToCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Aerith Rescue Mission
+ * {3}{W}
+ * Sorcery
+ * Choose one —
+ * • Take the Elevator — Create three 1/1 colorless Hero creature tokens.
+ * • Take 59 Flights of Stairs — Tap up to three target creatures. Put a stun counter on
+ *   one of them. (If a permanent with a stun counter would become untapped, remove one from
+ *   it instead.)
+ *
+ * Mode A creates three 1/1 colorless Hero tokens via a single [Effects.CreateToken]
+ * (count = 3, the Job-select Hero token shared across this set — same token image URI as
+ * Dwarven Castle Guard / White Mage's Staff et al.).
+ *
+ * Mode B is a single "up to three target creatures" requirement
+ * (`TargetCreature(count = 3, optional = true)`) — those targets are locked at cast time, then
+ * at resolution:
+ *   1. [Effects.TapEachTarget] taps every chosen target.
+ *   2. [GatherCardsEffect] from [CardSource.ChosenTargets] collects exactly those tapped
+ *      creatures (the mode's `EffectContext.targets`).
+ *   3. [SelectFromCollectionEffect] (`ChooseExactly(1)`, controller-chosen) honors the ruling
+ *      that the controller picks *which* of the tapped creatures gets the stun, and that the
+ *      choice is made at resolution — not at cast time. If zero creatures were targeted (the
+ *      "up to" lower bound), the gather is empty and the selection is a silent no-op.
+ *   4. [AddCountersToCollectionEffect] places the single stun counter on the chosen creature.
+ *
+ * This is the faithful "act on N targets, then a player-chosen sub-choice among them at
+ * resolution" shape — composed entirely from existing pipeline primitives (cf. Bolster /
+ * Blight in `MechanicPatterns`), so no determinism shortcut is taken.
+ */
+val AerithRescueMission = card("Aerith Rescue Mission") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Take the Elevator — Create three 1/1 colorless Hero creature tokens.\n" +
+        "• Take 59 Flights of Stairs — Tap up to three target creatures. Put a stun counter on one of them. " +
+        "(If a permanent with a stun counter would become untapped, remove one from it instead.)"
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Take the Elevator — Create three 1/1 colorless Hero creature tokens.") {
+                effect = Effects.CreateToken(
+                    power = 1,
+                    toughness = 1,
+                    creatureTypes = setOf("Hero"),
+                    count = 3,
+                    imageUri = "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030",
+                )
+            }
+            mode(
+                "Take 59 Flights of Stairs — Tap up to three target creatures. Put a stun counter on one of them."
+            ) {
+                target("creatures", TargetCreature(count = 3, optional = true))
+                effect = Effects.Composite(
+                    Effects.TapEachTarget(),
+                    GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "aerithTapped"),
+                    SelectFromCollectionEffect(
+                        from = "aerithTapped",
+                        selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                        chooser = Chooser.Controller,
+                        storeSelected = "aerithStunned",
+                        prompt = "Put a stun counter on one of the tapped creatures",
+                        useTargetingUI = true,
+                    ),
+                    AddCountersToCollectionEffect("aerithStunned", Counters.STUN, 1),
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "5"
+        artist = "Hokuyuu"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/3123d16c-e1e6-4659-a7a3-2ec6efc6bf08.jpg?1748705771"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FinalFantasyBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FinalFantasyBasicLands.kt
@@ -6,9 +6,7 @@ import com.wingedsheep.sdk.dsl.basicLand
  * Final Fantasy Basic Lands
  *
  * Final Fantasy contains 3 art variants of each colored basic land type (cards 294-308)
- * plus a borderless variant of each (cards 572-576).
- *
- * Note: FIN also prints a colorless Wastes (#309), which the `basicLand` DSL does not yet model.
+ * plus a borderless variant of each (cards 572-576), and a colorless Wastes (#309).
  */
 
 // =============================================================================
@@ -151,8 +149,18 @@ val FinalFantasyForest576 = basicLand("Forest") {
     imageUri = "https://cards.scryfall.io/normal/front/2/0/2036f825-ef57-4a40-b45f-0668d9c8ec6a.jpg?1748707608"
 }
 
+// =============================================================================
+// Wastes (Card 309) — colorless basic land, taps for {C}
+// =============================================================================
+
+val FinalFantasyWastes309 = basicLand("Wastes") {
+    collectorNumber = "309"
+    artist = "Eddie Mendoza"
+    imageUri = "https://cards.scryfall.io/normal/front/c/6/c61feafd-ef09-437c-a12c-fd7d6cb8c15a.jpg?1748706933"
+}
+
 /**
- * All Final Fantasy colored basic land variants.
+ * All Final Fantasy basic land variants.
  */
 val FinalFantasyBasicLands = listOf(
     FinalFantasyPlains294, FinalFantasyPlains295, FinalFantasyPlains296, FinalFantasyPlains572,
@@ -160,4 +168,5 @@ val FinalFantasyBasicLands = listOf(
     FinalFantasySwamp300, FinalFantasySwamp301, FinalFantasySwamp302, FinalFantasySwamp574,
     FinalFantasyMountain303, FinalFantasyMountain304, FinalFantasyMountain305, FinalFantasyMountain575,
     FinalFantasyForest306, FinalFantasyForest307, FinalFantasyForest308, FinalFantasyForest576,
+    FinalFantasyWastes309,
 )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GalufsFinalAct.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GalufsFinalAct.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Galuf's Final Act
+ * {1}{G}
+ * Instant
+ *
+ * Until end of turn, target creature gets +1/+0 and gains "When this creature dies,
+ * put a number of +1/+1 counters equal to its power on up to one target creature."
+ *
+ * Composition: a +1/+0 pump until end of turn ([Effects.ModifyStats], EOT) plus a granted
+ * self [Triggers.Dies] trigger ([GrantTriggeredAbilityEffect], EOT — mirrors the in-set
+ * Vincent's Limit Break "dies → return tapped" grant). The granted ability's effect puts a
+ * dynamic number of +1/+1 counters ([Effects.AddDynamicCounters]) equal to the dying
+ * creature's power on up to one target creature.
+ *
+ * "Its power" reads the dying creature's *last-known* power via [DynamicAmounts.sourcePower]
+ * (the granted ability's source is the creature it was granted to). The same
+ * `EntityProperty(Source, Power)` resolution backs Heartfire Hero's "deals damage equal to
+ * its power" dies trigger — the DynamicAmountEvaluator falls back to the leave-battlefield
+ * power snapshot once the source is in the graveyard, so the printed base power is never used.
+ *
+ * "Up to one target creature" is an optional (0-or-1) target requirement
+ * ([Targets.UpToCreatures] with `count = 1`); declining resolves with no counters placed.
+ */
+val GalufsFinalAct = card("Galuf's Final Act") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target creature gets +1/+0 and gains \"When this " +
+        "creature dies, put a number of +1/+1 counters equal to its power on up to one " +
+        "target creature.\""
+
+    spell {
+        val t = target("target", Targets.Creature)
+
+        val diesGrantCounters = TriggeredAbility.create(
+            trigger = Triggers.Dies.event,
+            binding = Triggers.Dies.binding,
+            effect = Effects.AddDynamicCounters(
+                Counters.PLUS_ONE_PLUS_ONE,
+                DynamicAmounts.sourcePower(),
+                EffectTarget.ContextTarget(0)
+            ),
+            targetRequirement = Targets.UpToCreatures(1),
+            descriptionOverride = "When this creature dies, put a number of +1/+1 counters " +
+                "equal to its power on up to one target creature."
+        )
+
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, t, Duration.EndOfTurn),
+            GrantTriggeredAbilityEffect(diesGrantCounters, t, Duration.EndOfTurn)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "186"
+        artist = "Nijihayashi"
+        flavorText = "\"I'll destroy you Exdeath... even if it means I have to take you " +
+            "into the afterlife myself!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0ce05634-6c01-4941-a135-904cb4e33ac4.jpg?1748706456"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RideTheShoopuf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RideTheShoopuf.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Ride the Shoopuf — Final Fantasy #197
+ * {1}{G} · Enchantment · Uncommon
+ *
+ * Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control.
+ * {5}{G}{G}: This enchantment becomes a 7/7 Beast creature in addition to its other types.
+ *
+ * The landfall trigger uses [Triggers.LandYouControlEnters] (fires for any land you control entering,
+ * not just lands you play) and targets a creature you control via [TargetFilter.CreatureYouControl].
+ *
+ * The animation is a permanent [Effects.BecomeCreature] on the source: it adds the CREATURE type
+ * (no `removeTypes`, so "in addition to its other types" — it stays an Enchantment), sets base 7/7,
+ * and adds the Beast subtype. `duration = Duration.Permanent` — the ability has no duration, so it
+ * remains a creature indefinitely (mirrors Emergent Haunting).
+ */
+val RideTheShoopuf = card("Ride the Shoopuf") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control.\n" +
+        "{5}{G}{G}: This enchantment becomes a 7/7 Beast creature in addition to its other types."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        val t = target("target creature you control", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        effect = AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 1, target = t)
+        description = "Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}{G}")
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = 7,
+            toughness = 7,
+            creatureTypes = setOf("Beast"),
+            duration = Duration.Permanent
+        )
+        description = "{5}{G}{G}: This enchantment becomes a 7/7 Beast creature in addition to its other types."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "197"
+        artist = "Leonardo Santanna"
+        flavorText = "\"Ride ze shoopuf? All aboards!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/19ad36d6-8bf4-490c-9980-b98a470af892.jpg?1748706498"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -307,6 +307,100 @@
     ]
 }
 
+// Aerith Rescue Mission
+{
+    "name": "Aerith Rescue Mission",
+    "manaCost": "{3}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Take the Elevator — Create three 1/1 colorless Hero creature tokens.\n• Take 59 Flights of Stairs — Tap up to three target creatures. Put a stun counter on one of them. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [],
+                        "creatureTypes": [
+                            "Hero"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                    },
+                    "description": "Take the Elevator — Create three 1/1 colorless Hero creature tokens."
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForEach",
+                                "space": "IterationSpace.Targets",
+                                "body": {
+                                    "type": "TapUntap",
+                                    "target": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    }
+                                }
+                            },
+                            {
+                                "type": "GatherCards",
+                                "source": "ChosenTargets",
+                                "storeAs": "aerithTapped"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "aerithTapped",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "aerithStunned",
+                                "prompt": "Put a stun counter on one of the tapped creatures",
+                                "useTargetingUI": true
+                            },
+                            {
+                                "type": "AddCountersToCollection",
+                                "collectionName": "aerithStunned",
+                                "counterType": "stun"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "count": 3,
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature"
+                            },
+                            "id": "creatures"
+                        }
+                    ],
+                    "description": "Take 59 Flights of Stairs — Tap up to three target creatures. Put a stun counter on one of them."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "artist": "Hokuyuu",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/3123d16c-e1e6-4659-a7a3-2ec6efc6bf08.jpg?1748705771"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Aettir and Priwen
 {
     "name": "Aettir and Priwen",
@@ -4737,6 +4831,91 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Galuf's Final Act
+{
+    "name": "Galuf's Final Act",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Until end of turn, target creature gets +1/+0 and gains \"When this creature dies, put a number of +1/+1 counters equal to its power on up to one target creature.\"",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantTriggeredAbility",
+                    "ability": {
+                        "id": "ability_1",
+                        "trigger": {
+                            "type": "ZoneChangeEvent",
+                            "from": "Battlefield",
+                            "to": "Graveyard"
+                        },
+                        "effect": {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Power"
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        "targetRequirement": {
+                            "type": "TargetObject",
+                            "optional": true,
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "descriptionOverride": "When this creature dies, put a number of +1/+1 counters equal to its power on up to one target creature."
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "186",
+        "rarity": "UNCOMMON",
+        "artist": "Nijihayashi",
+        "flavorText": "\"I'll destroy you Exdeath... even if it means I have to take you into the afterlife myself!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0ce05634-6c01-4941-a135-904cb4e33ac4.jpg?1748706456"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -9768,6 +9947,82 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Ride the Shoopuf
+{
+    "name": "Ride the Shoopuf",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control.\n{5}{G}{G}: This enchantment becomes a 7/7 Beast creature in addition to its other types.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 7
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 7
+                    },
+                    "creatureTypes": [
+                        "Beast"
+                    ],
+                    "duration": "Permanent"
+                },
+                "descriptionOverride": "{5}{G}{G}: This enchantment becomes a 7/7 Beast creature in addition to its other types."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "rarity": "UNCOMMON",
+        "artist": "Leonardo Santanna",
+        "flavorText": "\"Ride ze shoopuf? All aboards!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/19ad36d6-8bf4-490c-9980-b98a470af892.jpg?1748706498"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AerithRescueMissionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AerithRescueMissionScenarioTest.kt
@@ -1,0 +1,188 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.AerithRescueMission
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Aerith Rescue Mission — {3}{W} Sorcery, modal "Choose one —".
+ *
+ * Mode A (Take the Elevator): create three 1/1 colorless Hero creature tokens.
+ * Mode B (Take 59 Flights of Stairs): tap up to three target creatures, then put a stun
+ *        counter on one of them.
+ *
+ * Modeled on ModalCastTimeModeTest (cast-time mode selection via `chosenModes` +
+ * `modeTargetsOrdered`).
+ */
+class AerithRescueMissionScenarioTest : FunSpec({
+
+    val Bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Bear))
+        driver.registerCard(AerithRescueMission)
+        return driver
+    }
+
+    // {3}{W} — four white mana covers the {W} plus three generic.
+    fun giveWhiteMana(driver: GameTestDriver, player: com.wingedsheep.sdk.model.EntityId) {
+        driver.giveMana(player, Color.WHITE, 4)
+    }
+
+    test("Mode A — Take the Elevator creates three 1/1 colorless Hero tokens") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        giveWhiteMana(driver, activePlayer)
+        val spell = driver.putCardInHand(activePlayer, "Aerith Rescue Mission")
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = spell,
+                chosenModes = listOf(0)
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        val heroTokens = driver.getCreatures(activePlayer).filter { id ->
+            driver.state.getEntity(id)?.get<CardComponent>()?.name == "Hero Token"
+        }
+        heroTokens.size shouldBe 3
+        heroTokens.forEach { id ->
+            val stats = driver.state.getEntity(id)?.get<CardComponent>()?.baseStats
+            stats?.basePower shouldBe 1
+            stats?.baseToughness shouldBe 1
+        }
+    }
+
+    test("Mode B — Take 59 Flights of Stairs taps up to three creatures and stuns one") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear1 = driver.putCreatureOnBattlefield(opponent, "Test Bear")
+        val bear2 = driver.putCreatureOnBattlefield(opponent, "Test Bear")
+        val bear3 = driver.putCreatureOnBattlefield(opponent, "Test Bear")
+
+        // All three start untapped.
+        driver.isTapped(bear1) shouldBe false
+        driver.isTapped(bear2) shouldBe false
+        driver.isTapped(bear3) shouldBe false
+
+        giveWhiteMana(driver, activePlayer)
+        val spell = driver.putCardInHand(activePlayer, "Aerith Rescue Mission")
+
+        val chosenTargets = listOf(
+            ChosenTarget.Permanent(bear1),
+            ChosenTarget.Permanent(bear2),
+            ChosenTarget.Permanent(bear3)
+        )
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = spell,
+                targets = chosenTargets,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(chosenTargets)
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        // Resolution pauses so the controller picks WHICH of the tapped creatures gets the
+        // stun counter (per ruling, chosen at resolution). Choose bear2 explicitly.
+        val decision = driver.state.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        driver.submitCardSelection(activePlayer, listOf(bear2))
+
+        // All three targeted creatures are tapped.
+        driver.isTapped(bear1) shouldBe true
+        driver.isTapped(bear2) shouldBe true
+        driver.isTapped(bear3) shouldBe true
+
+        // Exactly one stun counter was placed, on the creature the controller chose (bear2).
+        fun stun(id: com.wingedsheep.sdk.model.EntityId) =
+            driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+        stun(bear2) shouldBe 1
+        listOf(bear1, bear2, bear3).sumOf { stun(it) } shouldBe 1
+    }
+
+    test("Mode B — works with a single target (stun lands on it)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bear = driver.putCreatureOnBattlefield(opponent, "Test Bear")
+
+        giveWhiteMana(driver, activePlayer)
+        val spell = driver.putCardInHand(activePlayer, "Aerith Rescue Mission")
+
+        val chosenTargets = listOf(ChosenTarget.Permanent(bear))
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = spell,
+                targets = chosenTargets,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(chosenTargets)
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        // With a single tapped creature the choice is unambiguous; answer it if surfaced.
+        if (driver.state.pendingDecision is SelectCardsDecision) {
+            driver.submitCardSelection(activePlayer, listOf(bear))
+        }
+
+        driver.isTapped(bear) shouldBe true
+        val stun = driver.state.getEntity(bear)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+        stun shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GalufsFinalActScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GalufsFinalActScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Galuf's Final Act (FIN #186) — {1}{G} Instant.
+ *
+ *   "Until end of turn, target creature gets +1/+0 and gains 'When this creature dies, put a
+ *    number of +1/+1 counters equal to its power on up to one target creature.'"
+ *
+ * Three things to prove end-to-end:
+ *   1. The +1/+0 pump lands (projected power rises by 1) until end of turn.
+ *   2. When the pumped creature dies, the granted trigger puts +1/+1 counters equal to its
+ *      LAST-KNOWN power (the pumped value at death) on the chosen creature.
+ *   3. "Up to one target creature" is optional — declining the target resolves with no counters.
+ */
+class GalufsFinalActScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Galuf's Final Act") {
+
+            test("pumps +1/+0, and on death grants +1/+1 counters equal to last-known power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Galuf's Final Act")
+                    // {1}{G} for the spell, plus {R} for Lightning Bolt to kill the creature.
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    // The creature that will be pumped and then die.
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // A second creature to receive the counters.
+                    .withCardOnBattlefield(1, "Trained Armodon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val recipient = game.findPermanent("Trained Armodon")!!
+                val powerBefore = projector.getProjectedPower(game.state, bears)
+
+                // Cast Galuf's Final Act on Grizzly Bears (2/2 → 3/2 until end of turn).
+                game.castSpell(1, "Galuf's Final Act", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the +1/+0 pump raises projected power by 1 (2 -> 3)") {
+                    projector.getProjectedPower(game.state, bears) shouldBe powerBefore + 1
+                }
+                withClue("toughness is unchanged by +1/+0") {
+                    projector.getProjectedToughness(game.state, bears) shouldBe 2
+                }
+
+                // Lightning Bolt (3 damage) kills the 3/2 Grizzly Bears.
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                // The granted dies trigger is now on the stack and asks for "up to one target
+                // creature" to receive the counters. Choose the Trained Armodon.
+                withClue("the dies trigger prompts for its up-to-one target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(recipient)).error shouldBe null
+                game.resolveStack()
+
+                withClue("recipient gets +1/+1 counters equal to last-known power (3)") {
+                    val counters = game.state.getEntity(recipient)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 3
+                }
+            }
+
+            test("up to one target may be declined — no counters are placed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Galuf's Final Act")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Trained Armodon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val recipient = game.findPermanent("Trained Armodon")!!
+
+                game.castSpell(1, "Galuf's Final Act", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("the dies trigger prompts for its up-to-one target") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                // Decline the optional target.
+                game.skipTargets().error shouldBe null
+                game.resolveStack()
+
+                withClue("declining places no +1/+1 counters anywhere") {
+                    val counters = game.state.getEntity(recipient)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RideTheShoopufScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RideTheShoopufScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fin.cards.RideTheShoopuf
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ride the Shoopuf {1}{G} Enchantment (FIN #197).
+ *
+ * Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control.
+ * {5}{G}{G}: This enchantment becomes a 7/7 Beast creature in addition to its other types.
+ */
+class RideTheShoopufScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(listOf(RideTheShoopuf))
+
+        context("Ride the Shoopuf") {
+
+            test("landfall puts a +1/+1 counter on a target creature you control") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ride the Shoopuf")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Grizzly Bears starts with no +1/+1 counters") {
+                    val counters = game.state.getEntity(bears)?.get<CountersComponent>()?.counters ?: emptyMap()
+                    counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe null
+                }
+
+                val forest = game.findCardsInHand(1, "Forest").first()
+                game.execute(PlayLand(game.player1Id, forest))
+
+                // Landfall trigger goes on the stack and asks for its "target creature you control".
+                if (game.getPendingDecision() is ChooseTargetsDecision) {
+                    game.selectTargets(listOf(bears))
+                }
+                game.resolveStack()
+
+                withClue("Landfall puts one +1/+1 counter on the targeted creature") {
+                    val counters = game.state.getEntity(bears)?.get<CountersComponent>()?.counters ?: emptyMap()
+                    counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 1
+                }
+            }
+
+            test("{5}{G}{G} turns it into a 7/7 Beast creature that is still an Enchantment") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Ride the Shoopuf")
+                    .withLandsOnBattlefield(1, "Forest", 7) // pays {5}{G}{G}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shoopuf = game.findPermanent("Ride the Shoopuf")!!
+
+                withClue("starts as a noncreature enchantment") {
+                    game.state.projectedState.isCreature(shoopuf) shouldBe false
+                    game.state.projectedState.hasType(shoopuf, "ENCHANTMENT") shouldBe true
+                }
+
+                val abilityId = cardRegistry.getCard("Ride the Shoopuf")!!
+                    .script.activatedAbilities[0].id
+
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = shoopuf,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("activating {5}{G}{G} should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                val projected = game.state.projectedState
+                withClue("becomes a creature") { projected.isCreature(shoopuf) shouldBe true }
+                withClue("7 power") { projected.getPower(shoopuf) shouldBe 7 }
+                withClue("7 toughness") { projected.getToughness(shoopuf) shouldBe 7 }
+                withClue("is a Beast") { projected.hasSubtype(shoopuf, "Beast") shouldBe true }
+                withClue("still an Enchantment (in addition to its other types)") {
+                    projected.hasType(shoopuf, "ENCHANTMENT") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of missing **Final Fantasy (FIN)** cards, each composing existing SDK primitives, plus one small DSL extension to support the colorless basic land.

## Cards

| Card | Type | Notes |
|------|------|-------|
| **Wastes** (#309) | Basic Land | Colorless basic — `{T}: Add {C}`. Required extending the `basicLand` DSL (see below). |
| **Aerith Rescue Mission** (#5) | `{3}{W}` Sorcery | Modal: create three 1/1 Hero tokens, **or** tap up to three target creatures and put a stun counter on one of them. |
| **Ride the Shoopuf** (#197) | `{1}{G}` Enchantment | Landfall +1/+1 counter on target creature you control; `{5}{G}{G}` animates into a 7/7 Beast in addition to its other types. |
| **Galuf's Final Act** (#186) | `{1}{G}` Instant | +1/+0 EOT and grants a dies-trigger placing +1/+1 counters equal to the dying creature's last-known power on up to one target creature. |

## SDK change — colorless basic land

`basicLand("Wastes")` now models a type-line-`Basic Land` (no subtype) basic with an intrinsic `{T}: Add {C}` ability (via `AddColorlessManaEffect`), alongside the five colored basics. `card-sdk-language-reference.md` updated. This closes the gap noted in `FinalFantasyBasicLands.kt` ("the `basicLand` DSL does not yet model" Wastes).

## Fidelity notes

- **Aerith Rescue Mission** mode B models "put a stun counter on **one of them**" as a *resolution-time controller choice* among the tapped creatures (`GatherCards(ChosenTargets) → SelectFromCollection(ChooseExactly 1) → AddCountersToCollection`), matching the ruling that the choice is made at resolution rather than auto-assigned.
- **Galuf's Final Act** uses `DynamicAmounts.sourcePower()` so the granted dies-trigger reads the dying creature's *last-known* power.

## Tests

- `CardDefinitionSnapshotTest` golden re-blessed (FIN) — only the three new spell cards added.
- New rules-engine scenario tests for Aerith Rescue Mission, Ride the Shoopuf, and Galuf's Final Act (both modes / both branches each).
- Full `mtg-sets` net (snapshot, `CardLintTest`, `FacadeBoundaryTest`, `CardDiscoveryEquivalenceTest`) and `just build` across all modules pass.

## Deferred — engine gap found

A fifth card, **Swallowed by Leviathan** (`Surveil 2, then counter ... unless its controller pays {1} for each card in your graveyard`), was authored but **dropped from this PR**. It surfaced an engine timing bug: because surveil pauses resolution, the deferred counter-unless-pay tail evaluates "cards in your graveyard" *after* Swallowed itself has moved to its controller's graveyard, so the spell counts itself (off by one). This is a continuation-ordering issue in the rules engine (self-referential graveyard count across a resolution pause), best fixed via the `add-feature` flow with cross-layer tracing rather than a card-level hack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)