### PR TITLE
Fix 500 on admin player detail: head-to-head ORDER BY alias

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -146,7 +146,7 @@ class StatsQueryService(private val jdbc: JdbcTemplate) {
         LEFT JOIN users u ON u.id = opp.user_id
         WHERE me.user_id = ?
         GROUP BY COALESCE(u.display_name, opp.player_name), opp.user_id
-        ORDER BY wins + losses DESC, opponent ASC
+        ORDER BY count(*) DESC, opponent ASC
         """.trimIndent(),
         { rs, _ ->
             HeadToHead(


### PR DESCRIPTION
## Problem

Opening any player from the admin dashboard's Players view returned **500**:

```
org.postgresql.util.PSQLException: ERROR: column "wins" does not exist
  Hint: Perhaps you meant to reference the column "me.won" or the column "opp.won".
```

The `headToHead` query in `StatsQueryService` ended with:

```sql
ORDER BY wins + losses DESC, opponent ASC
```

`wins` and `losses` are SELECT output aliases. PostgreSQL allows an output alias as a *standalone* `ORDER BY` term, but inside an expression (`wins + losses`) the names are resolved as **input** columns — which don't exist — so the query failed to parse. This affected every player-detail open, regardless of whether the player had played any games.

## Fix

Order by `count(*)` instead. Each match against a given opponent contributes exactly one win or one loss, so `count(*)` equals `wins + losses` and needs no alias reference.

```sql
ORDER BY count(*) DESC, opponent ASC
```

The other `ORDER BY` clauses in the file use bare aliases as standalone terms (allowed) or full expressions, so this was the only occurrence.

## Testing

- `:game-server:compileKotlin` passes.
- game-server has no unit-test harness for these queries (per module CLAUDE.md); the SQL is verified by inspection against PostgreSQL's `ORDER BY` alias-scoping rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)