### PR TITLE
Add Basilisk Collar to Worldwake

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BasiliskCollarReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BasiliskCollarReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Basilisk Collar reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in
+ * WWK's `cards/` package (the card's earliest real printing). This file contributes only
+ * the FDN-specific presentation row — set, collector number, art — picked up automatically
+ * by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BasiliskCollarReprint = Printing(
+    oracleId = "f5f4dd28-f4ae-4d39-b9b8-6ebfd63c93fe",
+    name = "Basilisk Collar",
+    setCode = "FDN",
+    collectorNumber = "669",
+    scryfallId = "7b36fba7-71f7-4b7f-bde5-b3a9752ad21c",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/7/b/7b36fba7-71f7-4b7f-bde5-b3a9752ad21c.jpg?1730491131",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/BasiliskCollar.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/BasiliskCollar.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.wwk.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Basilisk Collar
+ * {1}
+ * Artifact — Equipment
+ *
+ * Equipped creature has deathtouch and lifelink.
+ * Equip {2}
+ */
+val BasiliskCollar = card("Basilisk Collar") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has deathtouch and lifelink. (Any amount of damage it deals to a creature is enough to destroy it. Damage dealt by this creature also causes you to gain that much life.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.DEATHTOUCH, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.LIFELINK, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "122"
+        artist = "Howard Lyon"
+        flavorText = "During their endless travels, the mages of the Goma Fada caravan have learned ways to harness both life and death."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55cdba1b-7a80-435f-9cff-b9365f62e311.jpg?1562287734"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -1,3 +1,62 @@
+// Basilisk Collar
+{
+    "name": "Basilisk Collar",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has deathtouch and lifelink. (Any amount of damage it deals to a creature is enough to destroy it. Damage dealt by this creature also causes you to gain that much life.)\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEATHTOUCH"
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "LIFELINK"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "122",
+        "rarity": "RARE",
+        "artist": "Howard Lyon",
+        "flavorText": "During their endless travels, the mages of the Goma Fada caravan have learned ways to harness both life and death.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55cdba1b-7a80-435f-9cff-b9365f62e311.jpg?1562287734"
+    },
+    "colorIdentityOverride": []
+}
+
 // Pilgrim's Eye
 {
     "name": "Pilgrim's Eye",


### PR DESCRIPTION
## Basilisk Collar

Implements [Basilisk Collar](https://scryfall.com/card/wwk/122/basilisk-collar) — `{1}` Artifact — Equipment.

> Equipped creature has deathtouch and lifelink.
> Equip {2}

### Implementation
- Canonical `CardDefinition` placed in **Worldwake** (`wwk`), the card's earliest real-expansion printing.
- Composed entirely from existing primitives — two `staticAbility { ability = GrantKeyword(..., Filters.EquippedCreature) }` blocks (deathtouch + lifelink) plus `equipAbility("{2}")`. No new SDK mechanics.
- Added a `Printing` reprint row for **Foundations** (`fdn`, #669), the only other scaffolded set that reprints this card.
- Re-blessed `WWK.json` card snapshot (only Basilisk Collar added).

### Notes
- mtgish auto-draft rendered an AUTO tier draft; corrected its omission of the `Filters.EquippedCreature` scope on the `GrantKeyword` static abilities (matching the existing ShortBow equipment pattern).
- No new effects → no scenario test required (deathtouch/lifelink/equip are foundational).
- Verified every field against Scryfall and `just check-card-printing "Basilisk Collar"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)