### PR TITLE
Scaffold Avatar: The Last Airbender — 3 new cards + Lightning Strike / Corrupt Court Official reprints

### DIFF
--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 48 / 286  (17%)
+**Implemented:** 49 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -91,7 +91,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] Azula, Cunning Usurper
 - [ ] Azula, On the Hunt
 - [x] Ba Sing Se
-- [ ] Badgermole
+- [x] Badgermole
 - [x] Badgermole Cub
 - [ ] Barrels of Blasting Jelly
 - [ ] Beetle-Headed Merchants

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 46 / 286  (16%)
+**Implemented:** 47 / 286  (16%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -345,7 +345,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] Wolfbat
 - [ ] Yip Yip!
 - [ ] Yue, the Moon Spirit
-- [ ] Yuyan Archers
+- [x] Yuyan Archers
 - [ ] Zhao, Ruthless Admiral
 - [ ] Zhao, the Moon Slayer
 - [ ] Zuko's Conviction

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -1,0 +1,354 @@
+# Avatar: The Last Airbender (TLA) — Card Checklist
+
+**Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
+**Release Date:** November 21, 2025
+**Implemented:** 44 / 286  (15%)
+**Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
+
+## Mechanics needed to complete the set
+
+The set is built around four **"bending" keyword families** plus a returning **Exhaust** keyword. Counts below are over all 286 cards — *total* with the mechanic / *remaining* still unimplemented.
+
+### Signature / set-defining mechanics
+
+| Mechanic | Total | Remaining | Notes |
+|----------|------:|----------:|-------|
+| Earthbend | 27 | 22 | Target land you control becomes a 0/0 haste creature-land; put N +1/+1 counters on it. ✅ engine-supported (`Effects.Earthbend`). |
+| Waterbend | 24 | 23 | Alternative cost: tap your artifacts/creatures to help pay a waterbend cost. 🟡 activated abilities done; spell/ETB shapes pending. |
+| Firebending | 21 | 19 | Whenever this creature attacks, add N red mana lasting until end of combat. ❌ new keyword. |
+| Airbend | 10 | 10 | Exile target nonland permanent; owner may recast it for {2}. ❌ new keyword. |
+| Exhaust | 8 | 8 | Activated ability usable only once per game. ❌ returning keyword, not yet built. |
+
+### Other keywords present (evergreen + returning)
+
+| Keyword | Total | Remaining |
+|---------|------:|----------:|
+| Flying | 26 | 22 |
+| Vigilance | 15 | 12 |
+| Scry | 10 | 8 |
+| Flash | 9 | 8 |
+| Transform | 8 | 8 |
+| Mill | 8 | 8 |
+| Reach | 8 | 8 |
+| Prowess | 7 | 6 |
+| Menace | 6 | 6 |
+| Equip | 5 | 4 |
+| Food | 5 | 5 |
+| Enchant | 5 | 5 |
+| Landcycling | 5 | 5 |
+| Typecycling | 5 | 5 |
+| Cycling | 5 | 5 |
+| Crew | 5 | 4 |
+| Trample | 5 | 5 |
+| Kicker | 4 | 4 |
+| Defender | 4 | 3 |
+| Ward | 3 | 3 |
+| Deathtouch | 3 | 3 |
+| Raid | 3 | 3 |
+| Flashback | 3 | 3 |
+| Haste | 3 | 1 |
+| First strike | 2 | 1 |
+| Landfall | 2 | 2 |
+| Lifelink | 2 | 1 |
+| Fight | 2 | 2 |
+| Plainscycling | 1 | 1 |
+| Islandcycling | 1 | 1 |
+| Swampcycling | 1 | 1 |
+| Surveil | 1 | 1 |
+| Mountaincycling | 1 | 1 |
+| Foretell | 1 | 1 |
+| Affinity | 1 | 1 |
+| Forestcycling | 1 | 1 |
+
+**Sagas:** 7 total / 7 remaining (chapter abilities — engine-supported).
+
+---
+
+## Card checklist
+
+- [ ] Aang's Iceberg
+- [ ] Aang's Journey
+- [ ] Aang, Swift Savior
+- [ ] Aang, at the Crossroads
+- [ ] Aang, the Last Airbender
+- [ ] Abandon Attachments
+- [ ] Abandoned Air Temple
+- [ ] Accumulate Wisdom
+- [ ] Agna Qel'a
+- [ ] Air Nomad Legacy
+- [ ] Airbender Ascension
+- [ ] Airbender's Reversal
+- [ ] Airbending Lesson
+- [x] Airship Engine Room
+- [ ] Allies at Last
+- [ ] Appa, Loyal Sky Bison
+- [ ] Appa, Steadfast Guardian
+- [ ] Avatar Aang
+- [ ] Avatar Destiny
+- [x] Avatar Enthusiasts
+- [ ] Avatar's Wrath
+- [ ] Azula Always Lies
+- [ ] Azula, Cunning Usurper
+- [ ] Azula, On the Hunt
+- [x] Ba Sing Se
+- [ ] Badgermole
+- [x] Badgermole Cub
+- [ ] Barrels of Blasting Jelly
+- [ ] Beetle-Headed Merchants
+- [ ] Beifong's Bounty Hunters
+- [ ] Bender's Waterskin
+- [ ] Benevolent River Spirit
+- [ ] Bitter Work
+- [x] Boar-q-pine
+- [x] Boiling Rock Prison
+- [ ] Boiling Rock Rioter
+- [ ] Boomerang Basics
+- [ ] Bumi Bash
+- [ ] Bumi, King of Three Trials
+- [ ] Bumi, Unleashed
+- [ ] Buzzard-Wasp Colony
+- [ ] Callous Inspector
+- [ ] Canyon Crawler
+- [x] Cat-Gator
+- [x] Cat-Owl
+- [ ] Combustion Man
+- [ ] Combustion Technique
+- [ ] Compassionate Healer
+- [ ] Corrupt Court Official
+- [ ] Crashing Wave
+- [ ] Crescent Island Temple
+- [ ] Cruel Administrator
+- [ ] Cunning Maneuver
+- [ ] Curious Farm Animals
+- [x] Cycle of Renewal
+- [ ] Dai Li Agents
+- [ ] Dai Li Indoctrination
+- [ ] Day of Black Sun
+- [ ] Deadly Precision
+- [ ] Deserter's Disciple
+- [ ] Destined Confrontation
+- [x] Diligent Zookeeper
+- [ ] Dragonfly Swarm
+- [ ] Earth King's Lieutenant
+- [ ] Earth Kingdom General
+- [ ] Earth Kingdom Jailer
+- [ ] Earth Kingdom Protectors
+- [ ] Earth Kingdom Soldier
+- [ ] Earth Rumble
+- [ ] Earth Rumble Wrestlers
+- [x] Earth Village Ruffians
+- [ ] Earthbender Ascension
+- [x] Earthbending Lesson
+- [ ] Earthen Ally
+- [ ] Elemental Teachings
+- [ ] Ember Island Production
+- [ ] Energybending
+- [ ] Enter the Avatar State
+- [ ] Epic Downfall
+- [ ] Fancy Footwork
+- [ ] Fatal Fissure
+- [ ] Fated Firepower
+- [ ] Fire Lord Azula
+- [ ] Fire Lord Zuko
+- [ ] Fire Nation Attacks
+- [ ] Fire Nation Cadets
+- [ ] Fire Nation Engineer
+- [ ] Fire Nation Palace
+- [ ] Fire Nation Raider
+- [ ] Fire Nation Warship
+- [ ] Fire Navy Trebuchet
+- [x] Fire Sages
+- [ ] Firebender Ascension
+- [ ] Firebending Lesson
+- [ ] Firebending Student
+- [ ] First-Time Flyer
+- [ ] Flexible Waterbender
+- [ ] Flopsie, Bumi's Buddy
+- [x] Foggy Bottom Swamp
+- [ ] Foggy Swamp Hunters
+- [ ] Foggy Swamp Spirit Keeper
+- [ ] Foggy Swamp Vinebender
+- [ ] Foggy Swamp Visions
+- [ ] Forecasting Fortune Teller
+- [ ] Forest
+- [ ] Gather the White Lotus
+- [x] Geyser Leaper
+- [ ] Giant Koi
+- [x] Glider Kids
+- [ ] Glider Staff
+- [ ] Gran-Gran
+- [ ] Great Divide Guide
+- [ ] Guru Pathik
+- [ ] Hakoda, Selfless Commander
+- [ ] Hama, the Bloodbender
+- [x] Haru, Hidden Talent
+- [ ] Heartless Act
+- [ ] Hei Bai, Spirit of Balance
+- [ ] Hermitic Herbalist
+- [ ] Hog-Monkey
+- [ ] Honest Work
+- [ ] How to Start a Riot
+- [x] Iguana Parrot
+- [x] Invasion Reinforcements
+- [ ] Invasion Submersible
+- [ ] Invasion Tactics
+- [ ] Iroh's Demonstration
+- [ ] Iroh, Grand Lotus
+- [ ] Iroh, Tea Master
+- [ ] Island
+- [ ] It'll Quench Ya!
+- [ ] Jasmine Dragon Tea Shop
+- [x] Jeong Jeong's Deserters
+- [ ] Jeong Jeong, the Deserter
+- [ ] Jet's Brainwashing
+- [ ] Jet, Freedom Fighter
+- [ ] Joo Dee, One of Many
+- [ ] June, Bounty Hunter
+- [ ] Katara, Bending Prodigy
+- [ ] Katara, Water Tribe's Hope
+- [ ] Katara, the Fearless
+- [ ] Knowledge Seeker
+- [ ] Koh, the Face Stealer
+- [ ] Kyoshi Battle Fan
+- [ ] Kyoshi Island Plaza
+- [x] Kyoshi Village
+- [x] Kyoshi Warriors
+- [ ] Leaves from the Vine
+- [ ] Lightning Strike
+- [ ] Lo and Li, Twin Tutors
+- [ ] Long Feng, Grand Secretariat
+- [ ] Lost Days
+- [ ] Mai, Jaded Edge
+- [x] Mai, Scornful Striker
+- [ ] Master Pakku
+- [ ] Master Piandao
+- [x] Meditation Pools
+- [ ] Merchant of Many Hats
+- [ ] Messenger Hawk
+- [x] Meteor Sword
+- [x] Misty Palms Oasis
+- [ ] Momo, Friendly Flier
+- [ ] Momo, Playful Pet
+- [ ] Mongoose Lizard
+- [ ] Mountain
+- [x] North Pole Gates
+- [ ] North Pole Patrol
+- [ ] Northern Air Temple
+- [ ] Obsessive Pursuit
+- [x] Octopus Form
+- [x] Omashu City
+- [ ] Origin of Metalbending
+- [ ] Ostrich-Horse
+- [ ] Otter-Penguin
+- [x] Ozai's Cruelty
+- [ ] Ozai, the Phoenix King
+- [ ] Path to Redemption
+- [ ] Phoenix Fleet Airship
+- [x] Pillar Launch
+- [ ] Pirate Peddlers
+- [ ] Plains
+- [ ] Planetarium of Wan Shi Tong
+- [ ] Platypus-Bear
+- [x] Pretending Poxbearers
+- [ ] Price of Freedom
+- [ ] Professor Zei, Anthropologist
+- [ ] Rabaroo Troop
+- [ ] Ran and Shaw
+- [ ] Raucous Audience
+- [ ] Raven Eagle
+- [ ] Razor Rings
+- [x] Realm of Koh
+- [ ] Rebellious Captives
+- [ ] Redirect Lightning
+- [ ] Rockalanche
+- [ ] Rocky Rebuke
+- [ ] Rough Rhino Cavalry
+- [ ] Rowdy Snowballers
+- [ ] Ruinous Waterbending
+- [x] Rumble Arena
+- [ ] Saber-Tooth Moose-Lion
+- [ ] Sandbender Scavengers
+- [ ] Sandbenders' Storm
+- [ ] Secret Tunnel
+- [ ] Secret of Bloodbending
+- [ ] Seismic Sense
+- [ ] Serpent of the Pass
+- [x] Serpent's Pass
+- [x] Shared Roots
+- [ ] Sokka's Haiku
+- [ ] Sokka, Bold Boomeranger
+- [ ] Sokka, Lateral Strategist
+- [ ] Sokka, Tenacious Tactician
+- [ ] Sold Out
+- [ ] Solstice Revelations
+- [ ] South Pole Voyager
+- [ ] Southern Air Temple
+- [ ] Sozin's Comet
+- [ ] Sparring Dummy
+- [ ] Spirit Water Revival
+- [ ] Suki, Courageous Rescuer
+- [ ] Suki, Kyoshi Warrior
+- [ ] Sun Warriors
+- [x] Sun-Blessed Peak
+- [ ] Swamp
+- [ ] Swampsnare Trap
+- [ ] Team Avatar
+- [ ] Teo, Spirited Glider
+- [ ] The Boulder, Ready to Rumble
+- [ ] The Cave of Two Lovers
+- [ ] The Earth King
+- [ ] The Fire Nation Drill
+- [ ] The Last Agni Kai
+- [ ] The Legend of Kuruk
+- [ ] The Legend of Kyoshi
+- [ ] The Legend of Roku
+- [ ] The Legend of Yangchen
+- [ ] The Lion-Turtle
+- [ ] The Mechanist, Aerial Artisan
+- [ ] The Rise of Sozin
+- [ ] The Spirit Oasis
+- [ ] The Unagi of Kyoshi Island
+- [x] The Walls of Ba Sing Se
+- [ ] Tiger-Dillo
+- [ ] Tiger-Seal
+- [ ] Tolls of War
+- [ ] Toph, Hardheaded Teacher
+- [ ] Toph, the Blind Bandit
+- [ ] Toph, the First Metalbender
+- [x] Treetop Freedom Fighters
+- [ ] True Ancestry
+- [ ] Trusty Boomerang
+- [x] Tundra Tank
+- [ ] Turtle-Duck
+- [ ] Twin Blades
+- [ ] Ty Lee, Artful Acrobat
+- [ ] Ty Lee, Chi Blocker
+- [ ] Uncle Iroh
+- [ ] United Front
+- [ ] Unlucky Cabbage Merchant
+- [ ] Vengeful Villagers
+- [ ] Vindictive Warden
+- [ ] Walltop Sentries
+- [ ] Wan Shi Tong, Librarian
+- [x] Wandering Musicians
+- [ ] War Balloon
+- [x] Wartime Protestors
+- [x] Water Tribe Captain
+- [ ] Water Tribe Rallier
+- [ ] Waterbender Ascension
+- [ ] Waterbending Lesson
+- [ ] Waterbending Scroll
+- [ ] Watery Grasp
+- [ ] White Lotus Hideout
+- [x] White Lotus Reinforcements
+- [ ] White Lotus Tile
+- [ ] Wolfbat
+- [ ] Yip Yip!
+- [ ] Yue, the Moon Spirit
+- [ ] Yuyan Archers
+- [ ] Zhao, Ruthless Admiral
+- [ ] Zhao, the Moon Slayer
+- [ ] Zuko's Conviction
+- [ ] Zuko's Exile
+- [ ] Zuko, Conflicted
+- [ ] Zuko, Exiled Prince

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 45 / 286  (16%)
+**Implemented:** 46 / 286  (16%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -114,7 +114,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] Combustion Man
 - [ ] Combustion Technique
 - [ ] Compassionate Healer
