### PR TITLE
Add four Final Fantasy legends (Seifer, Squall, Rydia, Golbez)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GolbezCrystalCollector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GolbezCrystalCollector.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Golbez, Crystal Collector — Final Fantasy #225
+ * {U}{B} · Legendary Creature — Human Wizard · 1/4
+ *
+ * Whenever an artifact you control enters, surveil 1.
+ * At the beginning of your end step, if you control four or more artifacts, return target
+ * creature card from your graveyard to your hand. Then if you control eight or more artifacts,
+ * each opponent loses life equal to that card's power.
+ *
+ * First ability: an ANY-bound enters trigger filtered to "artifact you control" → [Effects.Surveil].
+ *
+ * The end-step ability is gated by an intervening-if (`triggerCondition`, checked both on trigger
+ * and on resolution — CR 603.4) requiring four or more artifacts. It returns a captured target
+ * creature card to hand (Ruin-Lurker Bat's `triggerCondition` shape + Rakdos Joins Up's captured
+ * target handle), then a [ConditionalEffect] runs only when you control eight or more artifacts:
+ * each opponent loses life equal to the returned card's power, read via
+ * [DynamicAmounts.targetPower] off the same bound target.
+ */
+val GolbezCrystalCollector = card("Golbez, Crystal Collector") {
+    manaCost = "{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human Wizard"
+    power = 1
+    toughness = 4
+    oracleText = "Whenever an artifact you control enters, surveil 1.\n" +
+        "At the beginning of your end step, if you control four or more artifacts, return target creature " +
+        "card from your graveyard to your hand. Then if you control eight or more artifacts, each opponent " +
+        "loses life equal to that card's power."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.Surveil(1)
+        description = "Whenever an artifact you control enters, surveil 1."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouControlAtLeast(4, GameObjectFilter.Artifact.youControl())
+        val creatureCard = target(
+            "target creature card from your graveyard",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard),
+        )
+        effect = Effects.Move(creatureCard, Zone.HAND)
+            .then(
+                ConditionalEffect(
+                    condition = Conditions.YouControlAtLeast(8, GameObjectFilter.Artifact.youControl()),
+                    effect = Effects.LoseLife(
+                        DynamicAmounts.targetPower(0),
+                        EffectTarget.PlayerRef(Player.EachOpponent),
+                    ),
+                ),
+            )
+        description = "At the beginning of your end step, if you control four or more artifacts, return " +
+            "target creature card from your graveyard to your hand. Then if you control eight or more " +
+            "artifacts, each opponent loses life equal to that card's power."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "225"
+        artist = "Bachzim"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/849f5716-7211-4e93-a220-f88d49f937f4.jpg?1748706611"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RydiaSummonerOfMist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RydiaSummonerOfMist.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Rydia, Summoner of Mist — Final Fantasy #239
+ * {R}{G} · Legendary Creature — Human Shaman · 1/2
+ *
+ * Landfall — Whenever a land you control enters, you may discard a card. If you do, draw a card.
+ * Summon — {X}, {T}: Return target Saga card with mana value X from your graveyard to the
+ * battlefield with a finality counter on it. It gains haste until end of turn. Activate only as
+ * a sorcery.
+ *
+ * "Landfall" and "Summon" are ability words (CR 207.2c) — flavor only, no rules meaning. The
+ * landfall trigger is the Giott rummage shape: [MayEffect] wrapping [IfYouDoEffect] (discard a
+ * card → if you do, draw a card).
+ *
+ * The Summon ability is the Ent-Draught Basin "{X} in the activation cost" shape: the chosen X
+ * threads into the target filter via `manaValueEqualsX()`, so only a Saga whose mana value is
+ * exactly X is a legal target. It then mirrors Rakdos Joins Up's "return target ... with
+ * counters" idiom — a captured target handle moved GRAVEYARD → BATTLEFIELD, then the
+ * [Counters.FINALITY] counter and haste are applied to that same returned permanent. The
+ * finality counter's exile-instead-of-die replacement is handled by the engine.
+ */
+val RydiaSummonerOfMist = card("Rydia, Summoner of Mist") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Human Shaman"
+    power = 1
+    toughness = 2
+    oracleText = "Landfall — Whenever a land you control enters, you may discard a card. If you do, draw a card.\n" +
+        "Summon — {X}, {T}: Return target Saga card with mana value X from your graveyard to the battlefield " +
+        "with a finality counter on it. It gains haste until end of turn. Activate only as a sorcery."
+
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = MayEffect(
+            effect = IfYouDoEffect(
+                action = Patterns.Hand.discardCards(1),
+                ifYouDo = Effects.DrawCards(1),
+            ),
+            descriptionOverride = "You may discard a card. If you do, draw a card.",
+        )
+        description = "Landfall — Whenever a land you control enters, you may discard a card. If you do, draw a card."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}"), Costs.Tap)
+        val saga = target(
+            "target Saga card with mana value X in your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Any.withSubtype(Subtype.SAGA).ownedByYou().manaValueEqualsX(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.Move(saga, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+            .then(AddCountersEffect(Counters.FINALITY, 1, saga))
+            .then(Effects.GrantKeyword(Keyword.HASTE, saga, Duration.EndOfTurn))
+        timing = TimingRule.SorcerySpeed
+        description = "Summon — {X}, {T}: Return target Saga card with mana value X from your graveyard to " +
+            "the battlefield with a finality counter on it. It gains haste until end of turn. Activate only " +
+            "as a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "239"
+        artist = "Yumi Yaoshida"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99450143-6ab5-463d-9e04-e8e6703a8b92.jpg?1748706673"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SeiferAlmasy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SeiferAlmasy.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Seifer Almasy — Final Fantasy #156
+ * {3}{R} · Legendary Creature — Human Knight · 3/4
+ *
+ * Whenever a creature you control attacks alone, it gains double strike until end of turn.
+ * Fire Cross — Whenever Seifer Almasy deals combat damage to a player, you may cast target
+ * instant or sorcery card with mana value 3 or less from your graveyard without paying its
+ * mana cost. If that spell would be put into your graveyard, exile it instead.
+ *
+ * First ability uses the Thoughtweft Imbuer "attacks alone" shape: an ANY-bound
+ * [Triggers.attacks] with [AttackPredicate.Alone] over "creature you control", granting the
+ * keyword to [EffectTarget.TriggeringEntity] (the lone attacker).
+ *
+ * "Fire Cross" is an ability word (CR 207.2c) — flavor only, no rules meaning, so it adds no
+ * keyword. The second ability mirrors Quistis Trepe's targeted graveyard cast: target an
+ * instant/sorcery in *your* graveyard with mana value ≤ 3, move it to exile, gather it into a
+ * collection, then grant a may-play-from-exile permission with `exileAfterResolve = true`
+ * (the "if it would be put into a graveyard, exile it instead" rider) paired with
+ * [Effects.GrantPlayWithoutPayingCost] (the "without paying its mana cost" clause, where
+ * Quistis instead lets any mana type pay). The "you may" is honored by the granted permission
+ * never being forced.
+ */
+val SeiferAlmasy = card("Seifer Almasy") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Knight"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever a creature you control attacks alone, it gains double strike until end of turn.\n" +
+        "Fire Cross — Whenever Seifer Almasy deals combat damage to a player, you may cast target instant " +
+        "or sorcery card with mana value 3 or less from your graveyard without paying its mana cost. If " +
+        "that spell would be put into your graveyard, exile it instead."
+
+    triggeredAbility {
+        trigger = Triggers.attacks(
+            filter = GameObjectFilter.Creature.youControl(),
+            requires = setOf(AttackPredicate.Alone),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.GrantKeyword(
+            Keyword.DOUBLE_STRIKE,
+            EffectTarget.TriggeringEntity,
+            Duration.EndOfTurn,
+        )
+        description = "Whenever a creature you control attacks alone, it gains double strike until end of turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        target = TargetObject(
+            filter = TargetFilter.InstantOrSorceryInYourGraveyard.manaValueAtMost(3),
+        )
+        effect = Effects.Composite(
+            // Exile the targeted card from your graveyard so the free-cast grant keys off it.
+            Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE),
+            GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "fireCross"),
+            // "You may cast ..." + "if it would be put into your graveyard, exile it instead."
+            Effects.GrantMayPlayFromExile(
+                from = "fireCross",
+                expiry = MayPlayExpiry.EndOfTurn,
+                exileAfterResolve = true,
+            ),
+            // "... without paying its mana cost."
+            Effects.GrantPlayWithoutPayingCost("fireCross"),
+        )
+        description = "Fire Cross — Whenever Seifer Almasy deals combat damage to a player, you may cast " +
+            "target instant or sorcery card with mana value 3 or less from your graveyard without paying " +
+            "its mana cost. If that spell would be put into your graveyard, exile it instead."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "156"
+        artist = "Kotetsu Kinoshita"
+        imageUri = "https://cards.scryfall.io/normal/front/9/c/9c776984-99ea-4181-ac95-78c41ba9d54f.jpg?1748706341"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SquallSeedMercenary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SquallSeedMercenary.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Squall, SeeD Mercenary — Final Fantasy #243
+ * {2}{W}{B} · Legendary Creature — Human Knight Mercenary · 3/4
+ *
+ * Rough Divide — Whenever a creature you control attacks alone, it gains double strike until
+ * end of turn.
+ * Whenever Squall deals combat damage to a player, return target permanent card with mana
+ * value 3 or less from your graveyard to the battlefield.
+ *
+ * "Rough Divide" is an ability word (CR 207.2c) — flavor only, no rules meaning. The first
+ * ability is the Thoughtweft Imbuer "attacks alone" shape: an ANY-bound [Triggers.attacks]
+ * with [AttackPredicate.Alone] over "creature you control", granting double strike to
+ * [EffectTarget.TriggeringEntity] (the lone attacker).
+ *
+ * The second ability mirrors Rydia's Return's "permanent card in your graveyard" target —
+ * `GameObjectFilter.Permanent.ownedByYou()` constrained with `manaValueAtMost(3)`, zone
+ * GRAVEYARD — then returns it to the battlefield via [Effects.PutOntoBattlefield] (under its
+ * owner's control, i.e. yours).
+ */
+val SquallSeedMercenary = card("Squall, SeeD Mercenary") {
+    manaCost = "{2}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Human Knight Mercenary"
+    power = 3
+    toughness = 4
+    oracleText = "Rough Divide — Whenever a creature you control attacks alone, it gains double strike " +
+        "until end of turn.\n" +
+        "Whenever Squall deals combat damage to a player, return target permanent card with mana value 3 " +
+        "or less from your graveyard to the battlefield."
+
+    triggeredAbility {
+        trigger = Triggers.attacks(
+            filter = GameObjectFilter.Creature.youControl(),
+            requires = setOf(AttackPredicate.Alone),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.GrantKeyword(
+            Keyword.DOUBLE_STRIKE,
+            EffectTarget.TriggeringEntity,
+            Duration.EndOfTurn,
+        )
+        description = "Rough Divide — Whenever a creature you control attacks alone, it gains double " +
+            "strike until end of turn."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        target = TargetObject(
+            filter = TargetFilter(
+                GameObjectFilter.Permanent.ownedByYou().manaValueAtMost(3),
+                zone = Zone.GRAVEYARD,
+            ),
+        )
+        effect = Effects.PutOntoBattlefield(EffectTarget.ContextTarget(0))
+        description = "Whenever Squall deals combat damage to a player, return target permanent card with " +
+            "mana value 3 or less from your graveyard to the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "243"
+        artist = "Yuu Fujiki"
+        imageUri = "https://cards.scryfall.io/normal/front/c/c/cc4e5234-fb41-48f7-91f4-039710542bc3.jpg?1748706690"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -5562,6 +5562,120 @@
     ]
 }
 
+// Golbez, Crystal Collector
+{
+    "name": "Golbez, Crystal Collector",
+    "manaCost": "{U}{B}",
+    "typeLine": "Legendary Creature — Human Wizard",
+    "oracleText": "Whenever an artifact you control enters, surveil 1.\nAt the beginning of your end step, if you control four or more artifacts, return target creature card from your graveyard to your hand. Then if you control eight or more artifacts, each opponent loses life equal to that card's power.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                },
+                "descriptionOverride": "Whenever an artifact you control enters, surveil 1."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card from your graveyard"
+                            },
+                            "destination": "Hand"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "artifact ctrl:you"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 8
+                                    }
+                                }
+                            },
+                            "then": {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "EntityProperty",
+                                    "entity": "Target",
+                                    "numericProperty": "Power"
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target creature card from your graveyard"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "artifact ctrl:you"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, if you control four or more artifacts, return target creature card from your graveyard to your hand. Then if you control eight or more artifacts, each opponent loses life equal to that card's power."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "RARE",
+        "artist": "Bachzim",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/849f5716-7211-4e93-a220-f88d49f937f4.jpg?1748706611"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Gongaga, Reactor Town
 {
     "name": "Gongaga, Reactor Town",
@@ -11480,6 +11594,165 @@
     ]
 }
 
