### PR TITLE
Add Agatha's Soul Cauldron to Wilds of Eldraine

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3451,13 +3451,21 @@ staticAbility {
   (Cursed Totem → `GameObjectFilter.Creature`). With `nonManaAbilitiesOnly = true`, mana abilities
   stay usable and only non-mana abilities are blocked — the "… can't be activated unless they're
   mana abilities" wording (Sharkey, Tyrant of the Shire → `GameObjectFilter.Land.opponentControls()`).
-- `HasAllActivatedAbilitiesOfLinkedExiledCard` (data object) — the source permanent gains **all
-  activated abilities of every card in its linked-exile pile** (`LinkedExileComponent`). Resolved
-  dynamically at activation-legality time: the engine pulls each exiled card's `activatedAbilities`
-  and surfaces them on the source, with the source as granter (so `{T}` taps the source and
-  "this card" self-references bind to the source — CR-faithful). Grants *activated* abilities only,
-  not triggered/static/replacement. Pair with `Effects.ExileLinkedToSource(target)` to fill the
-  pile. (Territory Forge.)
+- `HasAllActivatedAbilitiesOfLinkedExiledCard(filter = GroupFilter.source(), creatureCardsOnly = false)`
+  — the permanents matching `filter` gain **all activated abilities of the cards in this source's
+  linked-exile pile** (`LinkedExileComponent`). Resolved dynamically at activation-legality time: the
+  engine pulls each exiled card's `activatedAbilities` and surfaces them on every matching permanent,
+  with **that permanent** as granter (so `{T}` taps it and "this card" self-references bind to it —
+  CR-faithful). Grants *activated* abilities only, not triggered/static/replacement. Pair with
+  `Effects.ExileLinkedToSource(target)` to fill the pile.
+    - `filter = GroupFilter.source()` (the default) → "This permanent has all activated abilities of
+      the exiled card" — the source grants the abilities to *itself* (Territory Forge).
+    - any battlefield filter → the source grants the abilities to *other* matching permanents
+      ("Creatures you control with +1/+1 counters on them have all activated abilities of all creature
+      cards exiled with this" — Agatha's Soul Cauldron →
+      `HasAllActivatedAbilitiesOfLinkedExiledCard(GroupFilter.AllCreaturesYouControl.withCounter(Counters.PLUS_ONE_PLUS_ONE), creatureCardsOnly = true)`).
+    - `creatureCardsOnly = true` restricts the source pile to *creature* cards (the exiled card's
+      printed type), for the "all **creature** cards exiled with" wording.
 - `SuppressEntersTriggers(filter = GameObjectFilter.Creature)` — permanents matching `filter`
   entering the battlefield don't cause abilities to trigger (CR 603.6 enters-the-battlefield
   triggers). Suppresses both the entering permanent's *own* ETB triggers and any other permanent's
