### PR TITLE
Add five Final Fantasy cards (Cid, Choco, Phantom Train, Esper Ramuh, Bahamut)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ChocoSeekerOfParadise.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ChocoSeekerOfParadise.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Choco, Seeker of Paradise
+ * {1}{G}{W}{U}
+ * Legendary Creature — Bird
+ * 3/5
+ *
+ * Whenever one or more Birds you control attack, look at that many cards from the top of
+ * your library. You may put one of them into your hand. Then put any number of land cards
+ * from among them onto the battlefield tapped and the rest into your graveyard.
+ * Landfall — Whenever a land you control enters, Choco gets +1/+0 until end of turn.
+ *
+ * Modeling notes:
+ *  - The attack trigger is a once-per-combat group trigger ([Triggers.YouAttackWithFilter])
+ *    keyed on Birds you control — it fires once no matter how many Birds attack, not once
+ *    per Bird.
+ *  - "Look at that many cards" — the count is the number of attacking Birds you control,
+ *    read at resolution via [DynamicAmount.AggregateBattlefield] over attacking Birds. This
+ *    matches the established convention for attacker-count cards (Goblin Piledriver,
+ *    Shaleskin Bruiser).
+ *  - The hand/battlefield/graveyard distribution is built from the atomic
+ *    GatherCards → SelectFromCollection → MoveCollection pipeline (cf. Ignis Scientia,
+ *    Portent of Calamity): "look at" is a private gather; the optional one-to-hand pick is a
+ *    ChooseUpTo(1); the land pile is a ChooseAnyNumber filtered to lands (showAllCards so the
+ *    player sees every looked-at card); everything not chosen falls through to the graveyard.
+ */
+val ChocoSeekerOfParadise = card("Choco, Seeker of Paradise") {
+    manaCost = "{1}{G}{W}{U}"
+    colorIdentity = "GWU"
+    typeLine = "Legendary Creature — Bird"
+    power = 3
+    toughness = 5
+    oracleText = "Whenever one or more Birds you control attack, look at that many cards from the top of your library. " +
+        "You may put one of them into your hand. Then put any number of land cards from among them onto the " +
+        "battlefield tapped and the rest into your graveyard.\n" +
+        "Landfall — Whenever a land you control enters, Choco gets +1/+0 until end of turn."
+
+    // Whenever one or more Birds you control attack, look at that many cards...
+    triggeredAbility {
+        trigger = Triggers.YouAttackWithFilter(GameObjectFilter.Creature.withSubtype(Subtype.BIRD))
+        effect = Effects.Composite(
+            listOf(
+                // Look at that many cards from the top of your library.
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        count = DynamicAmount.AggregateBattlefield(
+                            Player.You,
+                            GameObjectFilter.Creature.withSubtype(Subtype.BIRD).attacking()
+                        ),
+                        player = Player.You
+                    ),
+                    storeAs = "looked"
+                ),
+                // You may put one of them into your hand.
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "toHand",
+                    storeRemainder = "remaining",
+                    showAllCards = true,
+                    prompt = "You may put one of them into your hand",
+                    selectedLabel = "Put into your hand",
+                    remainderLabel = "Keep among them"
+                ),
+                MoveCollectionEffect(
+                    from = "toHand",
+                    destination = CardDestination.ToZone(Zone.HAND, Player.You)
+                ),
+                // Then put any number of land cards from among them onto the battlefield tapped...
+                SelectFromCollectionEffect(
+                    from = "remaining",
+                    selection = SelectionMode.ChooseAnyNumber,
+                    filter = GameObjectFilter.Land,
+                    showAllCards = true,
+                    storeSelected = "toBattlefield",
+                    storeRemainder = "toGraveyard",
+                    prompt = "Put any number of land cards onto the battlefield tapped",
+                    selectedLabel = "Onto the battlefield tapped",
+                    remainderLabel = "Into your graveyard"
+                ),
+                MoveCollectionEffect(
+                    from = "toBattlefield",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, Player.You, ZonePlacement.Tapped)
+                ),
+                // ...and the rest into your graveyard.
+                MoveCollectionEffect(
+                    from = "toGraveyard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You)
+                )
+            )
+        )
+    }
+
+    // Landfall — Whenever a land you control enters, Choco gets +1/+0 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = ModifyStatsEffect(1, 0, EffectTarget.Self)
+        description = "Landfall — Whenever a land you control enters, Choco, Seeker of Paradise gets +1/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "215"
+        artist = "Miho Midorikawa"
+        imageUri = "https://cards.scryfall.io/normal/front/4/0/409c305a-52dc-4538-8e72-efcd568eaf49.jpg?1748706564"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CidTimelessArtificer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CidTimelessArtificer.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Cid, Timeless Artificer — Final Fantasy #216
+ * {2}{W}{U} · Legendary Creature — Human Artificer · 4/4
+ *
+ * Artifact creatures and Heroes you control get +1/+1 for each Artificer you control and each
+ * Artificer card in your graveyard.
+ * A deck can have any number of cards named Cid, Timeless Artificer.
+ * Cycling {W}{U}
+ *
+ * Modeling:
+ * - The lord is a continuous static ([GrantDynamicStatsEffect]) over the union group
+ *   "artifact creatures you control OR Heroes you control" (Hero is a creature subtype, so the
+ *   second branch is `Creature.withSubtype("Hero")`). The two homogeneous `youControl` branches
+ *   flatten into one `CardPredicate.Or` via the `or` infix on [GameObjectFilter].
+ * - The per-step bonus is the live sum of (Artificers you control on the battlefield) +
+ *   (Artificer cards in your graveyard), modeled with [DynamicAmount.Add] of an
+ *   [DynamicAmount.AggregateBattlefield] and a graveyard [DynamicAmount.Count]. The same amount
+ *   feeds both power and toughness (+N/+N). Cid itself is a Human Artificer (not an artifact
+ *   creature and not a Hero), so it counts toward the bonus but is not buffed by its own ability.
+ * - "A deck can have any number of cards named Cid, Timeless Artificer" is a deck-construction
+ *   rule (CR 105 / no in-game effect); it is captured in oracleText only and intentionally has no
+ *   mechanical modeling.
+ * - Cycling {W}{U} via [KeywordAbility.cycling].
+ */
+val CidTimelessArtificer = card("Cid, Timeless Artificer") {
+    manaCost = "{2}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Artificer"
+    power = 4
+    toughness = 4
+    oracleText = "Artifact creatures and Heroes you control get +1/+1 for each Artificer you control " +
+        "and each Artificer card in your graveyard.\n" +
+        "A deck can have any number of cards named Cid, Timeless Artificer.\n" +
+        "Cycling {W}{U} ({W}{U}, Discard this card: Draw a card.)"
+
+    // Artifact creatures and Heroes you control get +1/+1 for each Artificer you control and each
+    // Artificer card in your graveyard.
+    staticAbility {
+        val artificerCount = DynamicAmount.Add(
+            DynamicAmount.AggregateBattlefield(
+                Player.You,
+                GameObjectFilter.Creature.withSubtype(Subtype.ARTIFICER),
+            ),
+            DynamicAmount.Count(
+                Player.You,
+                Zone.GRAVEYARD,
+                GameObjectFilter.Any.withSubtype(Subtype.ARTIFICER),
+            ),
+        )
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter(
+                GameObjectFilter.ArtifactCreature.youControl() or
+                    GameObjectFilter.Creature.withSubtype("Hero").youControl(),
+            ),
+            powerBonus = artificerCount,
+            toughnessBonus = artificerCount,
+        )
+    }
+
+    // Cycling {W}{U}
+    keywordAbility(KeywordAbility.cycling("{W}{U}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "216"
+        artist = "Lius Lasahido"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7fb99393-d2b6-40a6-8de7-317efdc4c50b.jpg?1748706567"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PhantomTrain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/PhantomTrain.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Phantom Train — Final Fantasy #110
+ * {3}{B} · Artifact — Vehicle · 4/4 · Uncommon
+ *
+ * Trample
+ * Sacrifice another artifact or creature: Put a +1/+1 counter on this Vehicle.
+ * It becomes a Spirit artifact creature in addition to its other types until end of turn.
+ *
+ * The activated ability self-animates the Vehicle (Vehicles aren't creatures until something
+ * makes them one). The cost is [Costs.SacrificeAnother] of an artifact-or-creature (excludes the
+ * Train itself). The effect is a [Effects.Composite] of:
+ *   1. [Effects.AddCounters] — a permanent +1/+1 counter on the source (the counter persists past
+ *      end of turn even though the animation does not, matching the printed wording).
+ *   2. [Effects.BecomeCreature] on the source with base 4/4 (its printed Vehicle stats), adding the
+ *      Spirit creature subtype and the ARTIFACT card type, for `Duration.EndOfTurn`. BecomeCreature
+ *      always adds CREATURE without removing existing types, so the permanent stays a Vehicle —
+ *      "in addition to its other types". The +1/+1 counter then layers on top, so while animated it
+ *      is a 5/5 (and 4/4 again, but uncountered, after the turn ends until it is animated again).
+ */
+val PhantomTrain = card("Phantom Train") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Trample\n" +
+        "Sacrifice another artifact or creature: Put a +1/+1 counter on this Vehicle. " +
+        "It becomes a Spirit artifact creature in addition to its other types until end of turn."
+    power = 4
+    toughness = 4
+    keywords(Keyword.TRAMPLE)
+
+    activatedAbility {
+        cost = Costs.SacrificeAnother(GameObjectFilter.CreatureOrArtifact)
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            Effects.BecomeCreature(
+                target = EffectTarget.Self,
+                power = 4,
+                toughness = 4,
+                creatureTypes = setOf("Spirit"),
+                addTypes = setOf("ARTIFACT"),
+                duration = Duration.EndOfTurn
+            )
+        )
+        description = "Sacrifice another artifact or creature: Put a +1/+1 counter on this Vehicle. " +
+            "It becomes a Spirit artifact creature in addition to its other types until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "110"
+        artist = "Gal Or"
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a50d2ac-101d-41e1-b400-18fa7d2d7125.jpg?1748706172"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonBahamut.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonBahamut.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Summon: Bahamut
+ * {9}
+ * Enchantment Creature — Saga Dragon
+ * 9/9
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+ * I, II — Destroy up to one target nonland permanent.
+ * III — Draw two cards.
+ * IV — Mega Flare — This creature deals damage equal to the total mana value of other permanents
+ *       you control to each opponent.
+ * Flying
+ */
+val SummonBahamut = card("Summon: Bahamut") {
+    manaCost = "{9}"
+    typeLine = "Enchantment Creature — Saga Dragon"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\n" +
+        "I, II — Destroy up to one target nonland permanent.\n" +
+        "III — Draw two cards.\n" +
+        "IV — Mega Flare — This creature deals damage equal to the total mana value of other " +
+        "permanents you control to each opponent.\n" +
+        "Flying"
+    power = 9
+    toughness = 9
+
+    keywords(Keyword.FLYING)
+
+    // I, II — Destroy up to one target nonland permanent. ("up to one" → optional target.)
+    sagaChapter(1) {
+        val t = target("target", TargetObject(optional = true, filter = TargetFilter.NonlandPermanent))
+        effect = Effects.Destroy(t)
+    }
+    sagaChapter(2) {
+        val t = target("target", TargetObject(optional = true, filter = TargetFilter.NonlandPermanent))
+        effect = Effects.Destroy(t)
+    }
+
+    // III — Draw two cards.
+    sagaChapter(3) {
+        effect = Effects.DrawCards(2)
+    }
+
+    // IV — Mega Flare — deal damage equal to the total mana value of other permanents you control
+    //       to each opponent. excludeSelf drops Bahamut itself from the sum ("other permanents").
+    sagaChapter(4) {
+        effect = Effects.DealDamage(
+            amount = DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Any,
+                aggregation = Aggregation.SUM,
+                property = CardNumericProperty.MANA_VALUE,
+                excludeSelf = true,
+            ),
+            target = EffectTarget.PlayerRef(Player.EachOpponent),
+            damageSource = EffectTarget.Self,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "1"
+        artist = "Arif Wijaya"
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95318d85-4a08-47ac-a43d-ea83c0bea81c.jpg?1748705758"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonEsperRamuh.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonEsperRamuh.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Summon: Esper Ramuh
+ * {2}{R}{R}
+ * Enchantment Creature — Saga Wizard
+ * 3/3
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Judgment Bolt — This creature deals damage equal to the number of noncreature, nonland
+ *   cards in your graveyard to target creature an opponent controls.
+ * II, III — Wizards you control get +1/+0 until end of turn.
+ *
+ * Chapter I deals damage sourced by the saga-creature itself (EffectTarget.Self) equal to a
+ * graveyard count — noncreature AND nonland cards in the controller's graveyard — to a single
+ * mandatory target creature an opponent controls. Chapters II and III share one team pump:
+ * Wizards you control (including the saga, itself a Wizard) get +1/+0 until end of turn.
+ */
+val SummonEsperRamuh = card("Summon: Esper Ramuh") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment Creature — Saga Wizard"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Judgment Bolt — This creature deals damage equal to the number of noncreature, nonland cards in your graveyard to target creature an opponent controls.\n" +
+        "II, III — Wizards you control get +1/+0 until end of turn."
+    power = 3
+    toughness = 3
+
+    // Chapter I — "Judgment Bolt": damage = noncreature, nonland cards in your graveyard, dealt by
+    // this creature to a target creature an opponent controls.
+    sagaChapter(1) {
+        val victim = target("creature", TargetObject(filter = TargetFilter.CreatureOpponentControls))
+        val noncreatureNonland = DynamicAmounts.zone(
+            Player.You,
+            Zone.GRAVEYARD,
+            GameObjectFilter.Nonland.notCreature(),
+        ).count()
+        effect = Effects.DealDamage(noncreatureNonland, victim, damageSource = EffectTarget.Self)
+    }
+
+    // Chapters II & III — "Wizards you control get +1/+0 until end of turn."
+    val wizardPump = Patterns.Group.modifyStatsForAll(
+        power = 1,
+        toughness = 0,
+        filter = GroupFilter(GameObjectFilter.Creature.youControl().withSubtype("Wizard")),
+    )
+    sagaChapter(2) { effect = wizardPump }
+    sagaChapter(3) { effect = wizardPump }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "161"
+        artist = "Justyna Dura"
+        flavorText = "\"I am Ramuh—the esper.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/840659ee-1493-4190-a514-c2c9ae14e331.jpg?1748706366"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -2376,6 +2376,142 @@
     ]
 }
 
+// Choco, Seeker of Paradise
+{
+    "name": "Choco, Seeker of Paradise",
+    "manaCost": "{1}{G}{W}{U}",
+    "typeLine": "Legendary Creature — Bird",
+    "oracleText": "Whenever one or more Birds you control attack, look at that many cards from the top of your library. You may put one of them into your hand. Then put any number of land cards from among them onto the battlefield tapped and the rest into your graveyard.\nLandfall — Whenever a land you control enters, Choco gets +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "attackerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Bird"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "AggregateBattlefield",
+                                    "player": "You",
+                                    "filter": "creature Bird attacking"
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "toHand",
+                            "storeRemainder": "remaining",
+                            "prompt": "You may put one of them into your hand",
+                            "selectedLabel": "Put into your hand",
+                            "remainderLabel": "Keep among them",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "remaining",
+                            "selection": "ChooseAnyNumber",
+                            "filter": "land",
+                            "storeSelected": "toBattlefield",
+                            "storeRemainder": "toGraveyard",
+                            "prompt": "Put any number of land cards onto the battlefield tapped",
+                            "selectedLabel": "Onto the battlefield tapped",
+                            "remainderLabel": "Into your graveyard",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toBattlefield",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "toGraveyard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, Choco, Seeker of Paradise gets +1/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "RARE",
+        "artist": "Miho Midorikawa",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/0/409c305a-52dc-4538-8e72-efcd568eaf49.jpg?1748706564"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Choco-Comet
 {
     "name": "Choco-Comet",
@@ -2600,6 +2736,98 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Cid, Timeless Artificer
+{
+    "name": "Cid, Timeless Artificer",
+    "manaCost": "{2}{W}{U}",
+    "typeLine": "Legendary Creature — Human Artificer",
+    "oracleText": "Artifact creatures and Heroes you control get +1/+1 for each Artificer you control and each Artificer card in your graveyard.\nA deck can have any number of cards named Cid, Timeless Artificer.\nCycling {W}{U} ({W}{U}, Discard this card: Draw a card.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywordAbilities": [
+        {
+            "type": "Cycling",
+            "cost": "{W}{U}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsArtifact",
+                                            "IsCreature"
+                                        ]
+                                    },
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasSubtype",
+                                                "subtype": "Hero"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                },
+                "powerBonus": {
+                    "type": "Add",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Artificer"
+                    },
+                    "right": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "Artificer"
+                    }
+                },
+                "toughnessBonus": {
+                    "type": "Add",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Artificer"
+                    },
+                    "right": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "Artificer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "rarity": "UNCOMMON",
+        "artist": "Lius Lasahido",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7fb99393-d2b6-40a6-8de7-317efdc4c50b.jpg?1748706567"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
     ]
 }
 