+// Rydia, Summoner of Mist
+{
+    "name": "Rydia, Summoner of Mist",
+    "manaCost": "{R}{G}",
+    "typeLine": "Legendary Creature — Human Shaman",
+    "oracleText": "Landfall — Whenever a land you control enters, you may discard a card. If you do, draw a card.\nSummon — {X}, {T}: Return target Saga card with mana value X from your graveyard to the battlefield with a finality counter on it. It gains haste until end of turn. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    },
+                    "descriptionOverride": "You may discard a card. If you do, draw a card."
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, you may discard a card. If you do, draw a card."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Saga card with mana value X in your graveyard"
+                            },
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "finality",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Saga card with mana value X in your graveyard"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target Saga card with mana value X in your graveyard"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Saga"
+                                    },
+                                    "ManaValueEqualsX"
+                                ],
+                                "controllerPredicate": "OwnedByYou"
+                            },
+                            "zone": "Graveyard"
+                        },
+                        "id": "target Saga card with mana value X in your graveyard"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Summon — {X}, {T}: Return target Saga card with mana value X from your graveyard to the battlefield with a finality counter on it. It gains haste until end of turn. Activate only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "239",
+        "rarity": "UNCOMMON",
+        "artist": "Yumi Yaoshida",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99450143-6ab5-463d-9e04-e8e6703a8b92.jpg?1748706673"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // Sabotender
 {
     "name": "Sabotender",
@@ -12117,6 +12390,91 @@
     ]
 }
 
