### PR TITLE
Add four Final Fantasy cards (Paladin's Arms, Machinist's Arsenal, Astrologian's Planisphere, PuPu UFO)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AstrologiansPlanisphere.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AstrologiansPlanisphere.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Astrologian's Planisphere
+ * {1}{U}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature is a Wizard in addition to its other types and has "Whenever you cast a
+ *   noncreature spell and whenever you draw your third card each turn, put a +1/+1 counter on
+ *   this creature."
+ * Diana — Equip {2}
+ *
+ * The granted ability lives on the equipped creature ([GrantTriggeredAbility] over the
+ * attached-creature filter), so "you" resolves to the creature's controller and "this creature"
+ * ([EffectTarget.Self]) is the bearer. The single printed ability has two trigger conditions, so
+ * it is modeled as two granted triggered abilities: [Triggers.YouCastNoncreature] and
+ * [Triggers.NthCardDrawn]`(3)` (CR 121.2 — "draw your third card each turn"), each adding a
+ * +1/+1 counter to the equipped creature.
+ */
+val AstrologiansPlanisphere = card("Astrologian's Planisphere") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature is a Wizard in addition to its other types and has \"Whenever you cast a noncreature spell and whenever you draw your third card each turn, put a +1/+1 counter on this creature.\"\n" +
+        "Diana — Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = GrantSubtype("Wizard", Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.YouCastNoncreature.event,
+                binding = Triggers.YouCastNoncreature.binding,
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.NthCardDrawn(3).event,
+                binding = Triggers.NthCardDrawn(3).binding,
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "46"
+        artist = "Josephine Chang"
+        imageUri = "https://cards.scryfall.io/normal/front/b/f/bfa4e927-1d6f-4a64-9801-7d168a5ef3f6.jpg?1748705924"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MachinistsArsenal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/MachinistsArsenal.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Machinist's Arsenal
+ * {4}{W}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +2/+2 for each artifact you control and is an Artificer in addition
+ *   to its other types.
+ * Machina — Equip {4}
+ *
+ * The dynamic +2/+2 per artifact is a [GrantDynamicStatsEffect] whose bonus recomputes
+ * continuously: `Multiply(Count(artifacts you control), 2)`. The Equipment itself (and any
+ * artifact creatures) count toward "artifacts you control", matching the printed wording.
+ * "Machina" is flavor on the equip ability; it resolves as a standard equip {4}.
+ */
+val MachinistsArsenal = card("Machinist's Arsenal") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +2/+2 for each artifact you control and is an Artificer in addition to its other types.\n" +
+        "Machina — Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = Filters.EquippedCreature,
+            powerBonus = DynamicAmount.Multiply(
+                DynamicAmount.Count(
+                    player = Player.You,
+                    zone = Zone.BATTLEFIELD,
+                    filter = GameObjectFilter.Artifact
+                ),
+                2
+            ),
+            toughnessBonus = DynamicAmount.Multiply(
+                DynamicAmount.Count(
+                    player = Player.You,
+                    zone = Zone.BATTLEFIELD,
+                    filter = GameObjectFilter.Artifact
+                ),
+                2
+            )
+        )
+    }
+    staticAbility {
+        ability = GrantSubtype("Artificer", Filters.EquippedCreature)
+    }
+
+    equipAbility("{4}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "23"
+        artist = "Thanh Tuấn"
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ff976428-2145-4630-aab1-08870b90b2f0.jpg?1748705839"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PaladinsArms.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PaladinsArms.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.GrantWard
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.WardCost
+
+/**
+ * Paladin's Arms
+ * {2}{W}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +2/+1, has ward {1}, and is a Knight in addition to its other types.
+ * Lightbringer and Hero's Shield — Equip {4}
+ *
+ * The standard Job-select Equipment shell (token + auto-attach via [jobSelect]) plus three
+ * static grants on the equipped creature: a flat stat bump ([ModifyStats]), ward {1}
+ * ([GrantWard] with a mana ward cost), and the Knight type ([GrantSubtype]). "Lightbringer and
+ * Hero's Shield" is flavor on the equip ability; it resolves as a standard equip {4}.
+ */
+val PaladinsArms = card("Paladin's Arms") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +2/+1, has ward {1}, and is a Knight in addition to its other types.\n" +
+        "Lightbringer and Hero's Shield — Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = ModifyStats(2, 1, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantWard(WardCost.Mana("{1}"), Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantSubtype("Knight", Filters.EquippedCreature)
+    }
+
+    equipAbility("{4}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Immanuela Crovius"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/446506c5-5e1d-4b42-aef3-ea247d7881ef.jpg?1748705858"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PuPuUFO.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PuPuUFO.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * PuPu UFO
+ * {2}
+ * Artifact Creature — Construct Alien
+ * 0/4
+ * Flying
+ * {T}: You may put a land card from your hand onto the battlefield.
+ * {3}: Until end of turn, this creature's base power becomes equal to the number of Towns
+ *   you control.
+ *
+ * The land drop is the standard `Gather → Select(up to 1) → Move` pipeline
+ * ([Patterns.Hand.putFromHand]); the `ChooseUpTo(1)` selection models the "you may". The
+ * pump is a Layer 7b set-base-power effect ([Effects.SetBasePower]) lasting until end of turn,
+ * with the value recomputed at resolution as the count of Town lands the controller has in play.
+ */
+val PuPuUFO = card("PuPu UFO") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Construct Alien"
+    power = 0
+    toughness = 4
+    oracleText = "Flying\n" +
+        "{T}: You may put a land card from your hand onto the battlefield.\n" +
+        "{3}: Until end of turn, this creature's base power becomes equal to the number of Towns you control."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Patterns.Hand.putFromHand(filter = GameObjectFilter.Land)
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.SetBasePower(
+            target = EffectTarget.Self,
+            power = DynamicAmount.Count(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Land.withSubtype("Town")
+            ),
+            duration = Duration.EndOfTurn
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "266"
+        artist = "Racrufi"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/989b52f7-d8a5-4488-9a5d-f14a1d48686d.jpg?1748706782"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -918,6 +918,139 @@
     ]
 }
 
