### PR TITLE
Add Valgavoth, Terror Eater (DSK) — linked-exile graveyard replacement + play-from-exile

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -268,6 +268,12 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
 - `Costs.additional.PayLifePerTarget(amountPerTarget)` — "this spell costs N life more to cast for
   each target." Pair with an unbounded `TargetCreature(unlimited = true)` etc.; the engine
   auto-pays `amountPerTarget × action.targets.size` at cast resolution (Phyrexian Purge).
+- `Costs.additional.PayLifeEqualToManaValueOfSpell` — auto-pays life equal to the cast spell's own
+  mana value. The substitute cost for "pay life equal to its mana value rather than pay its mana cost"
+  (Valgavoth, Terror Eater; Bolas's Citadel-style effects). Pair it with a play-from-exile grant whose
+  mana cost is waived — `GrantMayCastFromLinkedExile(withoutPayingManaCost = true, additionalCost =
+  Costs.additional.PayLifeEqualToManaValueOfSpell)` — so the only cost paid is the life. The amount is
+  read from the cast card's mana value, checked at cast time (CR 119.4 — must have at least that much life).
 - `Costs.additional.ExileFromGraveyardOrPay(exileCount, alternativeManaCost, filter = Filters.Any)`
   — "as an additional cost to cast this spell, exile N cards from your graveyard or pay {mana}"
   (Soaring Stoneglider: "exile two cards from your graveyard or pay {1}{W}"). The sibling of the
@@ -3600,6 +3606,16 @@ riders, matching how the engine already treats e.g. City of Brass's damage durin
   your graveyard". Lands are *played*, not cast, so they need the lands permission separately. This
   grants permission over *other* cards in your graveyard from a battlefield permanent — for a card
   that grants permission to cast *itself* from a zone, use `MayCastSelfFromZones`.
+- `GrantMayCastFromLinkedExile(filter = Nonland, duringYourTurnOnly = false, additionalCost = null, ownedByYou = false, withoutPayingManaCost = false, oncePerTurn = false, maxManaValue = null, exiledThisTurnOnly = false)`
+  — "you may cast cards exiled with this permanent" — reads the source's `LinkedExileComponent` (Rona,
+  Disciple of Gix; Maralen, Fae Ascendant; Dawnhand Dissident). Casting spells from linked exile is
+  enumerated by `CastFromZoneEnumerator.enumerateLinkedExile`; the cast path deliberately skips lands.
+  For the "pay life equal to its mana value rather than pay its mana cost" shape (Valgavoth, Terror
+  Eater), set `withoutPayingManaCost = true` (waives the mana) and `additionalCost =
+  Costs.additional.PayLifeEqualToManaValueOfSpell` (substitutes the life). When `filter` admits lands
+  (e.g. `GameObjectFilter.Any`, no `IsNonland` predicate), the permission also covers *playing* land
+  cards from the linked exile — surfaced by `PlayLandEnumerator` and authorized by `PlayLandHandler`
+  (lands cost no life). Pair with a `RedirectZoneChange(linkToSource = true)` to fill the exile pile.
 - `GraveyardCreaturesHaveSneak(cost)` — "Creature cards in your graveyard have sneak `cost`. You may
   cast creature spells from your graveyard using their sneak abilities." (Ninja Teen level 3.) While
   the controller has this static active, their graveyard creature cards become castable via the
@@ -3816,9 +3832,11 @@ composite abilities).
 
 - `Ward(amount)` — opponent pays a mana cost to target this (CR 702.21). Non-mana costs use
   `KeywordAbility.Ward(WardCost.X)`: `WardCost.Mana`, `WardCost.Life(n)`, `WardCost.Discard(n, random, filter)`,