+// Seifer Almasy
+{
+    "name": "Seifer Almasy",
+    "manaCost": "{3}{R}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "Whenever a creature you control attacks alone, it gains double strike until end of turn.\nFire Cross — Whenever Seifer Almasy deals combat damage to a player, you may cast target instant or sorcery card with mana value 3 or less from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "filter": "creature ctrl:you",
+                    "requires": [
+                        "AttacksAlone"
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": "TriggeringEntity"
+                },
+                "descriptionOverride": "Whenever a creature you control attacks alone, it gains double strike until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "fireCross"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "fireCross",
+                            "exileAfterResolve": true
+                        },
+                        {
+                            "type": "GrantPlayWithoutPayingCost",
+                            "from": "fireCross"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "instant|sorcery mv<=3 own:you",
+                        "zone": "Graveyard"
+                    }
+                },
+                "descriptionOverride": "Fire Cross — Whenever Seifer Almasy deals combat damage to a player, you may cast target instant or sorcery card with mana value 3 or less from your graveyard without paying its mana cost. If that spell would be put into your graveyard, exile it instead."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "156",
+        "rarity": "RARE",
+        "artist": "Kotetsu Kinoshita",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/c/9c776984-99ea-4181-ac95-78c41ba9d54f.jpg?1748706341"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Self-Destruct
 {
     "name": "Self-Destruct",
@@ -12681,6 +13039,73 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Squall, SeeD Mercenary
+{
+    "name": "Squall, SeeD Mercenary",
+    "manaCost": "{2}{W}{B}",
+    "typeLine": "Legendary Creature — Human Knight Mercenary",
+    "oracleText": "Rough Divide — Whenever a creature you control attacks alone, it gains double strike until end of turn.\nWhenever Squall deals combat damage to a player, return target permanent card with mana value 3 or less from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "filter": "creature ctrl:you",
+                    "requires": [
+                        "AttacksAlone"
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "target": "TriggeringEntity"
+                },
+                "descriptionOverride": "Rough Divide — Whenever a creature you control attacks alone, it gains double strike until end of turn."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Battlefield"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent mv<=3 own:you",
+                        "zone": "Graveyard"
+                    }
+                },
+                "descriptionOverride": "Whenever Squall deals combat damage to a player, return target permanent card with mana value 3 or less from your graveyard to the battlefield."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "243",
+        "rarity": "RARE",
+        "artist": "Yuu Fujiki",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/c/cc4e5234-fb41-48f7-91f4-039710542bc3.jpg?1748706690"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 