@@ -3477,8 +3485,11 @@ staticAbility {
   portion of the activated-ability costs of permanents matching `filter` (a `GroupFilter`; use
   `GroupFilter.source()` for "this permanent's abilities"). Relaxes colored/hybrid/Phyrexian/colorless
   pips to generic per CR 118.14 / 609.4b; non-mana cost components are untouched. Honored by both
-  affordability checks and the mana solver. (Sharkey, Tyrant of the Shire — "Mana of any type can be
-  spent to activate Sharkey's abilities")
+  affordability checks and the mana solver. `filter` is matched against the permanent whose ability
+  is being activated, so a battlefield filter scopes the permission to a class of permanents —
+  `GroupFilter.AllCreaturesYouControl` for "spend mana as though it were mana of any color to activate
+  abilities of creatures you control" (Agatha's Soul Cauldron). (Sharkey, Tyrant of the Shire — "Mana
+  of any type can be spent to activate Sharkey's abilities" → `GroupFilter.source()`.)
 - `PreventManaPoolEmptying` — mana pools don't empty between steps/phases. (Upwelling)
 - `NoMaximumHandSize` — controller has no hand-size limit *while this permanent is on the
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -417,7 +417,9 @@ object Conditions {
      * printed types rather than projected state. The right test for a face-down permanent (which
      * projects as a typeless 2/2 Creature regardless of what it really is) — e.g. "Reveal target
      * face-down permanent. If it's a creature card, you may turn it face up." (Hauntwoods Shrieker).
-     * Resolution-only.
+     * Also handles a card target in another zone (a graveyard/exile card target), whose printed type
+     * survives the zone change — e.g. "Exile target card from a graveyard. When a creature card is
+     * exiled this way, …" (Agatha's Soul Cauldron). Resolution-only.
      */
     fun TargetIsCreatureCard(targetIndex: Int = 0): ConditionInterface =
         com.wingedsheep.sdk.scripting.conditions.TargetIsCreatureCard(targetIndex)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AbilityGrantStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AbilityGrantStaticAbilities.kt
@@ -61,20 +61,40 @@ data class GrantActivatedAbility(
 }
 
 /**
- * Grants the source permanent **all activated abilities of the card(s) it exiled** (its linked
- * exile pile). Models "This permanent has all activated abilities of the exiled card"
- * (Territory Forge).
+ * Grants the permanents matching [filter] **all activated abilities of the card(s) in this
+ * source's linked-exile pile**. Two shapes:
+ *  - `filter = GroupFilter.source()` (the default) → "This permanent has all activated abilities of
+ *    the exiled card" (Territory Forge — the source grants the abilities to *itself*).
+ *  - any battlefield filter → "Creatures you control with +1/+1 counters on them have all activated
+ *    abilities of all creature cards exiled with this" (Agatha's Soul Cauldron — the source grants
+ *    the abilities to *other* matching permanents). Pair with [creatureCardsOnly] when the printed
+ *    text restricts the source pile to creature cards.
  *
  * Resolution is dynamic: the engine reads the source's linked-exile pile at activation-legality
  * time, pulls every activated ability off each exiled card's definition, and surfaces them as
- * activatable on the source permanent (with the source as the ability's controller/source, so
- * self-references and `{T}` resolve against this permanent — CR-faithful to the Territory Forge
- * ruling that the exiled card's "this card" references become references to Territory Forge).
+ * activatable on each *matching* permanent — with that permanent as the ability's source, so
+ * self-references and `{T}` resolve against the creature that gained the ability (CR-faithful to
+ * the rulings that the exiled card's "this card" references become references to the permanent
+ * that has the ability).
  *
  * It grants only *activated* abilities — not triggered, static, or replacement abilities.
+ *
+ * @property filter The permanents that gain the exiled cards' abilities (default: the source itself).
+ * @property creatureCardsOnly When true, only *creature* cards in the linked-exile pile contribute
+ *   their abilities (Agatha's "all **creature** cards exiled with"). When false, every exiled card
+ *   contributes (Territory Forge).
  */
 @SerialName("HasAllActivatedAbilitiesOfLinkedExiledCard")
 @Serializable
-data object HasAllActivatedAbilitiesOfLinkedExiledCard : StaticAbility {
-    override val description: String = "this permanent has all activated abilities of the exiled card"
+data class HasAllActivatedAbilitiesOfLinkedExiledCard(
+    val filter: GroupFilter = GroupFilter.source(),
+    val creatureCardsOnly: Boolean = false,
+) : StaticAbility {
+    override val description: String =
+        "${filter.description} have all activated abilities of the${if (creatureCardsOnly) " creature" else ""} cards exiled with this"
+
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/GroupFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/GroupFilter.kt
@@ -213,6 +213,9 @@ data class GroupFilter(
     /** Add subtype by string */
     fun withSubtype(subtype: String) = copy(baseFilter = baseFilter.withSubtype(subtype))
 
+    /** Must have a counter of the given type (e.g. `Counters.PLUS_ONE_PLUS_ONE`) */
+    fun withCounter(counterType: String) = copy(baseFilter = baseFilter.withCounter(counterType))
+
     /** Add keyword requirement */
     fun withKeyword(keyword: Keyword) = copy(baseFilter = baseFilter.withKeyword(keyword))
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/TerritoryForge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/cards/TerritoryForge.kt
@@ -43,7 +43,8 @@ val TerritoryForge = card("Territory Forge") {
     }
 
     staticAbility {
-        ability = HasAllActivatedAbilitiesOfLinkedExiledCard
+        // Default filter = the source itself ("This artifact has all activated abilities …").
+        ability = HasAllActivatedAbilitiesOfLinkedExiledCard()
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AgathasSoulCauldron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/AgathasSoulCauldron.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfLinkedExiledCard
+import com.wingedsheep.sdk.scripting.SpendAnyManaTypeForActivatedAbilities
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Agatha's Soul Cauldron
+ * {2}
+ * Legendary Artifact (Wilds of Eldraine, mythic)
+ *
+ * "You may spend mana as though it were mana of any color to activate abilities of creatures
+ *  you control.
+ *  Creatures you control with +1/+1 counters on them have all activated abilities of all creature
+ *  cards exiled with Agatha's Soul Cauldron.
+ *  {T}: Exile target card from a graveyard. When a creature card is exiled this way, put a +1/+1
+ *  counter on target creature you control."
+ *
+ * Implementation — three reusable static/activated pieces:
+ *  - [SpendAnyManaTypeForActivatedAbilities] scoped to `AllCreaturesYouControl`: relaxes the
+ *    colored/colorless requirements of the mana cost of any ability activated from a creature you
+ *    control (CR 609.4b), so the granted (and printed) abilities of your creatures can be paid with
+ *    mana of any type. Same engine seam as Sharkey, Tyrant of the Shire (there scoped to Self).
+ *  - [HasAllActivatedAbilitiesOfLinkedExiledCard] with a battlefield filter ("creatures you control
+ *    with a +1/+1 counter") and `creatureCardsOnly = true`: every creature card in the Cauldron's
+ *    linked-exile pile lends its activated abilities to each such creature, with that creature as
+ *    the abilities' source (so `{T}` taps it and self-references bind to it — the printed ruling).
+ *  - The `{T}` activated ability exiles a targeted graveyard card linked to the Cauldron, then —
+ *    only if that card was a creature card (a reflexive trigger, resolved inline via
+ *    [ConditionalEffect]) — chooses a creature you control and puts a +1/+1 counter on it.
+ *
+ * Rulings (2023-09-01):
+ *  - Grants only *activated* abilities, never keyword (unless activated), triggered, or static ones.
+ *  - The granted abilities use "this permanent," so they're treated as printed on the creature that
+ *    gained them.
+ */
+val AgathasSoulCauldron = card("Agatha's Soul Cauldron") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact"
+    oracleText = "You may spend mana as though it were mana of any color to activate abilities of " +
+        "creatures you control.\n" +
+        "Creatures you control with +1/+1 counters on them have all activated abilities of all " +
+        "creature cards exiled with Agatha's Soul Cauldron.\n" +
+        "{T}: Exile target card from a graveyard. When a creature card is exiled this way, put a " +
+        "+1/+1 counter on target creature you control."
+
+    // "You may spend mana as though it were mana of any color to activate abilities of creatures
+    // you control."
+    staticAbility {
+        ability = SpendAnyManaTypeForActivatedAbilities(filter = GroupFilter.AllCreaturesYouControl)
+    }
+
+    // "Creatures you control with +1/+1 counters on them have all activated abilities of all
+    // creature cards exiled with Agatha's Soul Cauldron."
+    staticAbility {
+        ability = HasAllActivatedAbilitiesOfLinkedExiledCard(
+            filter = GroupFilter.AllCreaturesYouControl.withCounter(Counters.PLUS_ONE_PLUS_ONE),
+            creatureCardsOnly = true
+        )
+    }
+
+    // "{T}: Exile target card from a graveyard. When a creature card is exiled this way, put a
+    // +1/+1 counter on target creature you control."
+    activatedAbility {
+        cost = Costs.Tap
+        val exiled = target("target card from a graveyard", Targets.CardInGraveyard)
+        effect = Effects.Composite(
+            Effects.ExileLinkedToSource(exiled),
+            // Reflexive "when a creature card is exiled this way": tested on the exiled card's
+            // printed type (last-known via its CardComponent in exile). When true, choose a creature
+            // you control at resolution and add the counter.
+            ConditionalEffect(
+                condition = Conditions.TargetIsCreatureCard(0),
+                effect = Effects.Composite(
+                    Effects.SelectTarget(Targets.CreatureYouControl, storeAs = "cauldronCounterTarget"),
+                    Effects.AddCounters(
+                        Counters.PLUS_ONE_PLUS_ONE,
+                        1,
+                        EffectTarget.PipelineTarget("cauldronCounterTarget", 0)
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "242"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/019b51b0-e5c6-4208-922b-7736686dddcd.jpg?1692939838"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1,3 +1,107 @@
+// Agatha's Soul Cauldron
+{
+    "name": "Agatha's Soul Cauldron",
+    "manaCost": "{2}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "You may spend mana as though it were mana of any color to activate abilities of creatures you control.\nCreatures you control with +1/+1 counters on them have all activated abilities of all creature cards exiled with Agatha's Soul Cauldron.\n{T}: Exile target card from a graveyard. When a creature card is exiled this way, put a +1/+1 counter on target creature you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target card from a graveyard"
+                            },
+                            "destination": "Exile",
+                            "linkToSource": true
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": "TargetIsCreatureCard"
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SelectTarget",
+                                        "requirement": {
+                                            "type": "TargetObject",
+                                            "filter": {
+                                                "baseFilter": "creature ctrl:you"
+                                            }
+                                        },
+                                        "storeAs": "cauldronCounterTarget"
+                                    },
+                                    {
+                                        "type": "AddCounters",
+                                        "counterType": "+1/+1",
+                                        "count": 1,
+                                        "target": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "cauldronCounterTarget"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card from a graveyard"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "SpendAnyManaTypeForActivatedAbilities",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            },
+            {
+                "type": "HasAllActivatedAbilitiesOfLinkedExiledCard",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "+1/+1"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                },
+                "creatureCardsOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "MYTHIC",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/019b51b0-e5c6-4208-922b-7736686dddcd.jpg?1692939838"
+    },
+    "colorIdentityOverride": []
+}
+
 // Archive Dragon
 {
     "name": "Archive Dragon",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -1276,8 +1276,14 @@ class ConditionEvaluator(
         context: EffectContext
     ): Boolean {
         val target = context.positionalTarget(condition.index) ?: return false
-        val entityId = (target as? com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent)
-            ?.entityId ?: return false
+        // Works whether the target is a battlefield permanent (face-down reveal) or a card in another
+        // zone — a graveyard card exiled by Agatha's Soul Cauldron is a ChosenTarget.Card. Both expose
+        // the underlying entity, whose CardComponent still carries the printed type after it moves.
+        val entityId = when (target) {
+            is com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent -> target.entityId
+            is com.wingedsheep.engine.state.components.stack.ChosenTarget.Card -> target.cardId
+            else -> return false
+        }
         return state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.isCreature == true
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -2247,11 +2247,31 @@ class ActivateAbilityHandler(
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             val classLevel = container.get<com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent>()?.currentLevel
             for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
-                // Territory Forge: "this permanent has all activated abilities of the exiled card".
+                // "[filter] have all activated abilities of the [creature] cards exiled with this"
+                // (Territory Forge = Self; Agatha's Soul Cauldron = creatures you control with a
+                // +1/+1 counter). Mirror CastPermissionUtils.getStaticGrantedAbilitiesWithGranter:
+                // grant each pile ability to every matching permanent, recording the *receiver* as
+                // the granter so `{T}`/self-references bind to the permanent that gained the ability.
                 if (ability is com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfLinkedExiledCard) {
-                    if (permanentId != entityId) continue
-                    for (granted in com.wingedsheep.engine.legalactions.utils.linkedExiledActivatedAbilities(state, permanentId, cardRegistry)) {
-                        result.add(granted to permanentId)
+                    val receives = when (val scope = ability.filter.scope) {
+                        is Scope.Self -> permanentId == entityId
+                        is Scope.Specific -> scope.entityId == entityId
+                        is Scope.AttachedTo -> container.get<AttachedToComponent>()?.targetId == entityId
+                        is Scope.Battlefield -> {
+                            if (ability.filter.excludeSelf && permanentId == entityId) false
+                            else {
+                                val granterController = state.projectedState.getController(permanentId)
+                                granterController != null && predicateEvaluator.matches(
+                                    state, state.projectedState, entityId, ability.filter.baseFilter,
+                                    PredicateContext(controllerId = granterController, sourceId = permanentId)
+                                )
+                            }
+                        }
+                    }
+                    if (receives) {
+                        for (granted in com.wingedsheep.engine.legalactions.utils.linkedExiledActivatedAbilities(state, permanentId, cardRegistry, ability.creatureCardsOnly)) {
+                            result.add(granted to entityId)
+                        }
                     }
                     continue
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -870,12 +870,33 @@ class CastPermissionUtils(
             // Include unlocked Room face statics (CR 709.5) so a Room that grants activated
             // abilities (e.g. Greenhouse) only hands them out once its door is unlocked.
             for (ability in com.wingedsheep.engine.state.components.identity.RoomFaceStatics.activeStaticAbilities(container, cardDef)) {
-                // "This permanent has all activated abilities of the exiled card" (Territory Forge):
-                // pull every activated ability off each linked-exiled card and grant it to the source.
+                // "[filter] have all activated abilities of the [creature] cards exiled with this":
+                // pull every activated ability off each card in the granter's linked-exile pile and
+                // grant it to each matching permanent. Self filter = Territory Forge (grants to
+                // itself); a battlefield filter = Agatha's Soul Cauldron (grants to other creatures
+                // you control with +1/+1 counters). The granter recorded is the *receiver* so the
+                // ability's `{T}`/self-references bind to the permanent that gained it (CR-faithful).
                 if (ability is com.wingedsheep.sdk.scripting.HasAllActivatedAbilitiesOfLinkedExiledCard) {
-                    if (permanentId != entityId) continue
-                    for (granted in linkedExiledActivatedAbilities(state, permanentId, cardRegistry)) {
-                        result.add(StaticGrantedAbility(granted, permanentId))
+                    val receives = when (val scope = ability.filter.scope) {
+                        is com.wingedsheep.sdk.scripting.filters.unified.Scope.Self -> permanentId == entityId
+                        is com.wingedsheep.sdk.scripting.filters.unified.Scope.Specific -> scope.entityId == entityId
+                        is com.wingedsheep.sdk.scripting.filters.unified.Scope.AttachedTo ->
+                            container.get<com.wingedsheep.engine.state.components.battlefield.AttachedToComponent>()?.targetId == entityId
+                        is com.wingedsheep.sdk.scripting.filters.unified.Scope.Battlefield -> {
+                            if (ability.filter.excludeSelf && permanentId == entityId) false
+                            else {
+                                val granterController = state.projectedState.getController(permanentId)
+                                granterController != null && predicateEvaluator.matches(
+                                    state, state.projectedState, entityId, ability.filter.baseFilter,
+                                    PredicateContext(controllerId = granterController, sourceId = permanentId)
+                                )
+                            }
+                        }
+                    }
+                    if (receives) {
+                        for (granted in linkedExiledActivatedAbilities(state, permanentId, cardRegistry, ability.creatureCardsOnly)) {
+                            result.add(StaticGrantedAbility(granted, entityId))
+                        }
                     }
                     continue
                 }
@@ -1084,14 +1105,18 @@ data class StaticGrantedAbility(
 fun linkedExiledActivatedAbilities(
     state: GameState,
     sourceId: EntityId,
-    cardRegistry: CardRegistry
+    cardRegistry: CardRegistry,
+    creatureCardsOnly: Boolean = false
 ): List<com.wingedsheep.sdk.scripting.ActivatedAbility> {
     val exiledIds = state.getEntity(sourceId)
         ?.get<com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent>()
         ?.exiledIds ?: return emptyList()
     return exiledIds.flatMap { exiledId ->
-        val defId = state.getEntity(exiledId)?.get<CardComponent>()?.cardDefinitionId
-        val cardDef = defId?.let { cardRegistry.getCard(it) }
+        val card = state.getEntity(exiledId)?.get<CardComponent>()
+        // Agatha's "all *creature* cards exiled" restricts the source pile by the exiled card's
+        // printed type; Territory Forge (creatureCardsOnly = false) takes every exiled card.
+        if (creatureCardsOnly && card?.typeLine?.isCreature != true) return@flatMap emptyList()
+        val cardDef = card?.cardDefinitionId?.let { cardRegistry.getCard(it) }
         cardDef?.script?.activatedAbilities ?: emptyList()
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -806,7 +806,7 @@ class StaticAbilityHandler(
             // Activated abilities (ActivateAbilityHandler / ActivatedAbilityEnumerator):
             is ExtraLoyaltyActivation,
             is GrantActivatedAbility,
-            HasAllActivatedAbilitiesOfLinkedExiledCard,
+            is HasAllActivatedAbilitiesOfLinkedExiledCard,
             is GainActivatedAbilitiesOfPermanents,
             is SpendAnyManaTypeForActivatedAbilities,
             is PreventActivatedAbilities,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AgathasSoulCauldronScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AgathasSoulCauldronScenarioTest.kt
@@ -1,0 +1,157 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.AgathasSoulCauldron
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Agatha's Soul Cauldron — {2} Legendary Artifact (WOE #242).
+ *
+ *  - "{T}: Exile target card from a graveyard. When a creature card is exiled this way, put a
+ *    +1/+1 counter on target creature you control."
+ *  - "Creatures you control with +1/+1 counters on them have all activated abilities of all
+ *    creature cards exiled with Agatha's Soul Cauldron."
+ *  - "You may spend mana as though it were mana of any color to activate abilities of creatures
+ *    you control."
+ */
+class AgathasSoulCauldronScenarioTest : FunSpec({
+
+    // A creature card whose only ability has a COLORED cost — used to prove both the ability
+    // granting (its {R} ability lands on a counter-creature) and the mana permission (the {R}
+    // is payable with off-color mana).
+    val lifeMystic = card("Cauldron Test Mystic") {
+        manaCost = "{1}{R}"
+        typeLine = "Creature — Human Wizard"
+        power = 1
+        toughness = 1
+        oracleText = "{R}: You gain 1 life."
+        activatedAbility {
+            cost = Costs.Mana("{R}")
+            effect = Effects.GainLife(1)
+        }
+    }
+    val mysticAbilityId = lifeMystic.activatedAbilities[0].id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AgathasSoulCauldron, lifeMystic))
+        return driver
+    }
+
+    fun counters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("exile a creature card → reflexive +1/+1 counter → counter-creature gains and activates the exiled ability with off-color mana") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val cauldron = driver.putPermanentOnBattlefield(me, "Agatha's Soul Cauldron")
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val mysticInGrave = driver.putCardInGraveyard(me, "Cauldron Test Mystic")
+
+        // Activate "{T}: Exile target card from a graveyard." targeting the creature card.
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = cauldron,
+                abilityId = AgathasSoulCauldron.activatedAbilities[0].id,
+                targets = listOf(ChosenTarget.Card(mysticInGrave, ownerId = me, zone = Zone.GRAVEYARD))
+            )
+        )
+        // Resolve the ability: exile the mystic, then the reflexive trigger (creature card → true)
+        // auto-targets the only creature you control (Grizzly Bears) and adds a +1/+1 counter.
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+        driver.state.getZone(me, Zone.EXILE).contains(mysticInGrave) shouldBe true
+        counters(driver, bears) shouldBe 1
+
+        // The Bears now has a +1/+1 counter, so it has the exiled creature's "{R}: gain 1 life".
+        // Pay the {R} with GREEN mana — Agatha lets you spend mana as any color for your creatures.
+        driver.giveMana(me, Color.GREEN, 1)
+        val lifeBefore = driver.getLifeTotal(me)
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = bears, abilityId = mysticAbilityId))
+        guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+        driver.getLifeTotal(me) shouldBe lifeBefore + 1
+    }
+
+    test("a creature WITHOUT a +1/+1 counter does not gain the exiled creature's abilities") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val cauldron = driver.putPermanentOnBattlefield(me, "Agatha's Soul Cauldron")
+        // Two creatures: one will receive the reflexive counter, the other stays counter-less.
+        val withCounter = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val withoutCounter = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val mysticInGrave = driver.putCardInGraveyard(me, "Cauldron Test Mystic")
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = cauldron,
+                abilityId = AgathasSoulCauldron.activatedAbilities[0].id,
+                targets = listOf(ChosenTarget.Card(mysticInGrave, ownerId = me, zone = Zone.GRAVEYARD))
+            )
+        )
+        // Two eligible creatures → the reflexive trigger pauses to choose where the counter goes.
+        var guard = 0
+        while (driver.state.pendingDecision == null && driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+        driver.submitTargetSelection(me, listOf(withCounter)).isSuccess shouldBe true
+        guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+        counters(driver, withCounter) shouldBe 1
+        counters(driver, withoutCounter) shouldBe 0
+
+        // The counter-less creature has no granted ability — activating it fails.
+        driver.giveMana(me, Color.RED, 1)
+        driver.submit(ActivateAbility(playerId = me, sourceId = withoutCounter, abilityId = mysticAbilityId))
+            .isSuccess shouldBe false
+    }
+
+    test("exiling a non-creature card adds no counter (reflexive trigger does not fire)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val cauldron = driver.putPermanentOnBattlefield(me, "Agatha's Soul Cauldron")
+        val bears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val landInGrave = driver.putCardInGraveyard(me, "Forest")
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = cauldron,
+                abilityId = AgathasSoulCauldron.activatedAbilities[0].id,
+                targets = listOf(ChosenTarget.Card(landInGrave, ownerId = me, zone = Zone.GRAVEYARD))
+            )
+        )
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+        // The land is exiled, but it is not a creature card, so no counter is placed.
+        driver.state.getZone(me, Zone.EXILE).contains(landInGrave) shouldBe true
+        counters(driver, bears) shouldBe 0
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Agatha's Soul Cauldron** — `{2}` Legendary Artifact (WOE #242, mythic) — one of MTG's most mechanically dense cards. It composes existing engine seams rather than adding a bespoke executor.

Oracle text:
> You may spend mana as though it were mana of any color to activate abilities of creatures you control.
> Creatures you control with +1/+1 counters on them have all activated abilities of all creature cards exiled with Agatha's Soul Cauldron.
> {T}: Exile target card from a graveyard. When a creature card is exiled this way, put a +1/+1 counter on target creature you control.

## How each piece is modeled

| Ability | Implementation |
|---|---|
| Mana permission | Reuses `SpendAnyManaTypeForActivatedAbilities`, scoped with `GroupFilter.AllCreaturesYouControl`. The existing cost-color relaxation (`relaxAbilityCostColorsIfAny`) is matched against the permanent whose ability is being activated, so it applies to abilities of creatures you control. Same seam Sharkey uses (there scoped to `Self`). |
| Ability granting | Generalizes `HasAllActivatedAbilitiesOfLinkedExiledCard` from a `data object` (Territory Forge — source grants itself) to a `data class(filter, creatureCardsOnly)`. `filter` selects which permanents receive the abilities; `creatureCardsOnly` restricts the source pile to creature cards. The grant records the **receiving** creature as the ability's source, so `{T}`/self-references bind to it (CR-faithful to the printed ruling). |
| `{T}` activated ability | Exiles a targeted graveyard card linked to the Cauldron, then a reflexive `ConditionalEffect` (gated on `TargetIsCreatureCard`) chooses a creature you control and adds a `+1/+1` counter. |

## Engine changes (kept general / reusable)

- `HasAllActivatedAbilitiesOfLinkedExiledCard` → data class; both grant-resolution sites (`CastPermissionUtils` + `ActivateAbilityHandler`) and `linkedExiledActivatedAbilities` updated. **Territory Forge keeps its behaviour via the default filter — its snapshot is byte-identical.**
- `TargetIsCreatureCard` now also reads a `ChosenTarget.Card` target (a graveyard/exile card), not just battlefield permanents.
- `GroupFilter` gains a `withCounter(...)` fluent builder (consistent with its other delegating builders).
- SDK reference (`card-sdk-language-reference.md`) updated for all three.

## Tests

New `AgathasSoulCauldronScenarioTest` (rules-engine), all passing:
1. Exile a creature card → reflexive `+1/+1` counter → the counter-creature gains the exiled creature's activated ability and pays its `{R}` cost with **green** mana (proves grant + mana permission).
2. A creature without a `+1/+1` counter does not gain the abilities.
3. Exiling a non-creature card places no counter (reflexive trigger does not fire).

Full `just build` green; full `just test-rules` green; snapshots re-blessed (only `WOE.json` adds the new card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)