### PR TITLE
Add Freya Crescent, Clive's Hideaway, and Garnet to Final Fantasy (FIN)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ClivesHideaway.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ClivesHideaway.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.FaceDownMode
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Clive's Hideaway
+ * Land — Town
+ *
+ * Hideaway 4 (When this land enters, look at the top four cards of your library, exile one
+ * face down, then put the rest on the bottom in a random order.)
+ * {T}: Add {C}.
+ * {2}, {T}: You may play the exiled card without paying its mana cost if you control four or
+ * more legendary creatures.
+ *
+ * Modeled on the classic Hideaway 4 land (see Mosswort Bridge): the ETB trigger gathers the
+ * top four cards, prompts the controller to exile one face down and linked to this land, and
+ * bottom-randomizes the rest. The activated free-cast ability gathers from the linked exile
+ * and grants may-play + without-paying-cost. The "four or more legendary creatures" clause is
+ * modeled as an activation restriction so the ability cannot be activated otherwise. Modern
+ * Hideaway no longer enters tapped (CR errata 2022-04-29), and Clive's Hideaway has no
+ * "enters tapped" line, so no [EntersTapped] replacement is added.
+ */
+val ClivesHideaway = card("Clive's Hideaway") {
+    typeLine = "Land — Town"
+    oracleText = "Hideaway 4 (When this land enters, look at the top four cards of your " +
+        "library, exile one face down, then put the rest on the bottom in a random order.)\n" +
+        "{T}: Add {C}.\n" +
+        "{2}, {T}: You may play the exiled card without paying its mana cost if you control " +
+        "four or more legendary creatures."
+
+    keywordAbility(KeywordAbility.hideaway(4))
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        count = DynamicAmount.Fixed(4),
+                        player = Player.You
+                    ),
+                    storeAs = "hideawayTop"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hideawayTop",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    storeSelected = "hideawayPicked",
+                    storeRemainder = "hideawayRest",
+                    prompt = "Choose a card to exile face down",
+                    selectedLabel = "Exile face down",
+                    remainderLabel = "Put on bottom of library"
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayPicked",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    faceDown = FaceDownMode.HIDDEN,
+                    linkToSource = true
+                ),
+                MoveCollectionEffect(
+                    from = "hideawayRest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "hideawayLinked"
+                ),
+                GrantMayPlayFromExileEffect("hideawayLinked"),
+                GrantPlayWithoutPayingCostEffect("hideawayLinked")
+            )
+        )
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Compare(
+                    DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature.legendary()).count(),
+                    ComparisonOperator.GTE,
+                    DynamicAmount.Fixed(4)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "275"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/5/e/5e43c36f-b8a2-4b2b-b2ea-57e6fa97521c.jpg?1748706815"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FreyaCrescent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/FreyaCrescent.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Freya Crescent
+ * {R}
+ * Legendary Creature — Rat Knight
+ * 1/1
+ *
+ * Jump — During your turn, Freya Crescent has flying.
+ * {T}: Add {R}. Spend this mana only to cast an Equipment spell or activate an equip ability.
+ *
+ * "Jump" is an ability word (no rules meaning); it's modeled as a conditional static grant of
+ * flying to this creature gated on [Conditions.IsYourTurn] — the same shape as Dragoon's Lance.
+ *
+ * The mana restriction uses [ManaRestriction.SubtypeSpellsOrAbilitiesOnly] for the Equipment
+ * subtype. This faithfully covers "cast an Equipment spell" and "activate an equip ability"
+ * (equip is an activated ability of an Equipment source). The only over-broadness versus the
+ * printed wording is that it would also permit paying for a *non-equip* activated ability of an
+ * Equipment source — a marginal case (equip is almost always an Equipment's only activated
+ * ability). A dedicated equip-only restriction would require threading an `isEquipAction` flag
+ * through the activated-ability legal-action enumerator, which is out of scope for this card.
+ */
+val FreyaCrescent = card("Freya Crescent") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Rat Knight"
+    oracleText = "Jump — During your turn, Freya Crescent has flying.\n" +
+        "{T}: Add {R}. Spend this mana only to cast an Equipment spell or activate an equip ability."
+    power = 1
+    toughness = 1
+
+    // Jump — During your turn, Freya Crescent has flying.
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(Keyword.FLYING, Filters.Self)
+    }
+
+    // {T}: Add {R}. Spend this mana only to cast an Equipment spell or activate an equip ability.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(
+            color = Color.RED,
+            amount = 1,
+            restriction = ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Equipment")
+        )
+        manaAbility = true
+        description = "{T}: Add {R}. Spend this mana only to cast an Equipment spell or activate an equip ability."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "138"
+        artist = "Nereida"
+        flavorText = "\"We live not to forget our past, but to learn from it!\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/9921f646-e893-44db-ac89-0633c1009788.jpg?1748706279"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GarnetPrincessOfAlexandria.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GarnetPrincessOfAlexandria.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Garnet, Princess of Alexandria
+ * {G}{W}
+ * Legendary Creature — Human Noble Cleric
+ * 2/2
+ *
+ * Lifelink
+ * Whenever Garnet attacks, you may remove a lore counter from each of any number of Sagas you
+ * control. Put a +1/+1 counter on Garnet for each lore counter removed this way.
+ *
+ * Composed from atoms (no new effect): on attack, gather the Sagas you control that still have
+ * a lore counter, let the controller pick any number of them (the "you may … any number" — zero
+ * is a legal choice), remove one lore counter from each chosen Saga via
+ * [ForEachInCollectionEffect] (`EffectTarget.Self` binds to the iterated Saga), then put that
+ * many +1/+1 counters on Garnet. The gather filters to Sagas that have a lore counter so every
+ * chosen Saga removes exactly one — making "lore counters removed this way" equal to the number
+ * of chosen Sagas ([DynamicAmount.DistinctEntitiesInCollections] over the chosen collection).
+ * Removing a lore counter only lowers the count, so it never triggers a chapter ability.
+ */
+val GarnetPrincessOfAlexandria = card("Garnet, Princess of Alexandria") {
+    manaCost = "{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Noble Cleric"
+    oracleText = "Lifelink\n" +
+        "Whenever Garnet attacks, you may remove a lore counter from each of any number of " +
+        "Sagas you control. Put a +1/+1 counter on Garnet for each lore counter removed this way."
+    power = 2
+    toughness = 2
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Composite(
+            listOf(
+                // Gather the Sagas you control that still have a lore counter to remove.
+                GatherCardsEffect(
+                    source = CardSource.ControlledPermanents(
+                        player = Player.You,
+                        filter = GameObjectFilter.Enchantment.withSubtype("Saga").withCounter(Counters.LORE)
+                    ),
+                    storeAs = "garnetSagas"
+                ),
+                // "you may … any number" — the controller chooses 0 or more of them.
+                SelectFromCollectionEffect(
+                    from = "garnetSagas",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    chooser = Chooser.Controller,
+                    storeSelected = "garnetChosen",
+                    storeRemainder = "garnetRest",
+                    prompt = "Choose any number of Sagas to remove a lore counter from each",
+                    selectedLabel = "Remove a lore counter",
+                    remainderLabel = "Leave unchanged",
+                    useTargetingUI = true
+                ),
+                // Remove one lore counter from each chosen Saga.
+                ForEachInCollectionEffect(
+                    collection = "garnetChosen",
+                    effect = Effects.RemoveCounters(Counters.LORE, 1, EffectTarget.Self)
+                ),
+                // Put a +1/+1 counter on Garnet for each lore counter removed this way.
+                Effects.AddDynamicCounters(
+                    Counters.PLUS_ONE_PLUS_ONE,
+                    DynamicAmount.DistinctEntitiesInCollections(listOf("garnetChosen")),
+                    EffectTarget.Self
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "222"
+        artist = "Daniel Correia"
+        flavorText = "\"Someday I will be queen, but I will always be myself.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b883df14-8d7b-4f6a-9a6a-2f71f5b6ddda.jpg?1748706601"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -2709,6 +2709,165 @@
     ]
 }
 
+// Clive's Hideaway
+{
+    "name": "Clive's Hideaway",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "Hideaway 4 (When this land enters, look at the top four cards of your library, exile one face down, then put the rest on the bottom in a random order.)\n{T}: Add {C}.\n{2}, {T}: You may play the exiled card without paying its mana cost if you control four or more legendary creatures.",
+    "keywords": [
+        "HIDEAWAY"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "HIDEAWAY",
+            "n": 4
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "hideawayTop"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hideawayTop",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "hideawayPicked",
+                            "storeRemainder": "hideawayRest",
+                            "prompt": "Choose a card to exile face down",
+                            "selectedLabel": "Exile face down",
+                            "remainderLabel": "Put on bottom of library"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayPicked",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true,
+                            "faceDown": "HIDDEN"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hideawayRest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "hideawayLinked"
+                        },
+                        {
+                            "type": "GrantPlayWithoutPayingCost",
+                            "from": "hideawayLinked"
+                        }
+                    ]
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        "IsLegendary"
+                                    ]
+                                }
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "275",
+        "rarity": "RARE",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/e/5e43c36f-b8a2-4b2b-b2ea-57e6fa97521c.jpg?1748706815"
+    }
+}
+
 // Clive, Ifrit's Dominant
 {
     "name": "Clive, Ifrit's Dominant",
@@ -4784,6 +4943,60 @@
     ]
 }
 
