### PR TITLE
Add Predator Ooze to Dark Ascension

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/PredatorOoze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dka/cards/PredatorOoze.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.dka.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Predator Ooze
+ * {G}{G}{G}
+ * Creature — Ooze
+ * 1/1
+ * Indestructible (Damage and effects that say "destroy" don't destroy this creature.)
+ * Whenever this creature attacks, put a +1/+1 counter on it.
+ * Whenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature.
+ *
+ * The third ability uses last-known information: it checks whether Predator Ooze had dealt damage to the
+ * dying creature at any point this turn, regardless of who controlled it or whose graveyard it went to.
+ */
+val PredatorOoze = card("Predator Ooze") {
+    manaCost = "{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ooze"
+    oracleText = "Indestructible (Damage and effects that say \"destroy\" don't destroy this creature.)\n" +
+        "Whenever this creature attacks, put a +1/+1 counter on it.\n" +
+        "Whenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature."
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.CreatureDealtDamageByThisDies
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "124"
+        artist = "Ryan Yee"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73c71457-f7c9-4ab4-b89d-e235e3f15e16.jpg?1562922371"
+        ruling(
+            "2011-01-22",
+            "Each time a creature dies, check whether Predator Ooze had dealt any damage to it at any " +
+                "time during that turn. If so, Predator Ooze's ability will trigger. It doesn't matter who " +
+                "controlled the creature or whose graveyard it was put into."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PredatorOozeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PredatorOozeReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Predator Ooze reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * another set's `cards/` package (Dark Ascension). This file contributes only the
+ * FDN-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val PredatorOozeReprint = Printing(
+    oracleId = "a51ec70d-1356-4403-a858-b99445bac54a",
+    name = "Predator Ooze",
+    setCode = "FDN",
+    collectorNumber = "642",
+    scryfallId = "333b3cca-ebbf-4ceb-a6a5-3d49cb2e143a",
+    artist = "Ryan Yee",
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/333b3cca-ebbf-4ceb-a6a5-3d49cb2e143a.jpg?1730491033",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DKA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DKA.json
@@ -216,6 +216,60 @@
     ]
 }
 
+// Predator Ooze
+{
+    "name": "Predator Ooze",
+    "manaCost": "{G}{G}{G}",
+    "typeLine": "Creature — Ooze",
+    "oracleText": "Indestructible (Damage and effects that say \"destroy\" don't destroy this creature.)\nWhenever this creature attacks, put a +1/+1 counter on it.\nWhenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "CreatureDealtDamageBySourceDiesEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "RARE",
+        "artist": "Ryan Yee",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73c71457-f7c9-4ab4-b89d-e235e3f15e16.jpg?1562922371",
+        "rulings": [
+            {
+                "date": "2011-01-22",
+                "text": "Each time a creature dies, check whether Predator Ooze had dealt any damage to it at any time during that turn. If so, Predator Ooze's ability will trigger. It doesn't matter who controlled the creature or whose graveyard it was put into."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Wild Hunger
 {
     "name": "Wild Hunger",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PredatorOozeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PredatorOozeScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dka.cards.PredatorOoze
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Predator Ooze.
+ *
+ * Predator Ooze: {G}{G}{G}
+ * Creature — Ooze
+ * 1/1
+ * Indestructible
+ * Whenever this creature attacks, put a +1/+1 counter on it.
+ * Whenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature.
+ */
+class PredatorOozeScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(PredatorOoze)
+        return driver
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("attacking puts a +1/+1 counter on Predator Ooze") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val ooze = driver.putCreatureOnBattlefield(attacker, "Predator Ooze")
+        driver.removeSummoningSickness(ooze)
+
+        driver.plusOneCounters(ooze) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(ooze), defender)
+
+        // Attack trigger goes on the stack; resolve it.
+        driver.bothPass()
+
+        driver.plusOneCounters(ooze) shouldBe 1
+    }
+
+    test("a creature dealt combat damage by Predator Ooze that dies grows the Ooze; the Ooze survives via indestructible") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val ooze = driver.putCreatureOnBattlefield(attacker, "Predator Ooze")
+        driver.removeSummoningSickness(ooze)
+
+        // 2/2 blocker — dies to the post-attack 2/2 Ooze, and deals 2 back (lethal to a 1/1,
+        // but the Ooze is indestructible so it survives).
+        val blocker = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        driver.removeSummoningSickness(blocker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(ooze), defender)
+
+        // Attack trigger resolves on the way to declare-blockers: Ooze becomes 2/2 (one counter).
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.plusOneCounters(ooze) shouldBe 1
+
+        driver.declareBlockers(defender, mapOf(blocker to listOf(ooze)))
+
+        // Combat damage: Ooze deals 2 to Grizzly Bears (dies); Bears deals 2 to the indestructible Ooze.
+        // The dies-by-damage trigger then resolves on the way to end of combat.
+        driver.passPriorityUntil(Step.END_COMBAT)
+
+        // Blocker died.
+        driver.findPermanent(defender, "Grizzly Bears") shouldBe null
+        // Ooze survived the lethal damage (indestructible) and gained a second counter from the kill.
+        driver.findPermanent(attacker, "Predator Ooze") shouldNotBe null
+        driver.plusOneCounters(ooze) shouldBe 2
+    }
+
+    test("a creature dying to a different source (not the Ooze) does not trigger the Ooze") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        // The Ooze sits on the battlefield but does not attack — it deals no damage this turn.
+        val ooze = driver.putCreatureOnBattlefield(attacker, "Predator Ooze")
+        driver.removeSummoningSickness(ooze)
+
+        // A separate attacker that trades with the defender's blocker; the Ooze is uninvolved.
+        val bear = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+        driver.removeSummoningSickness(bear)
+        val blocker = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        driver.removeSummoningSickness(blocker)
+
+        driver.plusOneCounters(ooze) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(bear), defender)
+        driver.bothPass()
+
+        driver.declareBlockers(defender, mapOf(blocker to listOf(bear)))
+        driver.bothPass()
+
+        // Both 2/2 bears die to each other; the Ooze dealt none of that damage.
+        driver.passPriorityUntil(Step.END_COMBAT)
+        driver.bothPass()
+
+        driver.findPermanent(defender, "Grizzly Bears") shouldBe null
+        // The Ooze never dealt damage to the dying creature, so it gains no counter.
+        driver.plusOneCounters(ooze) shouldBe 0
+    }
+})


