### PR TITLE
Add four Final Fantasy cards (Opera Love Song, Magitek Scythe, The Regalia, Relentless X-ATM092)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagitekScythe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MagitekScythe.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Magitek Scythe
+ * {4}
+ * Artifact — Equipment
+ * A Test of Your Reflexes! — When this Equipment enters, you may attach it to target creature you
+ *   control. If you do, that creature gains first strike until end of turn and must be blocked this
+ *   turn if able.
+ * Equipped creature gets +2/+1.
+ * Equip {2}
+ *
+ * The ETB is "you may attach … if you do, …": the target creature you control is chosen when the
+ * trigger goes on the stack (CR 603.3d), then on resolution the controller may decline. Accepting
+ * runs the whole [MayEffect] body — attach, grant first strike until end of turn, and force the
+ * creature to be blocked this turn. "Must be blocked … if able" is the at-least-one-blocker form
+ * ([MustBeBlockedEffect] with `allCreatures = false`), not the Lure-style every-blocker form.
+ */
+val MagitekScythe = card("Magitek Scythe") {
+    manaCost = "{4}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "A Test of Your Reflexes! — When this Equipment enters, you may attach it to target " +
+        "creature you control. If you do, that creature gains first strike until end of turn and " +
+        "must be blocked this turn if able.\n" +
+        "Equipped creature gets +2/+1.\n" +
+        "Equip {2}"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        effect = MayEffect(
+            Effects.Composite(
+                Effects.AttachEquipment(t),
+                Effects.GrantKeyword(Keyword.FIRST_STRIKE, t),
+                MustBeBlockedEffect(t, allCreatures = false)
+            )
+        )
+    }
+
+    staticAbility {
+        ability = ModifyStats(2, 1)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "562"
+        artist = "Thanh Tuấn"
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b691d42-3498-4d47-9a46-f7c376df8886.jpg?1748707605"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/OperaLoveSong.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/OperaLoveSong.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Opera Love Song
+ * {1}{R}
+ * Instant
+ * Choose one —
+ * • Exile the top two cards of your library. You may play those cards until your next end step.
+ * • One or two target creatures each get +2/+0 until end of turn.
+ *
+ * Mode 1 is impulse draw: [Patterns.Exile.impulse] gathers the top two cards into exile and grants a
+ * play permission. The window is "until your next end step" — [MayPlayExpiry.UntilNextEndStep], which
+ * (unlike the default end-of-turn expiry) keeps the cards playable through the end step of *this* turn
+ * when cast on your own turn and otherwise lasts into your next turn.
+ *
+ * Mode 2 is "one or two target" — a single requirement with min 1 / max 2 targets locked at cast
+ * (`TargetObject(count = 2, minCount = 1)`), then [ForEachTargetEffect] applies +2/+0 until end of
+ * turn to each chosen creature.
+ */
+val OperaLoveSong = card("Opera Love Song") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Choose one —\n" +
+        "• Exile the top two cards of your library. You may play those cards until your next end step.\n" +
+        "• One or two target creatures each get +2/+0 until end of turn."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Exile the top two cards of your library. You may play those cards until your next end step.") {
+                effect = Patterns.Exile.impulse(count = 2, expiry = MayPlayExpiry.UntilNextEndStep)
+            }
+            mode("One or two target creatures each get +2/+0 until end of turn.") {
+                target = TargetObject(
+                    count = 2,
+                    minCount = 1,
+                    filter = TargetFilter(GameObjectFilter.Creature)
+                )
+                effect = ForEachTargetEffect(
+                    effects = listOf(Effects.ModifyStats(2, 0, EffectTarget.ContextTarget(0)))
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "147"
+        artist = "Grace Zhu"
+        flavorText = "\"O my hero, my beloved, shall we still be made to part?\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/3/0343916d-1b65-4e95-aef1-e72dbcebf0c4.jpg?1748706312"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RelentlessXatm092.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RelentlessXatm092.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByFewerThan
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Relentless X-ATM092
+ * {6}
+ * Artifact Creature — Robot Spider
+ * 6/5
+ * This creature can't be blocked except by three or more creatures.
+ * {8}: Return this card from your graveyard to the battlefield tapped with a finality counter on it.
+ *   (If a creature with a finality counter on it would die, exile it instead.)
+ *
+ * The evasion is the generalized-menace static [CantBeBlockedByFewerThan] (minBlockers = 3, like Troll
+ * of Khazad-dûm). The recursion is a graveyard-activated ability (`activateFromZone = GRAVEYARD`) that
+ * puts the card straight onto the battlefield tapped and stamps a finality counter; the
+ * [Counters.FINALITY] counter's exile-instead-of-die replacement is handled by the engine, so no
+ * extra wiring is needed for the reminder text.
+ */
+val RelentlessXatm092 = card("Relentless X-ATM092") {
+    manaCost = "{6}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Robot Spider"
+    oracleText = "This creature can't be blocked except by three or more creatures.\n" +
+        "{8}: Return this card from your graveyard to the battlefield tapped with a finality counter " +
+        "on it. (If a creature with a finality counter on it would die, exile it instead.)"
+    power = 6
+    toughness = 5
+
+    staticAbility {
+        ability = CantBeBlockedByFewerThan(3)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{8}")
+        effect = Effects.Composite(
+            Effects.PutOntoBattlefield(EffectTarget.Self, tapped = true),
+            Effects.AddCounters(Counters.FINALITY, 1, EffectTarget.Self)
+        )
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "268"
+        artist = "Kevin Glint"
+        flavorText = "\"Let's get the hell out of here!\"\n—Zell Dincht"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e09ee4c9-85ef-4d1e-864b-d659b8e8f51d.jpg?1748706789"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheRegalia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheRegalia.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherUntilMatchEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+
+/**
+ * The Regalia
+ * {4}
+ * Legendary Artifact — Vehicle
+ * 4/4
+ * Haste
+ * Whenever The Regalia attacks, reveal cards from the top of your library until you reveal a land
+ *   card. Put that card onto the battlefield tapped and the rest on the bottom of your library in a
+ *   random order.
+ * Crew 1
+ *
+ * The attack trigger is a reveal-until-land pipeline: [GatherUntilMatchEffect] reveals from the top
+ * until the first land (stops at one match), publishing everything seen into `allRevealed`.
+ * [FilterCollectionEffect] then splits that into the land (`landCard`) and the cards revealed before
+ * it (`rest`); the land is put onto the battlefield tapped and the rest go to the bottom of the
+ * library in a random order. If the library has no land, no match is found — `landCard` is empty (no
+ * permanent enters) and every revealed card goes to the bottom, matching the printed fallback.
+ */
+val TheRegalia = card("The Regalia") {
+    manaCost = "{4}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Vehicle"
+    oracleText = "Haste\n" +
+        "Whenever The Regalia attacks, reveal cards from the top of your library until you reveal a " +
+        "land card. Put that card onto the battlefield tapped and the rest on the bottom of your " +
+        "library in a random order.\n" +
+        "Crew 1"
+    power = 4
+    toughness = 4
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            GatherUntilMatchEffect(
+                filter = GameObjectFilter.Land,
+                storeMatch = "matchLand",
+                storeRevealed = "allRevealed"
+            ),
+            RevealCollectionEffect(from = "allRevealed"),
+            FilterCollectionEffect(
+                from = "allRevealed",
+                filter = CollectionFilter.MatchesFilter(GameObjectFilter.Land),
+                storeMatching = "landCard",
+                storeNonMatching = "rest"
+            ),
+            MoveCollectionEffect(
+                from = "landCard",
+                destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped)
+            ),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                order = CardOrder.Random
+            )
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "267"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc420e79-c483-474f-97cd-e9c6a636c306.jpg?1748706782"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -7742,6 +7742,108 @@
     ]
 }
 
+// Magitek Scythe
+{
+    "name": "Magitek Scythe",
+    "manaCost": "{4}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "A Test of Your Reflexes! — When this Equipment enters, you may attach it to target creature you control. If you do, that creature gains first strike until end of turn and must be blocked this turn if able.\nEquipped creature gets +2/+1.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AttachEquipment",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "FIRST_STRIKE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            },
+                            {
+                                "type": "MustBeBlocked",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                },
+                                "allCreatures": false
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "562",
+        "rarity": "RARE",
+        "artist": "Thanh Tuấn",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b691d42-3498-4d47-9a46-f7c376df8886.jpg?1748707605"
+    }
+}
+
 // Malboro
 {
     "name": "Malboro",
@@ -8613,6 +8715,98 @@
         "rarity": "MYTHIC",
         "artist": "Arou",
         "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d3e926a-74af-4996-849f-d31e0fdedeae.jpg?1748706306"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Opera Love Song
+{
+    "name": "Opera Love Song",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Choose one —\n• Exile the top two cards of your library. You may play those cards until your next end step.\n• One or two target creatures each get +2/+0 until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "TopOfLibrary",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 2
+                                    }
+                                },
+                                "storeAs": "impulseExiled"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "impulseExiled",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                }
+                            },
+                            {
+                                "type": "GrantMayPlayFromExile",
+                                "from": "impulseExiled",
+                                "expiry": {
+                                    "type": "UntilControllerStep",
+                                    "step": "END"
+                                }
+                            }
+                        ]
+                    },
+                    "description": "Exile the top two cards of your library. You may play those cards until your next end step."
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": "IterationSpace.Targets",
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "count": 2,
+                            "minCount": 1,
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "description": "One or two target creatures each get +2/+0 until end of turn."
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "rarity": "UNCOMMON",
+        "artist": "Grace Zhu",
+        "flavorText": "\"O my hero, my beloved, shall we still be made to part?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/3/0343916d-1b65-4e95-aef1-e72dbcebf0c4.jpg?1748706312"
     },
     "colorIdentityOverride": [
         "RED"
@@ -9706,6 +9900,64 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// Relentless X-ATM092
+{
+    "name": "Relentless X-ATM092",
+    "manaCost": "{6}",
+    "typeLine": "Artifact Creature — Robot Spider",
+    "oracleText": "This creature can't be blocked except by three or more creatures.\n{8}: Return this card from your graveyard to the battlefield tapped with a finality counter on it. (If a creature with a finality counter on it would die, exile it instead.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{8}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Battlefield",
+                            "placement": "Tapped"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "finality",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    ]
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByFewerThan",
+                "minBlockers": 3
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "268",
+        "rarity": "UNCOMMON",
+        "artist": "Kevin Glint",
+        "flavorText": "\"Let's get the hell out of here!\"\n—Zell Dincht",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e09ee4c9-85ef-4d1e-864b-d659b8e8f51d.jpg?1748706789"
+    },
+    "colorIdentityOverride": []
 }
 
 // Relm's Sketching