@@ -9894,6 +10122,74 @@
     ]
 }
 
+// Phantom Train
+{
+    "name": "Phantom Train",
+    "manaCost": "{3}{B}",
+    "typeLine": "Artifact — Vehicle",
+    "oracleText": "Trample\nSacrifice another artifact or creature: Put a +1/+1 counter on this Vehicle. It becomes a Spirit artifact creature in addition to its other types until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomSacrifice",
+                        "filter": "creature|artifact",
+                        "excludeSelf": true
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "BecomeCreature",
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 4
+                            },
+                            "creatureTypes": [
+                                "Spirit"
+                            ],
+                            "addTypes": [
+                                "ARTIFACT"
+                            ]
+                        }
+                    ]
+                },
+                "descriptionOverride": "Sacrifice another artifact or creature: Put a +1/+1 counter on this Vehicle. It becomes a Spirit artifact creature in addition to its other types until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "rarity": "UNCOMMON",
+        "artist": "Gal Or",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a50d2ac-101d-41e1-b400-18fa7d2d7125.jpg?1748706172"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Phoenix Down
 {
     "name": "Phoenix Down",
@@ -13781,6 +14077,99 @@
     ]
 }
 
+// Summon: Bahamut
+{
+    "name": "Summon: Bahamut",
+    "manaCost": "{9}",
+    "typeLine": "Enchantment Creature — Saga Dragon",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI, II — Destroy up to one target nonland permanent.\nIII — Draw two cards.\nIV — Mega Flare — This creature deals damage equal to the total mana value of other permanents you control to each opponent.\nFlying",
+    "creatureStats": {
+        "power": 9,
+        "toughness": 9
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "nonland permanent"
+                    },
+                    "id": "target"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "nonland permanent"
+                    },
+                    "id": "target"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            },
+            {
+                "chapter": 4,
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "aggregation": "SUM",
+                        "property": "MANA_VALUE",
+                        "excludeSelf": true
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    },
+                    "damageSource": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "rarity": "MYTHIC",
+        "artist": "Arif Wijaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95318d85-4a08-47ac-a43d-ea83c0bea81c.jpg?1748705758"
+    }
+}
+
 // Summon: Choco/Mog
 {
     "name": "Summon: Choco/Mog",
@@ -13902,6 +14291,112 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Summon: Esper Ramuh
+{
+    "name": "Summon: Esper Ramuh",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Enchantment Creature — Saga Wizard",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Judgment Bolt — This creature deals damage equal to the number of noncreature, nonland cards in your graveyard to target creature an opponent controls.\nII, III — Wizards you control get +1/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "AggregateZone",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsNonland",
+                                {
+                                    "type": "Not",
+                                    "predicate": "IsCreature"
+                                }
+                            ]
+                        }
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "damageSource": "Self"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Wizard ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Wizard ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "UNCOMMON",
+        "artist": "Justyna Dura",
+        "flavorText": "\"I am Ramuh—the esper.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/840659ee-1493-4190-a514-c2c9ae14e331.jpg?1748706366"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChocoSeekerOfParadiseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChocoSeekerOfParadiseScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.AmbrosiaWhiteheart
+import com.wingedsheep.mtg.sets.definitions.fin.cards.ChocoSeekerOfParadise
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Choco, Seeker of Paradise (FIN) — {1}{G}{W}{U} Legendary Creature — Bird, 3/5.
+ *
+ *  - Whenever one or more Birds you control attack, look at that many cards from the top of your
+ *    library. You may put one of them into your hand. Then put any number of land cards from among
+ *    them onto the battlefield tapped and the rest into your graveyard.
+ *  - Landfall — Whenever a land you control enters, Choco gets +1/+0 until end of turn.
+ *
+ * Both abilities are pure composition over existing primitives (group-attack trigger +
+ * GatherCards / SelectFromCollection / MoveCollection pipeline; LandYouControlEnters + ModifyStats),
+ * so this scenario test is the behavioural gate.
+ */
+class ChocoSeekerOfParadiseScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ChocoSeekerOfParadise)
+        driver.registerCard(AmbrosiaWhiteheart) // a second Bird, so two Birds can attack
+        return driver
+    }
+
+    /** Drain priority/stack until a player decision is pending (or nothing is left to resolve). */
+    fun GameTestDriver.resolveUntilDecision() {
+        var guard = 0
+        while (pendingDecision == null && stackSize > 0 && guard++ < 20) {
+            bothPass()
+        }
+    }
+
+    test("Landfall — a land entering gives Choco +1/+0 until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val choco = driver.putCreatureOnBattlefield(player, "Choco, Seeker of Paradise")
+        projector.project(driver.state).getPower(choco) shouldBe 3
+
+        // Play a land — landfall fires.
+        val forest = driver.putCardInHand(player, "Forest")
+        driver.playLand(player, forest)
+        driver.resolveUntilDecision()
+
+        withClue("Landfall should pump Choco to 4/5") {
+            projector.project(driver.state).getPower(choco) shouldBe 4
+        }
+    }
+
+    test("attack trigger — two Birds: look at two, decline hand, land enters tapped, the rest to graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Two attacking Birds → "that many" = 2 cards looked at.
+        val choco = driver.putCreatureOnBattlefield(player, "Choco, Seeker of Paradise")
+        val ambrosia = driver.putCreatureOnBattlefield(player, "Ambrosia Whiteheart")
+        driver.removeSummoningSickness(choco)
+        driver.removeSummoningSickness(ambrosia)
+
+        // Top of library: a non-land (Grizzly Bears), then a natural Forest (land).
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+
+        val landsBefore = driver.getLands(player).size
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(choco, ambrosia), opponent)
+        driver.resolveUntilDecision()
+
+        // First decision: "you may put one of them into your hand." Decline.
+        val handPick = driver.pendingDecision
+        withClue("expected the optional hand-pick selection, got $handPick") {
+            (handPick is SelectCardsDecision) shouldBe true
+        }
+        handPick as SelectCardsDecision
+        withClue("two attacking Birds should reveal exactly two cards") {
+            handPick.options.size shouldBe 2
+        }
+        driver.submitCardSelection(player, emptyList())
+        driver.resolveUntilDecision()
+
+        // Second decision: "put any number of land cards onto the battlefield tapped." Pick the Forest.
+        val landPick = driver.pendingDecision as SelectCardsDecision
+        val forestOption = landPick.options.first { driver.getCardName(it) == "Forest" }
+        driver.submitCardSelection(player, listOf(forestOption))
+        driver.resolveUntilDecision()
+
+        // The land entered tapped; the non-land "rest" went to the graveyard.
+        withClue("the chosen land should have entered the battlefield") {
+            driver.getLands(player).size shouldBe landsBefore + 1
+        }
+        val newLand = driver.getLands(player).first { driver.getCardName(it) == "Forest" }
+        withClue("land cards from this effect enter tapped") {
+            driver.isTapped(newLand) shouldBe true
+        }
+        driver.getGraveyardCardNames(player) shouldContain "Grizzly Bears"
+    }
+
+    test("attack trigger — may put one of the looked-at cards into hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val choco = driver.putCreatureOnBattlefield(player, "Choco, Seeker of Paradise")
+        val ambrosia = driver.putCreatureOnBattlefield(player, "Ambrosia Whiteheart")
+        driver.removeSummoningSickness(choco)
+        driver.removeSummoningSickness(ambrosia)
+
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val handBefore = driver.getHandSize(player)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(choco, ambrosia), opponent)
+        driver.resolveUntilDecision()
+
+        // Put Grizzly Bears into hand.
+        val handPick = driver.pendingDecision as SelectCardsDecision
+        val bearOption = handPick.options.first { driver.getCardName(it) == "Grizzly Bears" }
+        driver.submitCardSelection(player, listOf(bearOption))
+        driver.resolveUntilDecision()
+
+        // Then the land step (no lands need to be chosen — decline to keep the test focused on the hand pick).
+        val landPick = driver.pendingDecision as SelectCardsDecision
+        driver.submitCardSelection(player, emptyList())
+        driver.resolveUntilDecision()
+
+        withClue("Grizzly Bears should be in hand after the optional pick") {
+            driver.getHand(player).any { driver.getCardName(it) == "Grizzly Bears" } shouldBe true
+            driver.getHandSize(player) shouldBe handBefore + 1
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CidTimelessArtificerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CidTimelessArtificerScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CycleCard
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.CidTimelessArtificer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cid, Timeless Artificer (FIN) — {2}{W}{U} Legendary Creature — Human Artificer 4/4.
+ *
+ *  "Artifact creatures and Heroes you control get +1/+1 for each Artificer you control and each
+ *   Artificer card in your graveyard.
+ *   A deck can have any number of cards named Cid, Timeless Artificer.
+ *   Cycling {W}{U}"
+ *
+ * Covers the dynamic lord over the union "artifact creatures OR Heroes you control", the additive
+ * battlefield + graveyard Artificer count (Cid counts itself), the `youControl` scoping, and Cycling.
+ */
+class CidTimelessArtificerScenarioTest : FunSpec({
+
+    // A plain Hero creature to exercise the "Heroes you control" branch of the union filter.
+    val testHero = CardDefinition.creature(
+        name = "Test Hero",
+        manaCost = ManaCost.parse("{1}{W}"),
+        subtypes = setOf(Subtype("Hero")),
+        power = 2,
+        toughness = 2,
+    )
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CidTimelessArtificer)
+        driver.registerCard(testHero)
+        driver.initMirrorMatch(Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("buffs artifact creatures and Heroes you control by battlefield + graveyard Artificer count") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Cid is itself an Artificer you control → contributes 1 to the count on its own.
+        driver.putCreatureOnBattlefield(me, "Cid, Timeless Artificer")
+
+        val myArtifactCreature = driver.putCreatureOnBattlefield(me, "Artifact Creature") // base 2/2
+        val myHero = driver.putCreatureOnBattlefield(me, "Test Hero")                     // base 2/2
+        val myVanilla = driver.putCreatureOnBattlefield(me, "Centaur Courser")            // base 3/3, no buff
+        val oppArtifactCreature = driver.putCreatureOnBattlefield(opp, "Artifact Creature") // opponent's, no buff
+
+        withClue("Only Cid on battlefield, empty graveyard → bonus = 1 (Cid itself)") {
+            driver.state.projectedState.getPower(myArtifactCreature) shouldBe 3
+            driver.state.projectedState.getToughness(myArtifactCreature) shouldBe 3
+            driver.state.projectedState.getPower(myHero) shouldBe 3
+            driver.state.projectedState.getToughness(myHero) shouldBe 3
+        }
+
+        withClue("Vanilla (non-artifact, non-Hero) creature you control is unaffected") {
+            driver.state.projectedState.getPower(myVanilla) shouldBe 3
+            driver.state.projectedState.getToughness(myVanilla) shouldBe 3
+        }
+
+        withClue("Opponent's artifact creature is unaffected (the lord only buffs creatures you control)") {
+            driver.state.projectedState.getPower(oppArtifactCreature) shouldBe 2
+            driver.state.projectedState.getToughness(oppArtifactCreature) shouldBe 2
+        }
+
+        // Add two Artificer cards (more Cids) to YOUR graveyard → bonus becomes 1 + 2 = 3.
+        driver.putCardInGraveyard(me, "Cid, Timeless Artificer")
+        driver.putCardInGraveyard(me, "Cid, Timeless Artificer")
+
+        withClue("Cid on battlefield (1) + two Artificer cards in graveyard (2) → bonus = 3") {
+            driver.state.projectedState.getPower(myArtifactCreature) shouldBe 5
+            driver.state.projectedState.getToughness(myArtifactCreature) shouldBe 5
+            driver.state.projectedState.getPower(myHero) shouldBe 5
+            driver.state.projectedState.getToughness(myHero) shouldBe 5
+        }
+
+        withClue("An Artificer card in the OPPONENT's graveyard must not count for you") {
+            driver.putCardInGraveyard(opp, "Cid, Timeless Artificer")
+            driver.state.projectedState.getPower(myArtifactCreature) shouldBe 5
+        }
+    }
+
+    test("Cycling {W}{U} discards Cid and draws a card") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        val cid = driver.putCardInHand(me, "Cid, Timeless Artificer")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.giveMana(me, Color.BLUE, 1)
+
+        val handBefore = driver.getHandSize(me)
+        driver.submit(CycleCard(playerId = me, cardId = cid)).isSuccess shouldBe true
+        driver.bothPass() // cycling ability resolves: draw a card
+
+        withClue("Cid is discarded to the graveyard and a replacement card is drawn (net hand unchanged)") {
+            driver.getGraveyardCardNames(me) shouldContain "Cid, Timeless Artificer"
+            driver.getHandSize(me) shouldBe handBefore
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PhantomTrainScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PhantomTrainScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fin.cards.PhantomTrain
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Phantom Train {3}{B} Artifact — Vehicle 4/4 (FIN #110).
+ *
+ * Trample
+ * Sacrifice another artifact or creature: Put a +1/+1 counter on this Vehicle. It becomes a Spirit
+ * artifact creature in addition to its other types until end of turn.
+ *
+ * Proves the self-animating activated ability: paying the "sacrifice another artifact or creature"
+ * cost removes the chosen permanent, puts a +1/+1 counter on the Train, and makes it a creature
+ * (a 5/5 with the counter, keeping its Vehicle subtype) for the rest of the turn — then it reverts
+ * to a noncreature Vehicle, while the +1/+1 counter persists.
+ */
+class PhantomTrainScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(listOf(PhantomTrain))
+
+        context("Phantom Train") {
+
+            test("sacrificing a creature animates it into a 5/5 Spirit artifact creature until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Phantom Train")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val train = game.findPermanent("Phantom Train")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("starts as a noncreature artifact Vehicle") {
+                    val before = game.state.projectedState
+                    before.isCreature(train) shouldBe false
+                    before.hasType(train, "ARTIFACT") shouldBe true
+                    before.hasSubtype(train, "Vehicle") shouldBe true
+                }
+                withClue("starts with no +1/+1 counters") {
+                    val counters = game.state.getEntity(train)?.get<CountersComponent>()?.counters ?: emptyMap()
+                    counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe null
+                }
+
+                val abilityId = cardRegistry.getCard("Phantom Train")!!
+                    .script.activatedAbilities[0].id
+
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = train,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bears)),
+                    )
+                )
+                withClue("activating the sacrifice ability should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the sacrificed creature is gone") {
+                    game.findPermanent("Grizzly Bears") shouldBe null
+                }
+                withClue("Phantom Train gains a +1/+1 counter") {
+                    val counters = game.state.getEntity(train)?.get<CountersComponent>()?.counters ?: emptyMap()
+                    counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 1
+                }
+
+                val animated = game.state.projectedState
+                withClue("becomes a creature") { animated.isCreature(train) shouldBe true }
+                withClue("is a Spirit") { animated.hasSubtype(train, "Spirit") shouldBe true }
+                withClue("still an artifact (in addition to its other types)") {
+                    animated.hasType(train, "ARTIFACT") shouldBe true
+                }
+                withClue("still a Vehicle") { animated.hasSubtype(train, "Vehicle") shouldBe true }
+                withClue("base 4/4 plus the +1/+1 counter = 5/5 power") { animated.getPower(train) shouldBe 5 }
+                withClue("base 4/4 plus the +1/+1 counter = 5/5 toughness") { animated.getToughness(train) shouldBe 5 }
+            }
+
+            test("reverts to a noncreature Vehicle at end of turn but keeps the +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Phantom Train")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val train = game.findPermanent("Phantom Train")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.getCard("Phantom Train")!!
+                    .script.activatedAbilities[0].id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = train,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(bears)),
+                    )
+                )
+                game.resolveStack()
+                game.state.projectedState.isCreature(train) shouldBe true
+
+                // Advance into the opponent's turn; the until-end-of-turn animation is cleaned up.
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                val reverted = game.state.projectedState
+                withClue("no longer a creature once the turn ends") { reverted.isCreature(train) shouldBe false }
+                withClue("still an artifact Vehicle") {
+                    reverted.hasType(train, "ARTIFACT") shouldBe true
+                    reverted.hasSubtype(train, "Vehicle") shouldBe true
+                }
+                withClue("the +1/+1 counter persists past end of turn") {
+                    val counters = game.state.getEntity(train)?.get<CountersComponent>()?.counters ?: emptyMap()
+                    counters[CounterType.PLUS_ONE_PLUS_ONE] shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonBahamutScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonBahamutScenarioTest.kt
@@ -1,0 +1,182 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonBahamut
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Behaviour coverage for **Summon: Bahamut** (FIN), an Enchantment Creature — Saga Dragon (9/9, Flying).
+ *
+ *   I, II — Destroy up to one target nonland permanent.
+ *   III   — Draw two cards.
+ *   IV    — Mega Flare — This creature deals damage equal to the total mana value of other
+ *           permanents you control to each opponent.
+ *
+ * The generic saga-creature machinery (lore accrual, chapter triggers, final-chapter sacrifice) is
+ * proven by [CreatureSagaTest]; this pins Bahamut's specific chapters: the optional nonland-permanent
+ * destroy (chapter I/II), the chapter III draw, and the chapter IV mana-value-scaled damage to each
+ * opponent (an `AggregateBattlefield(SUM, MANA_VALUE, excludeSelf = true)` dynamic amount).
+ */
+class SummonBahamutScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // Plain vanilla bodies with distinct, non-trivial mana values so the Mega Flare total is
+    // unambiguously the SUM of their mana values (3 + 5 = 8), not a count or a power total.
+    val mvThree = card("MV Three Beast") {
+        manaCost = "{2}{G}"
+        typeLine = "Creature — Beast"
+        power = 1
+        toughness = 1
+    }
+    val mvFive = card("MV Five Beast") {
+        manaCost = "{4}{G}"
+        typeLine = "Creature — Beast"
+        power = 1
+        toughness = 1
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SummonBahamut, mvThree, mvFive))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castBahamut(controller: EntityId): EntityId {
+        val spell = putCardInHand(controller, "Summon: Bahamut")
+        giveColorlessMana(controller, 9)
+        castSpell(controller, spell)
+        return spell
+    }
+
+    /** Resolve the whole stack, declining every optional target ([chooseTargets] default = none). */
+    fun GameTestDriver.resolveStack(chooseTargets: () -> List<EntityId> = { emptyList() }) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard++ < 100) {
+            val pd = state.pendingDecision
+            when {
+                pd is ChooseTargetsDecision -> submitTargetSelection(pd.playerId, chooseTargets())
+                pd != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+        }
+    }
+
+    fun GameTestDriver.lore(saga: EntityId): Int =
+        state.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) ?: Int.MAX_VALUE
+
+    /** Advance turns until the saga has at least [targetLore] lore, declining any chapter targets. */
+    fun GameTestDriver.advanceToLore(saga: EntityId, targetLore: Int) {
+        var guard = 0
+        while (guard++ < 1000) {
+            if (state.gameOver) throw AssertionError("Game ended before reaching lore $targetLore")
+            if (lore(saga) >= targetLore) return
+            val pd = state.pendingDecision
+            when {
+                pd is ChooseTargetsDecision -> submitTargetSelection(pd.playerId, emptyList())
+                pd != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+        }
+        throw AssertionError("Saga never reached lore $targetLore")
+    }
+
+    /** Advance turns until the saga has left the battlefield (sacrificed after its final chapter). */
+    fun GameTestDriver.advanceUntilGone(controller: EntityId, name: String) {
+        var guard = 0
+        while (guard++ < 1000) {
+            if (findPermanent(controller, name) == null) return
+            if (state.gameOver) throw AssertionError("Game ended before the saga was sacrificed")
+            val pd = state.pendingDecision
+            when {
+                pd is ChooseTargetsDecision -> submitTargetSelection(pd.playerId, emptyList())
+                pd != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+        }
+        throw AssertionError("Saga was never sacrificed")
+    }
+
+    test("enters as a 9/9 flying Saga Dragon and chapter I destroys the chosen nonland permanent") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+
+        // A nonland permanent for chapter I to destroy.
+        val victim = driver.putCreatureOnBattlefield(opponent, "MV Three Beast")
+
+        driver.castBahamut(active)
+        // Saga resolves, enters, chapter I triggers — choose to destroy the opponent's creature.
+        driver.resolveStack(chooseTargets = { listOf(victim) })
+
+        // It is simultaneously a creature and a Saga, 9/9 with Flying.
+        val saga = driver.findPermanent(active, "Summon: Bahamut")
+        saga shouldNotBe null
+        val projected = projector.project(driver.state)
+        projected.isCreature(saga!!) shouldBe true
+        projected.hasType(saga, "Saga") shouldBe true
+        projected.hasType(saga, "Dragon") shouldBe true
+        projected.getPower(saga) shouldBe 9
+        projected.getToughness(saga) shouldBe 9
+        projected.hasKeyword(saga, Keyword.FLYING) shouldBe true
+
+        // Chapter I destroyed the targeted nonland permanent.
+        driver.findPermanent(opponent, "MV Three Beast") shouldBe null
+        driver.getGraveyardCardNames(opponent).contains("MV Three Beast") shouldBe true
+    }
+
+    test("chapter I/II decline (up to one), chapter III draws two, chapter IV Mega Flares each opponent, then sacrifices") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        val oppStartLife = driver.getLifeTotal(opponent)
+
+        // Other permanents you control: total mana value 3 + 5 = 8 (the saga itself is excluded).
+        driver.putCreatureOnBattlefield(active, "MV Three Beast")
+        driver.putCreatureOnBattlefield(active, "MV Five Beast")
+
+        driver.castBahamut(active)
+        // Chapter I on entry — decline the optional target (destroy nothing).
+        driver.resolveStack(chooseTargets = { emptyList() })
+        val saga = driver.findPermanent(active, "Summon: Bahamut")!!
+        driver.lore(saga) shouldBe 1
+
+        // Advance to chapter III's main (chapter II is auto-declined en route). Stop with the
+        // chapter III ability on the stack so the draw can be isolated from the turn's own draw.
+        driver.advanceToLore(saga, 3)
+        val handBeforeDraw = driver.getHandSize(active)
+        driver.resolveStack() // chapter III resolves
+        driver.getHandSize(active) shouldBe handBeforeDraw + 2
+
+        // Advance through chapter IV (Mega Flare) and the final-chapter sacrifice.
+        driver.advanceUntilGone(active, "Summon: Bahamut")
+
+        // Mega Flare dealt 8 (total MV of the two other permanents) to the opponent; chapters I–III
+        // never touched the opponent's life.
+        driver.getLifeTotal(opponent) shouldBe oppStartLife - 8
+        // CR 714.4 — sacrificed after its final chapter.
+        driver.findPermanent(active, "Summon: Bahamut") shouldBe null
+        driver.getGraveyardCardNames(active).contains("Summon: Bahamut") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonEsperRamuhScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonEsperRamuhScenarioTest.kt
@@ -1,0 +1,154 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonEsperRamuh
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Summon: Esper Ramuh (FIN) — {2}{R}{R} Enchantment Creature — Saga Wizard 3/3.
+ *
+ *  I — Judgment Bolt — This creature deals damage equal to the number of noncreature, nonland
+ *      cards in your graveyard to target creature an opponent controls.
+ *  II, III — Wizards you control get +1/+0 until end of turn.
+ *
+ * Generic saga machinery (lore accrual, chapter triggers, final-chapter sacrifice) is covered by
+ * [CreatureSagaTest]; this pins this card's two distinct chapter behaviours.
+ */
+class SummonEsperRamuhScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A noncreature, nonland card to seed the graveyard (counts toward Judgment Bolt).
+    val fillerInstant = card("Ramuh Test Bolt") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        oracleText = "Ramuh Test Bolt deals 1 damage to any target."
+    }
+    // A creature card in the graveyard — must NOT count toward Judgment Bolt.
+    val fillerCreature = card("Ramuh Test Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+    // A land card in the graveyard — must NOT count toward Judgment Bolt.
+    val fillerLand = card("Ramuh Test Waste") {
+        typeLine = "Land"
+    }
+    // A fat opponent creature that survives the bolt, so we can read the exact marked damage.
+    val opponentWall = card("Ramuh Test Wall") {
+        manaCost = "{4}"
+        typeLine = "Creature — Wall"
+        power = 0
+        toughness = 5
+    }
+    // A vanilla Wizard the controller owns, to observe the chapters II/III team pump.
+    val alliedWizard = card("Ramuh Test Mage") {
+        manaCost = "{1}{U}"
+        typeLine = "Creature — Wizard"
+        power = 2
+        toughness = 2
+    }
+
+    fun newDriver(extra: List<com.wingedsheep.sdk.model.CardDefinition>): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SummonEsperRamuh) + extra)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun advanceToNextTurnMain(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+    }
+
+    // Resolve everything currently on the stack without ever passing priority while a decision is
+    // pending (no targeted chapter is in play in the pump test, so any decision is auto-resolved).
+    fun settle(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 60) {
+            when {
+                driver.pendingDecision != null -> driver.autoResolveDecision()
+                driver.state.stack.isNotEmpty() -> driver.bothPass()
+                else -> break
+            }
+        }
+    }
+
+    test("Chapter I deals damage equal to noncreature, nonland cards in your graveyard to a target opponent creature") {
+        val driver = newDriver(listOf(fillerInstant, fillerCreature, fillerLand, opponentWall))
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        // Three noncreature, nonland cards count; the creature card and the land card do not.
+        repeat(3) { driver.putCardInGraveyard(me, "Ramuh Test Bolt") }
+        driver.putCardInGraveyard(me, "Ramuh Test Bear")
+        driver.putCardInGraveyard(me, "Ramuh Test Waste")
+
+        val wall = driver.putCreatureOnBattlefield(opponent, "Ramuh Test Wall")
+
+        val saga = driver.putCardInHand(me, "Summon: Esper Ramuh")
+        driver.giveMana(me, Color.RED, 4)
+        driver.castSpell(me, saga)
+
+        // Resolve the saga spell, then its chapter I trigger — targeting the opposing Wall.
+        var guard = 0
+        while (guard++ < 60) {
+            when (val pending = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(pending.playerId, listOf(wall))
+                null -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+                else -> driver.autoResolveDecision()
+            }
+        }
+
+        val damage = driver.state.getEntity(wall)?.get<DamageComponent>()?.amount ?: 0
+        withClue("Judgment Bolt counts only the 3 noncreature, nonland cards (not the creature or land)") {
+            damage shouldBe 3
+        }
+        // The 0/5 Wall took 3 < 5, so it is still on the battlefield.
+        driver.findPermanent(opponent, "Ramuh Test Wall") shouldBe wall
+    }
+
+    test("Chapters II/III pump: Wizards you control get +1/+0 until end of turn") {
+        val driver = newDriver(listOf(alliedWizard))
+        val me = driver.activePlayer!!
+
+        val wizard = driver.putCreatureOnBattlefield(me, "Ramuh Test Mage")
+        projector.project(driver.state).getPower(wizard) shouldBe 2
+
+        // Cast the saga. With no opposing creature in play, chapter I has no legal target and is
+        // removed, so it simply enters as a lore-1 Saga creature.
+        val saga = driver.putCardInHand(me, "Summon: Esper Ramuh")
+        driver.giveMana(me, Color.RED, 4)
+        driver.castSpell(me, saga)
+        settle(driver)
+
+        // Advance to the controller's next precombat main: lore 2 → chapter II fires.
+        advanceToNextTurnMain(driver) // opponent's turn
+        advanceToNextTurnMain(driver) // controller's next turn
+        driver.state.activePlayerId shouldBe me
+        settle(driver)
+
+        // Chapter II resolved this turn: Wizards you control get +1/+0 until end of turn.
+        val projected = projector.project(driver.state)
+        withClue("Wizard got +1/+0 from chapter II") {
+            projected.getPower(wizard) shouldBe 3
+            projected.getToughness(wizard) shouldBe 2
+        }
+        // The saga itself is a Wizard, so it is pumped too (3/3 base -> 4/3).
+        val sagaPerm = driver.findPermanent(me, "Summon: Esper Ramuh")!!
+        projected.getPower(sagaPerm) shouldBe 4
+        projected.getToughness(sagaPerm) shouldBe 3
+    }
+})


