### PR TITLE
Admin dashboard hub: Players view, per-account admin, scroll fix + polish

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -78,7 +78,7 @@ Flyway migration `V1__init.sql`:
 
 | Table | Purpose |
 |-------|---------|
-| `users` | account: email (unique), display name, created_at |
+| `users` | account: email (unique), display name, created_at, `is_admin` (added in `V3__admin_role.sql`) |
 | `login_tokens` | single-use magic-link tokens (SHA-256 hashed, short TTL) |
 | `decks` | saved decks: denormalized name/format + full `SharedDeck` JSON in `data` |
 | `match_results` | one row per finished game |
@@ -94,6 +94,9 @@ Flyway migration `V2__match_stats.sql` extends the stats schema:
 | `tournaments` | finished tournaments + settings (format, mode, set codes, player count, rounds, winner) |
 | `tournament_participants` | a seat in a tournament with final placement + W/L/D |
 
+Flyway migration `V3__admin_role.sql` adds `users.is_admin` (boolean, default false) — the per-account
+admin flag (see **Admin access** below).
+
 ## Auth flow (magic link)
 
 1. `POST /api/auth/request-login { email }` → upsert account, email a single-use link (logged to
@@ -107,13 +110,31 @@ Auth tokens are stateless HMAC-SHA256-signed (a minimal JWT shape) so REST calls
 authenticate. The token also links the in-game identity to the account so finished games count toward
 the account's stats.
 
+## Admin access
+
+The admin dashboard accepts **two** credentials, resolved by `AdminAuthService`:
+
+1. **Bootstrap password** — the `X-Admin-Password` header matching `GAME_ADMIN_PASSWORD`. Not tied to
+   an account; always works (a break-glass path), but meant only to get the first admin in. This also
+   works on a server with no database at all (the replay browser is password-only).
+2. **Admin account** — a normal `Authorization: Bearer …` whose account has `is_admin = true`. The
+   flag is resolved against the DB **per request** (not baked into the token), so a promotion/demotion
+   takes effect immediately. Promotion is done from the dashboard's **Players** view.
+
+Bootstrapping the first admin: set `GAME_ADMIN_PASSWORD`, open `/admin`, sign in with the password,
+go to **Players**, and promote an account. From then on that account reaches `/admin` with its normal
+sign-in and the password can be retired. `GET /api/auth/me` now includes `isAdmin`, which the client
+uses to show an **Admin dashboard** link on the profile and to skip the password prompt at `/admin`.
+
+Every admin endpoint (`/api/admin/**` and `/api/stats/admin/**`) accepts either credential.
+
 ## Endpoints
 
 | Method | Path | Notes |
 |--------|------|-------|
 | POST | `/api/auth/request-login` | `{ email }` → 200 |
 | POST | `/api/auth/verify` | `{ token }` → `{ authToken, user }` |
-| GET | `/api/auth/me` | Bearer → `user` |
+| GET | `/api/auth/me` | Bearer → `user` (includes `isAdmin`) |
 | PUT | `/api/auth/me` | Bearer + `{ displayName }` → updated `user` (1–40 chars; duplicates allowed) |
 | GET | `/api/account/decks` | list summaries |
 | GET | `/api/account/decks?full` | every deck in full (one round-trip; powers the unified deck browser) |
@@ -127,8 +148,8 @@ the account's stats.
 
 ### Stats (all under `/api/stats`)
 
-Per-user endpoints take `Authorization: Bearer …`; admin endpoints take `X-Admin-Password` (the same
-header as the replay browser). Both groups are only mounted when accounts are enabled.
+Per-user endpoints take `Authorization: Bearer …`; admin endpoints take either admin credential (see
+**Admin access**). Both groups are only mounted when accounts are enabled.
 
 | Method | Path | Notes |
 |--------|------|-------|
@@ -144,6 +165,17 @@ header as the replay browser). Both groups are only mounted when accounts are en
 | GET | `/api/stats/admin/cards` · `/cards/win-rates?minDecks` | most-played + per-card win rate |
 | GET | `/api/stats/admin/tournaments?limit` | recorded tournaments |
 | GET | `/api/stats/admin/geo` | IP → coarse location, aggregated by location (raw IPs never returned) |
+
+### Admin — players (`/api/admin/users`, either admin credential)
+
+| Method | Path | Notes |
+|--------|------|-------|
+| GET | `/api/admin/users` | roster: every account + lifetime games/wins, `isAdmin`, last played |
+| GET | `/api/admin/users/{id}` | one account's full stats (overview, colors, modes, head-to-head, top cards, tournaments, recent games) |
+| POST | `/api/admin/users/{id}/admin` | `{ isAdmin }` → grant/revoke admin access |
+
+The replay browser lives at `/api/admin/games` and `/api/admin/games/{id}/replay` (also either
+credential; password-only on a DB-less server).
 
 Aggregate queries live in `StatsQueryService` (plain SQL via `JdbcTemplate`). Geolocation
 (`GeoIpService`) resolves IPs via the free ip-api.com batch endpoint, cached in-process; it's only
@@ -167,9 +199,17 @@ called from the admin `geo` endpoint, never the hot recording path.
   sets, game modes, head-to-head, most-played cards, tournament finishes, and a recent-games list — all
   from `/api/stats/me/*` via `api/account.ts`. It also has a small **Manage my decks** launcher that
   opens the deckbuilder's deck browser (`/deckbuilder?decks=open`).