+// Freya Crescent
+{
+    "name": "Freya Crescent",
+    "manaCost": "{R}",
+    "typeLine": "Legendary Creature — Rat Knight",
+    "oracleText": "Jump — During your turn, Freya Crescent has flying.\n{T}: Add {R}. Spend this mana only to cast an Equipment spell or activate an equip ability.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "restriction": {
+                        "type": "SubtypeSpellsOrAbilitiesOnly",
+                        "subtype": "Equipment"
+                    }
+                },
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {R}. Spend this mana only to cast an Equipment spell or activate an equip ability."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "138",
+        "rarity": "UNCOMMON",
+        "artist": "Nereida",
+        "flavorText": "\"We live not to forget our past, but to learn from it!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/9921f646-e893-44db-ac89-0633c1009788.jpg?1748706279"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // From Father to Son
 {
     "name": "From Father to Son",
@@ -5121,6 +5334,102 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Garnet, Princess of Alexandria
+{
+    "name": "Garnet, Princess of Alexandria",
+    "manaCost": "{G}{W}",
+    "typeLine": "Legendary Creature — Human Noble Cleric",
+    "oracleText": "Lifelink\nWhenever Garnet attacks, you may remove a lore counter from each of any number of Sagas you control. Put a +1/+1 counter on Garnet for each lore counter removed this way.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "ControlledPermanents",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsEnchantment",
+                                        {
+                                            "type": "HasSubtype",
+                                            "subtype": "Saga"
+                                        }
+                                    ],
+                                    "statePredicates": [
+                                        {
+                                            "type": "HasCounter",
+                                            "counterType": "lore"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "garnetSagas"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "garnetSagas",
+                            "selection": "ChooseAnyNumber",
+                            "storeSelected": "garnetChosen",
+                            "storeRemainder": "garnetRest",
+                            "prompt": "Choose any number of Sagas to remove a lore counter from each",
+                            "selectedLabel": "Remove a lore counter",
+                            "remainderLabel": "Leave unchanged",
+                            "useTargetingUI": true
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Collection",
+                                "collection": "garnetChosen"
+                            },
+                            "body": {
+                                "type": "RemoveCounters",
+                                "counterType": "lore",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "DistinctEntitiesInCollections",
+                                "collections": [
+                                    "garnetChosen"
+                                ]
+                            },
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "UNCOMMON",
+        "artist": "Daniel Correia",
+        "flavorText": "\"Someday I will be queen, but I will always be myself.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b883df14-8d7b-4f6a-9a6a-2f71f5b6ddda.jpg?1748706601"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GarnetPrincessOfAlexandriaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GarnetPrincessOfAlexandriaScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.GarnetPrincessOfAlexandria
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Garnet, Princess of Alexandria — {G}{W} Legendary Creature — Human Noble Cleric 2/2, Lifelink.
+ *   Whenever Garnet attacks, you may remove a lore counter from each of any number of Sagas you
+ *   control. Put a +1/+1 counter on Garnet for each lore counter removed this way.
+ *
+ * Verifies the composed pipeline: gather your Sagas with a lore counter → choose any number →
+ * remove one lore counter from each chosen Saga → put that many +1/+1 counters on Garnet. Both the
+ * "two chosen" (count scales) and "decline / none chosen" (no counters) paths are covered.
+ */
+class GarnetPrincessOfAlexandriaScenarioTest : FunSpec({
+
+    // A harmless 4-chapter Saga used only to provide controllable lore counters. 4 chapters keeps
+    // it from being sacrificed while it carries fewer than 4 lore counters (CR 714.4).
+    val TestLoreSaga = card("Test Lore Saga") {
+        manaCost = "{2}"
+        typeLine = "Enchantment — Saga"
+        oracleText = "I, II, III, IV — You gain 1 life."
+        sagaChapter(1) { effect = Effects.GainLife(1) }
+        sagaChapter(2) { effect = Effects.GainLife(1) }
+        sagaChapter(3) { effect = Effects.GainLife(1) }
+        sagaChapter(4) { effect = Effects.GainLife(1) }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GarnetPrincessOfAlexandria, TestLoreSaga))
+        return driver
+    }
+
+    fun setLore(driver: GameTestDriver, entityId: EntityId, count: Int) {
+        val newState = driver.state.updateEntity(entityId) { container ->
+            val existing = container.get<CountersComponent>() ?: CountersComponent()
+            container.with(existing.withCounters(CounterType.LORE, count))
+        }
+        driver.replaceState(newState)
+    }
+
+    fun loreCount(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.LORE) ?: 0
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun drainStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 20 && driver.state.stack.isNotEmpty() && driver.pendingDecision == null) {
+            driver.bothPass()
+        }
+    }
+
+    test("attacking with Garnet: choosing two Sagas removes a lore counter from each and adds two +1/+1 counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        val garnet = driver.putCreatureOnBattlefield(active, "Garnet, Princess of Alexandria")
+        driver.removeSummoningSickness(garnet)
+
+        val saga1 = driver.putPermanentOnBattlefield(active, "Test Lore Saga")
+        val saga2 = driver.putPermanentOnBattlefield(active, "Test Lore Saga")
+        drainStack(driver)
+        setLore(driver, saga1, 2)
+        setLore(driver, saga2, 2)
+
+        plusOneCounters(driver, garnet) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(garnet), defendingPlayer = opponent).error shouldBe null
+
+        // Let the attack trigger go on the stack and resolve until it pauses for the selection.
+        var guard = 0
+        while (guard++ < 20 && driver.pendingDecision == null) driver.bothPass()
+        driver.submitCardSelection(active, listOf(saga1, saga2)).error shouldBe null
+        drainStack(driver)
+
+        // One lore counter removed from each chosen Saga, two +1/+1 counters on Garnet.
+        loreCount(driver, saga1) shouldBe 1
+        loreCount(driver, saga2) shouldBe 1
+        plusOneCounters(driver, garnet) shouldBe 2
+    }
+
+    test("attacking with Garnet: choosing no Sagas leaves lore counters intact and adds no +1/+1 counters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        val garnet = driver.putCreatureOnBattlefield(active, "Garnet, Princess of Alexandria")
+        driver.removeSummoningSickness(garnet)
+
+        val saga1 = driver.putPermanentOnBattlefield(active, "Test Lore Saga")
+        drainStack(driver)
+        setLore(driver, saga1, 2)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(active, listOf(garnet), defendingPlayer = opponent).error shouldBe null
+
+        var guard = 0
+        while (guard++ < 20 && driver.pendingDecision == null) driver.bothPass()
+        // "you may … any number" — decline by choosing zero Sagas.
+        driver.submitCardSelection(active, emptyList()).error shouldBe null
+        drainStack(driver)
+
+        loreCount(driver, saga1) shouldBe 2
+        plusOneCounters(driver, garnet) shouldBe 0
+    }
+})


