### PR TITLE
Always show both cast options for impending cards

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -435,7 +435,29 @@ data class ClientCard(
      * show only this face's name (CR 709.3b). Null for normal cards and for Rooms outside the
      * stack.
      */
-    val castFaceIndex: Int? = null
+    val castFaceIndex: Int? = null,
+
+    /**
+     * Impending alternative cost (CR 702.176), derived from the card's `KeywordAbility.Impending`.
+     * Present on any card whose definition has impending, regardless of zone, so the client can
+     * always offer the impending cast option alongside the normal cast — graying out whichever the
+     * player can't currently pay for — and annotate it with a time-counter glyph. Null for cards
+     * without impending.
+     */
+    val impending: ClientImpending? = null
+)
+
+/**
+ * The impending option on a card (CR 702.176): its reduced mana cost and the number of time
+ * counters the permanent enters with when cast this way. Used by the client to render the
+ * impending cast button (with a time-counter glyph showing [time]) even when it's unaffordable.
+ */
+@Serializable
+data class ClientImpending(
+    /** Reduced mana cost paid to cast for impending, e.g. "{2}{W}{W}". */
+    val cost: String,
+    /** Number of time counters the permanent enters with (e.g. 4). */
+    val time: Int
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1206,7 +1206,14 @@ class ClientStateTransformer(
             planeswalkerAbilities = buildPlaneswalkerAbilities(cardDef, zoneKey),
             isRoom = cardDef?.isRoom == true,
             cardFaces = buildClientCardFaces(container, cardDef),
-            castFaceIndex = spellOnStack?.faceIndex
+            castFaceIndex = spellOnStack?.faceIndex,
+            // Impending (CR 702.176): expose the reduced cost + time-counter count so the client can
+            // always present the impending cast option (graying it out when unaffordable). Intrinsic
+            // to the card definition, so it's surfaced in every zone.
+            impending = cardDef?.keywordAbilities
+                ?.filterIsInstance<KeywordAbility.Impending>()
+                ?.firstOrNull()
+                ?.let { ClientImpending(cost = it.cost.toString(), time = it.time) }
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ImpendingClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ImpendingClientViewTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The client view of an impending card (CR 702.176) must carry its impending alternative cost so
+ * the action menu can always present the impending cast option next to the normal cast — graying
+ * out whichever the player can't pay for — and annotate it with a time-counter glyph. The cost and
+ * time-counter count are intrinsic to the card definition, so they ride on [ClientCard] in every
+ * zone, independent of the legal actions (which only surface affordable casts).
+ */
+class ImpendingClientViewTest : ScenarioTestBase() {
+
+    private val transformer = com.wingedsheep.engine.view.ClientStateTransformer(cardRegistry)
+    private val p1 = EntityId.of("player-1")
+
+    init {
+        test("an impending card in hand exposes its impending cost and time-counter count") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Overlord of the Mistmoors")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cardId = game.state.getHand(p1).first {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Overlord of the Mistmoors"
+            }
+            val card = transformer.transform(game.state, p1).cards[cardId]!!
+
+            withClue("Overlord of the Mistmoors has Impending 4—{2}{W}{W}") {
+                val impending = card.impending
+                impending.shouldNotBeNull()
+                impending.cost shouldBe "{2}{W}{W}"
+                impending.time shouldBe 4
+            }
+        }
+
+        test("a card without impending exposes no impending option") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cardId = game.state.getHand(p1).first {
+                game.state.getEntity(it)?.get<CardComponent>()?.name == "Grizzly Bears"
+            }
+            val card = transformer.transform(game.state, p1).cards[cardId]!!
+
+            card.impending.shouldBeNull()
+        }
+    }
+}