-- [ ] Corrupt Court Official
+- [x] Corrupt Court Official
 - [ ] Crashing Wave
 - [ ] Crescent Island Temple
 - [ ] Cruel Administrator

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 44 / 286  (15%)
+**Implemented:** 45 / 286  (16%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -214,7 +214,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [x] Kyoshi Village
 - [x] Kyoshi Warriors
 - [ ] Leaves from the Vine
-- [ ] Lightning Strike
+- [x] Lightning Strike
 - [ ] Lo and Li, Twin Tutors
 - [ ] Long Feng, Grand Secretariat
 - [ ] Lost Days

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 47 / 286  (16%)
+**Implemented:** 48 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -319,7 +319,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] True Ancestry
 - [ ] Trusty Boomerang
 - [x] Tundra Tank
-- [ ] Turtle-Duck
+- [x] Turtle-Duck
 - [ ] Twin Blades
 - [ ] Ty Lee, Artful Acrobat
 - [ ] Ty Lee, Chi Blocker

--- a/backlog/sets/avatar-the-last-airbender/tla-engine-gaps.md
+++ b/backlog/sets/avatar-the-last-airbender/tla-engine-gaps.md
@@ -1,12 +1,17 @@
 # Avatar: The Last Airbender — Engine Gap Analysis
 
