### PR TITLE
Fix admin status not showing / lost after re-login (Jackson is-prefix)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminUsersController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminUsersController.kt
@@ -44,7 +44,9 @@ class AdminUsersController(
         val id: UUID,
         val email: String,
         val displayName: String,
-        val isAdmin: Boolean,
+        // Pin the wire name (see SetAdminBody) — the client reads `detail.isAdmin` for the badge
+        // and the promote/revoke toggle; without this Jackson emits `admin` and both misbehave.
+        @JsonProperty("isAdmin") val isAdmin: Boolean,
         val createdAt: String,
         val stats: StatsDto,
         val colors: List<StatBucket>,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AuthController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AuthController.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.gameserver.controller
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.wingedsheep.gameserver.auth.AuthSupport
 import com.wingedsheep.gameserver.auth.InvalidLoginTokenException
 import com.wingedsheep.gameserver.auth.MagicLinkService
@@ -45,7 +46,10 @@ class AuthController(
         val id: UUID,
         val email: String,
         val displayName: String,
-        val isAdmin: Boolean,
+        // No jackson-module-kotlin is on the classpath, so Jackson serializes via the JavaBean
+        // `isAdmin()` getter and would emit the key `admin` — but the client reads `user.isAdmin`
+        // (it gates the Admin button). Pin the wire name so a promoted account is seen as admin.
+        @JsonProperty("isAdmin") val isAdmin: Boolean,
         val hidePresence: Boolean,
     )
     data class LoginResponse(val authToken: String, val user: UserDto)

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.gameserver.stats
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Service
@@ -68,7 +69,9 @@ data class AdminUserStat(
     val id: UUID,
     val email: String,
     val displayName: String,
-    val isAdmin: Boolean,
+    // Pin the wire name (see SetAdminBody) — the admin Players list reads `u.isAdmin` for the ADMIN
+    // badge; without this Jackson emits `admin` and the badge never shows for promoted accounts.
+    @JsonProperty("isAdmin") val isAdmin: Boolean,
     val createdAt: String,
     val games: Long,
     val wins: Long,

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/UserDtoSerializationTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/auth/UserDtoSerializationTest.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.gameserver.auth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.wingedsheep.gameserver.controller.AdminUsersController
+import com.wingedsheep.gameserver.controller.AuthController
+import com.wingedsheep.gameserver.stats.AdminUserStat
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import java.util.UUID
+
+/**
+ * Pins the wire shape of the `isAdmin` flag on every account DTO the client deserializes.
+ *
+ * There is no jackson-module-kotlin on the REST classpath, so Jackson serializes via the JavaBean
+ * `isAdmin()` getter and — left unannotated — emits the key `admin`. The client reads `user.isAdmin`
+ * / `u.isAdmin` / `detail.isAdmin` (the Admin button, the players-list badge, the promote toggle), so
+ * the dropped `is` prefix made a promoted account look un-promoted everywhere. `@JsonProperty` pins
+ * the name. This uses Spring's own mapper builder, so it sees exactly the modules Spring MVC uses.
+ */
+class UserDtoSerializationTest : FunSpec({
+    val mapper: ObjectMapper = Jackson2ObjectMapperBuilder.json().build()
+    val id: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+
+    test("AuthController.UserDto serializes the admin flag as isAdmin") {
+        val dto = AuthController.UserDto(id, "a@b.com", "A", isAdmin = true, hidePresence = false)
+        mapper.writeValueAsString(dto) shouldContain "\"isAdmin\":true"
+    }
+
+    test("AdminUsersController.UserDetailDto serializes the admin flag as isAdmin") {
+        val dto = AdminUsersController.UserDetailDto(
+            id = id, email = "a@b.com", displayName = "A", isAdmin = true, createdAt = "now",
+            stats = AdminUsersController.StatsDto(0, 0, 0, 0.0),
+            colors = emptyList(), modes = emptyList(), opponents = emptyList(),
+            topCards = emptyList(), tournaments = emptyList(), recentGames = emptyList(),
+        )
+        mapper.writeValueAsString(dto) shouldContain "\"isAdmin\":true"
+    }
+
+    test("AdminUserStat serializes the admin flag as isAdmin") {
+        val dto = AdminUserStat(
+            id = id, email = "a@b.com", displayName = "A", isAdmin = true, createdAt = "now",
+            games = 0, wins = 0, lastPlayed = null,
+        )
+        mapper.writeValueAsString(dto) shouldContain "\"isAdmin\":true"
+    }
+})


### PR DESCRIPTION
## What

Fixes two reported symptoms with a single root cause:
1. A promoted account's admin status appeared **gone after the next login**.
2. The **Admin button never showed** next to the "Signed in as …" widget, even when promoted.

## Root cause — serialization, not persistence

The DB persisted the flag correctly the whole time (`users.is_admin`, set via `UserAdminService.setAdmin` → `UPDATE`). The flag was being **dropped on the wire**.

There is no `jackson-module-kotlin` on the REST classpath, so Jackson introspects the Kotlin `isAdmin()` getter as the JavaBean property **`admin`** and serializes the key as `"admin"` instead of `"isAdmin"`. The client reads `user.isAdmin` / `u.isAdmin` / `detail.isAdmin`, so the value was always `undefined` client-side → button hidden, badge missing, and a re-login (`GET /api/auth/me`) looked un-promoted.

The codebase already documented this exact gotcha on the **inbound** `SetAdminBody` and pinned its name with `@JsonProperty("isAdmin")`. The three **outbound** DTOs that carry the flag were missing the same pin.

## Change

`@JsonProperty("isAdmin")` on:
- `AuthController.UserDto` — `verify` / `me` (the reported Admin button + "gone after login")
- `AdminUsersController.UserDetailDto` — player detail badge + promote/revoke toggle
- `StatsQueryService.AdminUserStat` — admin Players-list ADMIN badge

Plus `UserDtoSerializationTest`, which serializes each DTO through Spring's own `Jackson2ObjectMapperBuilder` (the modules Spring MVC actually uses) and asserts the `isAdmin` wire key. It **fails on the pre-fix code** and passes after.

## Verification

- `UserDtoSerializationTest` — confirmed it fails before the fix (JSON had `admin`, not `isAdmin`) and passes after.
- Existing `AdminAuthServiceTest` still green.

## Notes
- DB persistence verified intact; no migration needed. Existing `is_admin` rows are correct and start showing immediately.
- Same Jackson `is`-prefix class affects `HeadToHead.isAi` on the stats REST endpoint (a separate, unreported feature). Left out to keep this PR scoped to the admin bug; a global `jackson-module-kotlin` would fix the whole class at once but has broader blast radius — flagging for a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)