### PR DESCRIPTION
Implements five missing **Final Fantasy (FIN)** cards via the `add-card` workflow. Each is composed entirely from existing SDK primitives — **no new engine features** — and is covered by a passing Kotest scenario test.

## Cards

| Card | Type | Modeling |
|------|------|----------|
| **Cid, Timeless Artificer** | `{2}{W}{U}` Legendary Creature | Dynamic lord (`GrantDynamicStatsEffect`) over the union "artifact creatures **or** Heroes you control"; bonus = battlefield + graveyard Artificer count; Cycling `{W}{U}`. |
| **Choco, Seeker of Paradise** | `{1}{G}{W}{U}` Legendary Creature — Bird | Once-per-combat Birds-attack trigger driving a `GatherCards → SelectFromCollection → MoveCollection` pipeline (look at N, optional one-to-hand, any-number lands to battlefield tapped, rest to graveyard); landfall self-pump. |
| **Phantom Train** | `{3}{B}` Artifact — Vehicle | Self-animating Vehicle: sacrifice-cost ability adds a persistent +1/+1 counter and `BecomeCreature` (Spirit + artifact **in addition to** its other types, EOT). |
| **Summon: Esper Ramuh** | `{2}{R}{R}` Saga Wizard | Chapter I: graveyard noncreature/nonland count damage to a target opponent creature; II/III: pump Wizards you control. |
| **Summon: Bahamut** | `{9}` Saga Dragon | I/II: destroy up-to-one nonland permanent; III: draw two; IV: Mega Flare (total mana value of *other* permanents you control to each opponent); flying. |

## Testing
- 11 scenario tests across the five cards — all pass (`:rules-engine:test`).
- `CardDefinitionSnapshotTest` re-blessed; FIN golden diff is **additive only** (just these five cards, no unrelated drift).
- `CardLintTest` green; `:mtg-sets:compileKotlin` + `:rules-engine:compileTestKotlin` clean.

## Notes
Two cards initially scoped for this batch (Zidane, Tantalus Thief and Unexpected Request) were dropped: each needs a genuinely new SDK capability (a "an opponent gains control of a permanent from you" control-change trigger, and an optional equipment-attach + delayed-unattach rider, respectively). Rather than ship a card with a silently-dropped ability, they were left for a follow-up `add-feature` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)