### PR TITLE
Add Leyline of Transformation to Duskmourn with GrantChosenSubtype support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3155,6 +3155,16 @@ staticAbility {
 - `GrantCardType(cardType, filter)` / `RemoveCardType(cardType, filter)` — Layer 4 type-changing statics that add or
   remove a card type (e.g. `"CREATURE"`). `RemoveCardType` backs Impending's "isn't a creature while it has a time
   counter" (wrapped in a `ConditionalStaticAbility`); reuse it for any "it's no longer a [type]" effect.
+- `GrantSubtype(subtype, filter)` — Layer 4 type-changing static that adds a **fixed** creature subtype to the group,
+  in addition to their other types ("is a Knight in addition to its other types"). (Dub)
+- `GrantChosenSubtype(filter)` — Layer 4 type-changing static that adds the creature type **chosen as the source
+  entered** (read from the source's `CastChoicesComponent`) to the group, in addition to their other types. Chosen-value
+  counterpart to `GrantSubtype`, mirroring `GrantChosenColor`/`GrantColor`; pair with
+  `EntersWithChoice(ChoiceType.CREATURE_TYPE)`. This is the Conspiracy / Xenograft mechanic ("Creatures you control are
+  the chosen type in addition to their other types"). Affects only **battlefield** permanents — type-changing statics
+  are projected through the layer system, which iterates the battlefield, so the "creature spells you control and
+  creature cards you own that aren't on the battlefield" half of effects like Leyline of Transformation is not modeled
+  (the engine has no type projection for the stack/hand/graveyard/library/exile). (Leyline of Transformation)
 - `TransformPermanent(setCardTypes, setSubtypes, setColors?, clearSubtypes, filter)` — Layer 4/5 "becomes a whole new
   identity" (Sugar Coat, Darksteel Mutation). A non-empty `setSubtypes` replaces all subtypes; an empty `setSubtypes`
   leaves subtypes alone **unless** `clearSubtypes = true`, which replaces them with none ("has no subtypes" — the

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3157,14 +3157,20 @@ staticAbility {
   counter" (wrapped in a `ConditionalStaticAbility`); reuse it for any "it's no longer a [type]" effect.
 - `GrantSubtype(subtype, filter)` — Layer 4 type-changing static that adds a **fixed** creature subtype to the group,
   in addition to their other types ("is a Knight in addition to its other types"). (Dub)
-- `GrantChosenSubtype(filter)` — Layer 4 type-changing static that adds the creature type **chosen as the source
-  entered** (read from the source's `CastChoicesComponent`) to the group, in addition to their other types. Chosen-value
-  counterpart to `GrantSubtype`, mirroring `GrantChosenColor`/`GrantColor`; pair with
-  `EntersWithChoice(ChoiceType.CREATURE_TYPE)`. This is the Conspiracy / Xenograft mechanic ("Creatures you control are
-  the chosen type in addition to their other types"). Affects only **battlefield** permanents — type-changing statics
-  are projected through the layer system, which iterates the battlefield, so the "creature spells you control and
-  creature cards you own that aren't on the battlefield" half of effects like Leyline of Transformation is not modeled
-  (the engine has no type projection for the stack/hand/graveyard/library/exile). (Leyline of Transformation)
+- `GrantChosenSubtype(filter, includeControlledSpells = false, includeOwnedCardsOutsideBattlefield = false)` — Layer 4
+  type-changing static that adds the creature type **chosen as the source entered** (read from the source's
+  `CastChoicesComponent`) to the group, in addition to their other types. Chosen-value counterpart to `GrantSubtype`,
+  mirroring `GrantChosenColor`/`GrantColor`; pair with `EntersWithChoice(ChoiceType.CREATURE_TYPE)`. This is the
+  Conspiracy / Xenograft mechanic. The `filter` half is normal Layer 4 battlefield projection ("Creatures you control
+  are the chosen type"). The two cross-zone flags extend the grant beyond the battlefield (the Conspiracy / Leyline-of-
+  Transformation clause "the same is true for creature spells you control and creature cards you own that aren't on the
+  battlefield"): `includeControlledSpells` reaches creature spells the controller controls on the stack, and
+  `includeOwnedCardsOutsideBattlefield` reaches creature cards the controller owns in hand/library/graveyard/exile/
+  command. Because Layer 4 projection only touches the battlefield, those flags are honored by a separate overlay —
+  `ProjectedState.crossZoneGrantedSubtypes`, consulted by every non-battlefield subtype read-site in `PredicateEvaluator`
+  and `SelectFromCollectionExecutor` — so a granted type drives type-matters checks everywhere ("target Zombie spell",
+  "return target Zombie card from your graveyard", search filters). Leave both flags `false` for battlefield-only effects
+  like Xenograft. (Leyline of Transformation)
 - `TransformPermanent(setCardTypes, setSubtypes, setColors?, clearSubtypes, filter)` — Layer 4/5 "becomes a whole new
   identity" (Sugar Coat, Darksteel Mutation). A non-empty `setSubtypes` replaces all subtypes; an empty `setSubtypes`
   leaves subtypes alone **unless** `clearSubtypes = true`, which replaces them with none ("has no subtypes" — the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
@@ -32,25 +32,46 @@ data class GrantSubtype(
  * Grants the creature type chosen as the source entered (resolved from the source's
  * `CastChoicesComponent`) to a group, in addition to their other types. The chosen-value
  * counterpart to [GrantSubtype], mirroring [GrantChosenColor]'s relationship to [GrantColor].
- * Used by Leyline of Transformation: "Creatures you control are the chosen type in addition
- * to their other types."
+ * Used by Leyline of Transformation / Conspiracy / Xenograft: "Creatures you control are the
+ * chosen type in addition to their other types."
  *
  * This is a Layer 4 (type-changing) continuous effect. If the source has no chosen creature
  * type, no subtype is added.
  *
- * Note: as a static ability projected through the layer system, it affects only permanents on
- * the battlefield. The "creature spells you control and creature cards you own that aren't on
- * the battlefield" clause of effects like Leyline of Transformation is not modeled — the engine
- * does not project types onto non-battlefield zones (see the card's definition for detail).
+ * The [filter] half is the standard battlefield projection (Layer 4). The two cross-zone flags
+ * extend the grant beyond the battlefield, modeling the Conspiracy / Leyline-of-Transformation
+ * clause "The same is true for creature spells you control and creature cards you own that aren't
+ * on the battlefield":
+ *  - [includeControlledSpells] — creature **spells the source's controller controls** (on the
+ *    stack) are also the chosen type.
+ *  - [includeOwnedCardsOutsideBattlefield] — creature **cards the source's controller owns** in
+ *    any non-battlefield, non-stack zone (hand, library, graveyard, exile, command) are also the
+ *    chosen type.
  *
- * @property filter Which permanents are affected (typically `AllCreaturesYouControl`).
+ * Type-changing statics are projected through the layer system, which iterates only the
+ * battlefield, so the cross-zone flags are honored by a separate overlay (`ProjectedState`'s
+ * cross-zone grant list, consulted by every subtype read-site for non-battlefield objects)
+ * rather than by Layer 4 projection. Leave both flags `false` for battlefield-only effects
+ * like Xenograft.
+ *
+ * @property filter Which battlefield permanents are affected (typically `AllCreaturesYouControl`).
+ * @property includeControlledSpells Whether creature spells the controller controls are also the type.
+ * @property includeOwnedCardsOutsideBattlefield Whether creature cards the controller owns outside
+ *   the battlefield are also the type.
  */
 @SerialName("GrantChosenSubtype")
 @Serializable
 data class GrantChosenSubtype(
-    val filter: GroupFilter = GroupFilter.source()
+    val filter: GroupFilter = GroupFilter.source(),
+    val includeControlledSpells: Boolean = false,
+    val includeOwnedCardsOutsideBattlefield: Boolean = false
 ) : StaticAbility {
-    override val description: String = "${filter.description} are the chosen type in addition to their other types"
+    override val description: String = buildString {
+        append("${filter.description} are the chosen type in addition to their other types")
+        if (includeControlledSpells || includeOwnedCardsOutsideBattlefield) {
+            append("; so are your creature spells and creature cards outside the battlefield")
+        }
+    }
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
         val newFilter = filter.applyTextReplacement(replacer)
         return if (newFilter !== filter) copy(filter = newFilter) else this

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/TypeStaticAbilities.kt
@@ -29,6 +29,35 @@ data class GrantSubtype(
 }
 
 /**
+ * Grants the creature type chosen as the source entered (resolved from the source's
+ * `CastChoicesComponent`) to a group, in addition to their other types. The chosen-value
+ * counterpart to [GrantSubtype], mirroring [GrantChosenColor]'s relationship to [GrantColor].
+ * Used by Leyline of Transformation: "Creatures you control are the chosen type in addition
+ * to their other types."
+ *
+ * This is a Layer 4 (type-changing) continuous effect. If the source has no chosen creature
+ * type, no subtype is added.
+ *
+ * Note: as a static ability projected through the layer system, it affects only permanents on
+ * the battlefield. The "creature spells you control and creature cards you own that aren't on
+ * the battlefield" clause of effects like Leyline of Transformation is not modeled — the engine
+ * does not project types onto non-battlefield zones (see the card's definition for detail).
+ *
+ * @property filter Which permanents are affected (typically `AllCreaturesYouControl`).
+ */
+@SerialName("GrantChosenSubtype")
+@Serializable
+data class GrantChosenSubtype(
+    val filter: GroupFilter = GroupFilter.source()
+) : StaticAbility {
+    override val description: String = "${filter.description} are the chosen type in addition to their other types"
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
+}
+
+/**
  * Grants every creature type to the target, in addition to its existing types,
  * without granting the Changeling keyword. Used for cards like Stalactite Dagger:
  * "Equipped creature ... is all creature types." The card text doesn't say

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -305,6 +305,7 @@ object CardLinter {
         "HasChosenColor" to "COLOR",
         "SharesChosenColorWithSource" to "COLOR",
         "GrantChosenColor" to "COLOR",
+        "GrantChosenSubtype" to "CREATURE_TYPE",
         "GrantProtectionFromChosenColorToGroup" to "COLOR",
         "GrantLandwalkOfChosenType" to "LAND_TYPE",
         "NotOfSourceChosenType" to "CREATURE_TYPE",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfTransformation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfTransformation.kt
@@ -20,16 +20,16 @@ import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
  *
  * `leyline()` adds the "begin the game on the battlefield" opening-hand marker (CR 103.6).
  * [EntersWithChoice] locks in the chosen creature type (CR 614 as-it-enters choice), and
- * [GrantChosenSubtype] is the Layer 4 (type-changing) static ability that adds that chosen
- * type to creatures you control — the Conspiracy / Xenograft mechanic.
+ * [GrantChosenSubtype] is the type-changing static ability that adds that chosen type to:
+ *  - creatures you control (battlefield) — Layer 4 projection via the `filter`;
+ *  - `includeControlledSpells` — creature spells you control on the stack;
+ *  - `includeOwnedCardsOutsideBattlefield` — creature cards you own in hand/library/graveyard/
+ *    exile/command.
  *
- * Limitation: the "creature spells you control and creature cards you own that aren't on the
- * battlefield are the chosen type" clause is NOT modeled. The engine projects type-changing
- * continuous effects only onto battlefield permanents (StateProjector iterates the
- * battlefield), so a chosen-type grant cannot reach the stack, hand, graveyard, library, or
- * exile. Implementing that would require type projection across every non-battlefield zone —
- * a broad, cross-cutting capability that no card in the engine currently exercises. The
- * battlefield clause (by far the dominant gameplay function) is fully faithful.
+ * The last two clauses are honored by the cross-zone subtype-grant overlay on `ProjectedState`,
+ * which every non-battlefield subtype read-site consults — so a Leyline-granted type drives
+ * type-matters checks everywhere (e.g. "target Zombie spell", "return target Zombie card from
+ * your graveyard"). This is the full Conspiracy / Xenograft mechanic.
  */
 val LeylineOfTransformation = card("Leyline of Transformation") {
     manaCost = "{2}{U}{U}"
@@ -44,7 +44,11 @@ val LeylineOfTransformation = card("Leyline of Transformation") {
     replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
 
     staticAbility {
-        ability = GrantChosenSubtype(filter = GroupFilter.AllCreaturesYouControl)
+        ability = GrantChosenSubtype(
+            filter = GroupFilter.AllCreaturesYouControl,
+            includeControlledSpells = true,
+            includeOwnedCardsOutsideBattlefield = true
+        )
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfTransformation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/LeylineOfTransformation.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.leyline
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GrantChosenSubtype
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Leyline of Transformation (DSK #63)
+ * {2}{U}{U}  Enchantment
+ *
+ * If this card is in your opening hand, you may begin the game with it on the battlefield.
+ * As this enchantment enters, choose a creature type.
+ * Creatures you control are the chosen type in addition to their other types. The same is
+ * true for creature spells you control and creature cards you own that aren't on the
+ * battlefield.
+ *
+ * `leyline()` adds the "begin the game on the battlefield" opening-hand marker (CR 103.6).
+ * [EntersWithChoice] locks in the chosen creature type (CR 614 as-it-enters choice), and
+ * [GrantChosenSubtype] is the Layer 4 (type-changing) static ability that adds that chosen
+ * type to creatures you control — the Conspiracy / Xenograft mechanic.
+ *
+ * Limitation: the "creature spells you control and creature cards you own that aren't on the
+ * battlefield are the chosen type" clause is NOT modeled. The engine projects type-changing
+ * continuous effects only onto battlefield permanents (StateProjector iterates the
+ * battlefield), so a chosen-type grant cannot reach the stack, hand, graveyard, library, or
+ * exile. Implementing that would require type projection across every non-battlefield zone —
+ * a broad, cross-cutting capability that no card in the engine currently exercises. The
+ * battlefield clause (by far the dominant gameplay function) is fully faithful.
+ */
+val LeylineOfTransformation = card("Leyline of Transformation") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "If this card is in your opening hand, you may begin the game with it on the battlefield.\n" +
+        "As this enchantment enters, choose a creature type.\n" +
+        "Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield."
+
+    leyline()
+
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
+
+    staticAbility {
+        ability = GrantChosenSubtype(filter = GroupFilter.AllCreaturesYouControl)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "63"
+        artist = "Sergey Glushakov"
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4bd941ca-f3d2-44c1-8df3-851362f6b848.jpg?1726286087"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -10334,6 +10334,40 @@
     ]
 }
 
+// Leyline of Transformation
+{
+    "name": "Leyline of Transformation",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "If this card is in your opening hand, you may begin the game with it on the battlefield.\nAs this enchantment enters, choose a creature type.\nCreatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantChosenSubtype",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CREATURE_TYPE"
+            }
+        ],
+        "mayStartOnBattlefield": true
+    },
+    "metadata": {
+        "collectorNumber": "63",
+        "rarity": "RARE",
+        "artist": "Sergey Glushakov",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4bd941ca-f3d2-44c1-8df3-851362f6b848.jpg?1726286087"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Lionheart Glimmer
 {
     "name": "Lionheart Glimmer",

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -10346,7 +10346,9 @@
                 "type": "GrantChosenSubtype",
                 "filter": {
                     "baseFilter": "creature ctrl:you"
-                }
+                },
+                "includeControlledSpells": true,
+                "includeOwnedCardsOutsideBattlefield": true
             }
         ],
         "replacementEffects": [

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.state.components.battlefield.chosenColor
 import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
 import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
 import com.wingedsheep.engine.mechanics.layers.ProjectedState
+import com.wingedsheep.engine.mechanics.layers.ProjectedValues
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
@@ -121,6 +122,47 @@ class PredicateEvaluator {
     }
 
     /**
+     * Whether an object with **no battlefield projection entry** (a spell on the stack, a card in
+     * hand/library/graveyard/exile) effectively has [subtype]. Honors its printed subtypes,
+     * Changeling (all creature types in all zones, Rule 702.73), and cross-zone "is the chosen
+     * type" grants (Conspiracy / Leyline of Transformation — see
+     * [ProjectedState.crossZoneGrantedSubtypes]). Battlefield permanents never reach this helper;
+     * their subtypes come from the projected `subtypes` set.
+     */
+    private fun matchesBaseSubtype(
+        state: GameState,
+        projected: ProjectedState,
+        entityId: EntityId,
+        card: CardComponent,
+        subtype: Subtype
+    ): Boolean =
+        card.typeLine.hasSubtype(subtype) ||
+            (Keyword.CHANGELING in card.baseKeywords && subtype.value in Subtype.ALL_CREATURE_TYPES) ||
+            projected.crossZoneGrantedSubtypes(state, entityId).any { it.equals(subtype.value, ignoreCase = true) }
+
+    /**
+     * The creature/other subtypes an object effectively has for "shares a type with" / chosen-type
+     * comparisons. Battlefield permanents use their projected subtype set (empty if face down,
+     * Rule 708.2); non-battlefield objects use their printed subtypes plus any cross-zone "is the
+     * chosen type" grants ([ProjectedState.crossZoneGrantedSubtypes]). Changeling is intentionally
+     * *not* folded in here (callers that honor Changeling check it separately), preserving the
+     * pre-existing semantics of the share/chosen predicates.
+     */
+    private fun effectiveSubtypes(
+        state: GameState,
+        projected: ProjectedState,
+        entityId: EntityId,
+        card: CardComponent,
+        projectedValues: ProjectedValues?
+    ): Set<String> {
+        if (projectedValues != null) {
+            return if (projectedValues.isFaceDown) emptySet() else projectedValues.subtypes
+        }
+        return card.typeLine.subtypes.map { it.value }.toSet() +
+            projected.crossZoneGrantedSubtypes(state, entityId)
+    }
+
+    /**
      * Evaluate a CardPredicate against an entity using projected state.
      */
     fun matchesCardPredicate(
@@ -228,10 +270,7 @@ class PredicateEvaluator {
                     false
                 } else {
                     projectedValues?.subtypes?.any { it.equals(predicate.subtype.value, ignoreCase = true) }
-                        ?: (card.typeLine.hasSubtype(predicate.subtype) ||
-                            // Changeling: has all creature types in all zones
-                            (Keyword.CHANGELING in card.baseKeywords &&
-                                predicate.subtype.value in Subtype.ALL_CREATURE_TYPES))
+                        ?: matchesBaseSubtype(state, projected, entityId, card, predicate.subtype)
                 }
             }
             is CardPredicate.NotSubtype -> {
@@ -239,10 +278,7 @@ class PredicateEvaluator {
                     true  // Face-down has no subtypes
                 } else {
                     val hasSubtype = projectedValues?.subtypes?.any { it.equals(predicate.subtype.value, ignoreCase = true) }
-                        ?: (card.typeLine.hasSubtype(predicate.subtype) ||
-                            // Changeling: has all creature types in all zones
-                            (Keyword.CHANGELING in card.baseKeywords &&
-                                predicate.subtype.value in Subtype.ALL_CREATURE_TYPES))
+                        ?: matchesBaseSubtype(state, projected, entityId, card, predicate.subtype)
                     !hasSubtype
                 }
             }
@@ -252,9 +288,7 @@ class PredicateEvaluator {
                 } else {
                     predicate.subtypes.any { subtype ->
                         projectedValues?.subtypes?.any { it.equals(subtype.value, ignoreCase = true) }
-                            ?: (card.typeLine.hasSubtype(subtype) ||
-                                (Keyword.CHANGELING in card.baseKeywords &&
-                                    subtype.value in Subtype.ALL_CREATURE_TYPES))
+                            ?: matchesBaseSubtype(state, projected, entityId, card, subtype)
                     }
                 }
             }
@@ -470,7 +504,8 @@ class PredicateEvaluator {
                     ?.chosenCreatureType()
                     ?: return true
                 val hasSubtype = projectedValues?.subtypes?.any { it.equals(chosenType, ignoreCase = true) }
-                    ?: card.typeLine.hasSubtype(Subtype(chosenType))
+                    ?: (card.typeLine.hasSubtype(Subtype(chosenType)) ||
+                        projected.crossZoneGrantedSubtypes(state, entityId).any { it.equals(chosenType, ignoreCase = true) })
                 !hasSubtype
             }
 
@@ -483,7 +518,7 @@ class PredicateEvaluator {
                         ?: emptySet()
                 }
                 if (sourceSubtypes.isEmpty()) return false
-                val entitySubtypes = projectedValues?.subtypes ?: card.typeLine.subtypes.map { it.value }.toSet()
+                val entitySubtypes = effectiveSubtypes(state, projected, entityId, card, projectedValues)
                 entitySubtypes.any { entitySubtype ->
                     sourceSubtypes.any { it.equals(entitySubtype, ignoreCase = true) }
                 }
@@ -497,7 +532,7 @@ class PredicateEvaluator {
                         ?: emptySet()
                 }
                 if (triggeringSubtypes.isEmpty()) return false
-                val entitySubtypes = projectedValues?.subtypes ?: card.typeLine.subtypes.map { it.value }.toSet()
+                val entitySubtypes = effectiveSubtypes(state, projected, entityId, card, projectedValues)
                 entitySubtypes.any { entitySubtype ->
                     triggeringSubtypes.any { it.equals(entitySubtype, ignoreCase = true) }
                 }
@@ -508,7 +543,7 @@ class PredicateEvaluator {
                 val chosenType = state.getEntity(sourceId)
                     ?.chosenCreatureType()
                     ?: return false
-                val entitySubtypes = projectedValues?.subtypes ?: card.typeLine.subtypes.map { it.value }.toSet()
+                val entitySubtypes = effectiveSubtypes(state, projected, entityId, card, projectedValues)
                 entitySubtypes.any { it.equals(chosenType, ignoreCase = true) } ||
                     // Changeling: has all creature types in all zones
                     (Keyword.CHANGELING in card.baseKeywords &&
@@ -522,7 +557,7 @@ class PredicateEvaluator {
                         ?: emptySet()
                 }
                 if (referenceSubtypes.isEmpty()) return false
-                val entitySubtypes = projectedValues?.subtypes ?: card.typeLine.subtypes.map { it.value }.toSet()
+                val entitySubtypes = effectiveSubtypes(state, projected, entityId, card, projectedValues)
                 entitySubtypes.any { entitySubtype ->
                     referenceSubtypes.any { it.equals(entitySubtype, ignoreCase = true) }
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/SelectFromCollectionExecutor.kt
@@ -83,7 +83,11 @@ class SelectFromCollectionExecutor(
                 eligibleCards = eligibleCards.filter { cardId ->
                     val cardComponent = state.getEntity(cardId)?.get<CardComponent>() ?: return@filter false
                     Keyword.CHANGELING in cardComponent.baseKeywords ||
-                        cardComponent.typeLine.hasSubtype(Subtype(chosenType))
+                        cardComponent.typeLine.hasSubtype(Subtype(chosenType)) ||
+                        // Cross-zone "is the chosen type" grants (Conspiracy / Leyline of
+                        // Transformation) make non-battlefield creature cards count as the type.
+                        state.projectedState.crossZoneGrantedSubtypes(state, cardId)
+                            .any { it.equals(chosenType, ignoreCase = true) }
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -143,6 +143,9 @@ internal class EffectApplicator(
                     values.subtypes.add(mod.subtype)
                 }
                 is Modification.AddChosenSubtype -> {
+                    // The cross-zone flags on the modification are read by StateProjector to build
+                    // ProjectedState.crossZoneSubtypeGrants; Layer 4 projection here only ever
+                    // touches battlefield permanents, so they're irrelevant to this branch.
                     val chosenType = state.getEntity(effect.sourceId)
                         ?.chosenCreatureType()
                     if (chosenType != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/EffectApplicator.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.mechanics.layers
 
 import com.wingedsheep.engine.state.components.battlefield.chosenLandType
 import com.wingedsheep.engine.state.components.battlefield.chosenColor
+import com.wingedsheep.engine.state.components.battlefield.chosenCreatureType
 import com.wingedsheep.engine.handlers.ConditionEvaluationContext
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
@@ -140,6 +141,14 @@ internal class EffectApplicator(
                 is Modification.AddSubtype -> {
                     values.types.add(mod.subtype)
                     values.subtypes.add(mod.subtype)
+                }
+                is Modification.AddChosenSubtype -> {
+                    val chosenType = state.getEntity(effect.sourceId)
+                        ?.chosenCreatureType()
+                    if (chosenType != null) {
+                        values.types.add(chosenType)
+                        values.subtypes.add(chosenType)
+                    }
                 }
                 is Modification.AddAllCreatureTypes -> {
                     values.subtypes.addAll(com.wingedsheep.sdk.core.Subtype.ALL_CREATURE_TYPES)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectedState.kt
@@ -4,6 +4,34 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+
+/**
+ * An active "this object is also the chosen creature type" grant that reaches **beyond** the
+ * battlefield (the Conspiracy / Leyline of Transformation clause "The same is true for creature
+ * spells you control and creature cards you own that aren't on the battlefield").
+ *
+ * Built by [StateProjector] from each battlefield `GrantChosenSubtype` whose cross-zone flags are
+ * set, then consulted by every subtype read-site for objects that have no battlefield projection
+ * entry (spells on the stack, cards in hand/library/graveyard/exile/command) via
+ * [ProjectedState.crossZoneGrantedSubtypes]. Battlefield permanents are unaffected — they get the
+ * type through normal Layer 4 projection.
+ *
+ * @property controllerId The granting permanent's controller — the player who "controls" the
+ *   affected spells and "owns" the affected cards (the asymmetry is in the card text).
+ * @property chosenType The creature type chosen as the granting permanent entered.
+ * @property includeControlledSpells Grant reaches creature spells [controllerId] controls (stack).
+ * @property includeOwnedCardsOutsideBattlefield Grant reaches creature cards [controllerId] owns in
+ *   any non-battlefield, non-stack zone.
+ */
+data class CrossZoneSubtypeGrant(
+    val controllerId: EntityId,
+    val chosenType: String,
+    val includeControlledSpells: Boolean,
+    val includeOwnedCardsOutsideBattlefield: Boolean
+)
 
 /**
  * Projected values for an entity after all effects are applied.
@@ -34,9 +62,50 @@ data class ProjectedValues(
  */
 class ProjectedState(
     private val baseState: GameState,
-    private val projectedValues: Map<EntityId, ProjectedValues>
+    private val projectedValues: Map<EntityId, ProjectedValues>,
+    /**
+     * Active cross-zone "is the chosen type" grants (Conspiracy / Leyline of Transformation).
+     * Empty for virtually every game state, so [crossZoneGrantedSubtypes] short-circuits to no-op.
+     */
+    val crossZoneSubtypeGrants: List<CrossZoneSubtypeGrant> = emptyList()
 ) {
     fun getBaseState(): GameState = baseState
+
+    /**
+     * The chosen creature types granted to a **non-battlefield** object (a creature spell on the
+     * stack, or a creature card in hand/library/graveyard/exile/command) by cross-zone
+     * [CrossZoneSubtypeGrant]s. Battlefield permanents return empty here — they get the type via
+     * normal Layer 4 projection ([getSubtypes]). Returns empty (fast path) when no such grant is
+     * active, which is the common case.
+     *
+     * Read by the subtype predicates in `PredicateEvaluator` and by `SelectFromCollectionExecutor`
+     * for objects with no projection entry, so a Leyline-granted type drives type-matters checks
+     * (targeting "a Zombie spell" / "a Zombie card in your graveyard", search filters, …).
+     */
+    fun crossZoneGrantedSubtypes(state: GameState, entityId: EntityId): Set<String> {
+        if (crossZoneSubtypeGrants.isEmpty()) return emptySet()
+        val container = state.getEntity(entityId) ?: return emptySet()
+        val card = container.get<CardComponent>() ?: return emptySet()
+        // Only creature spells / creature cards gain the type ("creature spells ... creature cards ...").
+        if (!card.typeLine.isCreature) return emptySet()
+
+        return if (state.isSpellOnStack(entityId)) {
+            // A spell's controller is its ControllerComponent if present, else its caster.
+            val controller = container.get<ControllerComponent>()?.playerId
+                ?: container.get<SpellOnStackComponent>()?.casterId
+                ?: return emptySet()
+            crossZoneSubtypeGrants
+                .filter { it.includeControlledSpells && it.controllerId == controller }
+                .mapTo(mutableSetOf()) { it.chosenType }
+        } else {
+            // Battlefield permanents are covered by Layer 4 projection, not this overlay.
+            if (entityId in state.getBattlefield()) return emptySet()
+            val owner = card.ownerId ?: return emptySet()
+            crossZoneSubtypeGrants
+                .filter { it.includeOwnedCardsOutsideBattlefield && it.controllerId == owner }
+                .mapTo(mutableSetOf()) { it.chosenType }
+        }
+    }
 
     fun getPower(entityId: EntityId): Int? = projectedValues[entityId]?.power
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -277,6 +277,19 @@ sealed interface Modification {
     }
 
     /**
+     * Add the creature type chosen as the source entered (resolved dynamically from the
+     * source's CastChoicesComponent) as a subtype, in addition to the affected entity's
+     * other types. The chosen-value counterpart to [AddSubtype], mirroring [AddChosenColor].
+     * Used by Leyline of Transformation: "Creatures you control are the chosen type in
+     * addition to their other types." If the source has no chosen creature type, no
+     * modification is applied.
+     */
+    @Serializable
+    data object AddChosenSubtype : Modification {
+        override val layer get() = Layer.TYPE
+    }
+
+    /**
      * Add every creature type to the affected entity, in addition to its other
      * subtypes. Used for cards that say "is all creature types" without granting
      * the Changeling keyword (e.g., Stalactite Dagger).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ProjectionModels.kt
@@ -283,9 +283,18 @@ sealed interface Modification {
      * Used by Leyline of Transformation: "Creatures you control are the chosen type in
      * addition to their other types." If the source has no chosen creature type, no
      * modification is applied.
+     *
+     * Layer 4 projection only ever touches battlefield permanents, so the two cross-zone
+     * flags ([includeControlledSpells], [includeOwnedCardsOutsideBattlefield]) are not read
+     * by [EffectApplicator]; they are read by [StateProjector] to register entries in
+     * [ProjectedState.crossZoneSubtypeGrants], which the non-battlefield subtype read-sites
+     * consult. See [com.wingedsheep.sdk.scripting.GrantChosenSubtype].
      */
     @Serializable
-    data object AddChosenSubtype : Modification {
+    data class AddChosenSubtype(
+        val includeControlledSpells: Boolean = false,
+        val includeOwnedCardsOutsideBattlefield: Boolean = false
+    ) : Modification {
         override val layer get() = Layer.TYPE
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StateProjector.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantCantBeBlockedToSmallCreaturesComponent
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.battlefield.chosenCreatureType
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.engine.state.components.identity.HexproofFromColorComponent
@@ -316,7 +317,26 @@ class StateProjector(
             )
         }
 
-        return ProjectedState(state, finalValues)
+        // Collect cross-zone "is the chosen type" grants (Conspiracy / Leyline of Transformation).
+        // A GrantChosenSubtype with cross-zone flags lowers to a Modification.AddChosenSubtype whose
+        // Layer 4 application above only touched battlefield permanents; here we additionally record
+        // an overlay entry so the non-battlefield subtype read-sites (spells on the stack, cards in
+        // hand/library/graveyard/exile) can honor it. Reads the source's *projected* controller (so
+        // it follows control changes) and the creature type it was made with.
+        val crossZoneGrants = sortedEffects.mapNotNull { effect ->
+            val mod = effect.modification as? Modification.AddChosenSubtype ?: return@mapNotNull null
+            if (!mod.includeControlledSpells && !mod.includeOwnedCardsOutsideBattlefield) return@mapNotNull null
+            val controllerId = projectedValues[effect.sourceId]?.controllerId ?: return@mapNotNull null
+            val chosenType = state.getEntity(effect.sourceId)?.chosenCreatureType() ?: return@mapNotNull null
+            CrossZoneSubtypeGrant(
+                controllerId = controllerId,
+                chosenType = chosenType,
+                includeControlledSpells = mod.includeControlledSpells,
+                includeOwnedCardsOutsideBattlefield = mod.includeOwnedCardsOutsideBattlefield
+            )
+        }
+
+        return ProjectedState(state, finalValues, crossZoneGrants)
     }
 
     fun getProjectedPower(state: GameState, entityId: EntityId): Int {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -600,7 +600,10 @@ class StaticAbilityHandler(
             }
             is GrantChosenSubtype -> {
                 ContinuousEffectData(
-                    modification = Modification.AddChosenSubtype,
+                    modification = Modification.AddChosenSubtype(
+                        includeControlledSpells = ability.includeControlledSpells,
+                        includeOwnedCardsOutsideBattlefield = ability.includeOwnedCardsOutsideBattlefield
+                    ),
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -42,6 +42,7 @@ import com.wingedsheep.sdk.scripting.SetEnchantedLandTypeFromChosen
 import com.wingedsheep.sdk.scripting.GrantKeywordByCounter
 import com.wingedsheep.sdk.scripting.GrantProtection
 import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.GrantChosenSubtype
 import com.wingedsheep.sdk.scripting.IsAllCreatureTypes
 import com.wingedsheep.sdk.scripting.GrantCardType
 import com.wingedsheep.sdk.scripting.RemoveCardType
@@ -594,6 +595,12 @@ class StaticAbilityHandler(
             is GrantSubtype -> {
                 ContinuousEffectData(
                     modification = Modification.AddSubtype(ability.subtype),
+                    affectsFilter = convertGroupFilter(ability.filter)
+                )
+            }
+            is GrantChosenSubtype -> {
+                ContinuousEffectData(
+                    modification = Modification.AddChosenSubtype,
                     affectsFilter = convertGroupFilter(ability.filter)
                 )
             }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfTransformationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfTransformationScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.LeylineOfTransformation
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+private val projector = StateProjector()
+
+/**
+ * Scenarios for Leyline of Transformation (DSK) — the new [com.wingedsheep.sdk.scripting.GrantChosenSubtype]
+ * static ability ("Creatures you control are the chosen type in addition to their other types").
+ *
+ * Only the battlefield clause is modeled (see the card definition for the documented limitation), so
+ * these tests cover: creatures you control gain the chosen type *in addition to* their printed types,
+ * opponents' creatures are unaffected, and the choice is made as the enchantment enters.
+ */
+class LeylineOfTransformationScenarioTest : FunSpec({
+
+    val bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    val goblin = CardDefinition.creature(
+        name = "Test Goblin",
+        manaCost = ManaCost.parse("{1}{R}"),
+        subtypes = setOf(Subtype("Goblin")),
+        power = 1,
+        toughness = 1
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LeylineOfTransformation, bear, goblin))
+        return driver
+    }
+
+    test("creatures you control gain the chosen type in addition to their printed types") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Leyline of Transformation on the battlefield with the chosen type "Goblin".
+        val leyline = driver.putPermanentOnBattlefield(activePlayer, "Leyline of Transformation")
+        driver.replaceState(driver.state.updateEntity(leyline) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        val bearId = driver.putCreatureOnBattlefield(activePlayer, "Test Bear")
+
+        val projected = projector.project(driver.state)
+        // The Bear is now a Goblin in addition to its other types.
+        projected.hasSubtype(bearId, "Goblin") shouldBe true
+        projected.hasSubtype(bearId, "Bear") shouldBe true
+        // P/T untouched — this is a pure type-change.
+        projected.getPower(bearId) shouldBe 2
+        projected.getToughness(bearId) shouldBe 2
+    }
+
+    test("opponents' creatures are unaffected (Creatures YOU control)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val leyline = driver.putPermanentOnBattlefield(activePlayer, "Leyline of Transformation")
+        driver.replaceState(driver.state.updateEntity(leyline) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        val myBear = driver.putCreatureOnBattlefield(activePlayer, "Test Bear")
+        val theirBear = driver.putCreatureOnBattlefield(opponent, "Test Bear")
+
+        val projected = projector.project(driver.state)
+        projected.hasSubtype(myBear, "Goblin") shouldBe true
+        projected.hasSubtype(theirBear, "Goblin") shouldBe false
+        projected.hasSubtype(theirBear, "Bear") shouldBe true
+    }
+
+    test("a creature already of the chosen type keeps its type and is unchanged") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val leyline = driver.putPermanentOnBattlefield(activePlayer, "Leyline of Transformation")
+        driver.replaceState(driver.state.updateEntity(leyline) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        val goblinId = driver.putCreatureOnBattlefield(activePlayer, "Test Goblin")
+
+        val projected = projector.project(driver.state)
+        projected.hasSubtype(goblinId, "Goblin") shouldBe true
+    }
+
+    test("choice is made as the enchantment enters (EntersWithChoice)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Forest" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bearId = driver.putCreatureOnBattlefield(activePlayer, "Test Bear")
+
+        // Cast Leyline of Transformation from hand — it should pause for the creature-type choice.
+        val spell = driver.putCardInHand(activePlayer, "Leyline of Transformation")
+        driver.giveMana(activePlayer, Color.BLUE, 4)
+        driver.castSpell(activePlayer, spell)
+        driver.bothPass()
+
+        driver.isPaused shouldBe true
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val goblinIndex = decision.options.indexOf("Goblin")
+        driver.submitDecision(activePlayer, OptionChosenResponse(decision.id, goblinIndex))
+
+        val projected = projector.project(driver.state)
+        projected.hasSubtype(bearId, "Goblin") shouldBe true
+        projected.hasSubtype(bearId, "Bear") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfTransformationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeylineOfTransformationScenarioTest.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ChooseOptionDecision
 import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.mechanics.layers.StateProjector
 import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
 import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
@@ -15,11 +16,13 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.scripting.ChoiceSlot
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 private val projector = StateProjector()
+private val predicateEvaluator = PredicateEvaluator()
 
 /**
  * Scenarios for Leyline of Transformation (DSK) — the new [com.wingedsheep.sdk.scripting.GrantChosenSubtype]
@@ -137,5 +140,118 @@ class LeylineOfTransformationScenarioTest : FunSpec({
         val projected = projector.project(driver.state)
         projected.hasSubtype(bearId, "Goblin") shouldBe true
         projected.hasSubtype(bearId, "Bear") shouldBe true
+    }
+
+    // ---- Cross-zone clause: "creature spells you control and creature cards you own that
+    //      aren't on the battlefield are the chosen type." ----
+
+    test("a creature card you own in your graveyard is the chosen type") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val leyline = driver.putPermanentOnBattlefield(activePlayer, "Leyline of Transformation")
+        driver.replaceState(driver.state.updateEntity(leyline) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        val gyBear = driver.putCardInGraveyard(activePlayer, "Test Bear")
+        val state = driver.state
+        val projected = projector.project(state)
+
+        // The graveyard Bear counts as a Goblin for type-matters checks (e.g. "Zombie card in graveyard").
+        projected.crossZoneGrantedSubtypes(state, gyBear) shouldBe setOf("Goblin")
+        predicateEvaluator.matchesCardPredicate(
+            state, projected, gyBear, CardPredicate.HasSubtype(Subtype("Goblin"))
+        ) shouldBe true
+        // Still a Bear too.
+        predicateEvaluator.matchesCardPredicate(
+            state, projected, gyBear, CardPredicate.HasSubtype(Subtype("Bear"))
+        ) shouldBe true
+    }
+
+    test("a creature card in an OPPONENT's graveyard is not the chosen type (you own)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val leyline = driver.putPermanentOnBattlefield(activePlayer, "Leyline of Transformation")
+        driver.replaceState(driver.state.updateEntity(leyline) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        val theirGyBear = driver.putCardInGraveyard(opponent, "Test Bear")
+        val state = driver.state
+        val projected = projector.project(state)
+
+        projected.crossZoneGrantedSubtypes(state, theirGyBear) shouldBe emptySet()
+        predicateEvaluator.matchesCardPredicate(
+            state, projected, theirGyBear, CardPredicate.HasSubtype(Subtype("Goblin"))
+        ) shouldBe false
+    }
+
+    test("a creature spell you control on the stack is the chosen type") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val leyline = driver.putPermanentOnBattlefield(activePlayer, "Leyline of Transformation")
+        driver.replaceState(driver.state.updateEntity(leyline) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        // Cast a Bear creature spell — it sits on the stack.
+        val spell = driver.putCardInHand(activePlayer, "Test Bear")
+        driver.giveMana(activePlayer, Color.GREEN, 2)
+        driver.castSpell(activePlayer, spell)
+
+        val state = driver.state
+        val spellId = state.stack.last()
+        val projected = projector.project(state)
+
+        projected.crossZoneGrantedSubtypes(state, spellId) shouldBe setOf("Goblin")
+        predicateEvaluator.matchesCardPredicate(
+            state, projected, spellId, CardPredicate.HasSubtype(Subtype("Goblin"))
+        ) shouldBe true
+    }
+
+    test("a non-creature card you own outside the battlefield is NOT granted the type") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val leyline = driver.putPermanentOnBattlefield(activePlayer, "Leyline of Transformation")
+        driver.replaceState(driver.state.updateEntity(leyline) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        // A land card in the graveyard is not a creature card, so the grant must not touch it.
+        val gyLand = driver.putCardInGraveyard(activePlayer, "Forest")
+        val state = driver.state
+        val projected = projector.project(state)
+
+        projected.crossZoneGrantedSubtypes(state, gyLand) shouldBe emptySet()
+        predicateEvaluator.matchesCardPredicate(
+            state, projected, gyLand, CardPredicate.HasSubtype(Subtype("Goblin"))
+        ) shouldBe false
+    }
+
+    test("no Leyline on the battlefield means no cross-zone grant (overlay is empty)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Mountain" to 20), skipMulligans = true)
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gyBear = driver.putCardInGraveyard(activePlayer, "Test Bear")
+        val state = driver.state
+        val projected = projector.project(state)
+
+        projected.crossZoneSubtypeGrants shouldBe emptyList()
+        projected.crossZoneGrantedSubtypes(state, gyBear) shouldBe emptySet()
     }
 })


### PR DESCRIPTION
## Summary

Implements **Leyline of Transformation** (DSK #63, `{2}{U}{U}` Enchantment) — the Conspiracy / Xenograft mechanic on a Leyline. DSK: 273 → 274 / 276 implemented.

The **full** card is modeled: "As this enchantment enters, choose a creature type. Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield."

## Engine feature: `GrantChosenSubtype` (battlefield + cross-zone)

New SDK static ability — the chosen-value counterpart to `GrantSubtype`, mirroring `GrantChosenColor`/`GrantColor`. The card composes `leyline()` + `EntersWithChoice(ChoiceType.CREATURE_TYPE)` + `GrantChosenSubtype(...)`.

**Battlefield half** (Layer 4 type-changing projection):
- `GrantChosenSubtype(filter)` static ability (`TypeStaticAbilities.kt`).
- `Modification.AddChosenSubtype` reads the source's chosen type from `CastChoicesComponent`; wired through `EffectApplicator` + `StaticAbilityHandler`.

**Cross-zone half** (resolves what was first shipped as a documented limitation): Layer 4 projection only touches the battlefield, so the stack/hand/graveyard/library/exile are reached by a dedicated overlay instead:
- Two opt-in flags on `GrantChosenSubtype` — `includeControlledSpells` (creature spells you control on the stack) and `includeOwnedCardsOutsideBattlefield` (creature cards you own elsewhere) — ride onto `Modification.AddChosenSubtype`.
- `StateProjector` collects active cross-zone grants (granting player's *projected* controller + chosen type) into `ProjectedState.crossZoneSubtypeGrants`.
- `ProjectedState.crossZoneGrantedSubtypes(state, entityId)` answers "which chosen types reach this non-battlefield object." **Empty grant list ⇒ immediate no-op**, so there is zero behavior change and negligible cost for every other card/state.
- Every non-battlefield subtype read-site consults it: the subtype predicates in `PredicateEvaluator` (`HasSubtype`, `NotSubtype`, `HasAnyOfSubtypes`, `HasChosenSubtype`, `SharesCreatureType*`, `NotOfSourceChosenType`) and `SelectFromCollectionExecutor`'s chosen-type filter.

Net effect: a Leyline-granted type drives type-matters checks **everywhere** — "target Zombie spell", "return target Zombie card from your graveyard", creature-type search filters, etc. Xenograft-style battlefield-only effects leave both flags `false`.

Docs: `card-sdk-language-reference.md` §9 + `CardLinter` slot classification updated.

## Tests

`LeylineOfTransformationScenarioTest` (9 scenarios):
- Battlefield: creatures you control gain the chosen type in addition to printed types; opponents' creatures unaffected; already-of-type unchanged; choice made as it enters (`EntersWithChoice`).
- Cross-zone: a creature card you own in your graveyard is the chosen type; an opponent's graveyard creature card is not (you-own clause); a creature spell you control on the stack is the chosen type; a non-creature card is not granted the type; empty overlay when no Leyline is out.

Re-blessed `DSK.json` snapshot (only the two new flags added to this card). `CardLintTest`, `CardDefinitionSnapshotTest`, and the full `just test` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)