### PR DESCRIPTION
## Summary
Implements **Predator Ooze** ({G}{G}{G}, Creature — Ooze, 1/1) with its canonical `CardDefinition` in **Dark Ascension** (its earliest real printing) plus a **Foundations (FDN)** reprint row.

Oracle text:
- Indestructible
- Whenever this creature attacks, put a +1/+1 counter on it.
- Whenever a creature dealt damage by this creature this turn dies, put a +1/+1 counter on this creature.

## Implementation notes
No new engine mechanics were needed — every building block already exists:
- `Keyword.INDESTRUCTIBLE`
- `Triggers.Attacks` → `Effects.AddCounters(+1/+1, Self)`
- `Triggers.CreatureDealtDamageByThisDies` → `Effects.AddCounters(+1/+1, Self)` (the Soul Collector / Zurgo Helmsmasher shape, which uses last-known information for the damaging source)

Canonical placement verified with `just check-card-printing "Predator Ooze"` (DKA canonical, FDN reprint row, C20 not scaffolded so no row).

## Tests
`PredatorOozeScenarioTest` (rules-engine) covers:
- attacking adds a +1/+1 counter
- a creature dealt combat damage by the Ooze that dies grows the Ooze, while the Ooze survives lethal combat damage via indestructible
- a creature dying to a *different* source does not trigger the Ooze

`just build` passes; the only `CardDefinitionSnapshotTest` diff is the added Predator Ooze tree in `DKA.json`.

## Follow-up (not in this PR)
The mtgish emitter still scaffolds (cannot render) the `CreatureDealtDamageByThisDies` trigger shape. Teaching the emitter that shape is a separate best-effort tooling task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)