### PR DESCRIPTION
## Summary

Implements a handful of missing **Final Fantasy (FIN)** legendary creatures via the `add-card` flow. All four are composed entirely from existing SDK primitives — **no engine/SDK changes**, so the only non-card change is the re-blessed `FIN.json` snapshot golden.

| Card | Cost | What it does |
|------|------|--------------|
| **Seifer Almasy** | `{3}{R}` | *Attacks alone* → grant double strike. **Fire Cross**: on combat damage, free-cast a target instant/sorcery (MV ≤ 3) from your graveyard, exiling it instead of letting it hit the graveyard. |
| **Squall, SeeD Mercenary** | `{2}{W}{B}` | **Rough Divide** *attacks alone* double strike. On combat damage, return a target permanent card (MV ≤ 3) from your graveyard to the battlefield. |
| **Rydia, Summoner of Mist** | `{R}{G}` | **Landfall** rummage (discard → draw). **Summon** `{X}, {T}`: return a target Saga with mana value X from your graveyard with a finality counter and haste (sorcery speed). |
| **Golbez, Crystal Collector** | `{U}{B}` | Artifact enters → surveil 1. End step, if you control ≥4 artifacts, return a target creature card to hand; then if ≥8 artifacts, each opponent loses life equal to that card's power. |

## Implementation notes (reuse, not new effects)

