### PR TITLE
Fix 400 when promoting/demoting admins (isAdmin deserialization)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminUsersController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminUsersController.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.gameserver.controller
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.wingedsheep.gameserver.auth.AdminAuthService
 import com.wingedsheep.gameserver.auth.UserAdminService
 import com.wingedsheep.gameserver.persistence.MatchResultRepository
@@ -53,7 +54,12 @@ class AdminUsersController(
         val recentGames: List<GameHistoryEntry>,
     )
 
-    data class SetAdminBody(val isAdmin: Boolean)
+    /**
+     * `@JsonProperty` pins the wire name to `isAdmin`. Without it, Jackson treats the `is`-prefixed
+     * Kotlin property as the getter for a property named `admin`, so the JSON key `isAdmin` the client
+     * sends no longer maps to the constructor parameter and deserialization fails with 400.
+     */
+    data class SetAdminBody(@JsonProperty("isAdmin") val isAdmin: Boolean)
 
     @GetMapping
     fun list(


### PR DESCRIPTION
## Problem

Promoting/demoting an account in the admin Players view always failed with **HTTP 400**:

```
JSON parse error: Cannot construct instance of `AdminUsersController$SetAdminBody`
(although at least one Creator exists): cannot deserialize from Object value
(no delegate- or property-based Creator)
```

## Cause

`SetAdminBody(val isAdmin: Boolean)` has a single `is`-prefixed boolean property. Jackson's Kotlin module reads that property as the getter for a property named `admin`, so the constructor parameter no longer matches the `isAdmin` key the client sends (`body: JSON.stringify({ isAdmin })` in `adminUsers.ts`). With no parameter to bind, Jackson reports it has no usable creator and rejects the body.

This is the same `is`-prefix gotcha that bites these REST DTOs on the serialization side.

## Fix

Pin the wire name with `@JsonProperty("isAdmin")` so the client payload `{ "isAdmin": true }` maps back to the constructor parameter. The response side already uses a `Map`, so it was unaffected.

## Testing

- `./gradlew :game-server:compileKotlin` passes.
- The change is a single annotation on the request DTO; behavior verified against the client call shape in `web-client/src/api/adminUsers.ts` (`POST /api/admin/users/{id}/admin` with `{ isAdmin }`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)