### PR TITLE
Add Vivien Reid to Core Set 2019

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VivienReidReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VivienReidReprint.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vivien Reid reprints in Foundations (FDN).
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, loyalty abilities) lives in
+ * the M19 `cards/` package — its earliest real printing. These files contribute only the
+ * FDN-specific presentation rows (set, collector number, art), picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ *
+ * FDN prints Vivien Reid three times: the main-set #234 (Anna Steinbauer) and two full-art
+ * variants #361 and #421 (Zara Alfonso).
+ */
+val VivienReidReprint = Printing(
+    oracleId = "b5f20a6d-8c3e-452f-9d98-4886f0fa052a",
+    name = "Vivien Reid",
+    setCode = "FDN",
+    collectorNumber = "234",
+    scryfallId = "38769247-42a1-4571-9071-6d59fe28650a",
+    artist = "Anna Steinbauer",
+    imageUri = "https://cards.scryfall.io/normal/front/3/8/38769247-42a1-4571-9071-6d59fe28650a.jpg?1730489472",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)
+
+val VivienReidReprintFullArt361 = Printing(
+    oracleId = "b5f20a6d-8c3e-452f-9d98-4886f0fa052a",
+    name = "Vivien Reid",
+    setCode = "FDN",
+    collectorNumber = "361",
+    scryfallId = "37cc3e80-2ffa-4d48-bd67-a6315375b236",
+    artist = "Zara Alfonso",
+    imageUri = "https://cards.scryfall.io/normal/front/3/7/37cc3e80-2ffa-4d48-bd67-a6315375b236.jpg?1730718627",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+    isFullArt = true,
+)
+
+val VivienReidReprintFullArt421 = Printing(
+    oracleId = "b5f20a6d-8c3e-452f-9d98-4886f0fa052a",
+    name = "Vivien Reid",
+    setCode = "FDN",
+    collectorNumber = "421",
+    scryfallId = "162a3a3b-257e-46c7-bb29-65627b00363d",
+    artist = "Zara Alfonso",
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/162a3a3b-257e-46c7-bb29-65627b00363d.jpg?1734454679",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+    isFullArt = true,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/VivienReid.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/VivienReid.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Vivien Reid
+ * {3}{G}{G}
+ * Legendary Planeswalker — Vivien
+ * Starting Loyalty: 5
+ *
+ * +1: Look at the top four cards of your library. You may reveal a creature or land card
+ *     from among them and put it into your hand. Put the rest on the bottom of your library
+ *     in a random order.
+ * −3: Destroy target artifact, enchantment, or creature with flying.
+ * −8: You get an emblem with "Creatures you control get +2/+2 and have vigilance, trample,
+ *     and indestructible."
+ */
+val VivienReid = card("Vivien Reid") {
+    manaCost = "{3}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Planeswalker — Vivien"
+    startingLoyalty = 5
+    oracleText = "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n−3: Destroy target artifact, enchantment, or creature with flying.\n−8: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\""
+
+    // +1: Look at the top four cards of your library. You may reveal a creature or land card
+    // from among them and put it into your hand. Put the rest on the bottom of your library in
+    // a random order. (Star Charter shape — the reveal is optional, filtered, and the remainder
+    // defaults to the bottom in a random order.)
+    loyaltyAbility(+1) {
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(4),
+            filter = GameObjectFilter.CreatureOrLand,
+            prompt = "You may reveal a creature or land card to put into your hand"
+        )
+    }
+
+    // −3: Destroy target artifact, enchantment, or creature with flying. A single battlefield
+    // target whose legal set is the union of "artifact", "enchantment", and "creature with
+    // flying" (the flying clause is projection-evaluated, so creatures that gain/lose flying are
+    // included/excluded correctly).
+    loyaltyAbility(-3) {
+        val t = target(
+            "permanent",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.ArtifactOrEnchantment or
+                        GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+                )
+            )
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    // −8: You get an emblem with "Creatures you control get +2/+2 and have vigilance, trample,
+    // and indestructible."
+    loyaltyAbility(-8) {
+        effect = Effects.CreatePermanentEmblem(
+            groupFilter = GroupFilter.AllCreaturesYouControl,
+            powerBonus = 2,
+            toughnessBonus = 2,
+            grantedKeywords = listOf(
+                Keyword.VIGILANCE.name,
+                Keyword.TRAMPLE.name,
+                Keyword.INDESTRUCTIBLE.name
+            ),
+            emblemDescription = "Creatures you control get +2/+2 and have vigilance, trample, and indestructible."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "208"
+        artist = "Anna Steinbauer"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/681fbd66-b622-4f20-a860-f101aff21109.jpg?1562302655"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -158,3 +158,160 @@
         "WHITE"
     ]
 }
+
+// Vivien Reid
+{
+    "name": "Vivien Reid",
+    "manaCost": "{3}{G}{G}",
+    "typeLine": "Legendary Planeswalker — Vivien",
+    "oracleText": "+1: Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\n−3: Destroy target artifact, enchantment, or creature with flying.\n−8: You get an emblem with \"Creatures you control get +2/+2 and have vigilance, trample, and indestructible.\"",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature|land",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature or land card to put into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -3
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "permanent"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            {
+                                                "type": "Or",
+                                                "predicates": [
+                                                    "IsArtifact",
+                                                    "IsEnchantment"
+                                                ]
+                                            },
+                                            {
+                                                "type": "And",
+                                                "predicates": [
+                                                    "IsCreature",
+                                                    {
+                                                        "type": "HasKeyword",
+                                                        "keyword": "FLYING"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "id": "permanent"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -8
+                },
+                "effect": {
+                    "type": "CreatePermanentEmblem",
+                    "groupFilter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "grantedKeywords": [
+                        "VIGILANCE",
+                        "TRAMPLE",
+                        "INDESTRUCTIBLE"
+                    ],
+                    "emblemDescription": "Creatures you control get +2/+2 and have vigilance, trample, and indestructible."
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "MYTHIC",
+        "artist": "Anna Steinbauer",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/681fbd66-b622-4f20-a860-f101aff21109.jpg?1562302655"
+    },
+    "startingLoyalty": 5,
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VivienReidScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VivienReidScenarioTest.kt
@@ -1,0 +1,174 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Vivien Reid (M19 #208, {3}{G}{G} planeswalker, loyalty 5).
+ *
+ *   +1: Look at the top four cards of your library. You may reveal a creature or land card from
+ *       among them and put it into your hand. Put the rest on the bottom of your library in a
+ *       random order.
+ *   -3: Destroy target artifact, enchantment, or creature with flying.
+ *   -8: You get an emblem with "Creatures you control get +2/+2 and have vigilance, trample,
+ *       and indestructible."
+ */
+class VivienReidScenarioTest : ScenarioTestBase() {
+
+    private fun loyalty(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LOYALTY) ?: 0
+
+    /** Seed a planeswalker's starting loyalty (withCardOnBattlefield doesn't stamp it). */
+    private fun seedLoyalty(game: TestGame, id: EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { c ->
+            c.with(CountersComponent().withAdded(CounterType.LOYALTY, amount))
+        }
+    }
+
+    private fun ability(index: Int) =
+        cardRegistry.getCard("Vivien Reid")!!.script.activatedAbilities[index]
+
+    init {
+        test("+1: reveal a creature card from the top four and put it into your hand") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Vivien Reid")
+                .withCardInLibrary(1, "Grizzly Bears")
+                .withCardInLibrary(1, "Shock")
+                .withCardInLibrary(1, "Shock")
+                .withCardInLibrary(1, "Shock")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val vivien = game.findPermanent("Vivien Reid")!!
+            seedLoyalty(game, vivien, 5)
+
+            val bearInLibrary = game.state.getLibrary(game.player1Id).single { id ->
+                game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+            }
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = vivien, abilityId = ability(0).id)
+            ).error shouldBe null
+            game.resolveStack()
+
+            // Optional reveal: choose the creature card.
+            withClue("the +1 pauses to let the player reveal a creature or land card") {
+                game.hasPendingDecision() shouldBe true
+            }
+            game.selectCards(listOf(bearInLibrary))
+            game.resolveStack()
+
+            withClue("Vivien is at loyalty 6 after +1") { loyalty(game, vivien) shouldBe 6 }
+            withClue("the revealed creature is now in hand") {
+                game.isInHand(1, "Grizzly Bears") shouldBe true
+            }
+            withClue("the other three cards went to the bottom of the library") {
+                game.state.getLibrary(game.player1Id).size shouldBe 3
+            }
+        }
+
+        test("-3: destroy target creature with flying; a ground creature is unaffected") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Vivien Reid")
+                .withCardOnBattlefield(2, "Air Elemental")
+                .withCardOnBattlefield(2, "Llanowar Elves")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val vivien = game.findPermanent("Vivien Reid")!!
+            seedLoyalty(game, vivien, 5)
+            val flyer = game.findPermanent("Air Elemental")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = vivien,
+                    abilityId = ability(1).id,
+                    targets = listOf(ChosenTarget.Permanent(flyer))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("Vivien is at loyalty 2 after -3") { loyalty(game, vivien) shouldBe 2 }
+            withClue("the flying creature is destroyed") {
+                game.findPermanent("Air Elemental") shouldBe null
+            }
+            withClue("the ground creature (no flying) is not a legal target and survives") {
+                game.findPermanent("Llanowar Elves") shouldNotBe null
+            }
+        }
+
+        test("-3: the artifact clause of the union can also be destroyed") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Vivien Reid")
+                .withCardOnBattlefield(2, "Millstone")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val vivien = game.findPermanent("Vivien Reid")!!
+            seedLoyalty(game, vivien, 5)
+            val artifact = game.findPermanent("Millstone")!!
+
+            game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = vivien,
+                    abilityId = ability(1).id,
+                    targets = listOf(ChosenTarget.Permanent(artifact))
+                )
+            ).error shouldBe null
+            game.resolveStack()
+
+            withClue("the targeted artifact is destroyed") {
+                game.findPermanent("Millstone") shouldBe null
+            }
+        }
+
+        test("-8: emblem grants +2/+2, vigilance, trample, and indestructible to your creatures") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Vivien Reid")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val vivien = game.findPermanent("Vivien Reid")!!
+            seedLoyalty(game, vivien, 8)
+            val bear = game.findPermanent("Grizzly Bears")!!
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = vivien, abilityId = ability(2).id)
+            ).error shouldBe null
+            game.resolveStack()
+
+            val projected = game.state.projectedState
+            withClue("Grizzly Bears is a 4/4 from the emblem (+2/+2)") {
+                projected.getPower(bear) shouldBe 4
+                projected.getToughness(bear) shouldBe 4
+            }
+            withClue("…and has vigilance, trample, and indestructible") {
+                projected.hasKeyword(bear, Keyword.VIGILANCE) shouldBe true
+                projected.hasKeyword(bear, Keyword.TRAMPLE) shouldBe true
+                projected.hasKeyword(bear, Keyword.INDESTRUCTIBLE) shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Vivien Reid** — a `{3}{G}{G}` legendary planeswalker (M19 #208, loyalty 5):

- **+1:** Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. Put the rest on the bottom of your library in a random order.
- **−3:** Destroy target artifact, enchantment, or creature with flying.
- **−8:** You get an emblem with "Creatures you control get +2/+2 and have vigilance, trample, and indestructible."

## Implementation notes

All three abilities compose from **existing SDK primitives** — no new engine building blocks:

- **+1** → `Patterns.Library.lookAtTopRevealMatchingToHand(count = 4, filter = CreatureOrLand)` (the Star Charter shape: optional filtered reveal, remainder defaults to bottom in a random order).
- **−3** → `Effects.Destroy` on a single battlefield target whose legal set is the union of `ArtifactOrEnchantment` and `Creature.withKeyword(FLYING)`, built with the `GameObjectFilter.or` infix. The flying clause is projection-evaluated, so creatures that gain/lose flying are included/excluded correctly.
- **−8** → `Effects.CreatePermanentEmblem(GroupFilter.AllCreaturesYouControl, +2/+2, [VIGILANCE, TRAMPLE, INDESTRUCTIBLE])`.

## Placement

- Canonical `CardDefinition` lives in **M19** (the card's earliest real printing).
- **FDN** is scaffolded and reprints Vivien three times, so it gets `Printing` rows for #234 (Anna Steinbauer) plus the two full-art variants #361/#421 (Zara Alfonso). `just check-card-printing "Vivien Reid"` is clean.

## Testing

- `VivienReidScenarioTest` covers each ability: +1 reveal-to-hand, −3 destroying a flyer (with a ground creature unaffected), −3 destroying the artifact clause of the union, and −8 emblem buff/keyword grants. All pass.
- Re-blessed the M19 card snapshot (only Vivien Reid added; no other card changed).
- `just build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)