+// Astrologian's Planisphere
+{
+    "name": "Astrologian's Planisphere",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature is a Wizard in addition to its other types and has \"Whenever you cast a noncreature spell and whenever you draw your third card each turn, put a +1/+1 counter on this creature.\"\nDiana — Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantSubtype",
+                "subtype": "Wizard",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "SpellCastEvent",
+                        "spellFilter": {
+                            "cardPredicates": [
+                                "IsNoncreature"
+                            ]
+                        }
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                }
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_4",
+                    "trigger": {
+                        "type": "NthCardDrawnEvent",
+                        "nthCard": 3
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "RARE",
+        "artist": "Josephine Chang",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/f/bfa4e927-1d6f-4a64-9801-7d168a5ef3f6.jpg?1748705924"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Auron's Inspiration
 {
     "name": "Auron's Inspiration",
@@ -7463,6 +7596,128 @@
     "colorIdentityOverride": []
 }
 
+// Machinist's Arsenal
+{
+    "name": "Machinist's Arsenal",
+    "manaCost": "{4}{W}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +2/+2 for each artifact you control and is an Artificer in addition to its other types.\nMachina — Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "artifact"
+                    },
+                    "multiplier": 2
+                },
+                "toughnessBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "artifact"
+                    },
+                    "multiplier": 2
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Artificer",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{4}",
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "RARE",
+        "artist": "Thanh Tuấn",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ff976428-2145-4630-aab1-08870b90b2f0.jpg?1748705839"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Magic Damper
 {
     "name": "Magic Damper",
@@ -8857,6 +9112,112 @@
     ]
 }
 