-  and `WardCost.Sacrifice(filter)` ("Ward—Sacrifice a Food", Ygra). For sacrifice ward, the opponent
-  chooses which matching permanent(s) they control to sacrifice (declining counters their spell); valid
-  fodder is matched against projected state, so subtypes granted by continuous effects count.
+  and `WardCost.Sacrifice(filter, count = 1)` ("Ward—Sacrifice a Food", Ygra; "Ward—Sacrifice three
+  nonland permanents" with `count = 3`, Valgavoth, Terror Eater, via `KeywordAbility.wardSacrifice(filter, count)`).
+  For sacrifice ward, the opponent chooses which `count` matching permanent(s) they control to sacrifice
+  (selecting fewer, or controlling fewer than `count`, counters their spell); valid fodder is matched
+  against projected state, so subtypes granted by continuous effects count.
   Composite costs ("Ward—{2}, Pay 2 life", Gisa, the Hellraiser) use
   `KeywordAbility.wardComposite(WardCost.Mana("{2}"), WardCost.Life(2))` → `WardCost.Composite(parts)`.
   The components are charged one at a time in order; the spell/ability resolves only if every
@@ -5418,6 +5436,18 @@ replacementEffect {
   "three or more lands total". The parallel "fast land" cycle (Blooming Marsh — "two or fewer other lands")
   uses an `LTE`-direction `Compare(AggregateBattlefield(You, Land), LTE, Fixed(3))`. `payLifeCost` renders
   the "you may pay N life; if you don't, it enters tapped" variant.
+- `RedirectZoneChange(newDestination, appliesTo, linkToSource = false)` — redirect a zone change to a
+  different destination (Rest in Peace / Leyline of the Void: graveyard → exile). `appliesTo` is an
+  `EventPattern.ZoneChangeEvent(filter, from?, to?)`; the `filter`'s `controllerPredicate` scopes it
+  (e.g. `OwnedByOpponent` for Leyline). When `linkToSource = true` and `newDestination = Zone.EXILE`,
+  each redirected card is added to the source permanent's `LinkedExileComponent`, so the source can
+  later reference — and grant playing of — the cards it exiled. Valgavoth, Terror Eater pairs it with
+  `GrantMayCastFromLinkedExile`: "If a card you didn't control would be put into an opponent's graveyard
+  from anywhere, exile it instead" is `RedirectZoneChange(newDestination = Zone.EXILE, linkToSource =
+  true, appliesTo = ZoneChangeEvent(to = Zone.GRAVEYARD, filter = GameObjectFilter(cardPredicates =
+  listOf(CardPredicate.IsNontoken), controllerPredicate = ControllerPredicate.And(listOf(OwnedByOpponent,
+  Not(ControlledByYou))))))`. The redirect (and link) is honored across every graveyard path: SBA deaths,
+  mill/discard/destroy (`ZoneTransitionService`), spell resolution, counters, and fizzles (`StackResolver`).
 - `ReplacementEffect.IfYouDoBranchEffect(...)` — branch on "if you do" replacement.
 - `OnEnterRunEffect(effect)` — generic "as ~ enters the battlefield, run [effect]". The wrapped effect
   executes via the normal effect-executor pipeline at entry time (so `EffectTarget.Self` resolves to

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -346,6 +346,13 @@ object Costs {
         fun PayLifePerTarget(amountPerTarget: Int): AdditionalCost =
             AdditionalCost.PayLifePerTarget(amountPerTarget)
 
+        /**
+         * Pay life equal to the cast spell's mana value — the substitute cost for "pay life equal
+         * to its mana value rather than pay its mana cost" (Valgavoth, Terror Eater). Pair with a
+         * play-from-exile grant whose mana cost is waived (`withoutPayingManaCost = true`).
+         */
+        val PayLifeEqualToManaValueOfSpell: AdditionalCost = AdditionalCost.PayLifeEqualToManaValueOfSpell
+
         /** Exile [count] cards matching [filter] from [fromZone]. */
         fun ExileCards(
             count: Int = 1,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -179,6 +179,19 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
+     * Pay life equal to the mana value of the spell being cast. Auto-paid (no player choice).
+     * Used as the substitute cost in "pay life equal to its mana value rather than pay its
+     * mana cost" permissions — Valgavoth, Terror Eater (paired with a play-from-exile grant
+     * whose mana cost is waived), and Bolas's Citadel-style effects. The amount is computed at
+     * cast time from the cast card's [com.wingedsheep.sdk.model.CardDefinition] mana value.
+     */
+    @SerialName("PayLifeEqualToManaValueOfSpell")
+    @Serializable
+    data object PayLifeEqualToManaValueOfSpell : AdditionalCost {
+        override val description: String = "pay life equal to its mana value"
+    }
+
+    /**
      * Blight N or pay additional mana: the caster must either put N -1/-1 counters on a creature
      * they control, or pay extra mana on top of the spell's base mana cost.
      * Used by Lorwyn Eclipsed cards (e.g., Wild Unraveling).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -731,10 +731,11 @@ sealed interface KeywordAbility {
             Ward(WardCost.Discard(count, random, filter))
 
         /**
-         * Create Ward with sacrifice cost.
+         * Create Ward with sacrifice cost. Pass [count] > 1 for "Ward—Sacrifice N ~"
+         * (e.g. Valgavoth, Terror Eater — "Ward—Sacrifice three nonland permanents").
          */
-        fun wardSacrifice(filter: GameObjectFilter): KeywordAbility =
-            Ward(WardCost.Sacrifice(filter))
+        fun wardSacrifice(filter: GameObjectFilter, count: Int = 1): KeywordAbility =
+            Ward(WardCost.Sacrifice(filter, count))
 
         /**
          * Create Ward with a composite cost — all components must be paid. E.g.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -223,12 +223,19 @@ data class ModifyCounterPlacement(
 /**
  * Redirect a zone change to a different destination.
  * Example: Rest in Peace (graveyard → exile), Leyline of the Void
+ *
+ * When [linkToSource] is true and [newDestination] is [Zone.EXILE], the redirected card is
+ * linked to the replacement's source permanent via its `LinkedExileComponent`, so the source
+ * can later reference the cards it exiled — e.g. Valgavoth, Terror Eater ("If a card you didn't
+ * control would be put into an opponent's graveyard from anywhere, exile it instead." + "you may
+ * play cards exiled with Valgavoth"). Ignored for non-exile destinations.
  */
 @SerialName("RedirectZoneChange")
 @Serializable
 data class RedirectZoneChange(
     val newDestination: Zone,
-    override val appliesTo: EventPattern
+    override val appliesTo: EventPattern,
+    val linkToSource: Boolean = false
 ) : ReplacementEffect {
     override val description: String =
         "If ${appliesTo.description}, put it into ${newDestination.displayName} instead"

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/SpellStaticAbilities.kt
@@ -137,6 +137,15 @@ data class GrantMayCastFromLinkedExile(
     val exiledThisTurnOnly: Boolean = false
 ) : StaticAbility {
     override val description: String = buildString {
+        // "pay life equal to its mana value rather than pay its mana cost" — Valgavoth, Terror Eater
+        // (the grant waives the mana cost via [withoutPayingManaCost] and substitutes the life cost).
+        if (additionalCost is AdditionalCost.PayLifeEqualToManaValueOfSpell) {
+            if (duringYourTurnOnly) append("During your turn, you may play ") else append("You may play ")
+            append("cards exiled with this permanent")
+            if (exiledThisTurnOnly) append(" this turn")
+            append(". If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.")
+            return@buildString
+        }
         if (duringYourTurnOnly) append("During your turn, y") else append("Y")
         if (oncePerTurn) append("ou may cast a ${filter.description} ")
         else append("ou may cast ${filter.description} ")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
@@ -356,11 +356,15 @@ sealed interface WardCost {
         }
     }
 
-    /** Ward with a sacrifice cost — e.g. Ward—Sacrifice a Food. */
+    /**
+     * Ward with a sacrifice cost — e.g. Ward—Sacrifice a Food, or
+     * Ward—Sacrifice three nonland permanents (Valgavoth, Terror Eater) via [count].
+     */
     @SerialName("WardCost.Sacrifice")
     @Serializable
-    data class Sacrifice(val filter: GameObjectFilter) : WardCost {
-        override val description: String = "a ${filter.description}"
+    data class Sacrifice(val filter: GameObjectFilter, val count: Int = 1) : WardCost {
+        override val description: String =
+            if (count == 1) "a ${filter.description}" else "$count ${filter.description}s"
     }
 
     /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ValgavothTerrorEater.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dsk/cards/ValgavothTerrorEater.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.dsk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantMayCastFromLinkedExile
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+
+/**
+ * Valgavoth, Terror Eater
+ * {6}{B}{B}{B}
+ * Legendary Creature — Elder Demon
+ * 9/9
+ *
+ * Flying, lifelink
+ * Ward—Sacrifice three nonland permanents.
+ * If a card you didn't control would be put into an opponent's graveyard from anywhere,
+ * exile it instead.
+ * During your turn, you may play cards exiled with Valgavoth. If you cast a spell this way,
+ * pay life equal to its mana value rather than pay its mana cost.
+ *
+ * Modeling notes:
+ *  - The graveyard-replacement is the reusable [RedirectZoneChange] with `linkToSource = true`,
+ *    so every card it exiles is tethered to Valgavoth's `LinkedExileComponent`. The filter scopes
+ *    it to nontoken cards whose owner is an opponent ("an opponent's graveyard") that the source's
+ *    controller doesn't control ("a card you didn't control") — a stolen opponent's permanent that
+ *    dies under your control is therefore not exiled (CR-faithful via `Not(ControlledByYou)`).
+ *  - The play permission is [GrantMayCastFromLinkedExile]: it waives the mana cost
+ *    (`withoutPayingManaCost`) and substitutes the alternative life cost
+ *    `PayLifeEqualToManaValueOfSpell`, so casting a spell this way pays life equal to its mana
+ *    value rather than its mana cost. Lands exiled with Valgavoth are played for free (no spell,
+ *    no life). The grant is timed to your turn (`duringYourTurnOnly`).
+ */
+val ValgavothTerrorEater = card("Valgavoth, Terror Eater") {
+    manaCost = "{6}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Elder Demon"
+    power = 9
+    toughness = 9
+    oracleText = "Flying, lifelink\n" +
+        "Ward—Sacrifice three nonland permanents.\n" +
+        "If a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.\n" +
+        "During your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost."
+
+    keywords(Keyword.FLYING, Keyword.LIFELINK)
+
+    // Ward—Sacrifice three nonland permanents.
+    keywordAbility(KeywordAbility.wardSacrifice(GameObjectFilter.NonlandPermanent, count = 3))
+
+    // If a card you didn't control would be put into an opponent's graveyard from anywhere,
+    // exile it instead — and link it to Valgavoth so the last ability can play it.
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            linkToSource = true,
+            appliesTo = ZoneChangeEvent(
+                to = Zone.GRAVEYARD,
+                filter = GameObjectFilter(
+                    cardPredicates = listOf(CardPredicate.IsNontoken),
+                    controllerPredicate = ControllerPredicate.And(
+                        listOf(
+                            ControllerPredicate.OwnedByOpponent,
+                            ControllerPredicate.Not(ControllerPredicate.ControlledByYou),
+                        )
+                    ),
+                ),
+            ),
+        )
+    )
+
+    // During your turn, you may play cards exiled with Valgavoth, paying life equal to a spell's
+    // mana value rather than its mana cost.
+    staticAbility {
+        ability = GrantMayCastFromLinkedExile(
+            filter = GameObjectFilter.Any,
+            duringYourTurnOnly = true,
+            withoutPayingManaCost = true,
+            additionalCost = Costs.additional.PayLifeEqualToManaValueOfSpell,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "120"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/7/7/7740ff55-67bb-409e-90f7-2c2c8b8c770a.jpg?1726286296"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -20169,6 +20169,79 @@
     ]
 }
 
+// Valgavoth, Terror Eater
+{
+    "name": "Valgavoth, Terror Eater",
+    "manaCost": "{6}{B}{B}{B}",
+    "typeLine": "Legendary Creature — Elder Demon",
+    "oracleText": "Flying, lifelink\nWard—Sacrifice three nonland permanents.\nIf a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.\nDuring your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.",
+    "creatureStats": {
+        "power": 9,
+        "toughness": 9
+    },
+    "keywords": [
+        "FLYING",
+        "LIFELINK",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Sacrifice",
+                "filter": "nonland permanent",
+                "count": 3
+            }
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantMayCastFromLinkedExile",
+                "filter": {},
+                "duringYourTurnOnly": true,
+                "additionalCost": "PayLifeEqualToManaValueOfSpell",
+                "withoutPayingManaCost": true
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "RedirectZoneChange",
+                "newDestination": "Exile",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsNontoken"
+                        ],
+                        "controllerPredicate": {
+                            "type": "ControllerAnd",
+                            "predicates": [
+                                "OwnedByOpponent",
+                                {
+                                    "type": "ControllerNot",
+                                    "predicate": "ControlledByYou"
+                                }
+                            ]
+                        }
+                    },
+                    "to": "Graveyard"
+                },
+                "linkToSource": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "120",
+        "rarity": "MYTHIC",
+        "artist": "Antonio José Manzanedo",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/7/7740ff55-67bb-409e-90f7-2c2c8b8c770a.jpg?1726286296"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Vanish from Sight
 {
     "name": "Vanish from Sight",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -931,6 +931,11 @@ class CostHandler(
                 // enough life to pay it.
                 cost.minCount <= 0 || state.lifeTotal(controllerId) >= cost.minCount
             }
+            is AdditionalCost.PayLifeEqualToManaValueOfSpell -> {
+                // Affordability is per-cast (depends on the cast card's mana value), so it is
+                // checked at CastSpellHandler time, not here. Always "payable" at this generic gate.
+                true
+            }
             is AdditionalCost.BeholdOrPay -> {
                 // Always payable: player can always choose the "pay mana" path
                 true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -92,9 +92,13 @@ class PlayLandHandler(
         val inHand = action.cardId in state.getZone(handZone)
         val onTopOfLibrary = !inHand && isOnTopOfLibraryWithPermission(state, action.playerId, action.cardId)
         val mayPlayFromExile = !inHand && !onTopOfLibrary && isInExileWithPlayPermission(state, action.playerId, action.cardId)
-        val mayPlayFromGraveyard = !inHand && !onTopOfLibrary && !mayPlayFromExile &&
+        // Lands exiled with a permanent granting "you may play cards exiled with this" (Valgavoth).
+        val mayPlayFromLinkedExile = !inHand && !onTopOfLibrary && !mayPlayFromExile &&
+            com.wingedsheep.engine.handlers.effects.linkedexile.LinkedExilePlayUtils
+                .canPlayLand(state, action.playerId, action.cardId, cardRegistry)
+        val mayPlayFromGraveyard = !inHand && !onTopOfLibrary && !mayPlayFromExile && !mayPlayFromLinkedExile &&
             isInGraveyardWithPlayPermission(state, action.playerId, action.cardId)
-        if (!inHand && !onTopOfLibrary && !mayPlayFromExile && !mayPlayFromGraveyard) {
+        if (!inHand && !onTopOfLibrary && !mayPlayFromExile && !mayPlayFromLinkedExile && !mayPlayFromGraveyard) {
             return "Land is not in your hand"
         }
 
@@ -186,6 +190,11 @@ class PlayLandHandler(
         // card if it later returned to exile.
         if (fromZone == Zone.EXILE) {
             newState = newState.removeMayPlayPermissionsForCard(action.cardId)
+            // Drop the card from any linked-exile granter (Valgavoth) now that it has left exile,
+            // so the granter no longer lists it. (Lands bypass ZoneTransitionService, which would
+            // otherwise unlink on the way out.)
+            newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .unlinkFromAllLinkedExiles(newState, action.cardId)
         }
 
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -1521,6 +1521,14 @@ class CastSpellHandler(
                         return "$name is not a valid choice for: ${additionalCost.description}"
                     }
                 }
+                is AdditionalCost.PayLifeEqualToManaValueOfSpell -> {
+                    val required = state.getEntity(action.cardId)?.get<CardComponent>()?.manaCost?.cmc ?: 0
+                    val currentLife = state.lifeTotal(action.playerId) // CR 810.9a — team's shared total
+                    // CR 119.4 — you can't pay life unless you have at least that much
+                    if (currentLife < required) {
+                        return "Not enough life to pay $required life (its mana value)"
+                    }
+                }
                 else -> {}
             }
         }
@@ -1850,6 +1858,8 @@ class CastSpellHandler(
                 atom is CostAtom.PayLife -> atom.amount
                 additionalCost is AdditionalCost.PayLifePerTarget -> additionalCost.amountPerTarget * action.targets.size
                 additionalCost is AdditionalCost.PayXLife -> action.additionalCostPayment?.payXLifeAmount ?: 0
+                additionalCost is AdditionalCost.PayLifeEqualToManaValueOfSpell ->
+                    currentState.getEntity(action.cardId)?.get<CardComponent>()?.manaCost?.cmc ?: 0
                 else -> continue
             }
             if (lifeToPay == 0) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -68,11 +68,16 @@ import com.wingedsheep.sdk.scripting.predicates.evaluateWith
  * @param additionalEffect An optional effect to execute when the redirect applies
  *        (e.g., TakeExtraTurnEffect from Ugin's Nexus)
  * @param effectControllerId The controller of the replacement effect source
+ * @param linkSourceId When non-null (and [destinationZone] is [Zone.EXILE]), the redirected
+ *        card should be linked to this source permanent's `LinkedExileComponent` after the move
+ *        — set by a [RedirectZoneChange] with `linkToSource = true` (Valgavoth, Terror Eater).
+ *        Each mover applies the link via [ZoneMovementUtils.linkExiledToSource].
  */
 data class ZoneChangeRedirectResult(
     val destinationZone: Zone,
     val additionalEffect: com.wingedsheep.sdk.scripting.effects.Effect? = null,
-    val effectControllerId: EntityId? = null
+    val effectControllerId: EntityId? = null,
+    val linkSourceId: EntityId? = null
 )
 
 /**
@@ -142,6 +147,21 @@ object ZoneMovementUtils {
             }
         }
         return newState
+    }
+
+    /**
+     * Append [exiledId] to [sourceId]'s [LinkedExileComponent]. Called by zone movers after a
+     * [RedirectZoneChange] with `linkToSource = true` sends a card to exile (Valgavoth, Terror
+     * Eater), so the source can later reference — and grant casting/playing of — the cards it
+     * exiled. No-op if the source has left the battlefield, or the card is already linked.
+     */
+    fun linkExiledToSource(state: GameState, exiledId: EntityId, sourceId: EntityId): GameState {
+        val container = state.getEntity(sourceId) ?: return state
+        val existing = container.get<LinkedExileComponent>()?.exiledIds ?: emptyList()
+        if (exiledId in existing) return state
+        return state.updateEntity(sourceId) { c ->
+            c.with(LinkedExileComponent(existing + exiledId))
+        }
     }
 
     /**
@@ -501,8 +521,11 @@ object ZoneMovementUtils {
                         // Check filter against the entity being moved
                         if (!matchesZoneChangeFilter(state, entityId, container, event.filter, sourceControllerId)) continue
 
-                        // Match found — redirect to new destination
-                        return ZoneChangeRedirectResult(effect.newDestination)
+                        // Match found — redirect to new destination. When the replacement links
+                        // its exiled cards to the source (Valgavoth), carry the source id so the
+                        // mover can attach the card to its LinkedExileComponent after the move.
+                        val linkSource = if (effect.linkToSource && effect.newDestination == Zone.EXILE) permanentId else null
+                        return ZoneChangeRedirectResult(effect.newDestination, linkSourceId = linkSource)
                     }
                     is RedirectZoneChangeWithEffect -> {
                         // selfOnly: only applies when the entity being moved IS this permanent

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -381,6 +381,10 @@ object ZoneTransitionService {
                 if (options.faceDownExile) {
                     newState = newState.updateEntity(entityId) { c -> c.with(FaceDownComponent) }
                 }
+                // Link the exiled card to a RedirectZoneChange(linkToSource) source (Valgavoth).
+                redirectResult.linkSourceId?.let { sourceId ->
+                    newState = ZoneMovementUtils.linkExiledToSource(newState, entityId, sourceId)
+                }
             }
             else -> {
                 // HAND, GRAVEYARD, STACK — simple addToZone

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/linkedexile/LinkedExilePlayUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/linkedexile/LinkedExilePlayUtils.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.handlers.effects.linkedexile
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GrantMayCastFromLinkedExile
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Shared logic for *playing lands* exiled with a permanent that has a
+ * [GrantMayCastFromLinkedExile] static ability (e.g. Valgavoth, Terror Eater —
+ * "During your turn, you may play cards exiled with Valgavoth").
+ *
+ * Casting *spells* from linked exile is handled by `CastFromZoneEnumerator.enumerateLinkedExile`
+ * (which deliberately skips lands — most linked-exile granters say "cast spells"). Lands are a
+ * separate play path: this helper lets `PlayLandEnumerator` surface them and `PlayLandHandler`
+ * authorize them, but only for granters whose `filter` actually admits land cards.
+ */
+object LinkedExilePlayUtils {
+
+    /** A linked-exile grant that currently lets [playerId] *play lands* from its pile. */
+    data class LandGranter(val sourceId: EntityId, val ability: GrantMayCastFromLinkedExile, val exiledIds: List<EntityId>)
+
+    /** All linked-exile grants controlled by [playerId] that admit land cards and are active now. */
+    fun landGranters(state: GameState, playerId: EntityId, cardRegistry: CardRegistry): List<LandGranter> {
+        val result = mutableListOf<LandGranter>()
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            if (container.get<ControllerComponent>()?.playerId != playerId) continue
+            val linked = container.get<LinkedExileComponent>() ?: continue
+            val cardDef = container.get<CardComponent>()?.let { cardRegistry.getCard(it.cardDefinitionId) } ?: continue
+            val grant = cardDef.script.staticAbilities.filterIsInstance<GrantMayCastFromLinkedExile>().firstOrNull() ?: continue
+            // The grant must admit lands (filter has no IsNonland predicate) — Valgavoth uses Any.
+            if (grant.filter.cardPredicates.any { it is CardPredicate.IsNonland }) continue
+            // Timing — "during your turn" grants only let you play lands on your own turn.
+            if (grant.duringYourTurnOnly && !state.isActiveTurnFor(playerId)) continue
+            result.add(LandGranter(entityId, grant, linked.exiledIds))
+        }
+        return result
+    }
+
+    /** True if [landCardId] is a land currently in exile that [playerId] may play via a linked-exile grant. */
+    fun canPlayLand(state: GameState, playerId: EntityId, landCardId: EntityId, cardRegistry: CardRegistry): Boolean {
+        val card = state.getEntity(landCardId)?.get<CardComponent>() ?: return false
+        if (!card.typeLine.isLand) return false
+        val inExile = state.turnOrder.any { pid -> landCardId in state.getZone(ZoneKey(pid, Zone.EXILE)) }
+        if (!inExile) return false
+        return landGranters(state, playerId, cardRegistry).any { granter ->
+            landCardId in granter.exiledIds &&
+                (!granter.ability.ownedByYou || card.ownerId == playerId)
+        }
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
@@ -132,7 +132,7 @@ class WardCounterEffectExecutor(
                 )
                 is WardCost.Sacrifice -> handleSacrificeCost(
                     state, cardRegistry, spellEntityId, container, payingPlayerId,
-                    cost.filter, remainingParts, wardSourceId, controllerId
+                    cost.filter, cost.count, remainingParts, wardSourceId, controllerId
                 )
                 is WardCost.Composite -> {
                     require(cost.parts.isNotEmpty()) { "WardCost.Composite must have at least one part" }
@@ -160,11 +160,11 @@ class WardCounterEffectExecutor(
             container: ComponentContainer,
             payingPlayerId: EntityId,
             filter: GameObjectFilter,
+            count: Int,
             remainingParts: List<WardCost>,
             wardSourceId: EntityId?,
             controllerId: EntityId?
         ): EffectResult {
-            val count = 1
             val validPermanents = BattlefieldFilterUtils.findMatchingOnBattlefield(
                 state, filter.youControl(), PredicateContext(controllerId = payingPlayerId)
             )
@@ -175,7 +175,11 @@ class WardCounterEffectExecutor(
             }
 
             val fodderLabel = filter.description
-            val prompt = "Sacrifice ${if (count == 1) "a" else "$count"} $fodderLabel or your spell will be countered"
+            val prompt = if (count == 1) {
+                "Sacrifice a $fodderLabel or your spell will be countered"
+            } else {
+                "Sacrifice $count ${fodderLabel}s or your spell will be countered"
+            }
 
             val decisionResult = DecisionHandler().createCardSelectionDecision(
                 state = state,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -743,8 +743,23 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         context.manaSolver.canPay(state, playerId, effectiveCost, precomputedSources = context.availableManaSources)
                     }
 
+                    // "Pay life equal to its mana value rather than pay its mana cost" (Valgavoth):
+                    // the life cost is per-card (the cast card's mana value), so its affordability
+                    // and display are computed here rather than once-per-granter.
+                    val payLifeMv = grantAbility.additionalCost is AdditionalCost.PayLifeEqualToManaValueOfSpell
+                    val lifeForThisCard = if (payLifeMv) exiledCard.manaCost.cmc else 0
+                    val lifeAffordable = !payLifeMv || state.lifeTotal(playerId) >= lifeForThisCard
+                    val perCardAdditionalCostInfo = if (payLifeMv) {
+                        AdditionalCostData(
+                            description = "Pay $lifeForThisCard life",
+                            costType = "PayLife"
+                        )
+                    } else {
+                        linkedAdditionalCostInfo
+                    }
+
                     val fullyAffordable = hasCorrectTiming && meetsRestrictions && canAfford &&
-                        canPayLinkedAdditionalCost
+                        canPayLinkedAdditionalCost && lifeAffordable
                     if (fullyAffordable) {
                         val targetReqs = buildList {
                             addAll(exiledCardDef?.script?.targetRequirements ?: emptyList())
@@ -771,7 +786,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                         xConstrainsTargetCount = firstInfo.xConstrainsCount,
                                         manaCostString = costString,
                                         sourceZone = "EXILE",
-                                        additionalCostInfo = linkedAdditionalCostInfo
+                                        additionalCostInfo = perCardAdditionalCostInfo
                                     )
                                 )
                             }
@@ -783,7 +798,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                     action = CastSpell(playerId, exiledId),
                                     manaCostString = costString,
                                     sourceZone = "EXILE",
-                                    additionalCostInfo = linkedAdditionalCostInfo
+                                    additionalCostInfo = perCardAdditionalCostInfo
                                 )
                             )
                         }
@@ -796,7 +811,7 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                 affordable = false,
                                 manaCostString = costString,
                                 sourceZone = "EXILE",
-                                additionalCostInfo = linkedAdditionalCostInfo
+                                additionalCostInfo = perCardAdditionalCostInfo
                             )
                         )
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/PlayLandEnumerator.kt
@@ -48,6 +48,26 @@ class PlayLandEnumerator : ActionEnumerator {
             }
         }
 
+        // Lands exiled with a permanent granting "you may play cards exiled with this" (Valgavoth).
+        val seenLinkedLands = mutableSetOf<com.wingedsheep.sdk.model.EntityId>()
+        for (granter in com.wingedsheep.engine.handlers.effects.linkedexile.LinkedExilePlayUtils
+            .landGranters(state, playerId, context.cardRegistry)) {
+            for (exiledId in granter.exiledIds) {
+                if (!seenLinkedLands.add(exiledId)) continue
+                val cardComponent = state.getEntity(exiledId)?.get<CardComponent>() ?: continue
+                if (!cardComponent.typeLine.isLand) continue
+                if (granter.ability.ownedByYou && cardComponent.ownerId != playerId) continue
+                val inExile = state.turnOrder.any { pid -> exiledId in state.getZone(ZoneKey(pid, Zone.EXILE)) }
+                if (!inExile) continue
+                result.add(LegalAction(
+                    actionType = "PlayLand",
+                    description = "Play ${cardComponent.name}",
+                    action = PlayLand(playerId, exiledId),
+                    sourceZone = "EXILE"
+                ))
+            }
+        }
+
         return result
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaZoneMovementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaZoneMovementHelper.kt
@@ -126,6 +126,12 @@ object SbaZoneMovementHelper {
             }
         }
 
+        // Link the exiled card to a RedirectZoneChange(linkToSource) source (Valgavoth) — the
+        // move above ran with skipZoneChangeRedirect=true, so the link is applied here.
+        if (!exileInstead && destinationZone == Zone.EXILE && redirectResult.linkSourceId != null) {
+            newState = ZoneMovementUtils.linkExiledToSource(newState, entityId, redirectResult.linkSourceId)
+        }
+
         // Apply additional replacement effect (e.g., Ugin's Nexus extra turn, Darigaaz egg counters)
         if (redirectResult.additionalEffect != null) {
             newState = ZoneMovementUtils.applyReplacementAdditionalEffect(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1627,6 +1627,13 @@ class StackResolver(
                     }
                 }
 
+                // Link an opponent's resolving spell exiled by a RedirectZoneChange(linkToSource)
+                // replacement (Valgavoth) even when the effect paused mid-resolution.
+                if (pausedDestZone == Zone.EXILE && pausedRedirect.linkSourceId != null) {
+                    pausedState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                        .linkExiledToSource(pausedState, spellId, pausedRedirect.linkSourceId)
+                }
+
                 // CR 715.3d — Adventure exiled by its own resolution: re-grant cast-from-exile.
                 if (pausedAdventureFaceExile && pausedDestZone == Zone.EXILE) {
                     val (permId, stateWithPerm) = pausedState.newEntity()
@@ -1796,6 +1803,13 @@ class StackResolver(
             }
         }
 
+        // Link an opponent's resolving spell exiled by a RedirectZoneChange(linkToSource)
+        // replacement (Valgavoth, Terror Eater) so its controller may later play it.
+        if (destinationZone == Zone.EXILE && redirect.linkSourceId != null) {
+            newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .linkExiledToSource(newState, spellId, redirect.linkSourceId)
+        }
+
         redirect.additionalEffect?.let { extra ->
             newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.applyReplacementAdditionalEffect(
                 newState, extra, redirect.effectControllerId, spellId
@@ -1886,13 +1900,25 @@ class StackResolver(
         // Goliath Daydreamer-style components only exile on actual resolution; if the spell
         // fizzles or is countered they go to graveyard normally.
         val exileAfterResolve = exileAfterResolveComp != null && !exileAfterResolveComp.onlyIfResolved
-        val destZone = if (flashbackExile || exileAfterResolve) Zone.EXILE else Zone.GRAVEYARD
+        // A fizzled spell heading to its owner's graveyard is a card put into a graveyard
+        // "from anywhere" — honor RedirectZoneChange replacements (Valgavoth, Leyline).
+        val fizzleRedirect = if (flashbackExile || exileAfterResolve) {
+            com.wingedsheep.engine.handlers.effects.ZoneChangeRedirectResult(Zone.EXILE)
+        } else {
+            com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .checkZoneChangeRedirect(state, spellId, Zone.STACK, Zone.GRAVEYARD)
+        }
+        val destZone = fizzleRedirect.destinationZone
         val destZoneKey = ZoneKey(ownerId, destZone)
 
         var newState = state.updateEntity(spellId) { c ->
             c.without<SpellOnStackComponent>().without<TargetsComponent>()
         }
         newState = newState.addToZone(destZoneKey, spellId)
+        if (destZone == Zone.EXILE && fizzleRedirect.linkSourceId != null) {
+            newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .linkExiledToSource(newState, spellId, fizzleRedirect.linkSourceId)
+        }
 
         return ExecutionResult.success(
             newState,
@@ -2260,9 +2286,21 @@ class StackResolver(
         // is countered they go to graveyard normally.
         val exileComp = container.get<ExileAfterResolveComponent>()
         val exileAfterResolve = exileComp != null && !exileComp.onlyIfResolved
-        val destZone = if (exileAfterResolve) Zone.EXILE else Zone.GRAVEYARD
+        // A countered spell heading to its owner's graveyard is still a card being put into a
+        // graveyard "from anywhere" — honor RedirectZoneChange replacements (Valgavoth, Leyline).
+        val counterRedirect = if (exileAfterResolve) {
+            com.wingedsheep.engine.handlers.effects.ZoneChangeRedirectResult(Zone.EXILE)
+        } else {
+            com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .checkZoneChangeRedirect(state, spellId, Zone.STACK, Zone.GRAVEYARD)
+        }
+        val destZone = counterRedirect.destinationZone
         val destZoneKey = ZoneKey(ownerId, destZone)
         newState = newState.addToZone(destZoneKey, spellId)
+        if (destZone == Zone.EXILE && counterRedirect.linkSourceId != null) {
+            newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .linkExiledToSource(newState, spellId, counterRedirect.linkSourceId)
+        }
 
         // Remove stack components
         newState = newState.updateEntity(spellId) { c ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValgavothTerrorEaterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValgavothTerrorEaterScenarioTest.kt
@@ -1,0 +1,240 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dsk.cards.ValgavothTerrorEater
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Valgavoth, Terror Eater (Duskmourn #120):
+ *   Flying, lifelink
+ *   Ward—Sacrifice three nonland permanents.
+ *   If a card you didn't control would be put into an opponent's graveyard from anywhere,
+ *     exile it instead.
+ *   During your turn, you may play cards exiled with Valgavoth. If you cast a spell this way,
+ *     pay life equal to its mana value rather than pay its mana cost.
+ *
+ * Exercises the three new engine capabilities: counted ward-sacrifice, the linked-exile
+ * graveyard replacement, and the play-from-linked-exile permission with the life-equal-to-mana
+ * value alternative cost (plus land plays from that exile pile).
+ */
+class ValgavothTerrorEaterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ValgavothTerrorEater))
+        return driver
+    }
+
+    fun linkedExileOf(driver: GameTestDriver, sourceId: EntityId): List<EntityId> =
+        driver.state.getEntity(sourceId)?.get<LinkedExileComponent>()?.exiledIds ?: emptyList()
+
+    // --- Replacement: exile cards bound for an opponent's graveyard, linked to Valgavoth ---
+
+    test("an opponent's creature that dies is exiled and linked to Valgavoth") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+
+        val valgavoth = driver.putCreatureOnBattlefield(you, "Valgavoth, Terror Eater")
+        val victim = driver.putCreatureOnBattlefield(opp, "Grizzly Bears") // 2/2
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // bolt resolves, the 2/2 dies into the opponent's graveyard
+
+        driver.getGraveyard(opp) shouldNotContain victim
+        driver.getExile(opp) shouldContain victim
+        linkedExileOf(driver, valgavoth) shouldContain victim
+    }
+
+    test("your own creature dying is unaffected (only an opponent's graveyard)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        val valgavoth = driver.putCreatureOnBattlefield(you, "Valgavoth, Terror Eater")
+        val mine = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, targets = listOf(mine)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getGraveyard(you) shouldContain mine
+        driver.getExile(you) shouldNotContain mine
+        linkedExileOf(driver, valgavoth) shouldNotContain mine
+    }
+
+    test("a card you control but an opponent owns is not exiled when it dies") {
+        // "a card you didn't control": a stolen permanent (owned by the opponent, controlled by
+        // you) that dies goes to its owner's (the opponent's) graveyard normally — Valgavoth does
+        // not exile it because you controlled it.
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+
+        val valgavoth = driver.putCreatureOnBattlefield(you, "Valgavoth, Terror Eater")
+        // A creature on your battlefield, but owned by the opponent.
+        val stolen = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        driver.replaceState(
+            driver.state.updateEntity(stolen) { c ->
+                val card = c.get<CardComponent>()!!
+                c.with(card.copy(ownerId = opp))
+            }
+        )
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, targets = listOf(stolen)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Goes to the opponent's graveyard (its owner), NOT exiled — you controlled it.
+        driver.getGraveyard(opp) shouldContain stolen
+        driver.getExile(opp) shouldNotContain stolen
+        linkedExileOf(driver, valgavoth) shouldNotContain stolen
+    }
+
+    // --- Play from linked exile: pay life equal to mana value rather than mana cost ---
+
+    test("you may cast a spell exiled with Valgavoth by paying life equal to its mana value") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+
+        driver.putCreatureOnBattlefield(you, "Valgavoth, Terror Eater")
+        val victim = driver.putCreatureOnBattlefield(opp, "Grizzly Bears") // {1}{G}, mana value 2
+
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // Grizzly Bears dies → exiled with Valgavoth
+
+        driver.getExile(opp) shouldContain victim
+
+        // Cast it from Valgavoth's exile — no mana paid, but 2 life (its mana value).
+        driver.getLifeTotal(you) shouldBe 20
+        driver.submit(
+            CastSpell(playerId = you, cardId = victim, paymentStrategy = PaymentStrategy.AutoPay)
+        ).isSuccess shouldBe true
+        driver.bothPass() // the creature spell resolves onto your battlefield
+
+        driver.getLifeTotal(you) shouldBe 18
+        driver.getController(victim) shouldBe you
+        driver.findPermanent(you, "Grizzly Bears") shouldNotBe null
+        driver.getExile(opp) shouldNotContain victim
+    }
+
+    test("you may play a land exiled with Valgavoth for free") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+
+        val valgavoth = driver.putCreatureOnBattlefield(you, "Valgavoth, Terror Eater")
+        // An opponent-owned land sitting in exile, linked to Valgavoth (as if its land had died
+        // into the opponent's graveyard and been redirected).
+        val land = driver.putCardInExile(opp, "Forest")
+        driver.replaceState(
+            driver.state.updateEntity(valgavoth) { c ->
+                c.with(LinkedExileComponent(listOf(land)))
+            }
+        )
+
+        driver.getLifeTotal(you) shouldBe 20
+        driver.playLand(you, land).isSuccess shouldBe true
+
+        driver.findPermanent(you, "Forest") shouldNotBe null
+        driver.getController(land) shouldBe you
+        driver.getLifeTotal(you) shouldBe 20 // lands cost no life
+        linkedExileOf(driver, valgavoth) shouldNotContain land
+    }
+
+    // --- Ward—Sacrifice three nonland permanents ---
+
+    test("ward counters the spell when the caster cannot sacrifice three nonland permanents") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val caster = driver.activePlayer!!       // casts the removal
+        val defender = driver.getOpponent(caster) // controls Valgavoth
+
+        val valgavoth = driver.putCreatureOnBattlefield(defender, "Valgavoth, Terror Eater")
+        // The caster controls only two nonland permanents — not enough for Ward (3).
+        driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(caster, "Grizzly Bears")
+
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+        driver.castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(valgavoth)))
+        repeat(4) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        // Can't pay 3 → ward auto-counters with no prompt; Valgavoth survives.
+        driver.pendingDecision shouldBe null
+        driver.findPermanent(defender, "Valgavoth, Terror Eater") shouldNotBe null
+        // The countered bolt heads to the caster's graveyard — Valgavoth exiles it instead.
+        driver.getExile(caster) shouldContain bolt
+    }
+
+    test("ward is satisfied by sacrificing three nonland permanents") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val caster = driver.activePlayer!!
+        val defender = driver.getOpponent(caster)
+
+        val valgavoth = driver.putCreatureOnBattlefield(defender, "Valgavoth, Terror Eater")
+        val fodder = listOf(
+            driver.putCreatureOnBattlefield(caster, "Grizzly Bears"),
+            driver.putCreatureOnBattlefield(caster, "Grizzly Bears"),
+            driver.putCreatureOnBattlefield(caster, "Grizzly Bears"),
+        )
+
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+        driver.castSpellWithTargets(caster, bolt, listOf(ChosenTarget.Permanent(valgavoth)))
+
+        // Ward resolves → caster is prompted to sacrifice three nonland permanents.
+        driver.bothPass()
+        val decision = driver.pendingDecision
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe caster
+        fodder.forEach { decision.options shouldContain it }
+
+        driver.submitDecision(caster, CardsSelectedResponse(decision.id, fodder))
+        repeat(6) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        // All three were sacrificed; the bolt resolved (Valgavoth, a 9/9, survived).
+        fodder.forEach { driver.getController(it) shouldNotBe caster }
+        driver.findPermanent(defender, "Valgavoth, Terror Eater") shouldNotBe null
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Valgavoth, Terror Eater** — the last missing Duskmourn card (**DSK now 276/276, 100%**). It's the set's chase mythic, so it needed three new, reusable engine capabilities rather than a single card script.

> Flying, lifelink
> Ward—Sacrifice three nonland permanents.
> If a card you didn't control would be put into an opponent's graveyard from anywhere, exile it instead.
> During your turn, you may play cards exiled with Valgavoth. If you cast a spell this way, pay life equal to its mana value rather than pay its mana cost.

## Engine features added

**Ward—Sacrifice N** — `WardCost.Sacrifice` gains `count` (`KeywordAbility.wardSacrifice(filter, count)`); the executor offers a multi-select and counters the spell if fewer than `count` are sacrificed.

**Linked-exile graveyard replacement** — `RedirectZoneChange` gains `linkToSource`: a card it redirects to exile is added to the source's `LinkedExileComponent`. Applied on every graveyard path — SBA deaths, mill/discard/destroy (`ZoneTransitionService`), and spell resolution / counters / fizzles (`StackResolver`). The counter & fizzle paths now honour `RedirectZoneChange` in general (a faithful fix that also makes Leyline/Rest in Peace exile countered spells). Valgavoth's filter is `OwnedByOpponent AND Not(ControlledByYou)` on nontoken cards, so a stolen opponent's permanent that dies under your control is **not** exiled.

**Play from linked exile, pay life = mana value** — new `AdditionalCost.PayLifeEqualToManaValueOfSpell` (auto-paid from the cast card's mana value). Paired with `GrantMayCastFromLinkedExile(withoutPayingManaCost = true)` it models "pay life equal to its mana value rather than pay its mana cost", wired through the cast enumerator (per-card life affordability + display), `CastSpellHandler` (validate + pay), and `CostHandler`. Playing **lands** from the linked exile is supported via `LinkedExilePlayUtils` consulted by `PlayLandEnumerator` + `PlayLandHandler` (lands cost no life).

## Tests
- `ValgavothTerrorEaterScenarioTest` (7 tests): opponent's creature → exiled & linked; own-graveyard untouched; "you didn't control" (stolen permanent) untouched; cast a spell paying life = MV; play a land for free; ward can't-pay-3 counters; ward sacrifice-3 satisfied.
- Card snapshot re-blessed (DSK.json only — no other card's tree changed).
- Full `just build` green (all modules).

## Reuse / UX
The card reuses existing decision/display flows — multi-select for ward, the linked-exile cast display (Rona/Maralen/Dawnhand), and play-land-from-exile (like Muldrotha's graveyard lands) — so no client changes were needed.

## Notes
- mtgish auto-gen stays at SCAFFOLD for this card; the new mechanics are too card-specific to render generally, so per the tooling's "decline → SCAFFOLD, don't widen" rule the emitter/bridge were intentionally left unchanged.
- `docs/card-sdk-language-reference.md` updated for all four SDK additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)