### PR TITLE
Redesign saved-deck gallery as full-art tiles

### DIFF
--- a/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
@@ -434,137 +434,181 @@
   overflow-y: auto;
   padding: var(--space-4);
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: var(--space-3);
   align-content: start;
 }
 
+/* Full-art deck tile: the deck's hero-card art fills the whole card, with a bottom
+ * scrim carrying the name, format, colours and count — like a game's deck gallery. */
 .deckCard {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  text-align: left;
-  background: rgba(255, 255, 255, 0.03);
+  aspect-ratio: 4 / 3;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-md);
-  padding: 0;
-  cursor: pointer;
-  color: inherit;
-  font: inherit;
   overflow: hidden;
-  transition: transform 0.1s ease, border-color 0.1s ease, background 0.1s ease;
+  background: #14141c;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
 }
 
 .deckCard:hover {
   border-color: var(--accent-primary, #6aa3ff);
-  background: rgba(106, 163, 255, 0.06);
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5);
 }
 
 .deckCardActive {
   border-color: var(--accent-primary, #6aa3ff);
-  background: rgba(106, 163, 255, 0.1);
-  box-shadow: 0 0 0 1px rgba(106, 163, 255, 0.4) inset;
+  box-shadow: 0 0 0 1px rgba(106, 163, 255, 0.55) inset, 0 6px 18px rgba(0, 0, 0, 0.45);
 }
 
-.deckCardBanner {
-  position: relative;
-  height: 64px;
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  padding: 6px 8px;
-}
-
-.deckCardBanner::after {
-  /* Subtle vignette so the banner reads against any colour combo. */
-  content: '';
+/* The clickable surface — fills the tile and carries the art + overlay. A plain button
+ * reset so the whole card reads as one big "load this deck" target. */
+.deckCardLoad {
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 0.35));
-  pointer-events: none;
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
 }
 
-.deckCardColors {
-  display: inline-flex;
-  gap: 3px;
-  z-index: 1;
-}
-
-.deckCardColorDot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  border: 1px solid rgba(0, 0, 0, 0.55);
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
-}
-
-.deckCardColorless {
-  font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.85);
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  z-index: 1;
-}
-
-.deckCardCount {
-  z-index: 1;
-  background: rgba(0, 0, 0, 0.55);
-  color: #fff;
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 0.7rem;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-}
-
-.deckCardPinBadge {
+.deckCardArt {
   position: absolute;
-  top: 6px;
-  left: 6px;
-  z-index: 1;
-  background: rgba(108, 210, 255, 0.18);
-  color: #6cd2ff;
-  border: 1px solid rgba(108, 210, 255, 0.45);
-  border-radius: 999px;
-  padding: 1px 7px;
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  inset: 0;
+  background-size: cover;
+  background-position: center 28%;
+  background-repeat: no-repeat;
+  transition: transform 0.3s ease;
 }
 
-.deckCardBody {
+.deckCard:hover .deckCardArt {
+  transform: scale(1.05);
+}
+
+.deckCardScrim {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    to top,
+    rgba(8, 8, 12, 0.94) 0%,
+    rgba(8, 8, 12, 0.82) 24%,
+    rgba(8, 8, 12, 0.34) 52%,
+    rgba(8, 8, 12, 0.04) 78%
+  );
+}
+
+.deckCardInfo {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 8px 10px 10px;
-  min-width: 0;
+  gap: 6px;
+  padding: 10px 12px 11px;
 }
 
 .deckCardName {
-  font-weight: 600;
-  font-size: 0.9rem;
-  color: var(--text-primary);
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.15;
+  letter-spacing: 0.01em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9), 0 0 16px rgba(0, 0, 0, 0.5);
 }
 