### PR DESCRIPTION
## Summary

Implements a handful of missing **Final Fantasy (FIN)** cards via the `add-card` skill. Each card is composed entirely from **existing SDK primitives** — no new effects, keywords, triggers, or conditions — so there are no SDK-reference changes.

| Card | Mana | Type | What it does |
|------|------|------|--------------|
| **Freya Crescent** | `{R}` | Legendary Creature — Rat Knight (1/1) | *Jump* (flying during your turn) + Equipment-restricted mana |
| **Clive's Hideaway** | — | Land — Town | Hideaway 4, `{T}: Add {C}`, free-cast the exiled card with 4+ legendary creatures |
| **Garnet, Princess of Alexandria** | `{G}{W}` | Legendary Creature — Human Noble Cleric (2/2) | Lifelink; on attack, remove a lore counter from any number of your Sagas, +1/+1 per counter removed |

## Implementation notes

- **Freya Crescent** — "Jump" is an ability word (no rules text), modeled as a conditional static grant of flying gated on `Conditions.IsYourTurn` (same shape as Dragoon's Lance). The mana uses `ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Equipment")`, which faithfully covers "cast an Equipment spell or activate an equip ability"; the only over-broadness vs. the printed wording is that it would also permit a *non-equip* activated ability of an Equipment source (a marginal case) — documented in a code comment, since a dedicated equip-only restriction would require threading an `isEquipAction` flag through the activated-ability legal-action enumerator.
- **Clive's Hideaway** — modeled directly on the classic Hideaway 4 land (Mosswort Bridge): ETB gather→exile-one-face-down-linked→bottom-randomize, plus an activated free-cast from the linked exile gated by an `ActivationRestriction.OnlyIfCondition` on legendary-creature count. Modern Hideaway no longer enters tapped (CR errata), and the card has no "enters tapped" line, so none is added.
- **Garnet** — pure atomic composition: `GatherCards(ControlledPermanents: Sagas with a lore counter)` → `SelectFromCollection(ChooseAnyNumber)` → `ForEachInCollection(RemoveCounters(lore, 1, Self))` → `AddDynamicCounters(+1/+1, DistinctEntitiesInCollections(chosen), Self)`. Filtering to Sagas that have a lore counter makes "lore counters removed this way" equal the number chosen.

## Testing

- `GarnetPrincessOfAlexandriaScenarioTest` — covers the two-Sagas-chosen path (a lore counter removed from each, +2/+2 on Garnet) and the decline path (choose none → no change). ✅
- `CardDefinitionSnapshotTest` re-blessed — diff adds **only** the three new cards. ✅
- `CardLintTest` + `:mtg-sets:test` green; `just check-card-printing` confirms FIN is the canonical (earliest real) printing for all three. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)