-Cross-reference of the **280 remaining (unimplemented) TLA cards** against the engine's actual
+Cross-reference of the **242 remaining (unimplemented) TLA cards** against the engine's actual
 capabilities (SDK reference + source verification, June 2026). Generated to scope what must be
 built before the set can be completed.
 
-**Status:** 6 / 286 implemented (2%). Card list from `scripts/card-status --cards TLA`. Oracle text
-pulled from Scryfall (`set:tla`, 286 unique cards). Implemented so far: Ba Sing Se, Badgermole Cub,
-Diligent Zookeeper, Earthbending Lesson, Mai Scornful Striker, Realm of Koh.
+**Status:** 44 / 286 implemented (15%). Card list from `scripts/card-status --cards TLA`. Oracle text
+pulled from Scryfall (`set:tla`, 286 unique cards; full payload in `bolav/tla_full.json`).
+The full per-card checklist lives alongside this file in [`cards.md`](cards.md).
+
+Per signature mechanic (implemented / total): **Earthbend 5/27**, **Firebending 2/21**,
+**Waterbend 1/24**, **Airbend 0/10**, **Exhaust 0/8**, **Vigilance counter 3/15**. The handful of
+Firebending/Waterbend cards already shipped lean on hand-wired approximations or avoid the gated cost —
+the keyword primitives below are still the real work.
 
 ## Bottom line
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LightningStrikeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/LightningStrikeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Strike reprint in DFT. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Theros (THS); this file contributes only presentation data for the DFT printing.
+ */
+val LightningStrikeReprint = Printing(
+    oracleId = "f34b9bc4-7bfe-47fd-ba23-4eeeb46026eb",
+    name = "Lightning Strike",
+    setCode = "DFT",
+    collectorNumber = "136",
+    scryfallId = "30077b49-b825-4dbb-a0c7-f3992f647df0",
+    artist = "Steve Ellis",
+    imageUri = "https://cards.scryfall.io/normal/front/3/0/30077b49-b825-4dbb-a0c7-f3992f647df0.jpg?1738356438",
+    releaseDate = "2025-02-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/LightningStrikeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/LightningStrikeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Strike reprint in DMU. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Theros (THS); this file contributes only presentation data for the DMU printing.
+ */
+val LightningStrikeReprint = Printing(
+    oracleId = "f34b9bc4-7bfe-47fd-ba23-4eeeb46026eb",
+    name = "Lightning Strike",
+    setCode = "DMU",
+    collectorNumber = "137",
+    scryfallId = "7d541125-bfb8-4f88-8bf3-ad7b6af7ad1d",
+    artist = "Marta Nael",
+    imageUri = "https://cards.scryfall.io/normal/front/7/d/7d541125-bfb8-4f88-8bf3-ad7b6af7ad1d.jpg?1673307449",
+    releaseDate = "2022-09-09",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/LightningStrikeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/LightningStrikeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Strike reprint in M15. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Theros (THS); this file contributes only presentation data for the M15 printing.
+ */
+val LightningStrikeReprint = Printing(
+    oracleId = "f34b9bc4-7bfe-47fd-ba23-4eeeb46026eb",
+    name = "Lightning Strike",
+    setCode = "M15",
+    collectorNumber = "155",
+    scryfallId = "a5603e1f-593c-45f0-9e13-fe3492464443",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/a/5/a5603e1f-593c-45f0-9e13-fe3492464443.jpg?1562792218",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LightningStrikeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/LightningStrikeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Strike reprint in M19. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Theros (THS); this file contributes only presentation data for the M19 printing.
+ */
+val LightningStrikeReprint = Printing(
+    oracleId = "f34b9bc4-7bfe-47fd-ba23-4eeeb46026eb",
+    name = "Lightning Strike",
+    setCode = "M19",
+    collectorNumber = "152",
+    scryfallId = "084b7337-c06f-4cbf-8fc0-0b20c221f1dc",
+    artist = "Adam Paquette",
+    imageUri = "https://cards.scryfall.io/normal/front/0/8/084b7337-c06f-4cbf-8fc0-0b20c221f1dc.jpg?1562300290",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/CorruptCourtOfficial.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ptk/cards/CorruptCourtOfficial.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.ptk.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Corrupt Court Official
+ * {1}{B}
+ * Creature — Human Advisor
+ * 1/1
+ * When this creature enters, target opponent discards a card.
+ *
+ * Canonical printing: Portal Three Kingdoms (PTK, 1999) — the earliest real printing.
+ * Later printings (SNC, Avatar: The Last Airbender) add only a
+ * [com.wingedsheep.sdk.model.Printing] row.
+ */
+val CorruptCourtOfficial = card("Corrupt Court Official") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Human Advisor"
+    power = 1
+    toughness = 1
+    oracleText = "When this creature enters, target opponent discards a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Patterns.Hand.discardCards(1, opponent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "71"
+        artist = "Li Yousong"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d3ba2e3-e680-47cd-81c5-555deea7d00f.jpg?1562257498"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CorruptCourtOfficialReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/CorruptCourtOfficialReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Corrupt Court Official reprint in SNC. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Portal Three Kingdoms (PTK); this file contributes only presentation data.
+ */
+val CorruptCourtOfficialReprint = Printing(
+    oracleId = "ec84201d-757f-4a7a-b3a2-85ccd5ee81ae",
+    name = "Corrupt Court Official",
+    setCode = "SNC",
+    collectorNumber = "70",
+    scryfallId = "505c6215-4006-4c4f-897a-be051cb73fa7",
+    artist = "Drew Baker",
+    imageUri = "https://cards.scryfall.io/normal/front/5/0/505c6215-4006-4c4f-897a-be051cb73fa7.jpg?1664410765",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LightningStrike.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ths/cards/LightningStrike.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.ths.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Strike
+ * {1}{R}
+ * Instant
+ * Lightning Strike deals 3 damage to any target.
+ *
+ * Canonical printing: Theros (THS, 2013) — the earliest real-expansion printing.
+ * Later printings (incl. Avatar: The Last Airbender) add only a [com.wingedsheep.sdk.model.Printing] row.
+ */
+val LightningStrike = card("Lightning Strike") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Lightning Strike deals 3 damage to any target."
+
+    spell {
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(3, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "127"
+        artist = "Adam Paquette"
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbb03f2e-2b92-4aa1-afae-301ed5d151d3.jpg?1562827848"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/AvatarTheLastAirbenderSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/AvatarTheLastAirbenderSet.kt
@@ -3,6 +3,7 @@ package com.wingedsheep.mtg.sets.definitions.tla
 import com.wingedsheep.mtg.sets.discovery.CardDiscovery
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.MtgSet
+import com.wingedsheep.sdk.model.Printing
 
 /**
  * Avatar: The Last Airbender (2025)
@@ -19,6 +20,10 @@ object AvatarTheLastAirbenderSet : MtgSet {
 
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
+    }
+
+    override val printings: List<Printing> by lazy {
+        CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
 
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.tla.cards"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/Badgermole.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/Badgermole.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Badgermole
+ * {4}{G}
+ * Creature — Badger Mole
+ * 4/4
+ * When this creature enters, earthbend 2.
+ * Creatures you control with +1/+1 counters on them have trample.
+ */
+val Badgermole = card("Badgermole") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Badger Mole"
+    power = 4
+    toughness = 4
+    oracleText = "When this creature enters, earthbend 2. (Target land you control becomes a 0/0 creature with haste that's still a land. Put two +1/+1 counters on it. When it dies or is exiled, return it to the battlefield tapped.)\n" +
+        "Creatures you control with +1/+1 counters on them have trample."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val land = target("target land you control", TargetObject(filter = TargetFilter.Land.youControl()))
+        effect = Effects.Earthbend(2, land)
+        description = "When this creature enters, earthbend 2."
+    }
+
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.TRAMPLE,
+            GroupFilter(GameObjectFilter.Creature.youControl().withCounter(Counters.PLUS_ONE_PLUS_ONE)),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "166"
+        artist = "Matteo Bassini"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aabbd420-b7fc-496f-9168-bad823d51d9e.jpg?1764121134"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/CorruptCourtOfficialReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/CorruptCourtOfficialReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Corrupt Court Official reprint in TLA. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Portal Three Kingdoms (PTK); this file contributes only presentation data.
+ */
+val CorruptCourtOfficialReprint = Printing(
+    oracleId = "ec84201d-757f-4a7a-b3a2-85ccd5ee81ae",
+    name = "Corrupt Court Official",
+    setCode = "TLA",
+    collectorNumber = "92",
+    scryfallId = "4692610e-d64c-438e-b5ad-0cf67fd57f1f",
+    artist = "Norikatsu Miyoshi",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/4692610e-d64c-438e-b5ad-0cf67fd57f1f.jpg?1764120636",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/LightningStrikeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/LightningStrikeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Strike reprint in Avatar: The Last Airbender. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Theros (THS); this file contributes
+ * only presentation data for the TLA printing.
+ */
+val LightningStrikeReprint = Printing(
+    oracleId = "f34b9bc4-7bfe-47fd-ba23-4eeeb46026eb",
+    name = "Lightning Strike",
+    setCode = "TLA",
+    collectorNumber = "146",
+    scryfallId = "5787b0e0-9469-4a6d-8b81-c992628e28c0",
+    artist = "Jo Cordisco",
+    imageUri = "https://cards.scryfall.io/normal/front/5/7/5787b0e0-9469-4a6d-8b81-c992628e28c0.jpg?1764121006",
+    releaseDate = "2025-11-21",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TurtleDuck.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TurtleDuck.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Turtle-Duck
+ * {G}
+ * Creature — Turtle Bird
+ * 0/4
+ * {3}: Until end of turn, this creature has base power 4 and gains trample.
+ */
+val TurtleDuck = card("Turtle-Duck") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Turtle Bird"
+    power = 0
+    toughness = 4
+    oracleText = "{3}: Until end of turn, this creature has base power 4 and gains trample."
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        effect = Effects.Composite(
+            Effects.SetBasePower(EffectTarget.Self, DynamicAmount.Fixed(4), Duration.EndOfTurn),
+            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self, Duration.EndOfTurn),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "200"
+        artist = "Sylvain Sarrailh"
+        flavorText = "\"A turtle-duckling's greatest defense comes not from their shell, but from their mother.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/aefcd734-3916-4c77-9d98-3ea2c2795658.jpg?1764121358"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/YuyanArchers.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/YuyanArchers.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Yuyan Archers
+ * {1}{R}
+ * Creature — Human Archer
+ * 3/1
+ * Reach
+ * When this creature enters, you may discard a card. If you do, draw a card.
+ */
+val YuyanArchers = card("Yuyan Archers") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Archer"
+    power = 3
+    toughness = 1
+    oracleText = "Reach\nWhen this creature enters, you may discard a card. If you do, draw a card."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(effect = IfYouDoEffect(action = Patterns.Hand.discardCards(1), ifYouDo = DrawCardsEffect(1)))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "161"
+        artist = "Domco."
+        flavorText = "\"Their precision is legendary. The Yuyan can pin a fly to a tree from a hundred yards away without killing it.\"\n—Admiral Zhao"
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99244462-a996-4a5b-91fb-947045647d6d.jpg?1764121103"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/LightningStrikeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/LightningStrikeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Lightning Strike reprint in XLN. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Theros (THS); this file contributes only presentation data for the XLN printing.
+ */
+val LightningStrikeReprint = Printing(
+    oracleId = "f34b9bc4-7bfe-47fd-ba23-4eeeb46026eb",
+    name = "Lightning Strike",
+    setCode = "XLN",
+    collectorNumber = "149",
+    scryfallId = "f0f55dee-7e39-4183-8e74-844d9c299bf5",
+    artist = "Craig J Spearing",
+    imageUri = "https://cards.scryfall.io/normal/front/f/0/f0f55dee-7e39-4183-8e74-844d9c299bf5.jpg?1562566447",
+    releaseDate = "2017-09-29",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/PTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/PTK.json
@@ -38,6 +38,86 @@
     ]
 }
 
+// Corrupt Court Official
+{
+    "name": "Corrupt Court Official",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Human Advisor",
+    "oracleText": "When this creature enters, target opponent discards a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "storeAs": "hand"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hand",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "chooser": "TargetPlayer",
+                            "storeSelected": "discarded",
+                            "prompt": "Choose 1 card to discard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "discarded",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                }
+                            },
+                            "moveType": "Discard"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "UNCOMMON",
+        "artist": "Li Yousong",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d3ba2e3-e680-47cd-81c5-555deea7d00f.jpg?1562257498"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Peach Garden Oath
 {
     "name": "Peach Garden Oath",

--- a/mtg-sets/src/test/resources/snapshots/cards/THS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THS.json
@@ -113,6 +113,41 @@
     ]
 }
 
+// Lightning Strike
+{
+    "name": "Lightning Strike",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Lightning Strike deals 3 damage to any target.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Fixed",
+                "amount": 3
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "any target"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "AnyTarget",
+                "id": "any target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "artist": "Adam Paquette",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbb03f2e-2b92-4aa1-afae-301ed5d151d3.jpg?1562827848"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Wild Celebrants
 {
     "name": "Wild Celebrants",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -2918,3 +2918,90 @@
         "GREEN"
     ]
 }
+
+// Yuyan Archers
+{
+    "name": "Yuyan Archers",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Archer",
+    "oracleText": "Reach\nWhen this creature enters, you may discard a card. If you do, draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "artist": "Domco.",
+        "flavorText": "\"Their precision is legendary. The Yuyan can pin a fly to a tree from a hundred yards away without killing it.\"\n—Admiral Zhao",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99244462-a996-4a5b-91fb-947045647d6d.jpg?1764121103"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -243,6 +243,133 @@
     ]
 }
 
+// Badgermole
+{
+    "name": "Badgermole",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Badger Mole",
+    "oracleText": "When this creature enters, earthbend 2. (Target land you control becomes a 0/0 creature with haste that's still a land. Put two +1/+1 counters on it. When it dies or is exiled, return it to the battlefield tapped.)\nCreatures you control with +1/+1 counters on them have trample.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AnimateLand",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land you control"
+                            },
+                            "power": 0,
+                            "toughness": 0,
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "HASTE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land you control"
+                            },
+                            "duration": "Permanent"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 2,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land you control"
+                            }
+                        },
+                        {
+                            "type": "GrantTriggeredAbility",
+                            "ability": {
+                                "id": "ability_2",
+                                "trigger": {
+                                    "type": "ZoneChangeEvent",
+                                    "from": "Battlefield"
+                                },
+                                "effect": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "MoveToZone",
+                                            "target": "Self",
+                                            "destination": "Battlefield",
+                                            "placement": "Tapped",
+                                            "fromZone": "Graveyard"
+                                        },
+                                        {
+                                            "type": "MoveToZone",
+                                            "target": "Self",
+                                            "destination": "Battlefield",
+                                            "placement": "Tapped",
+                                            "fromZone": "Exile"
+                                        }
+                                    ]
+                                },
+                                "descriptionOverride": "When this dies or is exiled, return it to the battlefield tapped."
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target land you control"
+                            },
+                            "duration": "Permanent"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "land ctrl:you"
+                    },
+                    "id": "target land you control"
+                },
+                "descriptionOverride": "When this creature enters, earthbend 2."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "+1/+1"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "artist": "Matteo Bassini",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aabbd420-b7fc-496f-9168-bad823d51d9e.jpg?1764121134"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Badgermole Cub
 {
     "name": "Badgermole Cub",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -2719,6 +2719,60 @@
     ]
 }
 