-.deckCardMeta {
+.deckCardMetaRow {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.deckCardFormat {
+  flex: 0 0 auto;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 7px;
+  border-radius: 4px;
+  border: 1px solid currentColor;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.deckCardPips {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.8));
+}
+
+.deckCardCount {
+  margin-left: auto;
+  flex: 0 0 auto;
   font-size: 0.72rem;
-  color: var(--text-muted);
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.85);
   font-variant-numeric: tabular-nums;
+}
+
+/* Storage badge — top-left. Cloud = synced to the account; monitor = browser-only. */
+.deckCardStorage {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 3px 8px 3px 6px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(3px);
+  pointer-events: auto;
+}
+
+.deckCardStorage svg {
+  display: block;
+}
+
+.deckCardStorageOnline {
+  color: #74e2a4;
+  background: rgba(16, 54, 38, 0.6);
+  border-color: rgba(116, 226, 164, 0.42);
+}
+
+.deckCardStorageLocal {
+  color: #cfd5e1;
 }
 
 .deckCardActions {
   position: absolute;
-  top: 4px;
-  right: 4px;
+  top: 6px;
+  right: 6px;
+  z-index: 4;
   display: flex;
   gap: 2px;
   opacity: 0;
-  transition: opacity 0.1s ease;
+  transition: opacity 0.12s ease;
 }
 
 .deckCard:hover .deckCardActions,
@@ -574,18 +618,18 @@
 
 .deckCardActions .savedIconButton,
 .deckCardActions .savedIconButtonDanger {
-  background: rgba(0, 0, 0, 0.55);
+  background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(2px);
+  color: #fff;
 }
 