- **"Attacks alone" double strike** (Seifer + Squall) reuses the Thoughtweft Imbuer shape: `Triggers.attacks(filter = Creature.youControl(), requires = {Alone}, binding = ANY)` granting the keyword to `TriggeringEntity`.
- **Seifer's Fire Cross** mirrors **Quistis Trepe** (same set): target instant/sorcery in *your* graveyard (`manaValueAtMost(3)`) → exile → `GrantMayPlayFromExile(exileAfterResolve = true)`, paired with `GrantPlayWithoutPayingCost` for the free cast (Quistis pays; Seifer doesn't).
- **Squall's reanimation** reuses **Rydia's Return**'s `GameObjectFilter.Permanent.ownedByYou()` graveyard target + `PutOntoBattlefield`.
- **Rydia's Summon** reuses **Ent-Draught Basin**'s `{X}`-in-activation-cost targeting (`manaValueEqualsX()`) + **Rakdos Joins Up**'s captured-target *move-then-counter* idiom (move → `AddCounters(FINALITY)` → `GrantKeyword(HASTE)`).
- **Golbez** reuses **Ruin-Lurker Bat**'s `triggerCondition` intervening-if + `ConditionalEffect` + `targetPower(0)` for the "that card's power" drain.

## Testing

- `just build` — all four compile.
- `CardDefinitionSnapshotTest` re-blessed; diff is scoped to **only** these four cards (425 insertions, nothing else moved).
- `CardLintTest` passes (dataflow/target/slot hygiene).
- The two async `game-server` tests that flaked under the full parallel build (`FreeForAllLobbyTest`, `GameConnectionTest`) pass green on isolated re-run — they're WebSocket/lobby timing tests, unaffected by data-only card additions.

> Note: **Noctis, Prince of Lucis** was scoped out of this batch — its "cast artifacts from your graveyard ... enters with a finality counter" rider needs a new `MayCastFromGraveyard` engine capability, which belongs in `add-feature`, not a composition-only card PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)