+// Paladin's Arms
+{
+    "name": "Paladin's Arms",
+    "manaCost": "{2}{W}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +2/+1, has ward {1}, and is a Knight in addition to its other types.\nLightbringer and Hero's Shield — Equip {4} ({4}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantWard",
+                "cost": {
+                    "type": "WardCost.Mana",
+                    "manaCost": "{1}"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Knight",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ]
+    },
+    "equipCost": "{4}",
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Immanuela Crovius",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/446506c5-5e1d-4b42-aef3-ea247d7881ef.jpg?1748705858"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Phoenix Down
 {
     "name": "Phoenix Down",
@@ -9200,6 +9561,90 @@
     "colorIdentityOverride": [
         "RED"
     ]
+}
+
+// PuPu UFO
+{
+    "name": "PuPu UFO",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Construct Alien",
+    "oracleText": "Flying\n{T}: You may put a land card from your hand onto the battlefield.\n{3}: Until end of turn, this creature's base power becomes equal to the number of Towns you control.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": "land"
+                            },
+                            "storeAs": "put_candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "put_candidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "putting"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "putting",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "SetBaseStats",
+                    "target": "Self",
+                    "power": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "land Town"
+                    },
+                    "duration": "EndOfTurn"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "266",
+        "rarity": "UNCOMMON",
+        "artist": "Racrufi",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/989b52f7-d8a5-4488-9a5d-f14a1d48686d.jpg?1748706782"
+    }
 }
 
 // Qiqirn Merchant

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinJobSelectBatchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinJobSelectBatchScenarioTest.kt
@@ -1,0 +1,201 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fin.cards.PuPuUFO
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Behavioural coverage for a batch of Final Fantasy cards implemented from existing SDK
+ * primitives (no new engine code):
+ *
+ *  - Paladin's Arms — Job-select Equipment granting +2/+1, ward {1}, and Knight.
+ *  - Machinist's Arsenal — Job-select Equipment granting a dynamic +2/+2 per artifact you
+ *    control and Artificer.
+ *  - Astrologian's Planisphere — Job-select Equipment granting Wizard and a triggered ability
+ *    that puts a +1/+1 counter on the equipped creature when its controller casts a noncreature
+ *    spell.
+ *  - PuPu UFO — flier whose {3} sets its base power to the number of Towns you control, and
+ *    whose {T} puts a land from hand onto the battlefield.
+ */
+class FinJobSelectBatchScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        context("Paladin's Arms") {
+            test("ETB makes a Hero token that is a 3/2 Knight with ward {1}") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Paladin's Arms")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Paladin's Arms")
+                withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val hero = game.findPermanent("Hero Token")!!
+                val projected = stateProjector.project(game.state)
+                withClue("Equipped Hero is 1/1 + (+2/+1) = 3/2") {
+                    projected.getPower(hero) shouldBe 3
+                    projected.getToughness(hero) shouldBe 2
+                }
+                withClue("Equipped Hero is a Knight in addition to Hero, and has ward") {
+                    projected.hasSubtype(hero, "Knight") shouldBe true
+                    projected.hasSubtype(hero, "Hero") shouldBe true
+                    projected.hasKeyword(hero, Keyword.WARD) shouldBe true
+                }
+            }
+        }
+
+        context("Machinist's Arsenal") {
+            test("equipped Hero gets +2/+2 for each artifact its controller controls") {
+                // One other artifact (Coral Sword) already in play; casting the Arsenal makes the
+                // second artifact, so 2 artifacts → +4/+4 on the 1/1 Hero token = 5/5.
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Machinist's Arsenal")
+                    .withCardOnBattlefield(1, "Coral Sword")
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Machinist's Arsenal")
+                withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val hero = game.findPermanent("Hero Token")!!
+                val projected = stateProjector.project(game.state)
+                withClue("2 artifacts (Coral Sword + Arsenal) → 1/1 + (+4/+4) = 5/5") {
+                    projected.getPower(hero) shouldBe 5
+                    projected.getToughness(hero) shouldBe 5
+                }
+                withClue("Equipped Hero is an Artificer in addition to Hero") {
+                    projected.hasSubtype(hero, "Artificer") shouldBe true
+                }
+            }
+        }
+
+        context("Astrologian's Planisphere") {
+            test("equipped Hero is a Wizard and gains a +1/+1 counter when its controller casts a noncreature spell") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Astrologian's Planisphere")
+                    .withCardInHand(1, "Shock")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Astrologian's Planisphere")
+                withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val hero = game.findPermanent("Hero Token")!!
+                val before = stateProjector.project(game.state)
+                withClue("Equipped Hero is a Wizard, base 1/1 before any noncreature spell") {
+                    before.hasSubtype(hero, "Wizard") shouldBe true
+                    before.getPower(hero) shouldBe 1
+                    before.getToughness(hero) shouldBe 1
+                }
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val shock = game.castSpell(1, "Shock", giant)
+                withClue("Shock should succeed: ${shock.error}") { shock.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val after = stateProjector.project(game.state)
+                withClue("Casting a noncreature spell puts a +1/+1 counter on the Hero → 2/2") {
+                    after.getPower(hero) shouldBe 2
+                    after.getToughness(hero) shouldBe 2
+                }
+            }
+        }
+
+        context("PuPu UFO") {
+            test("{3} sets its base power to the number of Towns you control") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "PuPu UFO", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Capital City", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ufo = game.findPermanent("PuPu UFO")!!
+                val pump = PuPuUFO.activatedAbilities[1].id
+
+                val before = stateProjector.project(game.state)
+                withClue("PuPu UFO starts as a 0/4") {
+                    before.getPower(ufo) shouldBe 0
+                    before.getToughness(ufo) shouldBe 4
+                }
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = ufo, abilityId = pump)
+                )
+                withClue("Activating the pump should succeed: ${result.error}") { result.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                val after = stateProjector.project(game.state)
+                withClue("Base power becomes the number of Towns you control (3); toughness unchanged") {
+                    after.getPower(ufo) shouldBe 3
+                    after.getToughness(ufo) shouldBe 4
+                }
+            }
+
+            test("{T} puts a land card from hand onto the battlefield") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardOnBattlefield(1, "PuPu UFO", summoningSickness = false)
+                    .withCardInHand(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ufo = game.findPermanent("PuPu UFO")!!
+                val putLand = PuPuUFO.activatedAbilities[0].id
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = ufo, abilityId = putLand)
+                )
+                withClue("Activating the land-drop should succeed: ${result.error}") { result.error shouldBe null }
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                decision.shouldBeInstanceOf<SelectCardsDecision>()
+                game.selectCards(listOf(decision.options.first()))
+                game.resolveStack()
+
+                withClue("The Forest should now be on the battlefield") {
+                    game.findPermanent("Forest") shouldNotBe null
+                }
+                withClue("The Forest left Alice's hand") {
+                    game.state.getHand(game.player1Id).count { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                    } shouldBe 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of missing **Final Fantasy (FIN)** cards via the `add-card` flow. All four are modeled entirely from **existing SDK primitives** — no new engine/SDK code, so no `docs/card-sdk-language-reference.md` changes.

## Cards

| Card | Cost | Type | Mechanics |
|------|------|------|-----------|
| **Paladin's Arms** | {2}{W} | Artifact — Equipment | Job select; equipped creature gets +2/+1, has ward {1} (`GrantWard`), is a Knight |
| **Machinist's Arsenal** | {4}{W} | Artifact — Equipment | Job select; equipped creature gets +2/+2 **for each artifact you control** (`GrantDynamicStatsEffect` + `Multiply(Count(Artifact), 2)`), is an Artificer |
| **Astrologian's Planisphere** | {1}{U} | Artifact — Equipment | Job select; equipped creature is a Wizard and has a granted trigger adding a +1/+1 counter on `YouCastNoncreature` and `NthCardDrawn(3)` ("draw your third card each turn") |
| **PuPu UFO** | {2} | Artifact Creature — Construct Alien (0/4) | Flying; `{T}` puts a land from hand onto the battlefield (`Patterns.Hand.putFromHand`); `{3}` sets base power to the number of Towns you control until end of turn (`SetBasePower` over a Town-subtype `Count`) |

The Job-select Equipment reuse the existing `jobSelect()` shell (create a 1/1 Hero token, attach) and the `GrantTriggeredAbility` / `ModifyStats` / `GrantSubtype` patterns established by the rest of the FIN Equipment cycle.

## Tests

- New `FinJobSelectBatchScenarioTest` (rules-engine) — 5 tests covering each card's behavior (stat grants, ward, dynamic per-artifact buff, noncreature-cast counter, Town-count pump, land drop) — all pass.
- Re-blessed the FIN card-definition snapshot golden; diff is limited to the four new cards.
- `:mtg-sets:test` (snapshot + `CardLintTest` + round-trip) and the new scenario test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)