-/* Sits at the top-left of the banner so it doesn't collide with the format
- * pills in the body. The banner gradient varies, so we layer a dark backdrop
- * + blur to keep contrast readable across all colour identities. */
+/* Active "Editing" ribbon — top-right, fades out on hover so the action buttons
+ * (same corner) take over cleanly. */
 .deckCardActiveBadge {
   position: absolute;
-  top: 6px;
-  left: 6px;
-  z-index: 2;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -600,6 +644,11 @@
   font-weight: 700;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
   backdrop-filter: blur(4px);
+  transition: opacity 0.12s ease;
+}
+
+.deckCard:hover .deckCardActiveBadge {
+  opacity: 0;
 }
 
 .deckCardActiveBadge::before {

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -25,7 +25,8 @@ import { ManaCost, ManaSymbol } from '@/components/ui/ManaSymbols'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
 import { useDfcHoverFlip } from '@/components/ui/useDfcHoverFlip'
 import { SetIcon } from '@/components/ui/SetIcon'
-import { getCardImageUrl } from '@/utils/cardImages'
+import { getCardImageUrl, getScryfallArtCropUrl } from '@/utils/cardImages'
+import { rarityColor } from '@/components/draft/RarityBadge'
 import {
   parseQuery,
   toggleToken,
@@ -2279,12 +2280,13 @@ function SavedDecksBrowser({
     return out
   }, [decks])
   const legalityMap = useDeckLegalFormats(legalityInput)
-  const heroArtMap = useDeckHeroArt(decks)
 
   // Pre-compute per-deck metadata once. Doing this up front keeps sort/filter
   // O(n) for hundreds of decks even when the user types fast. Card totals and
   // colour pips include the commander so the user-visible numbers match what
-  // they'd actually play with.
+  // they'd actually play with. `heroCard` is the deck's rarest non-land card —
+  // its Scryfall art crop becomes the tile background so a deck is recognisable
+  // by its splashiest spell at a glance.
   const enriched = useMemo(
     () =>
       decks.map((d) => {
@@ -2292,7 +2294,8 @@ function SavedDecksBrowser({
         const total = Object.values(fullCards).reduce((a, b) => a + b, 0)
         const colors = deckColors(fullCards, catalog)
         const legalFormats = legalityMap[d.id] ?? []
-        return { deck: d, total, colors, legalFormats }
+        const hero = rarestCard(fullCards, catalog, d.commander ?? null)
+        return { deck: d, total, colors, legalFormats, hero }
       }),
     [decks, catalog, legalityMap]
   )
@@ -2422,7 +2425,7 @@ function SavedDecksBrowser({
                 : 'No decks match the current filters.'}
             </div>
           ) : (
-            filtered.map(({ deck, total, colors, legalFormats }) => (
+            filtered.map(({ deck, total, colors, legalFormats, hero }) => (
               <DeckCard
                 key={deck.id}
                 deck={deck}
@@ -2430,7 +2433,7 @@ function SavedDecksBrowser({
                 colors={colors}
                 legalFormats={legalFormats}
                 isActive={deck.id === activeDeckId}
-                heroArt={heroArtMap[deck.id]}
+                hero={hero}
                 onLoad={onLoad}
                 onRename={onRename}
                 onDelete={onDelete}
@@ -2443,62 +2446,101 @@ function SavedDecksBrowser({
   )
 }
 
+// Rarity ranking for choosing a deck's "hero" card — the splashiest spell whose art
+// represents the deck in the gallery. Higher wins.
+const RARITY_RANK: Record<string, number> = { MYTHIC: 3, RARE: 2, UNCOMMON: 1, COMMON: 0 }
+
 /**
- * Bulk-fetch chosen-printing art for every saved deck that has pinned entries.
- *
- * One round-trip across the whole browser using `/api/printings?names=…` rather than
- * one request per deck — the saved-deck overlay can render dozens of cards at once.
- * For each deck we surface a single representative thumbnail (the first pinned entry
- * in the deck's stored order) so the user can recognise their deck at a glance by
- * the printing they actually chose, not the catalog default.
- *
- * Returns a map keyed by `deck.id`. Decks with no pins (or whose pinned printing
- * isn't in the registry) are simply absent — DeckCard falls back to its gradient banner.
+ * The deck's rarest non-land card, used as the gallery tile's hero art. Lands (even rare
+ * duals) and basics are skipped — they make for dull, repetitive tiles across a collection.
+ * Ties break toward the commander (the deck's identity), then the highest mana value (the
+ * marquee bomb), then name for stable ordering. Returns null only for an empty / all-land /
+ * uncatalogued deck, in which case the tile falls back to a colour-identity gradient.
  */
-function useDeckHeroArt(decks: SavedDeck[]): Record<string, string> {
-  const [art, setArt] = useState<Record<string, string>>({})
-  // Per-deck "(name, printing)" representative — first pinned entry in the deck's order.
-  // Recomputed when the decks change so renames / loads stay in sync. Memoised separately
-  // from the fetch so we don't re-fire when the parent re-renders for unrelated reasons.
-  const reps = useMemo(() => {
-    const out: Array<{ deckId: string; name: string; ref: PrintingRef }> = []
-    for (const d of decks) {
-      const pinned = d.entries?.find((e) => e.printing) ?? null
-      if (pinned?.printing) out.push({ deckId: d.id, name: pinned.name, ref: pinned.printing })
+function rarestCard(
+  cards: Record<string, number>,
+  catalog: Record<string, CardSummary>,
+  commander: string | null,
+): CardSummary | null {
+  let best: CardSummary | null = null
+  let bestRank = -1
+  let bestIsCommander = false
+  for (const [rawName, n] of Object.entries(cards)) {
+    if (n <= 0) continue
+    const name = rawName.split('#')[0] ?? rawName
+    const c = catalog[name]
+    if (!c || c.basicLand) continue
+    if (c.cardTypes.some((t) => t.toUpperCase() === 'LAND')) continue
+    const rank = RARITY_RANK[(c.rarity ?? 'COMMON').toUpperCase()] ?? 0
+    const isCommander = commander != null && name === commander
+    if (best === null || rank > bestRank) {
+      best = c
+      bestRank = rank
+      bestIsCommander = isCommander
+      continue
     }
-    return out
-  }, [decks])
+    if (rank === bestRank && !bestIsCommander) {
+      if (isCommander || c.cmc > best.cmc || (c.cmc === best.cmc && c.name < best.name)) {
+        best = c
+        bestIsCommander = isCommander
+      }
+    }
+  }
+  return best
+}
 
-  useEffect(() => {
-    if (reps.length === 0) {
-      setArt({})
-      return
-    }
-    let cancelled = false
-    const params = new URLSearchParams()
-    new Set(reps.map((r) => r.name)).forEach((n) => params.append('names', n))
-    fetch(`/api/printings?${params.toString()}`)
-      .then((r) => (r.ok ? r.json() : {}))
-      .then((data: Record<string, PrintingDTO[]>) => {
-        if (cancelled) return
-        const next: Record<string, string> = {}
-        for (const { deckId, name, ref } of reps) {
-          const match = data[name]?.find(
-            (p) => p.setCode === ref.setCode && p.collectorNumber === ref.collectorNumber,
-          )
-          if (match?.imageUri) next[deckId] = match.imageUri
-        }
-        setArt(next)
-      })
-      .catch(() => {
-        if (!cancelled) setArt({})
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [reps])
+// Deck-name tint by hero rarity — reuses the draft rarity palette so colours read
+// consistently across the app, but lifts COMMON off near-black so names stay legible
+// over the dark art scrim.
+function deckNameColor(rarity: string | undefined): string {
+  if (!rarity || rarity.toUpperCase() === 'COMMON') return '#eef1f6'
+  return rarityColor(rarity)
+}
 
-  return art
+// Per-format accent for the single saved-format chip. Keyed by upper-case format name;
+// anything unmapped falls back to a neutral slate so new formats still render cleanly.
+const FORMAT_ACCENT: Record<string, string> = {
+  STANDARD: '#6aa3ff',
+  PIONEER: '#c47dff',
+  MODERN: '#8a7bff',
+  LEGACY: '#7bd0ff',
+  VINTAGE: '#ff9d57',
+  PAUPER: '#9aa6b8',
+  COMMANDER: '#e0b15a',
+  BRAWL: '#e0b15a',
+  STANDARD_BRAWL: '#e0b15a',
+  HISTORIC: '#ff8aa8',
+  CUSTOM_DECKS: '#7be0a8',
+}
+function formatAccent(format: string): string {
+  return FORMAT_ACCENT[format.toUpperCase()] ?? '#9aa6b8'
+}
+
+function CloudIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4 7.5 7.5 0 0 0 5.35 8.04 5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z" />
+    </svg>
+  )
+}
+
+function MonitorIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <path d="M8 21h8M12 17v4" />
+    </svg>
+  )
 }
 
 function DeckCard({
@@ -2507,7 +2549,7 @@ function DeckCard({
   colors,
   legalFormats,
   isActive,
-  heroArt,
+  hero,
   onLoad,
   onRename,
   onDelete,
@@ -2517,96 +2559,88 @@ function DeckCard({
   colors: string[]
   legalFormats: string[]
   isActive: boolean
-  heroArt: string | undefined
+  hero: CardSummary | null
   onLoad: (d: UnifiedDeck) => void
   onRename: (d: UnifiedDeck) => void
   onDelete: (d: UnifiedDeck) => void
 }) {
-  const updated = useMemo(() => formatRelativeTime(deck.updatedAt), [deck.updatedAt])
-  // Banner gradient derived from the deck's colour identity. Falls back to a
-  // neutral gradient for colourless / empty decks.
-  const banner = useMemo(() => deckBannerGradient(colors), [colors])
-  // When the deck has at least one pinned printing, layer that printing's art
-  // *under* the colour-identity gradient so the deck is recognisable by what the user
-  // actually picked. The gradient stays — without it, art at this size is hard to read
-  // and the colour cue is the primary way users scan the browser.
-  const bannerStyle = heroArt
-    ? { background: `${banner}, url(${heroArt}) center/cover` }
-    : { background: banner }
-  const pinCount = useMemo(
-    () => (deck.entries ?? []).filter((e) => e.printing).length,
-    [deck.entries],
-  )
+  // Hero art = the deck's rarest card as a wide Scryfall art crop. Falls back to a
+  // colour-identity gradient when the deck has no catalogued non-land card yet.
+  const artUrl = useMemo(() => (hero ? getScryfallArtCropUrl(hero.name) : null), [hero])
+  const gradient = useMemo(() => deckBannerGradient(colors), [colors])
+  const nameColor = deckNameColor(hero?.rarity)
+  // One chip only: the format the deck was saved as, else the first format it's legal in.
+  const shownFormat = deck.format ?? legalFormats[0] ?? null
 
   return (
-    <button
-      type="button"
-      className={`${styles.deckCard} ${isActive ? styles.deckCardActive : ''}`}
-      onClick={() => onLoad(deck)}
-      title={`Load ${deck.name}`}
-    >
-      <div className={styles.deckCardBanner} style={bannerStyle}>
-        {pinCount > 0 && (
-          <span
-            className={styles.deckCardPinBadge}
-            title={`${pinCount} pinned printing${pinCount === 1 ? '' : 's'}`}
-          >
-            ◧ {pinCount}
+    <div className={`${styles.deckCard} ${isActive ? styles.deckCardActive : ''}`}>
+      <button
+        type="button"
+        className={styles.deckCardLoad}
+        onClick={() => onLoad(deck)}
+        title={`Load ${deck.name}`}
+      >
+        <span
+          className={styles.deckCardArt}
+          // The URL is quoted inside url() because card names can contain apostrophes
+          // ("Barrin's Spite"), which encodeURIComponent leaves literal — an unquoted
+          // url() with a bare ' is invalid CSS and the browser silently drops the art.
+          style={artUrl ? { backgroundImage: `url("${artUrl}")` } : { background: gradient }}
+          aria-hidden="true"
+        />
+        <span className={styles.deckCardScrim} aria-hidden="true" />
+        <span className={styles.deckCardInfo}>
+          <span className={styles.deckCardName} style={{ color: nameColor }}>
+            {deck.name}
           </span>
-        )}
-        {colors.length > 0 ? (
-          <div className={styles.deckCardColors}>
-            {colors.map((c) => (
+          <span className={styles.deckCardMetaRow}>
+            {shownFormat && (
               <span
-                key={c}
-                className={styles.deckCardColorDot}
-                style={{ background: COLOR_DOT[c] ?? '#888' }}
-                title={c}
-              />
-            ))}
-          </div>
-        ) : (
-          <span className={styles.deckCardColorless}>colourless</span>
-        )}
-        <span className={styles.deckCardCount}>{total}</span>
-      </div>
-      <div className={styles.deckCardBody}>
-        <div className={styles.deckCardName}>{deck.name}</div>
-        <div className={styles.deckCardMeta}>
-          <span>{updated}</span>
-          <span aria-hidden="true">·</span>
-          <span
-            style={{ color: deck.online ? '#9be8bd' : '#9a9aa8', fontWeight: 600 }}
-            title={deck.online ? 'Backed up to your account' : 'Saved only in this browser'}
-          >
-            {deck.online ? '● Online' : '○ Browser'}
-          </span>
-        </div>
-        {(deck.format || legalFormats.length > 0) && (
-          <span className={styles.formatBadges}>
-            {deck.format && (
-              <span
-                className={styles.formatBadgeSaved}
-                title={`Saved as ${labelForFormat(deck.format)}`}
+                className={styles.deckCardFormat}
+                style={{
+                  color: formatAccent(shownFormat),
+                  borderColor: `${formatAccent(shownFormat)}66`,
+                }}
+                title={
+                  deck.format
+                    ? `Saved as ${labelForFormat(shownFormat)}`
+                    : `Legal in ${labelForFormat(shownFormat)}`
+                }
               >
-                {labelForFormat(deck.format)}
+                {labelForFormat(shownFormat)}
               </span>
             )}
-            {legalFormats
-              .filter((f) => f !== deck.format)
-              .map((f) => (
-                <span
-                  key={f}
-                  className={styles.formatBadge}
-                  title={`Legal in ${labelForFormat(f)}`}
-                >
-                  {labelForFormat(f)}
-                </span>
-              ))}
+            <span className={styles.deckCardPips}>
+              {colors.length > 0 ? (
+                colors.map((c) => {
+                  const tok = COLOR_TOKENS.find((t) => t.key === c)
+                  return <ManaSymbol key={c} symbol={tok ? tok.label : 'C'} size={15} />
+                })
+              ) : (
+                <ManaSymbol symbol="C" size={15} />
+              )}
+            </span>
+            <span className={styles.deckCardCount}>{total} cards</span>
           </span>
-        )}
-      </div>
-      <div className={styles.deckCardActions} onClick={(e) => e.stopPropagation()}>
+        </span>
+      </button>
+
+      {/* Storage status — cloud (synced to your account) vs. local (this browser only). */}
+      <span
+        className={`${styles.deckCardStorage} ${
+          deck.online ? styles.deckCardStorageOnline : styles.deckCardStorageLocal
+        }`}
+        title={
+          deck.online
+            ? 'Saved to your account — synced to the cloud and available on any device'
+            : 'Saved only in this browser — not backed up to your account'
+        }
+      >
+        {deck.online ? <CloudIcon /> : <MonitorIcon />}
+        {deck.online ? 'Cloud' : 'Local'}
+      </span>
+
+      <div className={styles.deckCardActions}>
         <button
           className={styles.savedIconButton}
           onClick={() => onRename(deck)}
@@ -2626,8 +2660,9 @@ function DeckCard({
           ✕
         </button>
       </div>
+
       {isActive && <span className={styles.deckCardActiveBadge}>Editing</span>}
-    </button>
+    </div>
   )
 }
 
@@ -2673,25 +2708,6 @@ function deckColors(
   return Object.entries(counts)
     .sort((a, b) => b[1] - a[1])
     .map(([color]) => color)
-}
-
-function formatRelativeTime(ts: number): string {
-  const now = Date.now()
-  const diff = Math.max(0, now - ts)
-  const sec = Math.floor(diff / 1000)
-  if (sec < 60) return 'just now'
-  const min = Math.floor(sec / 60)
-  if (min < 60) return `${min}m ago`
-  const hr = Math.floor(min / 60)
-  if (hr < 24) return `${hr}h ago`
-  const day = Math.floor(hr / 24)
-  if (day < 7) return `${day}d ago`
-  const wk = Math.floor(day / 7)
-  if (wk < 5) return `${wk}w ago`
-  const mo = Math.floor(day / 30)
-  if (mo < 12) return `${mo}mo ago`
-  const yr = Math.floor(day / 365)
-  return `${yr}y ago`
 }
 
 function SearchBar({

--- a/web-client/src/utils/cardImages.ts
+++ b/web-client/src/utils/cardImages.ts
@@ -55,3 +55,17 @@ export function getScryfallFallbackUrl(
   const scryfallName = cardName.endsWith(' Token') ? cardName.slice(0, -6) : cardName
   return `https://api.scryfall.com/cards/named?exact=${encodeURIComponent(scryfallName)}&format=image&version=${version}`
 }
+
+/**
+ * Get the landscape *art crop* for a card by name (Scryfall `version=art_crop`).
+ *
+ * Unlike the full-card images above, this returns just the illustration with no frame,
+ * which is the right shape for a wide banner/tile background. Used by the saved-deck
+ * gallery to paint each deck's hero art from its rarest card.
+ *
+ * @param cardName The card's name (the default printing's art is used)
+ */
+export function getScryfallArtCropUrl(cardName: string): string {
+  const scryfallName = cardName.endsWith(' Token') ? cardName.slice(0, -6) : cardName
+  return `https://api.scryfall.com/cards/named?exact=${encodeURIComponent(scryfallName)}&format=image&version=art_crop`
+}


### PR DESCRIPTION
## What

Restyles the saved-decks browser into a full-art gallery, closer to a polished deck-manager UI, and makes the cloud/account storage status unmistakable.

### Tile redesign
- Each tile is now a full-bleed **art tile**: the background is the art crop of the deck's **rarest non-land card** (basics and lands skipped; ties break toward the commander, then highest mana value). A bottom scrim carries the deck name, a format chip, colour pips, and the card count.
- The deck **name is tinted by the hero card's rarity** (reuses the draft rarity palette; COMMON is lifted off near-black so it stays legible over the scrim).
- A single, **colour-accented format chip** per deck (saved format, else the first legal format) instead of the old stack of legality pills.
- Rename/delete actions reveal on hover; the "Editing" badge fades out under them.

### Clearer cloud vs. local status
The old `● Online` / `○ Browser` text didn't make it obvious that "Online" means *saved to your account*. It's replaced by an **icon badge**:
- ☁ **Cloud** — tooltip: *Saved to your account — synced to the cloud and available on any device*
- 🖥 **Local** — tooltip: *Saved only in this browser — not backed up to your account*

### Bug fix
Using card art inside CSS `url()` exposed a latent issue: `encodeURIComponent` leaves apostrophes literal, so a card like **"Barrin's Spite"** produced an invalid *unquoted* `url(...Barrin's...)` and the browser silently dropped the background (blank tile). The URL is now quoted inside `url()`. Many MTG card names have apostrophes, so this would have hit real decks.

### Notes
- The rarest-card art is derived from the already-loaded catalog, so this **removes** the previous per-deck pinned-printing art fetch (`/api/printings`) — one fewer round trip when opening the browser.
- No engine/SDK changes; web-client only. `npm run typecheck` and `npm run build` pass.

## Before / After

**Before**
![before](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-tile-redesign-screenshots/deck-gallery-before.png)

**After**
![after](https://raw.githubusercontent.com/wingedsheep/argentum-engine/deck-tile-redesign-screenshots/deck-gallery-after.png)

_(Screenshots driven via Playwright against the running stack with seeded sample decks — both a mocked Cloud account deck and local decks — to show both storage badges. The screenshot branch is throwaway.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)