-- Admin page at `/admin` has a **Dashboard** tab (`AdminDashboard`, fed by `api/adminStats.ts`)
-  alongside the replay browser: headline totals, a games-per-day line chart, mode/color distributions,
-  most-played + highest-win-rate cards, recorded tournaments, and a geolocation table.
+- Admin page at `/admin` is a **hub** (`AdminPage` → `AdminHub`) that routes to three areas, each its
+  own self-scrolling screen (`AdminScreen` in `adminUi.tsx` — the whole app runs in
+  `#root { overflow: hidden }`, so admin screens scroll themselves rather than the document):
+  - **Stats** (`AdminDashboard`, `api/adminStats.ts`) — headline totals, games-per-day line chart,
+    mode/color distributions, most-played + highest-win-rate cards, recorded tournaments, geolocation.
+  - **Replays** (`ReplayViewer`) — browse and play back every completed game.
+  - **Players** (`AdminPlayers`, `api/adminUsers.ts`) — the account roster, a per-account drill-down
+    (full stats + recent games), and the **Make admin / Revoke admin** control.
+  Admin auth is the shared `AdminAuth` (`api/adminAuth.ts`): the bootstrap password (kept in
+  sessionStorage) or, for an admin account, its Bearer token. A signed-in admin skips the password
+  prompt entirely; the profile page shows an **Admin dashboard** link when `user.isAdmin`.
 - On sign-in, a landing-page prompt (`DeckMigrationPrompt`) offers to copy browser-only decks to the
   account.
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/AdminAuthService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/AdminAuthService.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.gameserver.auth
+
+import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.gameserver.persistence.UserRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+
+/**
+ * The single authority for "may this request use the admin dashboard". There are two ways in:
+ *
+ *  1. **Bootstrap password** — the `X-Admin-Password` header matching `game.admin.password`. This is
+ *     how the very first admin gets in (and a break-glass path that always works), but it isn't tied
+ *     to any account, so it can't be the long-term answer for a team.
+ *  2. **Admin account** — a normal `Authorization: Bearer <token>` whose account has `is_admin = true`.
+ *     Admins are promoted from the dashboard's Players view, so after the one-time bootstrap nobody has
+ *     to share the password.
+ *
+ * The admin-account check is resolved against the database per request (not baked into the token) so a
+ * promotion or demotion takes effect immediately rather than on the next sign-in. Admin endpoints are
+ * low-traffic, so the extra lookup is cheap.
+ *
+ * This component is intentionally NOT gated on `accounts.enabled`: the replay browser
+ * ([com.wingedsheep.gameserver.controller.AdminController]) works on a server with no database at all,
+ * password-only. When accounts are disabled the account dependencies below are simply absent, leaving
+ * the password as the only path.
+ */
+@Component
+class AdminAuthService(private val gameProperties: GameProperties) {
+
+    /** Present only when accounts are enabled (gated beans). Null otherwise — password is then the only path. */
+    @Autowired(required = false)
+    var authSupport: AuthSupport? = null
+
+    @Autowired(required = false)
+    var users: UserRepository? = null
+
+    /** True if the request carries valid admin credentials by either path. */
+    fun isAuthorized(password: String?, authorization: String?): Boolean {
+        val configured = gameProperties.admin.password
+        if (configured.isNotBlank() && password != null && constantTimeEquals(password, configured)) return true
+
+        val claims = authSupport?.userOrNull(authorization) ?: return false
+        val user = users?.findById(claims.uid)?.orElse(null) ?: return false
+        return user.isAdmin
+    }
+
+    /** Whether an admin path even exists on this server (a password is set, or accounts are enabled). */
+    fun isConfigured(): Boolean = gameProperties.admin.password.isNotBlank() || authSupport != null
+
+    /**
+     * Guard helper for controllers: returns `null` when authorized, or the appropriate 401 response
+     * otherwise — `block()` only runs when authorized. Mirrors the shape the admin controllers used
+     * before this service existed.
+     */
+    fun guard(password: String?, authorization: String?, block: () -> ResponseEntity<Any>): ResponseEntity<Any> {
+        if (!isConfigured()) {
+            return ResponseEntity.status(401).body(mapOf("error" to "Admin feature is not configured"))
+        }
+        if (!isAuthorized(password, authorization)) {
+            return ResponseEntity.status(401).body(mapOf("error" to "Invalid admin credentials"))
+        }
+        return block()
+    }
+
+    private fun constantTimeEquals(a: String, b: String): Boolean {
+        if (a.length != b.length) return false
+        var result = 0
+        for (i in a.indices) result = result or (a[i].code xor b[i].code)
+        return result == 0
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/UserAdminService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/auth/UserAdminService.kt
@@ -1,0 +1,25 @@
+package com.wingedsheep.gameserver.auth
+
+import com.wingedsheep.gameserver.persistence.UserRepository
+import com.wingedsheep.gameserver.persistence.UserRow
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+
+/**
+ * Account-administration mutations performed from the admin dashboard. Kept separate from
+ * [MagicLinkService] (which owns the sign-in lifecycle) so the admin-only surface is isolated. Only
+ * exists when accounts are enabled — there are no accounts to administer otherwise.
+ */
+@Service
+@ConditionalOnProperty(name = ["accounts.enabled"], havingValue = "true")
+class UserAdminService(private val users: UserRepository) {
+
+    fun get(userId: Long): UserRow? = users.findById(userId).orElse(null)
+
+    /** Grant or revoke admin access for an account. Returns the updated account, or null if unknown. */
+    fun setAdmin(userId: Long, isAdmin: Boolean): UserRow? {
+        val user = users.findById(userId).orElse(null) ?: return null
+        if (user.isAdmin == isAdmin) return user
+        return users.save(user.copy(isAdmin = isAdmin))
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminController.kt
@@ -1,6 +1,6 @@
 package com.wingedsheep.gameserver.controller
 
-import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.gameserver.auth.AdminAuthService
 import com.wingedsheep.gameserver.handler.MessageSender
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.gameserver.replay.GameHistoryRepository
@@ -8,6 +8,7 @@ import com.wingedsheep.gameserver.replay.GameReplayRecord
 import com.wingedsheep.gameserver.replay.SpectatorReplayDelta
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.encodeToString
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -25,31 +26,26 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/admin")
 class AdminController(
     private val gameHistoryRepository: GameHistoryRepository,
-    private val gameProperties: GameProperties,
+    private val adminAuth: AdminAuthService,
     private val messageSender: MessageSender
 ) {
 
     @GetMapping("/games")
     fun listGames(
-        @RequestHeader("X-Admin-Password", required = false) password: String?
-    ): ResponseEntity<Any> {
-        val authError = checkAuth(password)
-        if (authError != null) return authError
-
-        val summaries = gameHistoryRepository.findAll().map { it.toSummary() }
-        return ResponseEntity.ok(summaries)
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        ResponseEntity.ok(gameHistoryRepository.findAll().map { it.toSummary() })
     }
 
     @GetMapping("/games/{gameId}/replay", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getReplay(
         @PathVariable gameId: String,
-        @RequestHeader("X-Admin-Password", required = false) password: String?
-    ): ResponseEntity<Any> {
-        val authError = checkAuth(password)
-        if (authError != null) return authError
-
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
         val record = gameHistoryRepository.findById(gameId)
-            ?: return ResponseEntity.notFound().build()
+            ?: return@guard ResponseEntity.status(404).body(mapOf("error" to "Replay not found"))
 
         val initialJson = messageSender.json.encodeToString(
             ServerMessage.SpectatorStateUpdate.serializer(),
@@ -59,22 +55,9 @@ class AdminController(
             ListSerializer(SpectatorReplayDelta.serializer()),
             record.deltas
         )
-        return ResponseEntity.ok()
+        ResponseEntity.ok()
             .contentType(MediaType.APPLICATION_JSON)
             .body("""{"initialSnapshot":$initialJson,"deltas":$deltasJson}""")
-    }
-
-    private fun checkAuth(password: String?): ResponseEntity<Any>? {
-        val configuredPassword = gameProperties.admin.password
-        if (configuredPassword.isBlank()) {
-            return ResponseEntity.status(401)
-                .body(mapOf("error" to "Admin feature is not configured"))
-        }
-        if (password != configuredPassword) {
-            return ResponseEntity.status(401)
-                .body(mapOf("error" to "Invalid admin password"))
-        }
-        return null
     }
 
     private fun GameReplayRecord.toSummary() = GameSummary(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminStatsController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminStatsController.kt
@@ -1,9 +1,10 @@
 package com.wingedsheep.gameserver.controller
 
-import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.gameserver.auth.AdminAuthService
 import com.wingedsheep.gameserver.stats.GeoIpService
 import com.wingedsheep.gameserver.stats.StatsQueryService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 class AdminStatsController(
     private val statsQuery: StatsQueryService,
     private val geoIp: GeoIpService,
-    private val gameProperties: GameProperties,
+    private val adminAuth: AdminAuthService,
 ) {
     /** One resolved location and how many games connected from it. */
     data class GeoBucket(
@@ -35,74 +36,79 @@ class AdminStatsController(
     )
 
     @GetMapping("/overview")
-    fun overview(@RequestHeader("X-Admin-Password", required = false) password: String?): ResponseEntity<Any> =
-        guard(password) { ResponseEntity.ok(statsQuery.overview()) }
+    fun overview(
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) { ResponseEntity.ok(statsQuery.overview()) }
 
     @GetMapping("/games-per-day")
     fun gamesPerDay(
         @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
         @RequestParam(defaultValue = "30") days: Int,
-    ): ResponseEntity<Any> = guard(password) {
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
         ResponseEntity.ok(statsQuery.gamesPerDay(days.coerceIn(1, 365)))
     }
 
     @GetMapping("/modes")
-    fun modes(@RequestHeader("X-Admin-Password", required = false) password: String?): ResponseEntity<Any> =
-        guard(password) { ResponseEntity.ok(statsQuery.modeDistribution()) }
+    fun modes(
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) { ResponseEntity.ok(statsQuery.modeDistribution()) }
 
     @GetMapping("/colors")
-    fun colors(@RequestHeader("X-Admin-Password", required = false) password: String?): ResponseEntity<Any> =
-        guard(password) { ResponseEntity.ok(statsQuery.colorDistribution()) }
+    fun colors(
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) { ResponseEntity.ok(statsQuery.colorDistribution()) }
 
     @GetMapping("/cards")
     fun cards(
         @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
         @RequestParam(defaultValue = "50") limit: Int,
-    ): ResponseEntity<Any> = guard(password) { ResponseEntity.ok(statsQuery.topCards(limit.coerceIn(1, 500))) }
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        ResponseEntity.ok(statsQuery.topCards(limit.coerceIn(1, 500)))
+    }
 
     @GetMapping("/cards/win-rates")
     fun cardWinRates(
         @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
         @RequestParam(defaultValue = "10") minDecks: Int,
         @RequestParam(defaultValue = "50") limit: Int,
-    ): ResponseEntity<Any> = guard(password) {
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
         ResponseEntity.ok(statsQuery.cardWinRates(minDecks.coerceAtLeast(1), limit.coerceIn(1, 500)))
     }
 
     @GetMapping("/tournaments")
     fun tournaments(
         @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
         @RequestParam(defaultValue = "50") limit: Int,
-    ): ResponseEntity<Any> = guard(password) { ResponseEntity.ok(statsQuery.recentTournaments(limit.coerceIn(1, 200))) }
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        ResponseEntity.ok(statsQuery.recentTournaments(limit.coerceIn(1, 200)))
+    }
 
     @GetMapping("/geo")
-    fun geo(@RequestHeader("X-Admin-Password", required = false) password: String?): ResponseEntity<Any> =
-        guard(password) {
-            val ipCounts = statsQuery.ipBreakdown()
-            val locations = geoIp.resolve(ipCounts.map { it.ip })
-            // Aggregate game counts by resolved location (raw IPs are dropped here).
-            val byLocation = ipCounts.groupBy { locations[it.ip] }
-                .map { (loc, rows) ->
-                    GeoBucket(
-                        country = loc?.country,
-                        countryCode = loc?.countryCode,
-                        region = loc?.region,
-                        city = loc?.city,
-                        games = rows.sumOf { it.count },
-                    )
-                }
-                .sortedByDescending { it.games }
-            ResponseEntity.ok(byLocation)
-        }
-
-    private fun guard(password: String?, block: () -> ResponseEntity<Any>): ResponseEntity<Any> {
-        val configured = gameProperties.admin.password
-        if (configured.isBlank()) {
-            return ResponseEntity.status(401).body(mapOf("error" to "Admin feature is not configured"))
-        }
-        if (password != configured) {
-            return ResponseEntity.status(401).body(mapOf("error" to "Invalid admin password"))
-        }
-        return block()
+    fun geo(
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        val ipCounts = statsQuery.ipBreakdown()
+        val locations = geoIp.resolve(ipCounts.map { it.ip })
+        // Aggregate game counts by resolved location (raw IPs are dropped here).
+        val byLocation = ipCounts.groupBy { locations[it.ip] }
+            .map { (loc, rows) ->
+                GeoBucket(
+                    country = loc?.country,
+                    countryCode = loc?.countryCode,
+                    region = loc?.region,
+                    city = loc?.city,
+                    games = rows.sumOf { it.count },
+                )
+            }
+            .sortedByDescending { it.games }
+        ResponseEntity.ok(byLocation)
     }
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminUsersController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminUsersController.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.gameserver.controller
+
+import com.wingedsheep.gameserver.auth.AdminAuthService
+import com.wingedsheep.gameserver.auth.UserAdminService
+import com.wingedsheep.gameserver.persistence.MatchResultRepository
+import com.wingedsheep.gameserver.stats.CardStat
+import com.wingedsheep.gameserver.stats.GameHistoryEntry
+import com.wingedsheep.gameserver.stats.HeadToHead
+import com.wingedsheep.gameserver.stats.StatBucket
+import com.wingedsheep.gameserver.stats.StatsQueryService
+import com.wingedsheep.gameserver.stats.UserTournamentEntry
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Admin view of the registered accounts: list everyone with their lifetime record, drill into one
+ * account's full stats, and grant/revoke admin access. Auth goes through [AdminAuthService] (the same
+ * password-or-admin-account gate as the rest of the dashboard). Mounted only when accounts are enabled
+ * — the data lives in Postgres.
+ */
+@RestController
+@RequestMapping("/api/admin/users")
+@ConditionalOnProperty(name = ["accounts.enabled"], havingValue = "true")
+class AdminUsersController(
+    private val adminAuth: AdminAuthService,
+    private val statsQuery: StatsQueryService,
+    private val userAdmin: UserAdminService,
+    private val matchResults: MatchResultRepository,
+) {
+    data class StatsDto(val games: Long, val wins: Long, val losses: Long, val winRate: Double)
+
+    /** One account's full profile + stats, for the player detail view. */
+    data class UserDetailDto(
+        val id: Long,
+        val email: String,
+        val displayName: String,
+        val isAdmin: Boolean,
+        val createdAt: String,
+        val stats: StatsDto,
+        val colors: List<StatBucket>,
+        val modes: List<StatBucket>,
+        val opponents: List<HeadToHead>,
+        val topCards: List<CardStat>,
+        val tournaments: List<UserTournamentEntry>,
+        val recentGames: List<GameHistoryEntry>,
+    )
+
+    data class SetAdminBody(val isAdmin: Boolean)
+
+    @GetMapping
+    fun list(
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        ResponseEntity.ok(statsQuery.allUsersWithStats())
+    }
+
+    @GetMapping("/{id}")
+    fun detail(
+        @PathVariable id: Long,
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        val user = userAdmin.get(id)
+            ?: return@guard ResponseEntity.status(404).body(mapOf("error" to "User not found"))
+        val games = matchResults.countGamesForUser(id)
+        val wins = matchResults.countWinsForUser(id)
+        ResponseEntity.ok(
+            UserDetailDto(
+                id = user.id!!,
+                email = user.email,
+                displayName = user.displayName,
+                isAdmin = user.isAdmin,
+                createdAt = user.createdAt.toString(),
+                stats = StatsDto(
+                    games = games,
+                    wins = wins,
+                    losses = games - wins,
+                    winRate = if (games > 0) wins.toDouble() / games else 0.0,
+                ),
+                colors = statsQuery.colorBreakdown(id),
+                modes = statsQuery.modeBreakdown(id),
+                opponents = statsQuery.headToHead(id),
+                topCards = statsQuery.topCardsForUser(id, 20),
+                tournaments = statsQuery.tournamentHistory(id, 25),
+                recentGames = statsQuery.recentGames(id, 25, 0),
+            )
+        )
+    }
+
+    @PostMapping("/{id}/admin")
+    fun setAdmin(
+        @PathVariable id: Long,
+        @RequestBody body: SetAdminBody,
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        val updated = userAdmin.setAdmin(id, body.isAdmin)
+            ?: return@guard ResponseEntity.status(404).body(mapOf("error" to "User not found"))
+        ResponseEntity.ok(mapOf("id" to updated.id, "isAdmin" to updated.isAdmin))
+    }
+}

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AuthController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AuthController.kt
@@ -34,7 +34,7 @@ class AuthController(
     data class RequestLoginBody(val email: String)
     data class VerifyBody(val token: String)
     data class UpdateProfileBody(val displayName: String)
-    data class UserDto(val id: Long, val email: String, val displayName: String)
+    data class UserDto(val id: Long, val email: String, val displayName: String, val isAdmin: Boolean)
     data class LoginResponse(val authToken: String, val user: UserDto)
 
     companion object {
@@ -86,5 +86,5 @@ class AuthController(
         return ResponseEntity.ok(updated.toDto())
     }
 
-    private fun UserRow.toDto() = UserDto(id = id!!, email = email, displayName = displayName)
+    private fun UserRow.toDto() = UserDto(id = id!!, email = email, displayName = displayName, isAdmin = isAdmin)
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Rows.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Rows.kt
@@ -18,6 +18,8 @@ data class UserRow(
     @Id val id: Long? = null,
     val email: String,
     val displayName: String,
+    /** Grants access to the admin dashboard via this account's normal auth token (set from the dashboard). */
+    val isAdmin: Boolean = false,
     val createdAt: Instant = Instant.now(),
 )
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -58,6 +58,18 @@ data class UserTournamentEntry(
     val playerCount: Int,
 )
 
+/** A registered account plus its lifetime game counts, for the admin Players list. */
+data class AdminUserStat(
+    val id: Long,
+    val email: String,
+    val displayName: String,
+    val isAdmin: Boolean,
+    val createdAt: String,
+    val games: Long,
+    val wins: Long,
+    val lastPlayed: String?,
+)
+
 /** A recorded tournament for the admin list. */
 data class TournamentSummary(
     val endedAt: String,
@@ -216,6 +228,37 @@ class StatsQueryService(private val jdbc: JdbcTemplate) {
     )
 
     // ---- Global (admin) ----------------------------------------------------------------------
+
+    /**
+     * Every registered account with its lifetime game/win counts and last-played time, most-active
+     * first. A LEFT JOIN keeps accounts that have never played (they show 0 games). Drives the admin
+     * Players list; per-account detail reuses the per-user methods above.
+     */
+    fun allUsersWithStats(): List<AdminUserStat> = jdbc.query(
+        """
+        SELECT u.id AS id, u.email AS email, u.display_name AS display_name, u.is_admin AS is_admin,
+               u.created_at AS created_at,
+               count(p.id) AS games,
+               count(p.id) FILTER (WHERE p.won) AS wins,
+               max(r.ended_at) AS last_played
+        FROM users u
+        LEFT JOIN match_participants p ON p.user_id = u.id
+        LEFT JOIN match_results r ON r.id = p.match_id
+        GROUP BY u.id, u.email, u.display_name, u.is_admin, u.created_at
+        ORDER BY games DESC, u.created_at ASC
+        """.trimIndent(),
+    ) { rs, _ ->
+        AdminUserStat(
+            id = rs.getLong("id"),
+            email = rs.getString("email"),
+            displayName = rs.getString("display_name"),
+            isAdmin = rs.getBoolean("is_admin"),
+            createdAt = rs.getTimestamp("created_at").toInstant().toString(),
+            games = rs.getLong("games"),
+            wins = rs.getLong("wins"),
+            lastPlayed = rs.getTimestamp("last_played")?.toInstant()?.toString(),
+        )
+    }
 
     fun overview(): GlobalOverview {
         val totalGames = jdbc.queryForObject("SELECT count(*) FROM match_results", Long::class.java) ?: 0

--- a/game-server/src/main/resources/db/migration/V3__admin_role.sql
+++ b/game-server/src/main/resources/db/migration/V3__admin_role.sql
@@ -1,0 +1,6 @@
+-- Per-account admin role. The `game.admin.password` env var stays as a bootstrap credential (it can
+-- always reach the dashboard), but a signed-in account flagged here can reach it via its normal auth
+-- token instead — so the shared password no longer has to be handed around. Promotion happens from the
+-- dashboard's Players view; the first admin is bootstrapped by signing in with the password once and
+-- promoting an account.
+ALTER TABLE users ADD COLUMN is_admin BOOLEAN NOT NULL DEFAULT false;

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/AdminAuthServiceTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/AdminAuthServiceTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.gameserver.auth
+
+import com.wingedsheep.gameserver.config.AdminProperties
+import com.wingedsheep.gameserver.config.GameProperties
+import com.wingedsheep.gameserver.persistence.UserRepository
+import com.wingedsheep.gameserver.persistence.UserRow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.Optional
+
+/**
+ * The two ways into the admin dashboard, and the rejections in between. The bootstrap password and the
+ * admin-account token are independent paths; either suffices, neither leaks the other's absence.
+ */
+class AdminAuthServiceTest : FunSpec({
+
+    fun service(password: String = "secret"): AdminAuthService =
+        AdminAuthService(GameProperties(admin = AdminProperties(password = password)))
+
+    fun claims(uid: Long) = AuthClaims(uid = uid, email = "u$uid@test", exp = Long.MAX_VALUE)
+
+    fun adminUser(uid: Long, isAdmin: Boolean) =
+        Optional.of(UserRow(id = uid, email = "u$uid@test", displayName = "u$uid", isAdmin = isAdmin))
+
+    // ---- Password (bootstrap) path ----
+
+    test("correct bootstrap password authorizes") {
+        service().isAuthorized(password = "secret", authorization = null) shouldBe true
+    }
+
+    test("wrong bootstrap password is rejected") {
+        service().isAuthorized(password = "nope", authorization = null) shouldBe false
+    }
+
+    test("a blank configured password never matches, even against blank/null input") {
+        service(password = "").isAuthorized(password = "", authorization = null) shouldBe false
+        service(password = "").isAuthorized(password = null, authorization = null) shouldBe false
+    }
+
+    // ---- Admin-account token path ----
+
+    test("an admin account's token authorizes") {
+        val svc = service().apply {
+            authSupport = mockk { every { userOrNull("Bearer t") } returns claims(5) }
+            users = mockk { every { findById(5) } returns adminUser(5, isAdmin = true) }
+        }
+        svc.isAuthorized(password = null, authorization = "Bearer t") shouldBe true
+    }
+
+    test("a non-admin account's token is rejected") {
+        val svc = service().apply {
+            authSupport = mockk { every { userOrNull(any()) } returns claims(6) }
+            users = mockk { every { findById(6) } returns adminUser(6, isAdmin = false) }
+        }
+        svc.isAuthorized(password = null, authorization = "Bearer t") shouldBe false
+    }
+
+    test("an invalid token is rejected") {
+        val svc = service().apply { authSupport = mockk { every { userOrNull(any()) } returns null } }
+        svc.isAuthorized(password = null, authorization = "Bearer bad") shouldBe false
+    }
+
+    test("when accounts are disabled (no beans) only the password path exists") {
+        val svc = service() // authSupport / users left null, as on an accounts-disabled server
+        svc.isAuthorized(password = "secret", authorization = "Bearer anything") shouldBe true
+        svc.isAuthorized(password = "wrong", authorization = "Bearer anything") shouldBe false
+    }
+
+    // ---- Feature availability ----
+
+    test("isConfigured is false with no password and accounts disabled") {
+        service(password = "").isConfigured() shouldBe false
+    }
+
+    test("isConfigured is true when accounts are enabled even without a password") {
+        service(password = "").apply { authSupport = mockk() }.isConfigured() shouldBe true
+    }
+})

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -39,6 +39,8 @@ export interface AccountUser {
   readonly id: number
   readonly email: string
   readonly displayName: string
+  /** True when this account has been granted access to the admin dashboard. */
+  readonly isAdmin: boolean
 }
 
 export interface LoginResponse {

--- a/web-client/src/api/adminAuth.ts
+++ b/web-client/src/api/adminAuth.ts
@@ -1,0 +1,17 @@
+/**
+ * Auth for the admin dashboard's REST calls. There are two ways to be an admin (mirrors the server's
+ * AdminAuthService): the bootstrap `X-Admin-Password`, or a signed-in account that has been promoted to
+ * admin (its normal `Authorization: Bearer` token). The whole dashboard threads an `AdminAuth` value —
+ * the bootstrap password when one was entered, or `null` to fall back to the signed-in account's token.
+ */
+import { getAuthToken } from './account'
+
+/** The bootstrap password if the user logged in with it, or null to use the signed-in account's token. */
+export type AdminAuth = string | null
+
+/** Headers for an admin request: the bootstrap password if present, else the account's Bearer token. */
+export function adminAuthHeaders(auth: AdminAuth): Record<string, string> {
+  if (auth) return { 'X-Admin-Password': auth }
+  const token = getAuthToken()
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}

--- a/web-client/src/api/adminStats.ts
+++ b/web-client/src/api/adminStats.ts
@@ -1,9 +1,10 @@
 /**
- * REST client for the admin dashboard's global stats (`/api/stats/admin/*`). Auth reuses the same
- * `X-Admin-Password` header as the replay browser; the password is held by the caller (AdminPage keeps
- * it in sessionStorage). These endpoints are only mounted when the server has accounts enabled.
+ * REST client for the admin dashboard's global stats (`/api/stats/admin/*`). Auth is the dashboard's
+ * shared {@link AdminAuth} — the bootstrap password, or the signed-in admin account's token. These
+ * endpoints are only mounted when the server has accounts enabled.
  */
 import type { StatBucket } from './account'
+import { type AdminAuth, adminAuthHeaders } from './adminAuth'
 
 export interface GlobalOverview {
   readonly totalGames: number
@@ -49,21 +50,21 @@ export interface TournamentSummary {
   readonly winnerName: string | null
 }
 
-async function getAdminStats<T>(password: string, path: string): Promise<T> {
-  const res = await fetch(`/api/stats/admin${path}`, { headers: { 'X-Admin-Password': password } })
+async function getAdminStats<T>(auth: AdminAuth, path: string): Promise<T> {
+  const res = await fetch(`/api/stats/admin${path}`, { headers: adminAuthHeaders(auth) })
   if (!res.ok) throw new Error(`Failed to load stats (${res.status})`)
   return (await res.json()) as T
 }
 
-export const fetchOverview = (pwd: string) => getAdminStats<GlobalOverview>(pwd, '/overview')
-export const fetchGamesPerDay = (pwd: string, days = 30) =>
-  getAdminStats<DailyCount[]>(pwd, `/games-per-day?days=${days}`)
-export const fetchModeDistribution = (pwd: string) => getAdminStats<StatBucket[]>(pwd, '/modes')
-export const fetchColorDistribution = (pwd: string) => getAdminStats<StatBucket[]>(pwd, '/colors')
-export const fetchGeo = (pwd: string) => getAdminStats<GeoBucket[]>(pwd, '/geo')
-export const fetchTopCards = (pwd: string, limit = 50) =>
-  getAdminStats<CardStat[]>(pwd, `/cards?limit=${limit}`)
-export const fetchCardWinRates = (pwd: string, minDecks = 10, limit = 50) =>
-  getAdminStats<CardWinRate[]>(pwd, `/cards/win-rates?minDecks=${minDecks}&limit=${limit}`)
-export const fetchTournaments = (pwd: string, limit = 50) =>
-  getAdminStats<TournamentSummary[]>(pwd, `/tournaments?limit=${limit}`)
+export const fetchOverview = (auth: AdminAuth) => getAdminStats<GlobalOverview>(auth, '/overview')
+export const fetchGamesPerDay = (auth: AdminAuth, days = 30) =>
+  getAdminStats<DailyCount[]>(auth, `/games-per-day?days=${days}`)
+export const fetchModeDistribution = (auth: AdminAuth) => getAdminStats<StatBucket[]>(auth, '/modes')
+export const fetchColorDistribution = (auth: AdminAuth) => getAdminStats<StatBucket[]>(auth, '/colors')
+export const fetchGeo = (auth: AdminAuth) => getAdminStats<GeoBucket[]>(auth, '/geo')
+export const fetchTopCards = (auth: AdminAuth, limit = 50) =>
+  getAdminStats<CardStat[]>(auth, `/cards?limit=${limit}`)
+export const fetchCardWinRates = (auth: AdminAuth, minDecks = 10, limit = 50) =>
+  getAdminStats<CardWinRate[]>(auth, `/cards/win-rates?minDecks=${minDecks}&limit=${limit}`)
+export const fetchTournaments = (auth: AdminAuth, limit = 50) =>
+  getAdminStats<TournamentSummary[]>(auth, `/tournaments?limit=${limit}`)

--- a/web-client/src/api/adminUsers.ts
+++ b/web-client/src/api/adminUsers.ts
@@ -1,0 +1,65 @@
+/**
+ * REST client for the admin Players view (`/api/admin/users/*`): the roster of registered accounts,
+ * one account's full stats, and promoting/demoting admins. Auth is the shared {@link AdminAuth}. Only
+ * mounted when the server has accounts enabled.
+ */
+import type { CardStat, GameHistoryEntry, HeadToHead, StatBucket, UserTournamentEntry } from './account'
+import { type AdminAuth, adminAuthHeaders } from './adminAuth'
+
+/** A registered account with its lifetime record, for the roster. */
+export interface AdminUserSummary {
+  readonly id: number
+  readonly email: string
+  readonly displayName: string
+  readonly isAdmin: boolean
+  readonly createdAt: string
+  readonly games: number
+  readonly wins: number
+  readonly lastPlayed: string | null
+}
+
+export interface AdminUserStats {
+  readonly games: number
+  readonly wins: number
+  readonly losses: number
+  readonly winRate: number
+}
+
+/** One account's full profile + stats, for the detail view. */
+export interface AdminUserDetail {
+  readonly id: number
+  readonly email: string
+  readonly displayName: string
+  readonly isAdmin: boolean
+  readonly createdAt: string
+  readonly stats: AdminUserStats
+  readonly colors: StatBucket[]
+  readonly modes: StatBucket[]
+  readonly opponents: HeadToHead[]
+  readonly topCards: CardStat[]
+  readonly tournaments: UserTournamentEntry[]
+  readonly recentGames: GameHistoryEntry[]
+}
+
+export async function fetchUsers(auth: AdminAuth): Promise<AdminUserSummary[]> {
+  const res = await fetch('/api/admin/users', { headers: adminAuthHeaders(auth) })
+  if (!res.ok) throw new Error(`Failed to load players (${res.status})`)
+  return (await res.json()) as AdminUserSummary[]
+}
+
+export async function fetchUserDetail(auth: AdminAuth, id: number): Promise<AdminUserDetail> {
+  const res = await fetch(`/api/admin/users/${id}`, { headers: adminAuthHeaders(auth) })
+  if (!res.ok) throw new Error(`Failed to load player (${res.status})`)
+  return (await res.json()) as AdminUserDetail
+}
+
+/** Grant or revoke admin access for an account. Returns the new admin flag. */
+export async function setUserAdmin(auth: AdminAuth, id: number, isAdmin: boolean): Promise<boolean> {
+  const res = await fetch(`/api/admin/users/${id}/admin`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...adminAuthHeaders(auth) },
+    body: JSON.stringify({ isAdmin }),
+  })
+  if (!res.ok) throw new Error(`Failed to update admin status (${res.status})`)
+  return ((await res.json()) as { isAdmin: boolean }).isAdmin
+}

--- a/web-client/src/components/admin/AdminDashboard.tsx
+++ b/web-client/src/components/admin/AdminDashboard.tsx
@@ -1,10 +1,10 @@
 /**
- * Admin dashboard: global, cross-user stats served from `/api/stats/admin/*`. Shows headline totals,
- * a games-per-day chart, mode/color distributions, the most-played cards and per-card win rates,
+ * Admin Stats: global, cross-user stats served from `/api/stats/admin/*`. Headline totals, a
+ * games-per-day chart, mode/color distributions, the most-played cards and per-card win rates,
  * recorded tournaments, and an IP-based geolocation estimate of where players connect from.
  *
- * All data is read-only and gated behind the same admin password as the replay browser. Raw IPs are
- * never returned here — the server resolves them to coarse locations server-side.
+ * Read-only and gated behind the dashboard's shared {@link AdminAuth}. Raw IPs are never returned —
+ * the server resolves them to coarse locations server-side. The screen scrolls itself (see AdminScreen).
  */
 import { useEffect, useState } from 'react'
 import type React from 'react'
@@ -35,10 +35,12 @@ import {
   fetchTopCards,
   fetchTournaments,
 } from '@/api/adminStats'
+import type { AdminAuth } from '@/api/adminAuth'
 import type { StatBucket } from '@/api/account'
 import { colorLabel } from './statFormat'
+import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle, chartTooltipStyle } from './adminUi'
 
-export function AdminDashboard({ password, onBack }: { password: string; onBack: () => void }) {
+export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () => void }) {
   const [overview, setOverview] = useState<GlobalOverview | null>(null)
   const [perDay, setPerDay] = useState<DailyCount[]>([])
   const [modes, setModes] = useState<StatBucket[]>([])
@@ -54,13 +56,13 @@ export function AdminDashboard({ password, onBack }: { password: string; onBack:
     async function load() {
       try {
         const [ov, pd, md, cl, cs, wr, tn] = await Promise.all([
-          fetchOverview(password),
-          fetchGamesPerDay(password, 30),
-          fetchModeDistribution(password),
-          fetchColorDistribution(password),
-          fetchTopCards(password, 25),
-          fetchCardWinRates(password, 5, 25),
-          fetchTournaments(password, 25),
+          fetchOverview(auth),
+          fetchGamesPerDay(auth, 30),
+          fetchModeDistribution(auth),
+          fetchColorDistribution(auth),
+          fetchTopCards(auth, 25),
+          fetchCardWinRates(auth, 5, 25),
+          fetchTournaments(auth, 25),
         ])
         if (cancelled) return
         setOverview(ov)
@@ -71,7 +73,7 @@ export function AdminDashboard({ password, onBack }: { password: string; onBack:
         setWinRates(wr)
         setTournaments(tn)
         // Geo can be slow (external lookups) — load it separately so the rest renders first.
-        fetchGeo(password).then((g) => !cancelled && setGeo(g)).catch(() => {})
+        fetchGeo(auth).then((g) => !cancelled && setGeo(g)).catch(() => {})
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load dashboard')
       }
@@ -80,199 +82,121 @@ export function AdminDashboard({ password, onBack }: { password: string; onBack:
     return () => {
       cancelled = true
     }
-  }, [password])
+  }, [auth])
 
   return (
-    <div style={s.page}>
-      <div style={s.container}>
-        <div style={s.headerRow}>
-          <h1 style={s.title}>Dashboard</h1>
-          <button type="button" style={s.link} onClick={onBack}>
-            ← Replays
-          </button>
-        </div>
+    <AdminScreen title="Stats" subtitle="Global activity across every recorded game" onBack={onBack} backLabel="← Dashboard">
+      {error && <p style={styles.error}>{error}</p>}
 
-        {error && <p style={s.error}>{error}</p>}
+      <div style={styles.cardRow}>
+        <StatCard label="Games" value={overview?.totalGames} />
+        <StatCard label="Players" value={overview?.totalPlayers} />
+        <StatCard label="Accounts" value={overview?.totalAccounts} />
+        <StatCard label="Tournaments" value={overview?.totalTournaments} />
+        <StatCard label="Games (24h)" value={overview?.gamesLast24h} accent />
+        <StatCard label="Games (7d)" value={overview?.gamesLast7d} accent />
+      </div>
 
-        <div style={s.cardRow}>
-          <Metric label="Games" value={overview?.totalGames} />
-          <Metric label="Players" value={overview?.totalPlayers} />
-          <Metric label="Accounts" value={overview?.totalAccounts} />
-          <Metric label="Tournaments" value={overview?.totalTournaments} />
-          <Metric label="Games (24h)" value={overview?.gamesLast24h} />
-          <Metric label="Games (7d)" value={overview?.gamesLast7d} />
-        </div>
+      <Panel title="Games per day (last 30 days)">
+        <ResponsiveContainer width="100%" height={220}>
+          <LineChart data={perDay} margin={{ top: 8, right: 16, bottom: 0, left: -16 }}>
+            <CartesianGrid stroke="#22223a" strokeDasharray="3 3" />
+            <XAxis dataKey="day" stroke="#666" fontSize={11} tickFormatter={(d: string) => d.slice(5)} />
+            <YAxis stroke="#666" fontSize={11} allowDecimals={false} />
+            <Tooltip contentStyle={chartTooltipStyle} />
+            <Line type="monotone" dataKey="count" stroke={adminTheme.accentSolid} strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </Panel>
 
-        <Panel title="Games per day (last 30 days)">
-          <ResponsiveContainer width="100%" height={220}>
-            <LineChart data={perDay} margin={{ top: 8, right: 16, bottom: 0, left: -16 }}>
-              <CartesianGrid stroke="#22223a" strokeDasharray="3 3" />
-              <XAxis dataKey="day" stroke="#666" fontSize={11} tickFormatter={(d: string) => d.slice(5)} />
-              <YAxis stroke="#666" fontSize={11} allowDecimals={false} />
-              <Tooltip contentStyle={tooltipStyle} />
-              <Line type="monotone" dataKey="count" stroke="#5b6ee1" strokeWidth={2} dot={false} />
-            </LineChart>
-          </ResponsiveContainer>
+      <div style={styles.twoCol}>
+        <Panel title="Game modes">
+          <BucketBars data={modes} fill="#5b9ee1" />
         </Panel>
-
-        <div style={s.twoCol}>
-          <Panel title="Game modes">
-            <BucketBars data={modes} fill="#5b9ee1" />
-          </Panel>
-          <Panel title="Colors played">
-            <BucketBars data={colors.map((c) => ({ label: colorLabel(c.label), count: c.count }))} fill="#e1a35b" />
-          </Panel>
-        </div>
-
-        <div style={s.twoCol}>
-          <Panel title="Most-played cards">
-            <Table head={['Card', 'Copies', 'Decks']}>
-              {cards.map((c) => (
-                <tr key={c.cardName}>
-                  <td style={s.td}>{c.cardName}</td>
-                  <td style={s.tdNum}>{c.copies}</td>
-                  <td style={s.tdNum}>{c.decks}</td>
-                </tr>
-              ))}
-            </Table>
-          </Panel>
-          <Panel title="Highest win-rate cards (≥5 decks)">
-            <Table head={['Card', 'Win %', 'Decks']}>
-              {winRates.map((c) => (
-                <tr key={c.cardName}>
-                  <td style={s.td}>{c.cardName}</td>
-                  <td style={s.tdNum}>{Math.round(c.winRate * 100)}%</td>
-                  <td style={s.tdNum}>{c.decks}</td>
-                </tr>
-              ))}
-            </Table>
-          </Panel>
-        </div>
-
-        <Panel title="Tournaments">
-          {tournaments.length === 0 ? (
-            <p style={s.muted}>No tournaments recorded yet.</p>
-          ) : (
-            <Table head={['Date', 'Name', 'Mode', 'Players', 'Winner']}>
-              {tournaments.map((t, i) => (
-                <tr key={`${t.endedAt}-${i}`}>
-                  <td style={s.td}>{t.endedAt.slice(0, 10)}</td>
-                  <td style={s.td}>{t.name ?? '—'}</td>
-                  <td style={s.td}>{t.gameMode ?? '—'}</td>
-                  <td style={s.tdNum}>{t.playerCount}</td>
-                  <td style={s.td}>{t.winnerName ?? '—'}</td>
-                </tr>
-              ))}
-            </Table>
-          )}
-        </Panel>
-
-        <Panel title="Where players connect from">
-          {geo.length === 0 ? (
-            <p style={s.muted}>Resolving locations…</p>
-          ) : (
-            <Table head={['Country', 'Region', 'City', 'Games']}>
-              {geo.map((g, i) => (
-                <tr key={`${g.countryCode}-${g.city}-${i}`}>
-                  <td style={s.td}>{g.country ?? 'Unknown'}</td>
-                  <td style={s.td}>{g.region ?? '—'}</td>
-                  <td style={s.td}>{g.city ?? '—'}</td>
-                  <td style={s.tdNum}>{g.games}</td>
-                </tr>
-              ))}
-            </Table>
-          )}
+        <Panel title="Colors played">
+          <BucketBars data={colors.map((c) => ({ label: colorLabel(c.label), count: c.count }))} fill="#e1a35b" />
         </Panel>
       </div>
-    </div>
-  )
-}
 
-function Metric({ label, value }: { label: string; value?: number | undefined }) {
-  return (
-    <div style={s.metric}>
-      <div style={s.metricValue}>{value ?? '—'}</div>
-      <div style={s.metricLabel}>{label}</div>
-    </div>
-  )
-}
+      <div style={styles.twoCol}>
+        <Panel title="Most-played cards">
+          <Table head={['Card', 'Copies', 'Decks']}>
+            {cards.map((c) => (
+              <tr key={c.cardName}>
+                <td style={cellStyle.td}>{c.cardName}</td>
+                <td style={cellStyle.tdNum}>{c.copies}</td>
+                <td style={cellStyle.tdNum}>{c.decks}</td>
+              </tr>
+            ))}
+          </Table>
+        </Panel>
+        <Panel title="Highest win-rate cards (≥5 decks)">
+          <Table head={['Card', 'Win %', 'Decks']}>
+            {winRates.map((c) => (
+              <tr key={c.cardName}>
+                <td style={cellStyle.td}>{c.cardName}</td>
+                <td style={cellStyle.tdNum}>{Math.round(c.winRate * 100)}%</td>
+                <td style={cellStyle.tdNum}>{c.decks}</td>
+              </tr>
+            ))}
+          </Table>
+        </Panel>
+      </div>
 
-function Panel({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div style={s.panel}>
-      <h2 style={s.panelTitle}>{title}</h2>
-      {children}
-    </div>
+      <Panel title="Tournaments">
+        {tournaments.length === 0 ? (
+          <p style={cellStyle.muted}>No tournaments recorded yet.</p>
+        ) : (
+          <Table head={['Date', 'Name', 'Mode', 'Players', 'Winner']}>
+            {tournaments.map((t, i) => (
+              <tr key={`${t.endedAt}-${i}`}>
+                <td style={cellStyle.td}>{t.endedAt.slice(0, 10)}</td>
+                <td style={cellStyle.td}>{t.name ?? '—'}</td>
+                <td style={cellStyle.td}>{t.gameMode ?? '—'}</td>
+                <td style={cellStyle.tdNum}>{t.playerCount}</td>
+                <td style={cellStyle.td}>{t.winnerName ?? '—'}</td>
+              </tr>
+            ))}
+          </Table>
+        )}
+      </Panel>
+
+      <Panel title="Where players connect from">
+        {geo.length === 0 ? (
+          <p style={cellStyle.muted}>Resolving locations…</p>
+        ) : (
+          <Table head={['Country', 'Region', 'City', 'Games']}>
+            {geo.map((g, i) => (
+              <tr key={`${g.countryCode}-${g.city}-${i}`}>
+                <td style={cellStyle.td}>{g.country ?? 'Unknown'}</td>
+                <td style={cellStyle.td}>{g.region ?? '—'}</td>
+                <td style={cellStyle.td}>{g.city ?? '—'}</td>
+                <td style={cellStyle.tdNum}>{g.games}</td>
+              </tr>
+            ))}
+          </Table>
+        )}
+      </Panel>
+    </AdminScreen>
   )
 }
 
 function BucketBars({ data, fill }: { data: StatBucket[]; fill: string }) {
-  if (data.length === 0) return <p style={s.muted}>No data yet.</p>
+  if (data.length === 0) return <p style={cellStyle.muted}>No data yet.</p>
   return (
     <ResponsiveContainer width="100%" height={Math.max(120, data.length * 28)}>
       <BarChart data={data} layout="vertical" margin={{ top: 4, right: 16, bottom: 4, left: 8 }}>
         <XAxis type="number" stroke="#666" fontSize={11} allowDecimals={false} />
         <YAxis type="category" dataKey="label" stroke="#999" fontSize={11} width={90} />
-        <Tooltip contentStyle={tooltipStyle} cursor={{ fill: '#ffffff10' }} />
+        <Tooltip contentStyle={chartTooltipStyle} cursor={{ fill: '#ffffff10' }} />
         <Bar dataKey="count" fill={fill} radius={[0, 4, 4, 0]} />
       </BarChart>
     </ResponsiveContainer>
   )
 }
 
-function Table({ head, children }: { head: string[]; children: React.ReactNode }) {
-  return (
-    <div style={s.tableWrap}>
-      <table style={s.table}>
-        <thead>
-          <tr>
-            {head.map((h, i) => (
-              <th key={h} style={i === 0 ? s.th : s.thNum}>
-                {h}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>{children}</tbody>
-      </table>
-    </div>
-  )
-}
-
-const tooltipStyle: React.CSSProperties = {
-  backgroundColor: '#12121e',
-  border: '1px solid #2a2a3e',
-  borderRadius: 6,
-  color: '#ddd',
-  fontSize: 12,
-}
-
-const s: Record<string, React.CSSProperties> = {
-  page: { minHeight: '100vh', backgroundColor: '#0a0a12', color: '#ccc', padding: '24px 16px' },
-  container: { maxWidth: 960, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 16 },
-  headerRow: { display: 'flex', justifyContent: 'space-between', alignItems: 'center' },
-  title: { margin: 0, color: '#fff', fontSize: 26 },
-  link: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 14 },
-  error: { color: '#ef4444', fontSize: 13, margin: 0 },
+const styles: Record<string, React.CSSProperties> = {
+  error: { color: adminTheme.bad, fontSize: 13, margin: 0 },
   cardRow: { display: 'flex', gap: 12, flexWrap: 'wrap' },
-  metric: {
-    flex: '1 1 120px',
-    backgroundColor: '#12121e',
-    border: '1px solid #1f1f33',
-    borderRadius: 12,
-    padding: '14px 12px',
-    textAlign: 'center',
-  },
-  metricValue: { color: '#fff', fontSize: 24, fontWeight: 700 },
-  metricLabel: { color: '#777', fontSize: 11, marginTop: 4, textTransform: 'uppercase', letterSpacing: 0.5 },
-  panel: { backgroundColor: '#12121e', border: '1px solid #1f1f33', borderRadius: 12, padding: 16 },
-  panelTitle: { margin: '0 0 12px', color: '#e0e0e0', fontSize: 16 },
-  twoCol: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 16 },
-  muted: { color: '#777', fontSize: 13, margin: 0 },
-  tableWrap: { overflowX: 'auto' },
-  table: { width: '100%', borderCollapse: 'collapse', fontSize: 13 },
-  th: { textAlign: 'left', color: '#888', fontWeight: 600, padding: '6px 8px', borderBottom: '1px solid #2a2a3e' },
-  thNum: { textAlign: 'right', color: '#888', fontWeight: 600, padding: '6px 8px', borderBottom: '1px solid #2a2a3e' },
-  td: { textAlign: 'left', color: '#ccc', padding: '6px 8px', borderBottom: '1px solid #1a1a2a' },
-  tdNum: { textAlign: 'right', color: '#ccc', padding: '6px 8px', borderBottom: '1px solid #1a1a2a' },
+  twoCol: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 18 },
 }

--- a/web-client/src/components/admin/AdminHub.tsx
+++ b/web-client/src/components/admin/AdminHub.tsx
@@ -1,0 +1,80 @@
+/**
+ * The admin dashboard landing page: a hub that routes to the three admin areas (Stats, Replays,
+ * Players). It's the starting point a signed-in admin lands on; the bootstrap-password login also
+ * arrives here after authenticating.
+ */
+import type React from 'react'
+import { AdminScreen, adminTheme } from './adminUi'
+
+export type AdminArea = 'stats' | 'replays' | 'players'
+
+interface HubItem {
+  area: AdminArea
+  icon: string
+  title: string
+  description: string
+}
+
+const ITEMS: HubItem[] = [
+  { area: 'stats', icon: '📊', title: 'Stats', description: 'Global activity, decks, cards, win rates and geography.' },
+  { area: 'replays', icon: '🎞️', title: 'Replays', description: 'Browse and play back every completed game.' },
+  { area: 'players', icon: '👥', title: 'Players', description: 'Registered accounts, their games, and admin access.' },
+]
+
+export function AdminHub({
+  onNavigate,
+  onExit,
+  authLabel,
+}: {
+  onNavigate: (area: AdminArea) => void
+  onExit: () => void
+  authLabel: string
+}) {
+  return (
+    <AdminScreen
+      title="Admin Dashboard"
+      subtitle={authLabel}
+      onBack={onExit}
+      backLabel="← Home"
+    >
+      <div style={styles.grid}>
+        {ITEMS.map((item) => (
+          <button key={item.area} type="button" style={styles.card} onClick={() => onNavigate(item.area)}>
+            <span style={styles.icon} aria-hidden>
+              {item.icon}
+            </span>
+            <span style={styles.cardTitle}>{item.title}</span>
+            <span style={styles.cardDesc}>{item.description}</span>
+            <span style={styles.cardArrow}>Open →</span>
+          </button>
+        ))}
+      </div>
+    </AdminScreen>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+    gap: 18,
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: 8,
+    textAlign: 'left',
+    backgroundColor: adminTheme.panel,
+    border: `1px solid ${adminTheme.border}`,
+    borderRadius: 16,
+    padding: '22px 20px 18px',
+    color: adminTheme.text,
+    cursor: 'pointer',
+    transition: 'border-color 120ms ease, transform 120ms ease',
+  },
+  icon: { fontSize: 30, lineHeight: 1 },
+  cardTitle: { fontSize: 18, fontWeight: 700, marginTop: 4 },
+  cardDesc: { fontSize: 13, color: adminTheme.textSecondary, lineHeight: 1.45 },
+  cardArrow: { marginTop: 6, fontSize: 13, fontWeight: 600, color: adminTheme.accent },
+}

--- a/web-client/src/components/admin/AdminPage.tsx
+++ b/web-client/src/components/admin/AdminPage.tsx
@@ -1,232 +1,267 @@
-import { useState, useEffect, useCallback } from 'react'
+/**
+ * Admin dashboard entry point. Resolves admin access two ways (mirroring the server's AdminAuthService):
+ *
+ *  1. a signed-in account flagged as admin — taken straight in, using its normal auth token, or
+ *  2. the bootstrap `X-Admin-Password`, entered once and kept in sessionStorage for the session.
+ *
+ * Once in, it's a hub that routes to the three admin areas (Stats / Replays / Players). The bootstrap
+ * password is only needed to create the first admin: sign in with it, open Players, and promote an
+ * account — that account can then reach the dashboard with its own sign-in.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import type React from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ReplayViewer, type GameSummary } from './ReplayViewer'
 import { AdminDashboard } from './AdminDashboard'
+import { AdminPlayers } from './AdminPlayers'
+import { AdminHub, type AdminArea } from './AdminHub'
+import { adminTheme } from './adminUi'
+import { type AdminAuth, adminAuthHeaders } from '@/api/adminAuth'
+import { useAuthStore } from '@/store/authStore'
 import type { ReplayData } from '@/replay/reconstructSnapshots.ts'
 
-// ============================================================================
-// AdminPage
-// ============================================================================
-
-type View = 'login' | 'replays' | 'dashboard'
+type Access = 'pending' | 'granted' | 'denied'
 
 export function AdminPage() {
-  const [view, setView] = useState<View>('login')
-  const [password, setPassword] = useState(() => sessionStorage.getItem('adminPassword') ?? '')
+  const navigate = useNavigate()
+  const user = useAuthStore((s) => s.user)
+  const authStatus = useAuthStore((s) => s.status)
+  const initAuth = useAuthStore((s) => s.init)
+
+  const [access, setAccess] = useState<Access>('pending')
+  /** Bootstrap password if that's how we got in, else null (use the signed-in account's token). */
+  const [auth, setAuth] = useState<AdminAuth>(null)
+  const [view, setView] = useState<'hub' | AdminArea>('hub')
+
+  const [passwordDraft, setPasswordDraft] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  const validatePassword = useCallback(async (pwd: string): Promise<boolean> => {
+  /** Validate a bootstrap password against an admin endpoint. */
+  const validatePassword = useCallback(async (pwd: string): Promise<{ ok: boolean; error?: string }> => {
     try {
-      const res = await fetch('/api/admin/games', {
-        headers: { 'X-Admin-Password': pwd },
-      })
+      const res = await fetch('/api/admin/games', { headers: { 'X-Admin-Password': pwd } })
       if (res.status === 401) {
-        const data = await res.json()
-        setError(data.error ?? 'Unauthorized')
-        return false
+        const data = (await res.json().catch(() => null)) as { error?: string } | null
+        return { ok: false, error: data?.error ?? 'Invalid admin password' }
       }
-      if (!res.ok) {
-        setError(`Server error: ${res.status}`)
-        return false
-      }
-      return true
+      if (!res.ok) return { ok: false, error: `Server error: ${res.status}` }
+      return { ok: true }
     } catch {
-      setError('Failed to connect to server')
-      return false
+      return { ok: false, error: 'Failed to connect to server' }
     }
   }, [])
+
+  // Resolve the account session once.
+  useEffect(() => {
+    if (authStatus === 'idle') void initAuth()
+  }, [authStatus, initAuth])
+
+  // Decide access: admin account first, then a stored bootstrap password.
+  useEffect(() => {
+    if (access === 'granted') return
+    if (authStatus === 'idle' || authStatus === 'loading') return // wait for the session to resolve
+    let cancelled = false
+    async function resolve() {
+      if (user?.isAdmin) {
+        if (!cancelled) {
+          setAuth(null)
+          setAccess('granted')
+        }
+        return
+      }
+      const saved = sessionStorage.getItem('adminPassword')
+      if (saved) {
+        const { ok } = await validatePassword(saved)
+        if (cancelled) return
+        if (ok) {
+          setAuth(saved)
+          setAccess('granted')
+          return
+        }
+        sessionStorage.removeItem('adminPassword')
+      }
+      if (!cancelled) setAccess('denied')
+    }
+    void resolve()
+    return () => {
+      cancelled = true
+    }
+  }, [authStatus, user, access, validatePassword])
 
   const handleLogin = async () => {
     setLoading(true)
     setError(null)
-    const ok = await validatePassword(password)
-    if (ok) {
-      sessionStorage.setItem('adminPassword', password)
-      setView('replays')
+    const result = await validatePassword(passwordDraft)
+    if (result.ok) {
+      sessionStorage.setItem('adminPassword', passwordDraft)
+      setAuth(passwordDraft)
+      setView('hub')
+      setAccess('granted')
+    } else {
+      setError(result.error ?? 'Login failed')
     }
     setLoading(false)
   }
 
   const fetchGames = useCallback(async (): Promise<GameSummary[]> => {
-    const res = await fetch('/api/admin/games', {
-      headers: { 'X-Admin-Password': password },
-    })
+    const res = await fetch('/api/admin/games', { headers: adminAuthHeaders(auth) })
     if (!res.ok) throw new Error(`Server error: ${res.status}`)
-    return await res.json() as GameSummary[]
-  }, [password])
+    return (await res.json()) as GameSummary[]
+  }, [auth])
 
-  const fetchReplay = useCallback(async (gameId: string): Promise<ReplayData> => {
-    const res = await fetch(`/api/admin/games/${gameId}/replay`, {
-      headers: { 'X-Admin-Password': password },
-    })
-    if (!res.ok) throw new Error(`Failed to load replay: ${res.status}`)
-    return await res.json() as ReplayData
-  }, [password])
-
-  // Try auto-login on mount
-  useEffect(() => {
-    const saved = sessionStorage.getItem('adminPassword')
-    if (saved) {
-      validatePassword(saved).then((ok) => {
-        if (ok) setView('replays')
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  if (view === 'login') {
-    return <LoginView password={password} setPassword={setPassword} onLogin={handleLogin} error={error} loading={loading} />
-  }
-
-  if (view === 'dashboard') {
-    return <AdminDashboard password={password} onBack={() => setView('replays')} />
-  }
-
-  return (
-    <>
-      <div style={navStyles.bar}>
-        <span style={navStyles.tabActive}>Replays</span>
-        <button type="button" style={navStyles.tab} onClick={() => setView('dashboard')}>
-          Dashboard
-        </button>
-      </div>
-      <ReplayViewer
-        fetchGames={fetchGames}
-        fetchReplay={fetchReplay}
-        onBack={() => {
-          sessionStorage.removeItem('adminPassword')
-          setView('login')
-        }}
-      />
-    </>
+  const fetchReplay = useCallback(
+    async (gameId: string): Promise<ReplayData> => {
+      const res = await fetch(`/api/admin/games/${gameId}/replay`, { headers: adminAuthHeaders(auth) })
+      if (!res.ok) throw new Error(`Failed to load replay: ${res.status}`)
+      return (await res.json()) as ReplayData
+    },
+    [auth],
   )
-}
 
-const navStyles: Record<string, React.CSSProperties> = {
-  bar: {
-    display: 'flex',
-    gap: 8,
-    padding: '8px 16px',
-    backgroundColor: '#0a0a12',
-    borderBottom: '1px solid #1a1a2e',
-  },
-  tabActive: {
-    padding: '6px 12px',
-    borderRadius: 6,
-    backgroundColor: '#1a1a2e',
-    color: '#fff',
-    fontSize: 13,
-  },
-  tab: {
-    padding: '6px 12px',
-    borderRadius: 6,
-    backgroundColor: 'transparent',
-    color: '#8b9bff',
-    border: '1px solid #2a2a3e',
-    cursor: 'pointer',
-    fontSize: 13,
-  },
+  if (access === 'pending') {
+    return (
+      <div style={styles.pageContainer}>
+        <p style={styles.loadingText}>Loading…</p>
+      </div>
+    )
+  }
+
+  if (access === 'denied') {
+    return (
+      <LoginView
+        password={passwordDraft}
+        setPassword={setPasswordDraft}
+        onLogin={handleLogin}
+        onHome={() => navigate('/')}
+        error={error}
+        loading={loading}
+      />
+    )
+  }
+
+  if (view === 'stats') {
+    return <AdminDashboard auth={auth} onBack={() => setView('hub')} />
+  }
+  if (view === 'players') {
+    return <AdminPlayers auth={auth} onBack={() => setView('hub')} />
+  }
+  if (view === 'replays') {
+    return <ReplayViewer fetchGames={fetchGames} fetchReplay={fetchReplay} onBack={() => setView('hub')} />
+  }
+
+  const authLabel = auth ? 'Signed in with the admin password' : `Signed in as ${user?.displayName ?? 'admin'}`
+  return <AdminHub onNavigate={setView} onExit={() => navigate('/')} authLabel={authLabel} />
 }
 
 // ============================================================================
-// Login View
+// Login View (bootstrap password)
 // ============================================================================
 
 function LoginView({
   password,
   setPassword,
   onLogin,
+  onHome,
   error,
   loading,
 }: {
   password: string
   setPassword: (p: string) => void
   onLogin: () => void
+  onHome: () => void
   error: string | null
   loading: boolean
 }) {
   return (
     <div style={styles.pageContainer}>
       <div style={styles.loginCard}>
-        <h1 style={styles.loginTitle}>Game Replays</h1>
-        <p style={styles.loginSubtitle}>Enter admin password to continue</p>
+        <div style={styles.loginIcon} aria-hidden>
+          🔑
+        </div>
+        <h1 style={styles.loginTitle}>Admin Dashboard</h1>
+        <p style={styles.loginSubtitle}>
+          Enter the admin password, or sign in with an admin account to skip this step.
+        </p>
         <input
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && onLogin()}
-          placeholder="Password"
+          placeholder="Admin password"
           style={styles.input}
           autoFocus
         />
         <button onClick={onLogin} disabled={loading || !password} style={styles.primaryButton}>
-          {loading ? 'Connecting...' : 'Login'}
+          {loading ? 'Connecting…' : 'Continue'}
         </button>
         {error && <p style={styles.errorText}>{error}</p>}
+        <button type="button" onClick={onHome} style={styles.homeLink}>
+          ← Back to home
+        </button>
       </div>
     </div>
   )
 }
 
-// ============================================================================
-// Styles
-// ============================================================================
-
 const styles: Record<string, React.CSSProperties> = {
   pageContainer: {
     minHeight: '100vh',
-    backgroundColor: '#0a0a12',
-    color: '#ccc',
+    height: '100vh',
+    overflowY: 'auto',
+    backgroundColor: adminTheme.bg,
+    color: adminTheme.textSecondary,
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'flex-start',
-    paddingTop: 80,
+    alignItems: 'center',
     fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
   },
+  loadingText: { color: adminTheme.textMuted, fontSize: 14 },
   loginCard: {
-    backgroundColor: '#12121e',
-    borderRadius: 12,
-    padding: '40px 48px',
+    backgroundColor: adminTheme.panel,
+    borderRadius: 16,
+    padding: '36px 40px',
     textAlign: 'center',
-    border: '1px solid #1a1a2e',
-    width: 360,
+    border: `1px solid ${adminTheme.border}`,
+    width: 380,
+    maxWidth: '92vw',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
   },
-  loginTitle: {
-    margin: '0 0 8px',
-    fontSize: 24,
-    color: '#e0e0e0',
-  },
-  loginSubtitle: {
-    margin: '0 0 24px',
-    fontSize: 14,
-    color: '#666',
-  },
+  loginIcon: { fontSize: 34, marginBottom: 8 },
+  loginTitle: { margin: '0 0 8px', fontSize: 22, color: adminTheme.text, fontWeight: 700 },
+  loginSubtitle: { margin: '0 0 22px', fontSize: 13.5, color: adminTheme.textMuted, lineHeight: 1.5 },
   input: {
     width: '100%',
-    padding: '10px 14px',
+    padding: '11px 14px',
     fontSize: 14,
     backgroundColor: '#0a0a14',
-    color: '#ccc',
-    border: '1px solid #2a2a3e',
-    borderRadius: 6,
+    color: adminTheme.text,
+    border: `1px solid ${adminTheme.border}`,
+    borderRadius: 9,
     outline: 'none',
-    marginBottom: 16,
+    marginBottom: 14,
     boxSizing: 'border-box',
   },
   primaryButton: {
     width: '100%',
-    padding: '10px 0',
+    padding: '11px 0',
     fontSize: 14,
-    backgroundColor: '#2563eb',
+    fontWeight: 600,
+    backgroundColor: adminTheme.accentSolid,
     color: '#fff',
     border: 'none',
-    borderRadius: 6,
+    borderRadius: 9,
     cursor: 'pointer',
   },
-  errorText: {
-    color: '#ef4444',
+  errorText: { color: adminTheme.bad, fontSize: 13, marginTop: 12, marginBottom: 0 },
+  homeLink: {
+    marginTop: 18,
+    background: 'none',
+    border: 'none',
+    color: adminTheme.accent,
+    cursor: 'pointer',
     fontSize: 13,
-    marginTop: 12,
-    marginBottom: 0,
   },
 }

--- a/web-client/src/components/admin/AdminPlayers.tsx
+++ b/web-client/src/components/admin/AdminPlayers.tsx
@@ -1,0 +1,336 @@
+/**
+ * Admin Players: the roster of registered accounts and a per-account drill-down (lifetime record,
+ * colors, modes, head-to-head, recent games, tournaments) — plus the control to grant/revoke admin
+ * access. This is the page from which the first admin is bootstrapped: sign in once with the admin
+ * password, open a player here, and promote their account; from then on they reach the dashboard with
+ * their normal sign-in. Auth is the dashboard's shared {@link AdminAuth}.
+ */
+import { useEffect, useState } from 'react'
+import type React from 'react'
+import {
+  type AdminUserDetail,
+  type AdminUserSummary,
+  fetchUserDetail,
+  fetchUsers,
+  setUserAdmin,
+} from '@/api/adminUsers'
+import type { AdminAuth } from '@/api/adminAuth'
+import { colorLabel } from './statFormat'
+import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle } from './adminUi'
+
+export function AdminPlayers({ auth, onBack }: { auth: AdminAuth; onBack: () => void }) {
+  const [users, setUsers] = useState<AdminUserSummary[]>([])
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    fetchUsers(auth)
+      .then((u) => !cancelled && setUsers(u))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Failed to load players'))
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [auth])
+
+  /** Reflect an admin-flag change from the detail view back into the roster row. */
+  const applyAdminChange = (id: number, isAdmin: boolean) =>
+    setUsers((prev) => prev.map((u) => (u.id === id ? { ...u, isAdmin } : u)))
+
+  if (selectedId != null) {
+    return (
+      <PlayerDetail
+        auth={auth}
+        id={selectedId}
+        onBack={() => setSelectedId(null)}
+        onAdminChange={applyAdminChange}
+      />
+    )
+  }
+
+  return (
+    <AdminScreen
+      title="Players"
+      subtitle={`${users.length} registered account${users.length === 1 ? '' : 's'}`}
+      onBack={onBack}
+      backLabel="← Dashboard"
+    >
+      {error && <p style={styles.error}>{error}</p>}
+      <Panel>
+        {loading ? (
+          <p style={cellStyle.muted}>Loading players…</p>
+        ) : users.length === 0 ? (
+          <p style={cellStyle.muted}>No registered accounts yet.</p>
+        ) : (
+          <Table head={['Player', 'Games', 'Wins', 'Win %', 'Last played', '']}>
+            {users.map((u) => {
+              const winRate = u.games > 0 ? Math.round((u.wins / u.games) * 100) : 0
+              return (
+                <tr key={u.id} style={styles.row} onClick={() => setSelectedId(u.id)}>
+                  <td style={cellStyle.td}>
+                    <div style={styles.playerCell}>
+                      <span style={styles.playerName}>{u.displayName}</span>
+                      {u.isAdmin && <span style={styles.adminBadge}>ADMIN</span>}
+                    </div>
+                    <div style={styles.playerEmail}>{u.email}</div>
+                  </td>
+                  <td style={cellStyle.tdNum}>{u.games}</td>
+                  <td style={cellStyle.tdNum}>{u.wins}</td>
+                  <td style={cellStyle.tdNum}>{u.games > 0 ? `${winRate}%` : '—'}</td>
+                  <td style={cellStyle.tdNum}>{u.lastPlayed ? u.lastPlayed.slice(0, 10) : '—'}</td>
+                  <td style={cellStyle.tdNum}>
+                    <span style={styles.viewLink}>View →</span>
+                  </td>
+                </tr>
+              )
+            })}
+          </Table>
+        )}
+      </Panel>
+    </AdminScreen>
+  )
+}
+
+function PlayerDetail({
+  auth,
+  id,
+  onBack,
+  onAdminChange,
+}: {
+  auth: AdminAuth
+  id: number
+  onBack: () => void
+  onAdminChange: (id: number, isAdmin: boolean) => void
+}) {
+  const [detail, setDetail] = useState<AdminUserDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [updating, setUpdating] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchUserDetail(auth, id)
+      .then((d) => !cancelled && setDetail(d))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Failed to load player'))
+    return () => {
+      cancelled = true
+    }
+  }, [auth, id])
+
+  const toggleAdmin = async () => {
+    if (!detail) return
+    const next = !detail.isAdmin
+    setUpdating(true)
+    setError(null)
+    try {
+      const isAdmin = await setUserAdmin(auth, id, next)
+      setDetail({ ...detail, isAdmin })
+      onAdminChange(id, isAdmin)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update admin status')
+    } finally {
+      setUpdating(false)
+    }
+  }
+
+  const adminButton = detail && (
+    <button
+      type="button"
+      style={detail.isAdmin ? styles.demoteBtn : styles.promoteBtn}
+      disabled={updating}
+      onClick={() => void toggleAdmin()}
+    >
+      {updating ? 'Saving…' : detail.isAdmin ? 'Revoke admin' : 'Make admin'}
+    </button>
+  )
+
+  return (
+    <AdminScreen
+      title={detail?.displayName ?? 'Player'}
+      subtitle={detail?.email}
+      onBack={onBack}
+      backLabel="← Players"
+      right={adminButton}
+    >
+      {error && <p style={styles.error}>{error}</p>}
+      {!detail ? (
+        <p style={cellStyle.muted}>Loading…</p>
+      ) : (
+        <>
+          {detail.isAdmin && (
+            <div style={styles.adminNotice}>
+              <span style={styles.adminBadge}>ADMIN</span>
+              <span style={cellStyle.muted}>This account can reach the admin dashboard with its own sign-in.</span>
+            </div>
+          )}
+
+          <div style={styles.cardRow}>
+            <StatCard label="Games" value={detail.stats.games} />
+            <StatCard label="Wins" value={detail.stats.wins} />
+            <StatCard label="Losses" value={detail.stats.losses} />
+            <StatCard
+              label="Win rate"
+              value={detail.stats.games > 0 ? `${Math.round(detail.stats.winRate * 100)}%` : '—'}
+              accent
+            />
+          </div>
+
+          <div style={styles.meta}>Joined {detail.createdAt.slice(0, 10)}</div>
+
+          {detail.colors.length > 0 && (
+            <Panel title="Colors played">
+              <ChipList items={detail.colors.map((c) => `${colorLabel(c.label)} · ${c.count}`)} />
+            </Panel>
+          )}
+
+          {detail.modes.length > 0 && (
+            <Panel title="Game modes">
+              <ChipList items={detail.modes.map((m) => `${prettyMode(m.label)} · ${m.count}`)} />
+            </Panel>
+          )}
+
+          {detail.opponents.length > 0 && (
+            <Panel title="Head to head">
+              <Table head={['Opponent', 'W', 'L']}>
+                {detail.opponents.map((o, i) => (
+                  <tr key={`${o.opponent}-${i}`}>
+                    <td style={cellStyle.td}>
+                      {o.opponent}
+                      {o.isAi && <span style={styles.aiTag}> AI</span>}
+                    </td>
+                    <td style={cellStyle.tdNum}>{o.wins}</td>
+                    <td style={cellStyle.tdNum}>{o.losses}</td>
+                  </tr>
+                ))}
+              </Table>
+            </Panel>
+          )}
+
+          {detail.topCards.length > 0 && (
+            <Panel title="Most-played cards">
+              <ChipList items={detail.topCards.map((c) => `${c.cardName} · ${c.copies}`)} />
+            </Panel>
+          )}
+
+          {detail.tournaments.length > 0 && (
+            <Panel title="Tournaments">
+              <Table head={['Date', 'Tournament', 'Place']}>
+                {detail.tournaments.map((t, i) => (
+                  <tr key={`${t.endedAt}-${i}`}>
+                    <td style={cellStyle.td}>{t.endedAt.slice(0, 10)}</td>
+                    <td style={cellStyle.td}>{t.name ?? '—'}</td>
+                    <td style={cellStyle.tdNum}>
+                      {t.placement}/{t.playerCount}
+                    </td>
+                  </tr>
+                ))}
+              </Table>
+            </Panel>
+          )}
+
+          {detail.recentGames.length > 0 && (
+            <Panel title="Recent games">
+              <Table head={['Date', 'Mode', 'Colors', 'Opponent', 'Result']}>
+                {detail.recentGames.map((g, i) => (
+                  <tr key={`${g.endedAt}-${i}`}>
+                    <td style={cellStyle.td}>{g.endedAt.slice(0, 10)}</td>
+                    <td style={cellStyle.td}>{prettyMode(g.gameMode)}</td>
+                    <td style={cellStyle.td}>{g.colors ? colorLabel(g.colors) : '—'}</td>
+                    <td style={cellStyle.td}>{g.opponents ?? '—'}</td>
+                    <td style={{ ...cellStyle.tdNum, color: g.won ? adminTheme.good : adminTheme.bad }}>
+                      {g.won ? 'Win' : 'Loss'}
+                    </td>
+                  </tr>
+                ))}
+              </Table>
+            </Panel>
+          )}
+        </>
+      )}
+    </AdminScreen>
+  )
+}
+
+function ChipList({ items }: { items: string[] }) {
+  return (
+    <div style={styles.chipRow}>
+      {items.map((it) => (
+        <span key={it} style={styles.chip}>
+          {it}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/** Turn a raw game-mode token (TOURNAMENT / QUICK_GAME / ...) into a readable label. */
+function prettyMode(mode: string | null): string {
+  if (!mode) return '—'
+  return mode
+    .toLowerCase()
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  error: { color: adminTheme.bad, fontSize: 13, margin: 0 },
+  row: { cursor: 'pointer' },
+  playerCell: { display: 'flex', alignItems: 'center', gap: 8 },
+  playerName: { color: adminTheme.text, fontWeight: 600 },
+  playerEmail: { color: adminTheme.textMuted, fontSize: 12, marginTop: 2 },
+  adminBadge: {
+    fontSize: 10,
+    fontWeight: 700,
+    letterSpacing: 0.6,
+    color: adminTheme.accent,
+    backgroundColor: 'rgba(139,155,255,0.12)',
+    border: `1px solid ${adminTheme.accent}55`,
+    borderRadius: 999,
+    padding: '2px 7px',
+  },
+  viewLink: { color: adminTheme.accent, fontSize: 13, whiteSpace: 'nowrap' },
+  cardRow: { display: 'flex', gap: 12, flexWrap: 'wrap' },
+  meta: { color: adminTheme.textMuted, fontSize: 13 },
+  adminNotice: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: 'rgba(139,155,255,0.06)',
+    border: `1px solid ${adminTheme.border}`,
+    borderRadius: 12,
+    padding: '10px 14px',
+  },
+  aiTag: { color: adminTheme.textMuted, fontSize: 11 },
+  chipRow: { display: 'flex', flexWrap: 'wrap', gap: 8 },
+  chip: {
+    backgroundColor: adminTheme.panelAlt,
+    border: `1px solid ${adminTheme.border}`,
+    borderRadius: 999,
+    padding: '4px 12px',
+    color: adminTheme.textSecondary,
+    fontSize: 13,
+  },
+  promoteBtn: {
+    padding: '8px 14px',
+    borderRadius: 9,
+    border: 'none',
+    backgroundColor: adminTheme.accentSolid,
+    color: '#fff',
+    fontWeight: 600,
+    fontSize: 13,
+    cursor: 'pointer',
+  },
+  demoteBtn: {
+    padding: '8px 14px',
+    borderRadius: 9,
+    border: `1px solid ${adminTheme.bad}66`,
+    backgroundColor: 'transparent',
+    color: adminTheme.bad,
+    fontWeight: 600,
+    fontSize: 13,
+    cursor: 'pointer',
+  },
+}

--- a/web-client/src/components/admin/adminUi.tsx
+++ b/web-client/src/components/admin/adminUi.tsx
@@ -1,0 +1,238 @@
+/**
+ * Shared chrome and primitives for the admin dashboard's sub-screens (hub, stats, players). The whole
+ * app runs inside `#root { height:100%; overflow:hidden }` (the game board is a fixed full-screen
+ * surface), so a normal tall page is clipped with no way to scroll. Every admin screen therefore makes
+ * itself its OWN scroll container via {@link AdminScreen} (`height:100vh; overflowY:auto`) rather than
+ * relying on document scroll — this is the fix for the dashboard running off-screen.
+ */
+import type React from 'react'
+
+export const adminTheme = {
+  bg: '#0a0a12',
+  panel: '#13131f',
+  panelAlt: '#171724',
+  border: '#23233a',
+  borderSoft: '#1c1c2c',
+  accent: '#8b9bff',
+  accentSolid: '#5b6ee1',
+  text: '#f1f1f6',
+  textSecondary: '#a6a6bd',
+  textMuted: '#6c6c82',
+  good: '#5bd16e',
+  bad: '#e15b6e',
+} as const
+
+/**
+ * A full-height, self-scrolling admin screen with a sticky header (back affordance + title + optional
+ * subtitle + right-aligned slot) and a centered content column.
+ */
+export function AdminScreen({
+  title,
+  subtitle,
+  onBack,
+  backLabel = '← Back',
+  right,
+  children,
+}: {
+  title: string
+  subtitle?: string | undefined
+  onBack?: (() => void) | undefined
+  backLabel?: string
+  right?: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <div style={shell.screen}>
+      <div style={shell.topbar}>
+        <div style={shell.topbarInner}>
+          <div style={shell.titleBlock}>
+            {onBack && (
+              <button type="button" style={shell.backBtn} onClick={onBack}>
+                {backLabel}
+              </button>
+            )}
+            <div>
+              <h1 style={shell.title}>{title}</h1>
+              {subtitle && <p style={shell.subtitle}>{subtitle}</p>}
+            </div>
+          </div>
+          {right && <div style={shell.right}>{right}</div>}
+        </div>
+      </div>
+      <div style={shell.container}>{children}</div>
+    </div>
+  )
+}
+
+export function Panel({
+  title,
+  action,
+  children,
+  span2,
+}: {
+  title?: string
+  action?: React.ReactNode
+  children: React.ReactNode
+  span2?: boolean
+}) {
+  return (
+    <div style={span2 ? { ...panelStyle.panel, gridColumn: '1 / -1' } : panelStyle.panel}>
+      {(title || action) && (
+        <div style={panelStyle.panelHead}>
+          {title && <h2 style={panelStyle.panelTitle}>{title}</h2>}
+          {action}
+        </div>
+      )}
+      {children}
+    </div>
+  )
+}
+
+export function StatCard({ label, value, accent }: { label: string; value: React.ReactNode; accent?: boolean }) {
+  return (
+    <div style={panelStyle.metric}>
+      <div style={accent ? { ...panelStyle.metricValue, color: adminTheme.accent } : panelStyle.metricValue}>
+        {value ?? '—'}
+      </div>
+      <div style={panelStyle.metricLabel}>{label}</div>
+    </div>
+  )
+}
+
+export function Table({ head, children }: { head: React.ReactNode[]; children: React.ReactNode }) {
+  return (
+    <div style={tableStyle.wrap}>
+      <table style={tableStyle.table}>
+        <thead>
+          <tr>
+            {head.map((h, i) => (
+              <th key={i} style={i === 0 ? tableStyle.th : tableStyle.thNum}>
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  )
+}
+
+export const chartTooltipStyle: React.CSSProperties = {
+  backgroundColor: adminTheme.panelAlt,
+  border: `1px solid ${adminTheme.border}`,
+  borderRadius: 8,
+  color: adminTheme.text,
+  fontSize: 12,
+}
+
+const shell: Record<string, React.CSSProperties> = {
+  screen: {
+    height: '100vh',
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    backgroundColor: adminTheme.bg,
+    color: adminTheme.text,
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  },
+  topbar: {
+    position: 'sticky',
+    top: 0,
+    zIndex: 10,
+    backgroundColor: 'rgba(10,10,18,0.86)',
+    backdropFilter: 'blur(10px)',
+    WebkitBackdropFilter: 'blur(10px)',
+    borderBottom: `1px solid ${adminTheme.border}`,
+  },
+  topbarInner: {
+    maxWidth: 1040,
+    margin: '0 auto',
+    padding: '14px 20px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  titleBlock: { display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 },
+  backBtn: {
+    flexShrink: 0,
+    background: 'none',
+    border: `1px solid ${adminTheme.border}`,
+    color: adminTheme.accent,
+    cursor: 'pointer',
+    fontSize: 13,
+    borderRadius: 8,
+    padding: '7px 12px',
+  },
+  title: { margin: 0, color: adminTheme.text, fontSize: 20, fontWeight: 700, letterSpacing: -0.2 },
+  subtitle: { margin: '2px 0 0', color: adminTheme.textMuted, fontSize: 13 },
+  right: { display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 },
+  container: {
+    maxWidth: 1040,
+    margin: '0 auto',
+    padding: '24px 20px 64px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 18,
+  },
+}
+
+const panelStyle: Record<string, React.CSSProperties> = {
+  panel: {
+    backgroundColor: adminTheme.panel,
+    border: `1px solid ${adminTheme.border}`,
+    borderRadius: 14,
+    padding: 18,
+  },
+  panelHead: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    marginBottom: 14,
+  },
+  panelTitle: { margin: 0, color: adminTheme.text, fontSize: 15, fontWeight: 600 },
+  metric: {
+    flex: '1 1 130px',
+    backgroundColor: adminTheme.panel,
+    border: `1px solid ${adminTheme.border}`,
+    borderRadius: 14,
+    padding: '16px 14px',
+    textAlign: 'center',
+  },
+  metricValue: { color: adminTheme.text, fontSize: 26, fontWeight: 700, lineHeight: 1.1 },
+  metricLabel: {
+    color: adminTheme.textMuted,
+    fontSize: 11,
+    marginTop: 6,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+}
+
+const tableStyle: Record<string, React.CSSProperties> = {
+  wrap: { overflowX: 'auto' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: 13 },
+  th: {
+    textAlign: 'left',
+    color: adminTheme.textMuted,
+    fontWeight: 600,
+    padding: '8px 10px',
+    borderBottom: `1px solid ${adminTheme.border}`,
+    whiteSpace: 'nowrap',
+  },
+  thNum: {
+    textAlign: 'right',
+    color: adminTheme.textMuted,
+    fontWeight: 600,
+    padding: '8px 10px',
+    borderBottom: `1px solid ${adminTheme.border}`,
+    whiteSpace: 'nowrap',
+  },
+}
+
+export const cellStyle: Record<string, React.CSSProperties> = {
+  td: { textAlign: 'left', color: adminTheme.textSecondary, padding: '8px 10px', borderBottom: `1px solid ${adminTheme.borderSoft}` },
+  tdNum: { textAlign: 'right', color: adminTheme.textSecondary, padding: '8px 10px', borderBottom: `1px solid ${adminTheme.borderSoft}` },
+  muted: { color: adminTheme.textMuted, fontSize: 13, margin: 0 },
+}

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -138,6 +138,14 @@ export function ProfilePage() {
           )}
           {nameError ? <p style={styles.error}>{nameError}</p> : <p style={styles.muted}>{user.email}</p>}
 
+          {user.isAdmin && (
+            <button type="button" style={styles.adminLink} onClick={() => navigate('/admin')}>
+              <span style={styles.adminLinkBadge}>ADMIN</span>
+              <span style={styles.adminLinkText}>Open the admin dashboard</span>
+              <span style={styles.adminLinkArrow}>→</span>
+            </button>
+          )}
+
           <div style={styles.statsRow}>
             <Stat label="Games" value={stats?.games ?? 0} />
             <Stat label="Wins" value={stats?.wins ?? 0} />
@@ -347,7 +355,32 @@ const tooltipStyle: React.CSSProperties = {
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  wrap: { minHeight: '100vh', backgroundColor: '#0a0a15', padding: '32px 16px' },
+  wrap: { height: '100vh', overflowY: 'auto', backgroundColor: '#0a0a15', padding: '32px 16px' },
+  adminLink: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 10,
+    marginTop: 8,
+    backgroundColor: 'rgba(139,155,255,0.08)',
+    border: '1px solid #2f2f55',
+    borderRadius: 12,
+    padding: '12px 16px',
+    color: '#fff',
+    cursor: 'pointer',
+    textAlign: 'left',
+  },
+  adminLinkBadge: {
+    fontSize: 10,
+    fontWeight: 700,
+    letterSpacing: 0.6,
+    color: '#8b9bff',
+    backgroundColor: 'rgba(139,155,255,0.14)',
+    border: '1px solid #8b9bff55',
+    borderRadius: 999,
+    padding: '2px 7px',
+  },
+  adminLinkText: { flex: 1, fontSize: 14, fontWeight: 600 },
+  adminLinkArrow: { color: '#8b9bff', fontSize: 16, fontWeight: 700 },
   container: { maxWidth: 720, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 12 },
   header: { display: 'flex', justifyContent: 'space-between' },
   link: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 14, padding: 0 },


### PR DESCRIPTION
## What & why

The admin Stats overview ran off-screen with no way to scroll (the whole app lives inside `#root { height:100%; overflow:hidden }` for the fixed game board, so a tall page is clipped), and the admin area was a flat Replays-page-with-a-Dashboard-tab. This reworks it into a proper dashboard:

- **Hub landing page** routing to **Stats / Replays / Players**.
- **New Players view** — every registered account with its lifetime record, a per-account drill-down (full stats + recent games), and a **Make admin / Revoke admin** control.
- **Promote accounts to admin.** The `GAME_ADMIN_PASSWORD` is now only a *bootstrap*: sign in with it once, promote your account from Players, then reach the dashboard with your normal sign-in. Every admin endpoint accepts either the password **or** an admin account's token.
- **Scroll fix + polish.** Each admin screen is its own scroll container (`AdminScreen`) with a sticky header and a cohesive restyle. The same scroll fix is applied to the profile page (it had the identical latent bug).

## Server

- `V3__admin_role.sql` adds `users.is_admin`; `UserRow.isAdmin`.
- `AdminAuthService` — single gate for all admin endpoints: bootstrap `X-Admin-Password` **or** a Bearer token whose account is `is_admin`. The admin flag is resolved against the DB **per request**, so promotion/demotion is immediate. Works password-only on a DB-less server (replays). `AdminController` + `AdminStatsController` route through it.
- `AdminUsersController` (`/api/admin/users`): roster, per-account detail, `POST /{id}/admin` to promote/revoke. `/api/auth/me` now returns `isAdmin`.

## Client

- `AdminPage` → `AdminHub` (Stats/Replays/Players). Signed-in admins skip the password prompt; the profile page shows an **Admin dashboard** link when `user.isAdmin`.
- `AdminPlayers` (roster + drill-down + promote). Shared `adminUi` (AdminScreen/Panel/StatCard/Table) so all screens share the polish and the scroll fix.
- Admin REST auth unified behind `AdminAuth` (`adminAuth.ts`): bootstrap password or account token.

## Tests / verification

- `AdminAuthServiceTest` (11 cases) covers both auth paths and rejections (`:game-server:test` green).
- `web-client` `npm run typecheck` + `npm run build` green.
- Screenshots below captured against the running client with the admin APIs mocked (the new Players/Stats endpoints need Postgres, so runtime DB wiring is covered by review + the unit test rather than a live DB run).

## Screenshots

**Hub**
![hub](https://raw.githubusercontent.com/wingedsheep/argentum-engine/admin-dashboard-hub-screenshots/1-hub.png)

**Stats (now scrolls within its own container, sticky header)**
![stats](https://raw.githubusercontent.com/wingedsheep/argentum-engine/admin-dashboard-hub-screenshots/2-stats.png)

**Players**
![players](https://raw.githubusercontent.com/wingedsheep/argentum-engine/admin-dashboard-hub-screenshots/3-players.png)

**Player detail + Make admin**
![player detail](https://raw.githubusercontent.com/wingedsheep/argentum-engine/admin-dashboard-hub-screenshots/4-player-detail.png)

**Bootstrap login**
![login](https://raw.githubusercontent.com/wingedsheep/argentum-engine/admin-dashboard-hub-screenshots/5-login.png)

> The `admin-dashboard-hub-screenshots` branch is a throwaway image host, not part of this PR's code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)