@@ -13233,6 +13485,88 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// The Regalia
+{
+    "name": "The Regalia",
+    "manaCost": "{4}",
+    "typeLine": "Legendary Artifact — Vehicle",
+    "oracleText": "Haste\nWhenever The Regalia attacks, reveal cards from the top of your library until you reveal a land card. Put that card onto the battlefield tapped and the rest on the bottom of your library in a random order.\nCrew 1",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "HASTE",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherUntilMatch",
+                            "filter": "land",
+                            "storeMatch": "matchLand",
+                            "storeRevealed": "allRevealed"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "allRevealed"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "allRevealed",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "land"
+                            },
+                            "storeMatching": "landCard",
+                            "storeNonMatching": "rest"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "landCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "267",
+        "rarity": "RARE",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc420e79-c483-474f-97cd-e9c6a636c306.jpg?1748706782"
+    },
+    "colorIdentityOverride": []
 }
 
 // The Wind Crystal

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagitekScytheScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MagitekScytheScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.MagitekScythe
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Magitek Scythe — {4} Artifact — Equipment.
+ *
+ * "A Test of Your Reflexes! — When this Equipment enters, you may attach it to target creature you
+ *  control. If you do, that creature gains first strike until end of turn and must be blocked this
+ *  turn if able.
+ *  Equipped creature gets +2/+1.
+ *  Equip {2}"
+ *
+ * Exercises the optional ETB attach + first-strike rider (the must-be-blocked rider is the engine's
+ * already-tested `MustBeBlockedEffect`).
+ */
+class MagitekScytheScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MagitekScythe)
+        return driver
+    }
+
+    test("accepting the may-attach equips the chosen creature with +2/+1 and first strike") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val courser = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.project(driver.state).hasKeyword(courser, Keyword.FIRST_STRIKE) shouldBe false
+
+        val scythe = driver.putCardInHand(me, "Magitek Scythe")
+        driver.giveMana(me, Color.RED, 4) // {4} generic
+        driver.castSpell(me, scythe)
+        driver.bothPass() // resolve the artifact -> it enters -> ETB trigger on stack
+
+        // Resolve the ETB trigger, answering its decisions: accept the "you may attach" and pick the
+        // creature to equip (order-agnostic).
+        repeat(8) {
+            when (driver.state.pendingDecision) {
+                is YesNoDecision -> driver.submitYesNo(me, true)
+                is ChooseTargetsDecision -> driver.submitTargetSelection(me, listOf(courser))
+                else -> if (driver.stackSize > 0) driver.bothPass() else return@repeat
+            }
+        }
+
+        val swordId = driver.findPermanent(me, "Magitek Scythe")!!
+        driver.state.getEntity(swordId)?.get<AttachedToComponent>()?.targetId shouldBe courser
+
+        projector.getProjectedPower(driver.state, courser) shouldBe 5  // +2
+        projector.getProjectedToughness(driver.state, courser) shouldBe 4 // +1
+        projector.project(driver.state).hasKeyword(courser, Keyword.FIRST_STRIKE) shouldBe true
+    }
+
+    test("declining the may-attach leaves the Equipment unattached") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val courser = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+
+        val scythe = driver.putCardInHand(me, "Magitek Scythe")
+        driver.giveMana(me, Color.RED, 4)
+        driver.castSpell(me, scythe)
+        driver.bothPass()
+        if (driver.stackSize > 0) driver.bothPass()
+
+        driver.submitYesNo(me, false)
+        if (driver.isPaused) driver.bothPass()
+
+        val swordId = driver.findPermanent(me, "Magitek Scythe")!!
+        driver.state.getEntity(swordId)?.get<AttachedToComponent>() shouldBe null
+        // The creature gained nothing.
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.project(driver.state).hasKeyword(courser, Keyword.FIRST_STRIKE) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OperaLoveSongScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OperaLoveSongScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.OperaLoveSong
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Opera Love Song — {1}{R} Instant, modal "Choose one —".
+ *
+ * Mode 1: exile the top two cards of your library; you may play them until your next end step.
+ * Mode 2: one or two target creatures each get +2/+0 until end of turn.
+ */
+class OperaLoveSongScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(OperaLoveSong)
+        return driver
+    }
+
+    test("Mode 1 — impulse exiles the top two cards and grants permission to play them") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(me, "Mountain")
+        driver.putCardOnTopOfLibrary(me, "Mountain")
+
+        val spell = driver.putCardInHand(me, "Opera Love Song")
+        driver.giveMana(me, Color.RED, 2)
+        driver.submit(CastSpell(playerId = me, cardId = spell, chosenModes = listOf(0))).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Two cards exiled, both flagged playable.
+        val exiled = driver.getExile(me)
+        exiled.size shouldBe 2
+        exiled.forEach { card ->
+            driver.state.mayPlayPermissions.any { card in it.cardIds } shouldBe true
+        }
+    }
+
+    test("Mode 2 — two target creatures each get +2/+0 until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val a = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+        val b = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+
+        val spell = driver.putCardInHand(me, "Opera Love Song")
+        driver.giveMana(me, Color.RED, 2)
+
+        val targets = listOf(ChosenTarget.Permanent(a), ChosenTarget.Permanent(b))
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = targets,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(targets)
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Each gets +2/+0.
+        projector.getProjectedPower(driver.state, a) shouldBe 5
+        projector.getProjectedToughness(driver.state, a) shouldBe 3
+        projector.getProjectedPower(driver.state, b) shouldBe 5
+        projector.getProjectedToughness(driver.state, b) shouldBe 3
+    }
+
+    test("Mode 2 — works with a single target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val a = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+
+        val spell = driver.putCardInHand(me, "Opera Love Song")
+        driver.giveMana(me, Color.RED, 2)
+
+        val targets = listOf(ChosenTarget.Permanent(a))
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = targets,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(targets)
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        projector.getProjectedPower(driver.state, a) shouldBe 5
+        projector.getProjectedToughness(driver.state, a) shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RelentlessXatm092ScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RelentlessXatm092ScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.RelentlessXatm092
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Relentless X-ATM092 — {6} Artifact Creature — Robot Spider, 6/5.
+ *
+ * "This creature can't be blocked except by three or more creatures.
+ *  {8}: Return this card from your graveyard to the battlefield tapped with a finality counter on
+ *  it."
+ *
+ * Exercises the graveyard-activated recursion that returns the card to the battlefield tapped with a
+ * finality counter. (The generalized-menace evasion is the shared `CantBeBlockedByFewerThan(3)`
+ * static, already covered by `TrollOfKhazadDumScenarioTest`.)
+ */
+class RelentlessXatm092ScenarioTest : FunSpec({
+
+    val abilityId = RelentlessXatm092.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(RelentlessXatm092)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("{8} returns it from the graveyard to the battlefield tapped with a finality counter") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val xatm = driver.putCardInGraveyard(me, "Relentless X-ATM092")
+        driver.giveMana(me, Color.RED, 8)
+
+        driver.submit(ActivateAbility(playerId = me, sourceId = xatm, abilityId = abilityId)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.isPaused shouldBe false
+
+        // Back on the battlefield, out of the graveyard.
+        driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD)).contains(xatm) shouldBe true
+        driver.state.getZone(ZoneKey(me, Zone.GRAVEYARD)).contains(xatm) shouldBe false
+
+        // It entered tapped, with one finality counter.
+        driver.isTapped(xatm) shouldBe true
+        val counters = driver.state.getEntity(xatm)?.get<CountersComponent>()?.counters ?: emptyMap()
+        counters[CounterType.FINALITY] shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRegaliaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRegaliaScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.TheRegalia
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Regalia — {4} Legendary Artifact — Vehicle, 4/4, Haste, Crew 1.
+ *
+ * "Whenever The Regalia attacks, reveal cards from the top of your library until you reveal a land
+ *  card. Put that card onto the battlefield tapped and the rest on the bottom of your library in a
+ *  random order."
+ *
+ * Exercises the reveal-until-land attack trigger: a nonland is revealed, then the first land is put
+ * onto the battlefield tapped while the nonland goes to the bottom of the library.
+ */
+class TheRegaliaScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TheRegalia)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("attacking reveals until a land, putting it onto the battlefield tapped") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // The Regalia and a crewer present since before the turn (no summoning sickness).
+        val regalia = driver.putPermanentOnBattlefield(me, "The Regalia")
+        driver.removeSummoningSickness(regalia)
+        val crewer = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        driver.removeSummoningSickness(crewer)
+
+        // Stack the library: top is a nonland, the land sits just beneath it.
+        driver.putCardOnTopOfLibrary(me, "Forest")          // becomes 2nd from top
+        driver.putCardOnTopOfLibrary(me, "Centaur Courser") // top (nonland)
+
+        val landsBefore = driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD))
+            .count { driver.getCardName(it) == "Forest" }
+
+        // Crew The Regalia (Crew 1, Courser power 3 covers it), then attack.
+        driver.submitSuccess(CrewVehicle(me, regalia, listOf(crewer)))
+        driver.bothPass() // resolve the crew activation
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.submitSuccess(DeclareAttackers(me, mapOf(regalia to opponent)))
+
+        // Resolve the attack trigger.
+        if (driver.stackSize > 0) driver.bothPass()
+
+        // The Forest is on the battlefield, tapped; the nonland went to the bottom of the library.
+        val forest = driver.findPermanent(me, "Forest")!!
+        driver.isTapped(forest) shouldBe true
+
+        val landsAfter = driver.state.getZone(ZoneKey(me, Zone.BATTLEFIELD))
+            .count { driver.getCardName(it) == "Forest" }
+        landsAfter shouldBe landsBefore + 1
+
+        // The revealed nonland is back in the library (bottom), not exiled or in hand.
+        driver.state.getZone(ZoneKey(me, Zone.LIBRARY)).any { driver.getCardName(it) == "Centaur Courser" } shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary

A handful of Final Fantasy (FIN) cards, each a pure composition of existing SDK primitives — **no engine/SDK changes**, so no `card-sdk-language-reference.md` update is needed.

| Card | Type | What it does |
|------|------|--------------|
| **Opera Love Song** | `{1}{R}` Instant | Choose-one modal: impulse-draw the top 2 (playable until your next end step) **or** +2/+0 to one or two target creatures |
| **Magitek Scythe** | `{4}` Equipment | ETB *may* attach to a target creature you control → first strike + must-be-blocked; equipped gets +2/+1; Equip `{2}` |
| **The Regalia** | `{4}` Legendary Vehicle | Haste, Crew 1; on attack, reveal until a land, put it onto the battlefield tapped, rest to the bottom in random order |
| **Relentless X-ATM092** | `{6}` 6/5 Artifact Creature | Can't be blocked except by three or more creatures; `{8}` returns it from the graveyard to the battlefield tapped with a finality counter |

## Implementation notes

- **Opera Love Song** — `modal(chooseCount = 1)`; mode 2 uses `TargetObject(count = 2, minCount = 1)` for "one or two target" + `ForEachTargetEffect` to apply +2/+0 per target. Mode 1 is `Patterns.Exile.impulse(2, UntilNextEndStep)`.
- **Magitek Scythe** — `MayEffect` wraps the attach + rider so declining is a clean no-op (mirrors Coral Sword, plus the optional gate). `MustBeBlockedEffect(allCreatures = false)` = "must be blocked if able".
- **The Regalia** — `GatherUntilMatch(Land)` → `FilterCollection` splits matched land vs. the revealed nonlands → land onto battlefield tapped, rest to bottom (`CardOrder.Random`). No-land library falls through correctly (nothing enters, all to bottom).
- **Relentless X-ATM092** — generalized-menace static `CantBeBlockedByFewerThan(3)` (Troll of Khazad-dûm precedent) + a `Zone.GRAVEYARD` activated ability composing `PutOntoBattlefield(tapped)` + `AddCounters(FINALITY)`.

## Testing

- New rules-engine scenario test per card (7 tests total) — all pass.
- `:mtg-sets:test` green (snapshot/lint/facade/Patterns); FIN snapshot golden re-blessed (only the four new cards added, no other card moved).
- Canonical placement verified via `just check-card-printing` for all four (FIN is the earliest real printing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)