### PR TITLE
Add four Final Fantasy cards (Light of Judgment, Ninja's Blades, Summoner's Grimoire, Swallowed by Leviathan)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1612,6 +1612,13 @@ effect = Effects.Pipeline {
   You may play that card from exile this turn" (Norin, Swift Survivalist): `gather(TriggeringEntity)` →
   `exile(...)` → `GrantMayPlayFromExile(EndOfTurn)`.
 - `CardSource.TappedAsCost` — the permanents tapped to pay the activation cost.
+- `CardSource.AttachedTo(host, filter?)` — the permanents attached to the `host` entity (any
+  `EffectTarget` that resolves to a permanent — a spell's `ContextTarget`, `Self`, `TriggeringEntity`, …)
+  that match `filter`, read off the host's `AttachmentsComponent` and intersected with the projected
+  filter matches. The non-targeted counterpart of "the Equipment/Aura attached to that creature": yields
+  nothing when the host has left play or has no matching attachments. Backs "destroy up to one Equipment
+  attached to that creature" (Light of Judgment): `gather(AttachedTo(targetCreature, Equipment))` →
+  `chooseUpTo(1)` → `destroy(...)`.
 - `CardSource.ChosenTargets` — the spell/ability's already-resolved targets.
 - `CardSource.FromLinkedExile(count?)` — the cards in the source's linked-exile pile.
 - `CardSource.LastKnownCombatPairedWithSource` — creatures blocking/blocked by the source at the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -137,6 +137,28 @@ sealed interface CardSource {
     }
 
     /**
+     * Permanents attached to a host entity (resolved from an [EffectTarget]) that match
+     * [filter]. Reads the host's `AttachmentsComponent` and keeps the attached permanents
+     * that match the filter under projected state.
+     *
+     * The non-targeted counterpart of putting "the Equipment attached to that creature" into a
+     * pipeline — e.g. "destroy up to one Equipment attached to that creature" gathers the
+     * equipment here, then a [SelectionMode.ChooseUpTo]`(1)` select + a destroying move pick
+     * and destroy at most one. The host typically comes from a spell's own target
+     * ([EffectTarget.ContextTarget]); any [EffectTarget] that resolves to a permanent works
+     * (Self, TriggeringEntity, …). Yields nothing when the host has left play or has no
+     * matching attachments.
+     */
+    @SerialName("AttachedToTarget")
+    @Serializable
+    data class AttachedTo(
+        val host: EffectTarget,
+        val filter: GameObjectFilter = GameObjectFilter.Companion.Any
+    ) : CardSource {
+        override val description: String = "${filter.description} attached to ${host.description}"
+    }
+
+    /**
      * Permanents that were tapped as part of the ability's activation cost.
      * Reads from `EffectContext.tappedPermanents`, populated at cost-payment time.
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LightOfJudgment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LightOfJudgment.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+
+/**
+ * Light of Judgment
+ * {4}{R}
+ * Instant
+ *
+ * Light of Judgment deals 6 damage to target creature. Destroy up to one Equipment attached
+ * to that creature.
+ *
+ * One target creature, two sequential clauses:
+ *  1. [Effects.DealDamage]`(6)` to the target.
+ *  2. A non-targeted "up to one" destroy, modeled as a Gather → choose-up-to-1 → destroy
+ *     pipeline. [CardSource.AttachedTo] gathers the Equipment attached to the *same* target
+ *     (state-based actions that would move the lethally-damaged creature only run after the
+ *     spell finishes resolving, so its Equipment is still attached here), then the controller
+ *     may pick at most one to destroy via on-battlefield selection (`useTargetingUI`). The
+ *     destroy is intentionally *not* a target — it ignores targeting restrictions and is chosen
+ *     at resolution, per the oracle wording.
+ */
+val LightOfJudgment = card("Light of Judgment") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Light of Judgment deals 6 damage to target creature. Destroy up to one " +
+        "Equipment attached to that creature."
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.DealDamage(6, creature),
+            Effects.Pipeline {
+                val onCreature = gather(
+                    CardSource.AttachedTo(
+                        host = creature,
+                        filter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT),
+                    )
+                )
+                val chosen = chooseUpTo(
+                    count = 1,
+                    from = onCreature,
+                    useTargetingUI = true,
+                    prompt = "Destroy up to one Equipment attached to that creature",
+                )
+                destroy(chosen)
+            },
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Daniel Landerman"
+        flavorText = "\"I was there... I saw when Kefka used his Light of Judgment to torch the " +
+            "village of Mobliz, far to the east.\"\n—Tzen resident"
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98bb716d-ca66-445f-9cb3-0fc656c8ebff.jpg?1748706299"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/NinjasBlades.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/NinjasBlades.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Ninja's Blades
+ * {2}{B}
+ * Artifact — Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature gets +1/+1, is a Ninja in addition to its other types, and has "Whenever
+ *   this creature deals combat damage to a player, draw a card, then discard a card. That player
+ *   loses life equal to the discarded card's mana value."
+ * Mutsunokami — Equip {2}
+ *
+ * Standard Job-select Equipment shell ([jobSelect]) plus three grants on the equipped creature:
+ * a flat [ModifyStats] bump, the Ninja type ([GrantSubtype]), and a granted combat-damage
+ * trigger ([GrantTriggeredAbility] over the equipped-creature filter, so "this creature" /
+ * [EffectTarget.Self] is the bearer and "you" / [EffectTarget.Controller] is its controller).
+ *
+ * The granted ability loots (draw 1, then discard 1 — [Patterns.Hand.discardCards] stores the
+ * discarded card under the `discarded` collection), then the player dealt the combat damage
+ * ([Player.TriggeringPlayer]) loses life equal to that card's mana value
+ * ([DynamicAmount.StoredCardManaValue]). The discard is mandatory, so the looter holds at least
+ * the freshly drawn card to pitch.
+ */
+val NinjasBlades = card("Ninja's Blades") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature gets +1/+1, is a Ninja in addition to its other types, and has \"Whenever this creature deals combat damage to a player, draw a card, then discard a card. That player loses life equal to the discarded card's mana value.\"\n" +
+        "Mutsunokami — Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = ModifyStats(1, 1, Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantSubtype("Ninja", Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToPlayer.event,
+                binding = Triggers.DealsCombatDamageToPlayer.binding,
+                effect = Effects.Composite(
+                    Effects.DrawCards(1),
+                    Patterns.Hand.discardCards(1),
+                    Effects.LoseLife(
+                        DynamicAmount.StoredCardManaValue("discarded"),
+                        EffectTarget.PlayerRef(Player.TriggeringPlayer),
+                    ),
+                )
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "108"
+        artist = "Immanuela Crovius"
+        imageUri = "https://cards.scryfall.io/normal/front/a/6/a6b5af82-3646-44f9-ac12-1d7fa698f037.jpg?1748706165"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonersGrimoire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonersGrimoire.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.jobSelect
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Summoner's Grimoire
+ * {3}{G}
+ * Artifact — Book Equipment
+ * Job select (When this Equipment enters, create a 1/1 colorless Hero creature token,
+ *   then attach this to it.)
+ * Equipped creature is a Shaman in addition to its other types and has "Whenever this creature
+ *   attacks, you may put a creature card from your hand onto the battlefield. If that card is an
+ *   enchantment card, it enters tapped and attacking."
+ * Abraxas — Equip {3}
+ *
+ * Job-select Equipment shell ([jobSelect]) granting the Shaman type plus an attack trigger on the
+ * equipped creature ([GrantTriggeredAbility]). The granted ability is a Gather → choose-up-to-one
+ * → conditional-placement pipeline:
+ *  - gather the controller's creature cards in hand, then `chooseUpTo(1)` models "you may put a
+ *    creature card" (declining = choosing zero);
+ *  - `filterSplit` on [GameObjectFilter.Enchantment] partitions the chosen card into enchantment
+ *    creatures vs. the rest, so the printed conditional ("if that card is an enchantment card, it
+ *    enters tapped and attacking") becomes two moves: enchantment creatures enter with
+ *    [ZonePlacement.TappedAndAttacking], everything else enters normally. One of the two slots is
+ *    always empty, so exactly the chosen card enters.
+ */
+val SummonersGrimoire = card("Summoner's Grimoire") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Book Equipment"
+    oracleText = "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\n" +
+        "Equipped creature is a Shaman in addition to its other types and has \"Whenever this creature attacks, you may put a creature card from your hand onto the battlefield. If that card is an enchantment card, it enters tapped and attacking.\"\n" +
+        "Abraxas — Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    jobSelect()
+
+    staticAbility {
+        ability = GrantSubtype("Shaman", Filters.EquippedCreature)
+    }
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.Attacks.event,
+                binding = Triggers.Attacks.binding,
+                effect = Effects.Pipeline {
+                    val hand = gather(
+                        CardSource.FromZone(Zone.HAND, Player.You, GameObjectFilter.Creature)
+                    )
+                    val chosen = chooseUpTo(
+                        count = 1,
+                        from = hand,
+                        prompt = "You may put a creature card from your hand onto the battlefield",
+                    )
+                    val (enchantmentCreatures, rest) = filterSplit(chosen, GameObjectFilter.Enchantment)
+                    move(
+                        enchantmentCreatures,
+                        CardDestination.ToZone(Zone.BATTLEFIELD, Player.You, ZonePlacement.TappedAndAttacking),
+                    )
+                    move(rest, CardDestination.ToZone(Zone.BATTLEFIELD, Player.You))
+                }
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "205"
+        artist = "Daniel Correia"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d9fda3fc-569d-49f8-a2ed-e0b1d6668426.jpg?1748706528"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SwallowedByLeviathan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SwallowedByLeviathan.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Swallowed by Leviathan
+ * {2}{U}
+ * Instant
+ *
+ * Choose target spell. Surveil 2, then counter the chosen spell unless its controller pays
+ * {1} for each card in your graveyard.
+ *
+ * Pure composition over existing effects, ordered to match the printed sequence:
+ *  1. [Effects.Surveil]`(2)` — resolves *first*, so any cards milled into your graveyard
+ *     count toward the tax below (the card is intentionally a "fill your own graveyard to
+ *     raise the price" spell).
+ *  2. [Effects.CounterUnlessDynamicPays] with [DynamicAmount.Count] over your graveyard —
+ *     "{1} for each card in your graveyard", evaluated when this step runs (post-surveil).
+ *     Swallowed by Leviathan and the chosen spell are still on the stack, so neither is
+ *     counted.
+ */
+val SwallowedByLeviathan = card("Swallowed by Leviathan") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Choose target spell. Surveil 2, then counter the chosen spell unless its " +
+        "controller pays {1} for each card in your graveyard. (To surveil 2, look at the top " +
+        "two cards of your library, then put any number of them into your graveyard and the " +
+        "rest on top of your library in any order.)"
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.Composite(
+            Effects.Surveil(2),
+            Effects.CounterUnlessDynamicPays(
+                amount = DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Any),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "79"
+        artist = "Sansyu"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/2270642d-fe2a-4265-aff0-a24a43ebe0a1.jpg?1756047948"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -7229,6 +7229,90 @@
     ]
 }
 
+// Light of Judgment
+{
+    "name": "Light of Judgment",
+    "manaCost": "{4}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Light of Judgment deals 6 damage to target creature. Destroy up to one Equipment attached to that creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 6
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "AttachedToTarget",
+                                "host": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                },
+                                "filter": "artifact Equipment"
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "selected1",
+                            "prompt": "Destroy up to one Equipment attached to that creature",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Daniel Landerman",
+        "flavorText": "\"I was there... I saw when Kefka used his Light of Judgment to torch the village of Mobliz, far to the east.\"\n—Tzen resident",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98bb716d-ca66-445f-9cb3-0fc656c8ebff.jpg?1748706299"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Lindblum, Industrial Regency
 {
     "name": "Lindblum, Industrial Regency",
@@ -8973,6 +9057,175 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Ninja's Blades
+{
+    "name": "Ninja's Blades",
+    "manaCost": "{2}{B}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature gets +1/+1, is a Ninja in addition to its other types, and has \"Whenever this creature deals combat damage to a player, draw a card, then discard a card. That player loses life equal to the discarded card's mana value.\"\nMutsunokami — Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Ninja",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "DealsDamageEvent",
+                        "damageType": "DamageCombat",
+                        "recipient": "AnyPlayer"
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "StoredCardManaValue",
+                                    "collectionName": "discarded"
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "TriggeringPlayer"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "108",
+        "rarity": "RARE",
+        "artist": "Immanuela Crovius",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6b5af82-3646-44f9-ac12-1d7fa698f037.jpg?1748706165"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -13553,6 +13806,162 @@
     ]
 }
 
+// Summoner's Grimoire
+{
+    "name": "Summoner's Grimoire",
+    "manaCost": "{3}{G}",
+    "typeLine": "Artifact — Book Equipment",
+    "oracleText": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)\nEquipped creature is a Shaman in addition to its other types and has \"Whenever this creature attacks, you may put a creature card from your hand onto the battlefield. If that card is an enchantment card, it enters tapped and attacking.\"\nAbraxas — Equip {3} ({3}: Attach to target creature you control. Equip only as a sorcery.)",
+    "keywords": [
+        "JOB_SELECT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Hero"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0657ce1-bf75-4007-ac1b-0623eb263357.jpg?1748704030"
+                        },
+                        {
+                            "type": "AttachEquipment",
+                            "target": {
+                                "type": "PipelineTarget",
+                                "collectionName": "createdTokens"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach this to it.)"
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantSubtype",
+                "subtype": "Shaman",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand",
+                                    "filter": "creature"
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "selected1",
+                                "prompt": "You may put a creature card from your hand onto the battlefield"
+                            },
+                            {
+                                "type": "FilterCollection",
+                                "from": "selected1",
+                                "filter": {
+                                    "type": "MatchesFilter",
+                                    "filter": "enchantment"
+                                },
+                                "storeMatching": "matching2",
+                                "storeNonMatching": "rest2"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "matching2",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "TappedAndAttacking"
+                                }
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "rest2",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "205",
+        "rarity": "RARE",
+        "artist": "Daniel Correia",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d9fda3fc-569d-49f8-a2ed-e0b1d6668426.jpg?1748706528"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Suplex
 {
     "name": "Suplex",
@@ -13629,6 +14038,54 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Swallowed by Leviathan
+{
+    "name": "Swallowed by Leviathan",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Choose target spell. Surveil 2, then counter the chosen spell unless its controller pays {1} for each card in your graveyard. (To surveil 2, look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Surveil",
+                    "count": 2
+                },
+                {
+                    "type": "Counter",
+                    "condition": {
+                        "type": "CounterCondition.UnlessPaysDynamic",
+                        "amount": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard"
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "79",
+        "rarity": "UNCOMMON",
+        "artist": "Sansyu",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/2270642d-fe2a-4265-aff0-a24a43ebe0a1.jpg?1756047948"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -158,6 +158,25 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
                 }
             }
 
+            is CardSource.AttachedTo -> {
+                // Permanents attached to the resolved host that match the filter (projected).
+                // Intersect the host's live attachments with the projected filter matches so
+                // type/control-changing effects are respected (e.g. "Equipment attached to that
+                // creature"). Empty when the host left play or has no matching attachments.
+                val hostId = context.resolveTarget(source.host)
+                val attachedIds = hostId
+                    ?.let { state.getEntity(it)?.get<AttachmentsComponent>()?.attachedIds }
+                    ?: emptyList()
+                if (attachedIds.isEmpty()) {
+                    emptyList()
+                } else {
+                    val matching = BattlefieldFilterUtils
+                        .findMatchingOnBattlefield(state, source.filter, context)
+                        .toSet()
+                    attachedIds.filter { it in matching }
+                }
+            }
+
             is CardSource.ChosenTargets -> {
                 context.targets.mapNotNull { chosen ->
                     when (chosen) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightOfJudgmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightOfJudgmentScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Light of Judgment — {4}{R} Instant: "deals 6 damage to target creature. Destroy up to one
+ * Equipment attached to that creature."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.effects.CardSource.AttachedTo] gather: the
+ * non-targeted "up to one" destroy is a Gather (Equipment attached to the damaged creature) →
+ * choose-up-to-1 → destroy pipeline. The "up to one" choice is genuinely optional, so the
+ * destroy is proven both ways (select the Equipment vs. decline).
+ */
+class LightOfJudgmentScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Light of Judgment") {
+            test("deals 6 damage to the target and destroys the chosen attached Equipment") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Light of Judgment")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(2, "Bonesplitter", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val sword = game.findPermanent("Bonesplitter")!!
+
+                val cast = game.castSpell(1, "Light of Judgment", bears)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                // Pipeline pauses to choose up to one Equipment attached to the creature.
+                withClue("Should prompt to choose the attached Equipment") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectCards(listOf(sword))
+                game.resolveStack()
+
+                withClue("6 damage kills the 2/2 creature") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("The chosen Equipment is destroyed") {
+                    game.isInGraveyard(2, "Bonesplitter") shouldBe true
+                }
+            }
+
+            test("declining the destroy leaves the Equipment on the battlefield") {
+                val game = scenario()
+                    .withPlayers("Alice", "Bob")
+                    .withCardInHand(1, "Light of Judgment")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(2, "Bonesplitter", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpell(1, "Light of Judgment", bears)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Should prompt to choose up to one Equipment") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.skipSelection()
+                game.resolveStack()
+
+                withClue("Creature still dies to 6 damage") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("Declined Equipment stays on the battlefield (just unattached)") {
+                    game.isInGraveyard(2, "Bonesplitter") shouldBe false
+                    (game.findPermanent("Bonesplitter") != null) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A handful of missing **Final Fantasy (FIN)** cards, implemented via the `add-card` skill. All four are modeled by composing existing SDK primitives, except for one small reusable gather source added for Light of Judgment.

| Card | Cost | What it does |
|------|------|--------------|
| **Light of Judgment** | `{4}{R}` Instant | 6 damage to target creature, then destroy **up to one** Equipment attached to it |
| **Ninja's Blades** | `{2}{B}` Equipment (Job select) | +1/+1, Ninja, granted combat-damage loot trigger; damaged player loses life = discarded card's MV |
| **Summoner's Grimoire** | `{3}{G}` Book Equipment (Job select) | Shaman + granted attack trigger that may put a creature card from hand onto the battlefield (enchantment creatures enter tapped & attacking) |
| **Swallowed by Leviathan** | `{2}{U}` Instant | Surveil 2, then counter target spell unless its controller pays `{1}` per card in your graveyard |

## SDK addition (reusable)

Light of Judgment's *"destroy up to one Equipment attached to that creature"* is a non-targeted, resolution-time choice. Rather than fake it as a target, it composes a **Gather → choose-up-to-1 → destroy** pipeline over a new general gather source:

- **`CardSource.AttachedTo(host, filter)`** — gathers the permanents attached to a resolved `EffectTarget` (a spell's `ContextTarget`, `Self`, `TriggeringEntity`, …) matching `filter`, by intersecting the host's `AttachmentsComponent` with the projected filter matches. The non-targeted counterpart of "the Equipment/Aura attached to that creature". Wired into `GatherCardsExecutor` and documented in the SDK reference.

The lethally-damaged creature is still on the battlefield when the destroy resolves (SBAs run after the spell finishes), so its Equipment is reachable — covered by the scenario test.

## How the other three reuse existing primitives

- **Ninja's Blades / Summoner's Grimoire** — `jobSelect()` shell + `GrantTriggeredAbility` granting the printed quoted ability on the equipped creature (same pattern as Astrologian's Planisphere). Ninja's Blades reuses `Patterns.Hand.discardCards` (stores `discarded`) + `DynamicAmount.StoredCardManaValue` + `Player.TriggeringPlayer`. Summoner's Grimoire uses a `filterSplit` on `Enchantment` to render the conditional `TappedAndAttacking` placement.
- **Swallowed by Leviathan** — `Effects.Surveil(2)` then `Effects.CounterUnlessDynamicPays` with a graveyard `DynamicAmount.Count`. Surveil resolves first so milled cards raise the tax (intended).

## Tests
- `LightOfJudgmentScenarioTest` — destroy-the-Equipment path and decline path (declined Equipment survives unattached after the creature dies). Covers the new `CardSource.AttachedTo`.
- The other three compose already-tested effects; covered by `CardLintTest` (dataflow/slots/targets), `CardDefinitionSnapshotTest`, and the full suite.
- `just test` — green. FIN snapshot re-blessed (additive: only the four new cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)