+// Turtle-Duck
+{
+    "name": "Turtle-Duck",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Turtle Bird",
+    "oracleText": "{3}: Until end of turn, this creature has base power 4 and gains trample.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SetBaseStats",
+                            "target": "Self",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "duration": "EndOfTurn"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "TRAMPLE",
+                            "target": "Self"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "200",
+        "artist": "Sylvain Sarrailh",
+        "flavorText": "\"A turtle-duckling's greatest defense comes not from their shell, but from their mother.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/aefcd734-3916-4c77-9d98-3ea2c2795658.jpg?1764121358"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Wandering Musicians
 {
     "name": "Wandering Musicians",


### PR DESCRIPTION
Scaffolds more of the Avatar: The Last Airbender (TLA) set and wires up two
shared reprints to their canonical homes.

### New TLA cards
- **Badgermole** {4}{G} — ETB earthbend 2; static "creatures you control with
  +1/+1 counters have trample" (composes `Effects.Earthbend` + `GrantKeyword`/
  `GroupFilter`, no new SDK types).
- **Turtle-Duck** {G} — `{3}`: base power 4 + trample until end of turn.
- **Yuyan Archers** {1}{R} — Reach; ETB loot (may discard, if you do draw).

### Reprints
- Hosts canonical **Lightning Strike** in THS (earliest real printing) and
  **Corrupt Court Official** in PTK, with `Printing` rows for every later set
  (DFT/DMU/M15/M19/SNC/XLN/TLA). Adds the `printings` override to the TLA set.

### Docs / bookkeeping
- New TLA card checklist (`backlog/.../cards.md`); moves and refreshes the
  engine-gap analysis under the set folder.
- Updated PTK/THS/TLA card snapshots.

All cards compose existing primitives; oracle text, P/T, and collector numbers
match Scryfall, and `check-card-printing` passes for both canonicals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)