--- a/web-client/src/components/ui/ActionMenu.tsx
+++ b/web-client/src/components/ui/ActionMenu.tsx
@@ -31,6 +31,12 @@ interface ActionOption {
    * When present, the button renders a mana-font loyalty icon instead of a text prefix.
    */
   loyaltyChange?: number
+  /**
+   * For the impending cast option (CR 702.176): the number of time counters the permanent enters
+   * with. When present, the button renders a time-counter glyph + count to mark the option as
+   * impending. Undefined for every other option.
+   */
+  impendingTime?: number
 }
 
 /**
@@ -102,6 +108,58 @@ function buildActionOptions(
         actionType: 'cast',
       })
     })
+  } else if (cardInfo.impending && castActions.length > 0) {
+    // 1a-bis. Impending (CR 702.176) — an alternative cost the player chooses, so always present
+    // BOTH the normal cast and the impending cast, graying out whichever can't be paid for. The
+    // impending option is marked with a time-counter glyph (the card enters with `time` time
+    // counters and isn't a creature until the last is removed). The server only emits the cast
+    // actions it can afford; we synthesize a disabled placeholder (action: null) for the other.
+    const impendingInfo = cardInfo.impending
+    const impendingCast = castActions.find(
+      (a) => (a.action as { alternativeCostType?: string }).alternativeCostType === 'IMPENDING'
+    ) ?? null
+    const normalCast = castActions.find((a) => a.actionType === 'CastSpell') ?? null
+
+    options.push(
+      normalCast
+        ? {
+            key: 'cast',
+            label: `Cast ${cardInfo.name}`,
+            manaCost: normalCast.manaCostString || cardInfo.manaCost || null,
+            isAvailable: normalCast.isAffordable !== false,
+            action: normalCast,
+            actionType: 'cast',
+          }
+        : {
+            key: 'cast',
+            label: `Cast ${cardInfo.name}`,
+            manaCost: cardInfo.manaCost || null,
+            isAvailable: false,
+            action: null,
+            actionType: 'cast',
+          }
+    )
+    options.push(
+      impendingCast
+        ? {
+            key: 'impending',
+            label: 'Cast for Impending',
+            manaCost: impendingCast.manaCostString || impendingInfo.cost || null,
+            isAvailable: impendingCast.isAffordable !== false,
+            action: impendingCast,
+            actionType: 'cast',
+            impendingTime: impendingInfo.time,
+          }
+        : {
+            key: 'impending',
+            label: 'Cast for Impending',
+            manaCost: impendingInfo.cost || null,
+            isAvailable: false,
+            action: null,
+            actionType: 'cast',
+            impendingTime: impendingInfo.time,
+          }
+    )
   } else if (castActions.length > 1) {
     // 1b. Multiple cast options (e.g., BlightOrPay — blight path vs pay path)
     castActions.forEach((ca, index) => {
@@ -471,6 +529,24 @@ function LoyaltyIcon({ change }: { change: number }) {
 }
 
 /**
+ * Time-counter glyph for the impending cast option (CR 702.176). Mirrors the battlefield
+ * time-counter badge (mana-font `ms ms-counter-time` + count) so the player recognizes that
+ * casting for impending makes the permanent enter with `time` time counters.
+ */
+function ImpendingTimeIcon({ time }: { time: number }) {
+  return (
+    <span
+      aria-label={`Enters with ${time} time counters`}
+      title={`Enters with ${time} time counters`}
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 2, marginRight: 6, flexShrink: 0 }}
+    >
+      <i className="ms ms-counter-time" style={{ fontSize: 18 }} aria-hidden />
+      <span style={{ fontWeight: 700, fontSize: 13 }}>{time}</span>
+    </span>
+  )
+}
+
+/**
  * Get the style class for an action type.
  */
 function getActionStyleClass(actionType: ActionOption['actionType'], isAvailable: boolean): string {
@@ -542,6 +618,9 @@ function ActionOptionButton({
         <span className={styles.actionButtonLeading}>
           {option.loyaltyChange !== undefined && (
             <LoyaltyIcon change={option.loyaltyChange} />
+          )}
+          {option.impendingTime !== undefined && (
+            <ImpendingTimeIcon time={option.impendingTime} />
           )}
           <span className={styles.actionButtonLabel}>
             <AbilityText text={option.label} size={14} />

--- a/web-client/src/types/actions.ts
+++ b/web-client/src/types/actions.ts
@@ -103,6 +103,14 @@ export interface CastSpellAction {
   readonly alternativePayment?: AlternativePaymentChoice
   /** Whether to cast this card face-down (for Morph creatures) */
   readonly castFaceDown?: boolean
+  /** Whether the spell is being cast for an alternative cost (impending, evoke, flashback, …) */
+  readonly useAlternativeCost?: boolean
+  /**
+   * Which alternative cost was chosen, when `useAlternativeCost` is set. Matches the server's
+   * `AlternativeCostType` enum (e.g. "IMPENDING", "EVOKE", "GRANTED", "SELF_ALTERNATIVE",
+   * "MIRACLE"). Used by the action menu to identify the impending cast option.
+   */
+  readonly alternativeCostType?: string
   /** Whether to cast this spell with kicker */
   readonly wasKicked?: boolean
   /** Pre-chosen damage distribution for DividedDamageEffect spells (target ID -> damage amount) */

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -384,6 +384,19 @@ export interface ClientCard {
 
   /** For Rooms on the stack: index into `cardFaces` of the face that was cast. */
   readonly castFaceIndex?: number | null
+
+  /**
+   * Impending alternative cost (CR 702.176), present iff the card definition has impending. Lets
+   * the action menu always offer the impending cast option (reduced `cost`, enters with `time`
+   * time counters) next to the normal cast, graying out whichever the player can't pay for and
+   * annotating impending with a time-counter glyph.
+   */
+  readonly impending?: {
+    /** Reduced mana cost to cast for impending, e.g. "{2}{W}{W}". */
+    readonly cost: string
+    /** Number of time counters the permanent enters with (e.g. 4). */
+    readonly time: number
+  } | null
 }
 
 /** One face of a split-layout card (CR 709). */


### PR DESCRIPTION
## What

When casting an **impending** card (CR 702.176 — the cycle of Overlords in Duskmourn, e.g. *Overlord of the Mistmoors*), the action menu now **always presents both the normal cast and the impending cast**, graying out whichever the player can't currently pay for. The impending option is labeled **"Cast for Impending"** and annotated with the same **time-counter glyph** used on the battlefield, showing how many time counters the permanent will enter with.

### Why

Previously the legal-action enumerator only surfaced the cast paths a player could *afford*. So a player with enough mana for the impending cost but not the full mana cost saw **only** the impending option (and vice versa), making it easy to miss that the other mode even existed. Impending is an alternative cost the player chooses (CR 702.176 / 118.9a) — both choices should always be visible.

## Screenshots

**Only impending affordable** (4 Plains) — the full {5}{W}{W} cast is grayed out; "Cast for Impending" ({2}{W}{W}) is active with the ⏱ time-counter glyph showing **4**:

![Impending affordable, normal grayed out](https://raw.githubusercontent.com/wingedsheep/argentum-engine/impending-cast-options-screenshots/impending-only.png)

**Both affordable** (7 Plains) — both options are active; the impending one still carries the time-counter glyph + count so the choice is unambiguous:

![Both cast options affordable](https://raw.githubusercontent.com/wingedsheep/argentum-engine/impending-cast-options-screenshots/impending-both.png)

> The screenshot branch `impending-cast-options-screenshots` is throwaway (images are not committed to the feature branch).

## How

- **`ClientCard`** now carries an intrinsic `impending` field (reduced `cost` + time-counter `time`), derived from `KeywordAbility.Impending`. It rides on the card in **every zone**, independent of the affordable-only legal actions, so the client always knows the impending cost/count.
- **`ActionMenu`** gets a dedicated impending branch: it renders the normal cast and the impending cast side by side, synthesizing a **disabled placeholder** (no action, not clickable) for whichever path the server didn't emit. The executable option is still the server's own legal action — no legality is computed client-side, matching the existing grayed-placeholder pattern used for cycling/plot/land/planeswalker abilities.
- The impending button renders the `ms ms-counter-time` glyph + count, mirroring the battlefield time-counter badge.
- `CastSpellAction` (TS) gains `alternativeCostType` / `useAlternativeCost` so the impending action can be identified.

No SDK/engine mechanic change — impending already exists; this only surfaces its data to the client UI.

## Tests

- New `ImpendingClientViewTest` — asserts `ClientCard.impending` is populated (`{2}{W}{W}`, time 4) for Overlord of the Mistmoors and `null` for a non-impending card.
- Existing `ImpendingMechanicTest` behavior unchanged.
- `web-client` typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)