### PR TITLE
Polish admin dashboard + shared deck view across the app

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminUsersController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminUsersController.kt
@@ -3,13 +3,20 @@ package com.wingedsheep.gameserver.controller
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wingedsheep.gameserver.auth.AdminAuthService
 import com.wingedsheep.gameserver.auth.UserAdminService
+import com.wingedsheep.gameserver.persistence.DeckRepository
 import com.wingedsheep.gameserver.persistence.MatchResultRepository
 import com.wingedsheep.gameserver.stats.CardStat
+import com.wingedsheep.gameserver.stats.GameDeckCard
 import com.wingedsheep.gameserver.stats.GameHistoryEntry
 import com.wingedsheep.gameserver.stats.HeadToHead
 import com.wingedsheep.gameserver.stats.StatBucket
 import com.wingedsheep.gameserver.stats.StatsQueryService
 import com.wingedsheep.gameserver.stats.UserTournamentEntry
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
@@ -19,6 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -36,8 +44,20 @@ class AdminUsersController(
     private val statsQuery: StatsQueryService,
     private val userAdmin: UserAdminService,
     private val matchResults: MatchResultRepository,
+    private val decks: DeckRepository,
 ) {
+    private val json = Json { ignoreUnknownKeys = true }
+
     data class StatsDto(val games: Long, val wins: Long, val losses: Long, val winRate: Double)
+
+    /** One of the account's saved decks, enriched so the admin deck viewer renders it the polished way. */
+    data class AdminDeckDto(
+        val id: Long,
+        val name: String,
+        val format: String?,
+        val updatedAt: String,
+        val cards: List<GameDeckCard>,
+    )
 
     /** One account's full profile + stats, for the player detail view. */
     data class UserDetailDto(
@@ -116,4 +136,78 @@ class AdminUsersController(
             ?: return@guard ResponseEntity.status(404).body(mapOf("error" to "User not found"))
         ResponseEntity.ok(mapOf("id" to updated.id, "isAdmin" to updated.isAdmin))
     }
+
+    /**
+     * A page of the account's games, newest first, with the total in `X-Total-Count` so the admin UI
+     * can page through every game (the detail view only embeds the most recent handful). Reuses the
+     * same per-user history query as the player's own profile.
+     */
+    @GetMapping("/{id}/games")
+    fun games(
+        @PathVariable id: UUID,
+        @RequestParam(defaultValue = "25") limit: Int,
+        @RequestParam(defaultValue = "0") offset: Int,
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        val entries = statsQuery.recentGames(id, limit.coerceIn(1, 100), offset.coerceAtLeast(0))
+        ResponseEntity.ok()
+            .header("X-Total-Count", statsQuery.recentGamesCount(id).toString())
+            .body(entries)
+    }
+
+    /**
+     * Both seats' decks for one of the account's games. Scoped to [id] (who must be a participant),
+     * mirroring the player-facing deck viewer — so colours and the `isSelf` seat are from this
+     * account's perspective. 404 when the game isn't one this account played.
+     */
+    @GetMapping("/{id}/games/{gameId}/decks")
+    fun gameDecks(
+        @PathVariable id: UUID,
+        @PathVariable gameId: String,
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        val decks = statsQuery.decksForGame(id, gameId)
+            ?: return@guard ResponseEntity.status(404).body(mapOf("error" to "Game not found for this user"))
+        ResponseEntity.ok(decks)
+    }
+
+    /**
+     * The account's saved decks, newest first, each enriched with per-card cost/type/colour so the
+     * admin deck viewer renders them the polished way. The stored body is the client's `SharedDeck`
+     * JSON; we pull its `cards` map (plus the commander) and enrich through the registry.
+     */
+    @GetMapping("/{id}/decks")
+    fun savedDecks(
+        @PathVariable id: UUID,
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        val rows = decks.findByUserIdOrderByUpdatedAtDesc(id)
+        val dtos = rows.map { row ->
+            AdminDeckDto(
+                id = row.id!!,
+                name = row.name,
+                format = row.format,
+                updatedAt = row.updatedAt.toString(),
+                cards = statsQuery.enrichDeck(deckCardCounts(row.data)),
+            )
+        }
+        ResponseEntity.ok(dtos)
+    }
+
+    /** Extract the `name -> copies` card map from a stored SharedDeck JSON body (commander included). */
+    private fun deckCardCounts(body: String): Map<String, Int> = runCatching {
+        val root = json.parseToJsonElement(body).jsonObject
+        val cards = LinkedHashMap<String, Int>()
+        root["cards"]?.jsonObject?.forEach { (name, count) ->
+            count.jsonPrimitive.intOrNull?.let { if (it > 0) cards[name] = it }
+        }
+        // The commander lives in the command zone (CR 903.6a) and isn't in `cards` — include it so the
+        // deck the admin sees matches what the player built.
+        root["commander"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+            ?.let { cards.putIfAbsent(it, 1) }
+        cards
+    }.getOrDefault(emptyMap())
 }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -37,6 +37,23 @@ data class GameHistoryEntry(
 /** One card line in a stored deck (for the recent-games deck viewer). */
 data class DeckCardEntry(val cardName: String, val copies: Int)
 
+/**
+ * One card line enriched with the registry metadata the client needs to render a deck the polished
+ * way (group by type, draw a mana curve, colour the pips) — so the deck viewer doesn't have to load
+ * the full card catalog just to know a card's cost/type/colour. Field names match the client's
+ * `DeckStatsCard` shape so `computeDeckStats` consumes them directly.
+ */
+data class GameDeckCard(
+    val cardName: String,
+    val copies: Int,
+    /** Converted mana cost; 0 when the card can't be resolved. */
+    val cmc: Int,
+    /** Card type enum names (e.g. ["CREATURE"], ["LAND"]) — empty when unresolved. */
+    val cardTypes: List<String>,
+    /** The card's own colours as enum names (e.g. ["WHITE","BLUE"]); empty = colourless/unresolved. */
+    val colors: List<String>,
+)
+
 /** One seat's recorded deck within a finished game, for the recent-games deck viewer. */
 data class GameDeckParticipant(
     val playerName: String,
@@ -46,8 +63,8 @@ data class GameDeckParticipant(
     val won: Boolean,
     /** Color identity recomputed from the stored deck, canonical WUBRG order; "" = colorless. */
     val colors: String,
-    /** The deck's cards, most copies first then alphabetical. */
-    val cards: List<DeckCardEntry>,
+    /** The deck's cards, most copies first then alphabetical, each enriched with display metadata. */
+    val cards: List<GameDeckCard>,
 )
 
 /** Both seats' decks for one finished game the requesting user played. */
@@ -313,7 +330,7 @@ class StatsQueryService(
                     isSelf = seat.isSelf,
                     won = seat.won,
                     colors = deckProfiler.profile(cards.map { it.cardName }).colors,
-                    cards = cards.sortedWith(compareByDescending<DeckCardEntry> { it.copies }.thenBy { it.cardName }),
+                    cards = enrichDeckCards(cards),
                 )
             },
         )
@@ -420,6 +437,29 @@ class StatsQueryService(
     /** Registry lookup tolerant of a "name#collector" pin (mirrors [DeckProfiler]). */
     private fun lookupCard(name: String) =
         cardRegistry.getCard(name) ?: cardRegistry.getCard(name.substringBefore('#'))
+
+    /**
+     * Enrich bare `(name, copies)` deck lines with the cost/type/colour the client needs to render a
+     * deck the polished way (group by type, mana curve, colour pips). Sorted most-copies-first then
+     * alphabetically — a stable order the client regroups for display. Unresolved cards keep sensible
+     * zero/empty defaults so a deck with an unknown card still renders.
+     */
+    fun enrichDeckCards(cards: List<DeckCardEntry>): List<GameDeckCard> =
+        cards.sortedWith(compareByDescending<DeckCardEntry> { it.copies }.thenBy { it.cardName })
+            .map { e ->
+                val card = lookupCard(e.cardName)
+                GameDeckCard(
+                    cardName = e.cardName,
+                    copies = e.copies,
+                    cmc = card?.cmc ?: 0,
+                    cardTypes = card?.typeLine?.cardTypes?.map { it.name } ?: emptyList(),
+                    colors = card?.colors?.map { it.name } ?: emptyList(),
+                )
+            }
+
+    /** Enrich a name→copies map (a stored [SharedDeck]'s card list) for the saved-deck viewer. */
+    fun enrichDeck(cardCounts: Map<String, Int>): List<GameDeckCard> =
+        enrichDeckCards(cardCounts.map { (name, copies) -> DeckCardEntry(name, copies) })
 
     /** The single dominant card type used to bucket a card in [cardTypeBreakdown]. */
     private fun primaryTypeLabel(types: Set<CardType>): String {
@@ -574,22 +614,26 @@ class StatsQueryService(
         """.trimIndent(),
     ) { rs, _ -> IpCount(rs.getString("ip"), rs.getLong("n")) }
 
-    /** Most-played cards across every recorded deck. */
+    /**
+     * Most-played cards across every recorded deck. Basic lands are excluded — every deck runs a pile
+     * of them, so they'd otherwise crowd out the cards that actually characterize the metagame (same
+     * reasoning as [topCardsForUser]). Filtering is done after the group-by, so [limit] applies to the
+     * non-basic results.
+     */
     fun topCards(limit: Int): List<CardStat> = jdbc.query(
         """
         SELECT card_name, sum(copies) AS copies, count(*) AS decks
         FROM match_participant_cards
         GROUP BY card_name
         ORDER BY copies DESC, decks DESC
-        LIMIT ?
         """.trimIndent(),
         { rs, _ -> CardStat(rs.getString("card_name"), rs.getLong("copies"), rs.getLong("decks")) },
-        limit,
-    )
+    ).filterNot { lookupCard(it.cardName)?.typeLine?.isBasicLand == true }.take(limit)
 
     /**
      * Win rate per card: of the decks containing the card, how many won. Restricted to cards seen in
-     * at least [minDecks] decks so a single lucky game can't top the chart.
+     * at least [minDecks] decks so a single lucky game can't top the chart. Basic lands are excluded
+     * (see [topCards]) — they appear in nearly every deck and say nothing about a card's win impact.
      */
     fun cardWinRates(minDecks: Int, limit: Int): List<CardWinRate> = jdbc.query(
         """
@@ -601,15 +645,14 @@ class StatsQueryService(
         GROUP BY c.card_name
         HAVING count(*) >= ?
         ORDER BY (count(*) FILTER (WHERE p.won))::float / count(*) DESC, decks DESC
-        LIMIT ?
         """.trimIndent(),
         { rs, _ ->
             val decks = rs.getLong("decks")
             val wins = rs.getLong("wins")
             CardWinRate(rs.getString("card_name"), decks, wins, if (decks > 0) wins.toDouble() / decks else 0.0)
         },
-        minDecks, limit,
-    )
+        minDecks,
+    ).filterNot { lookupCard(it.cardName)?.typeLine?.isBasicLand == true }.take(limit)
 
     /** Recorded tournaments, newest first. */
     fun recentTournaments(limit: Int): List<TournamentSummary> = jdbc.query(

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "argentum-web-client",
       "version": "0.1.0",
       "dependencies": {
+        "d3-geo": "^3.1.1",
         "keyrune": "^3.19.0",
         "mana-font": "^1.18.0",
         "qrcode.react": "^4.2.0",
@@ -15,12 +16,17 @@
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.18.0",
         "recharts": "^2.15.0",
+        "topojson-client": "^3.1.0",
+        "world-atlas": "^2.0.2",
+        "world-countries": "^5.1.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
+        "@types/d3-geo": "^3.1.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/topojson-client": "^3.1.5",
         "@vitejs/plugin-react": "^6.0.3",
         "typescript": "^6.0.3",
         "vite": "^8.1.0",
@@ -901,6 +907,16 @@
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -960,6 +976,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -978,6 +1001,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1148,6 +1192,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1208,6 +1258,18 @@
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2166,6 +2228,20 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2409,6 +2485,17 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/world-atlas": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz",
+      "integrity": "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==",
+      "license": "ISC"
+    },
+    "node_modules/world-countries": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/world-countries/-/world-countries-5.1.0.tgz",
+      "integrity": "sha512-CXR6EBvTbArDlDDIWU3gfKb7Qk0ck2WNZ234b/A0vuecPzIfzzxH+O6Ejnvg1sT8XuiZjVlzOH0h08ZtaO7g0w=="
     },
     "node_modules/zustand": {
       "version": "5.0.14",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -15,6 +15,7 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "d3-geo": "^3.1.1",
     "keyrune": "^3.19.0",
     "mana-font": "^1.18.0",
     "qrcode.react": "^4.2.0",
@@ -22,12 +23,17 @@
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.0",
     "recharts": "^2.15.0",
+    "topojson-client": "^3.1.0",
+    "world-atlas": "^2.0.2",
+    "world-countries": "^5.1.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
+    "@types/d3-geo": "^3.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/topojson-client": "^3.1.5",
     "@vitejs/plugin-react": "^6.0.3",
     "typescript": "^6.0.3",
     "vite": "^8.1.0",

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -249,6 +249,22 @@ export interface DeckCardEntry {
   readonly copies: number
 }
 
+/**
+ * One card line enriched with the registry metadata the deck viewer needs to render a deck the
+ * polished way (group by type, mana curve, colour pips). Structurally satisfies `DeckStatsCard`
+ * (see `DeckSummary`) so `computeDeckStats` consumes it directly.
+ */
+export interface GameDeckCard {
+  readonly cardName: string
+  readonly copies: number
+  /** Converted mana cost. */
+  readonly cmc: number
+  /** Card type enum names, e.g. `["CREATURE"]`, `["LAND"]`. */
+  readonly cardTypes: string[]
+  /** The card's own colours as enum names, e.g. `["WHITE","BLUE"]`; empty = colourless. */
+  readonly colors: string[]
+}
+
 /** One seat's recorded deck within a finished game. */
 export interface GameDeckParticipant {
   readonly playerName: string
@@ -256,7 +272,7 @@ export interface GameDeckParticipant {
   readonly isSelf: boolean
   readonly won: boolean
   readonly colors: string
-  readonly cards: DeckCardEntry[]
+  readonly cards: GameDeckCard[]
 }
 
 /** Both seats' decks for a finished game, for the recent-games deck viewer. */

--- a/web-client/src/api/adminUsers.ts
+++ b/web-client/src/api/adminUsers.ts
@@ -3,7 +3,15 @@
  * one account's full stats, and promoting/demoting admins. Auth is the shared {@link AdminAuth}. Only
  * mounted when the server has accounts enabled.
  */
-import type { CardStat, GameHistoryEntry, HeadToHead, StatBucket, UserTournamentEntry } from './account'
+import type {
+  CardStat,
+  GameDeckCard,
+  GameDecks,
+  GameHistoryEntry,
+  HeadToHead,
+  StatBucket,
+  UserTournamentEntry,
+} from './account'
 import { type AdminAuth, adminAuthHeaders } from './adminAuth'
 
 /** A registered account with its lifetime record, for the roster. */
@@ -62,4 +70,49 @@ export async function setUserAdmin(auth: AdminAuth, id: string, isAdmin: boolean
   })
   if (!res.ok) throw new Error(`Failed to update admin status (${res.status})`)
   return ((await res.json()) as { isAdmin: boolean }).isAdmin
+}
+
+/** One of an account's saved decks, enriched for the admin deck viewer. */
+export interface AdminUserDeck {
+  readonly id: number
+  readonly name: string
+  readonly format?: string
+  readonly updatedAt: string
+  readonly cards: GameDeckCard[]
+}
+
+/** A page of a player's games plus the total count (for the pager). */
+export interface AdminGamesPage {
+  readonly entries: GameHistoryEntry[]
+  readonly total: number
+}
+
+/** A page of the account's games, newest first; `total` comes from the `X-Total-Count` header. */
+export async function fetchUserGames(
+  auth: AdminAuth,
+  id: string,
+  limit: number,
+  offset: number,
+): Promise<AdminGamesPage> {
+  const res = await fetch(`/api/admin/users/${id}/games?limit=${limit}&offset=${offset}`, {
+    headers: adminAuthHeaders(auth),
+  })
+  if (!res.ok) throw new Error(`Failed to load games (${res.status})`)
+  const total = Number(res.headers.get('X-Total-Count') ?? '0')
+  const entries = (await res.json()) as GameHistoryEntry[]
+  return { entries, total: Number.isFinite(total) ? total : entries.length }
+}
+
+/** Both seats' decks for one of the account's games (from this account's perspective). */
+export async function fetchUserGameDecks(auth: AdminAuth, id: string, gameId: string): Promise<GameDecks> {
+  const res = await fetch(`/api/admin/users/${id}/games/${gameId}/decks`, { headers: adminAuthHeaders(auth) })
+  if (!res.ok) throw new Error(`Failed to load decks (${res.status})`)
+  return (await res.json()) as GameDecks
+}
+
+/** The account's saved decks, newest first, enriched for the deck viewer. */
+export async function fetchUserSavedDecks(auth: AdminAuth, id: string): Promise<AdminUserDeck[]> {
+  const res = await fetch(`/api/admin/users/${id}/decks`, { headers: adminAuthHeaders(auth) })
+  if (!res.ok) throw new Error(`Failed to load saved decks (${res.status})`)
+  return (await res.json()) as AdminUserDeck[]
 }

--- a/web-client/src/components/admin/AdminDashboard.tsx
+++ b/web-client/src/components/admin/AdminDashboard.tsx
@@ -38,7 +38,11 @@ import {
 import type { AdminAuth } from '@/api/adminAuth'
 import type { StatBucket } from '@/api/account'
 import { colorLabel } from './statFormat'
+import { GeoMap } from './GeoMap'
 import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle, chartTooltipStyle } from './adminUi'
+
+/** How many card rows to show before the "Show all" toggle — keeps the tables from running forever. */
+const CARD_PREVIEW = 12
 
 export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () => void }) {
   const [overview, setOverview] = useState<GlobalOverview | null>(null)
@@ -49,6 +53,8 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
   const [winRates, setWinRates] = useState<CardWinRate[]>([])
   const [tournaments, setTournaments] = useState<TournamentSummary[]>([])
   const [geo, setGeo] = useState<GeoBucket[]>([])
+  const [showAllCards, setShowAllCards] = useState(false)
+  const [showAllWinRates, setShowAllWinRates] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -60,8 +66,8 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
           fetchGamesPerDay(auth, 30),
           fetchModeDistribution(auth),
           fetchColorDistribution(auth),
-          fetchTopCards(auth, 25),
-          fetchCardWinRates(auth, 5, 25),
+          fetchTopCards(auth, 100),
+          fetchCardWinRates(auth, 5, 100),
           fetchTournaments(auth, 25),
         ])
         if (cancelled) return
@@ -119,9 +125,12 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
       </div>
 
       <div style={styles.twoCol}>
-        <Panel title="Most-played cards">
+        <Panel
+          title="Most-played cards"
+          action={<ShowMoreToggle total={cards.length} expanded={showAllCards} onToggle={() => setShowAllCards((v) => !v)} />}
+        >
           <Table head={['Card', 'Copies', 'Decks']}>
-            {cards.map((c) => (
+            {(showAllCards ? cards : cards.slice(0, CARD_PREVIEW)).map((c) => (
               <tr key={c.cardName}>
                 <td style={cellStyle.td}>{c.cardName}</td>
                 <td style={cellStyle.tdNum}>{c.copies}</td>
@@ -130,9 +139,12 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
             ))}
           </Table>
         </Panel>
-        <Panel title="Highest win-rate cards (≥5 decks)">
+        <Panel
+          title="Highest win-rate cards (≥5 decks)"
+          action={<ShowMoreToggle total={winRates.length} expanded={showAllWinRates} onToggle={() => setShowAllWinRates((v) => !v)} />}
+        >
           <Table head={['Card', 'Win %', 'Decks']}>
-            {winRates.map((c) => (
+            {(showAllWinRates ? winRates : winRates.slice(0, CARD_PREVIEW)).map((c) => (
               <tr key={c.cardName}>
                 <td style={cellStyle.td}>{c.cardName}</td>
                 <td style={cellStyle.tdNum}>{Math.round(c.winRate * 100)}%</td>
@@ -165,19 +177,20 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
         {geo.length === 0 ? (
           <p style={cellStyle.muted}>Resolving locations…</p>
         ) : (
-          <Table head={['Country', 'Region', 'City', 'Games']}>
-            {geo.map((g, i) => (
-              <tr key={`${g.countryCode}-${g.city}-${i}`}>
-                <td style={cellStyle.td}>{g.country ?? 'Unknown'}</td>
-                <td style={cellStyle.td}>{g.region ?? '—'}</td>
-                <td style={cellStyle.td}>{g.city ?? '—'}</td>
-                <td style={cellStyle.tdNum}>{g.games}</td>
-              </tr>
-            ))}
-          </Table>
+          <GeoMap buckets={geo} />
         )}
       </Panel>
     </AdminScreen>
+  )
+}
+
+/** "Show all (N) / Show top N" link rendered in a card panel's header when there's more to see. */
+function ShowMoreToggle({ total, expanded, onToggle }: { total: number; expanded: boolean; onToggle: () => void }) {
+  if (total <= CARD_PREVIEW) return null
+  return (
+    <button type="button" style={styles.toggle} onClick={onToggle}>
+      {expanded ? `Show top ${CARD_PREVIEW}` : `Show all ${total}`}
+    </button>
   )
 }
 
@@ -199,4 +212,5 @@ const styles: Record<string, React.CSSProperties> = {
   error: { color: adminTheme.bad, fontSize: 13, margin: 0 },
   cardRow: { display: 'flex', gap: 12, flexWrap: 'wrap' },
   twoCol: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 18 },
+  toggle: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 12, padding: 0 },
 }

--- a/web-client/src/components/admin/AdminPlayerDecks.tsx
+++ b/web-client/src/components/admin/AdminPlayerDecks.tsx
@@ -1,0 +1,201 @@
+/**
+ * Admin-side deck viewers for the player detail screen: a modal that shows both seats' decks for one
+ * of the player's games, and a panel that lists the account's saved decks (each openable). Both reuse
+ * the shared, polished {@link GameDeckColumns}/{@link DeckCardBody} renderer — the same one the
+ * player's own profile uses — so there's a single deck look across the app. Data comes from the
+ * admin endpoints (`/api/admin/users/{id}/games/{gameId}/decks` and `.../decks`).
+ */
+import { useEffect, useState } from 'react'
+import type React from 'react'
+import {
+  type AdminUserDeck,
+  fetchUserGameDecks,
+  fetchUserSavedDecks,
+} from '@/api/adminUsers'
+import type { AdminAuth } from '@/api/adminAuth'
+import type { GameDecks } from '@/api/account'
+import { DeckCardBody, GameDeckColumns } from '@/components/deck/GameDeckView'
+import { Panel, adminTheme, cellStyle } from './adminUi'
+import { colorLabel } from './statFormat'
+
+/** A dark modal shell shared by both admin deck viewers. */
+function ModalShell({ title, subtitle, onClose, children }: {
+  title: string
+  subtitle?: string | undefined
+  onClose: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <div style={styles.backdrop} onClick={onClose} role="presentation">
+      <div style={styles.modal} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
+        <div style={styles.header}>
+          <div>
+            <h2 style={styles.title}>{title}</h2>
+            {subtitle && <p style={styles.subtitle}>{subtitle}</p>}
+          </div>
+          <button type="button" style={styles.close} onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        </div>
+        <div style={styles.bodyWrap}>{children}</div>
+      </div>
+    </div>
+  )
+}
+
+/** Both seats' decks for one of a player's games. */
+export function AdminDeckModal({ auth, userId, gameId, opponentLabel, onClose }: {
+  auth: AdminAuth
+  userId: string
+  gameId: string
+  opponentLabel: string
+  onClose: () => void
+}) {
+  const [decks, setDecks] = useState<GameDecks | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let live = true
+    setDecks(null)
+    setError(null)
+    fetchUserGameDecks(auth, userId, gameId)
+      .then((d) => live && setDecks(d))
+      .catch(() => live && setError('Could not load this game’s decks.'))
+    return () => {
+      live = false
+    }
+  }, [auth, userId, gameId])
+
+  return (
+    <ModalShell title="Game decks" subtitle={`vs ${opponentLabel}`} onClose={onClose}>
+      {error ? (
+        <p style={styles.error}>{error}</p>
+      ) : !decks ? (
+        <p style={cellStyle.muted}>Loading…</p>
+      ) : decks.participants.length === 0 ? (
+        <p style={cellStyle.muted}>No decklist was recorded for this game.</p>
+      ) : (
+        <GameDeckColumns participants={decks.participants} />
+      )}
+    </ModalShell>
+  )
+}
+
+/** A panel listing the account's saved decks, each openable into the polished deck viewer. */
+export function AdminSavedDecks({ auth, userId }: { auth: AdminAuth; userId: string }) {
+  const [decks, setDecks] = useState<AdminUserDeck[] | null>(null)
+  const [open, setOpen] = useState<AdminUserDeck | null>(null)
+
+  useEffect(() => {
+    let live = true
+    fetchUserSavedDecks(auth, userId)
+      .then((d) => live && setDecks(d))
+      .catch(() => live && setDecks([]))
+    return () => {
+      live = false
+    }
+  }, [auth, userId])
+
+  if (decks === null) {
+    return (
+      <Panel title="Saved decks">
+        <p style={cellStyle.muted}>Loading…</p>
+      </Panel>
+    )
+  }
+  if (decks.length === 0) {
+    return (
+      <Panel title="Saved decks">
+        <p style={cellStyle.muted}>This account hasn’t saved any decks.</p>
+      </Panel>
+    )
+  }
+
+  return (
+    <Panel title={`Saved decks · ${decks.length}`}>
+      <div style={styles.deckGrid}>
+        {decks.map((d) => {
+          const total = d.cards.reduce((sum, c) => sum + c.copies, 0)
+          const colors = colorsOf(d)
+          return (
+            <button key={d.id} type="button" style={styles.deckCard} onClick={() => setOpen(d)}>
+              <span style={styles.deckName}>{d.name}</span>
+              <span style={styles.deckMeta}>
+                {d.format ? `${prettyFormat(d.format)} · ` : ''}
+                {total} cards
+              </span>
+              <span style={styles.deckColors}>{colors ? colorLabel(colors) : 'Colourless'}</span>
+            </button>
+          )
+        })}
+      </div>
+      {open && (
+        <ModalShell
+          title={open.name}
+          subtitle={open.format ? prettyFormat(open.format) : undefined}
+          onClose={() => setOpen(null)}
+        >
+          <DeckCardBody cards={open.cards} />
+        </ModalShell>
+      )}
+    </Panel>
+  )
+}
+
+/** Canonical WUBRG colour string for a saved deck, from its cards' colours. */
+function colorsOf(d: AdminUserDeck): string {
+  const order = ['W', 'U', 'B', 'R', 'G']
+  const sym: Record<string, string> = { WHITE: 'W', BLUE: 'U', BLACK: 'B', RED: 'R', GREEN: 'G' }
+  const present = new Set<string>()
+  for (const c of d.cards) for (const col of c.colors) if (sym[col]) present.add(sym[col]!)
+  return order.filter((s) => present.has(s)).join('')
+}
+
+function prettyFormat(f: string): string {
+  return f.charAt(0).toUpperCase() + f.slice(1).toLowerCase()
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backdrop: {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    zIndex: 1000,
+  },
+  modal: {
+    width: 'min(820px, 100%)',
+    maxHeight: '85vh',
+    overflowY: 'auto',
+    backgroundColor: '#12121e',
+    border: '1px solid #2a2a3e',
+    borderRadius: 14,
+    padding: '20px 22px',
+  },
+  header: { display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 },
+  title: { margin: 0, color: '#fff', fontSize: 20 },
+  subtitle: { margin: '4px 0 0', color: '#888', fontSize: 13 },
+  close: { background: 'none', border: 'none', color: '#999', cursor: 'pointer', fontSize: 18 },
+  bodyWrap: { marginTop: 14 },
+  error: { margin: '8px 0 0', color: '#ff6b6b', fontSize: 13 },
+  deckGrid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(190px, 1fr))', gap: 10 },
+  deckCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    alignItems: 'flex-start',
+    textAlign: 'left',
+    backgroundColor: adminTheme.panelAlt,
+    border: `1px solid ${adminTheme.border}`,
+    borderRadius: 10,
+    padding: '12px 14px',
+    cursor: 'pointer',
+    color: adminTheme.text,
+  },
+  deckName: { fontSize: 14, fontWeight: 600, color: adminTheme.text },
+  deckMeta: { fontSize: 12, color: adminTheme.textMuted },
+  deckColors: { fontSize: 12, color: adminTheme.textSecondary },
+}

--- a/web-client/src/components/admin/AdminPlayers.tsx
+++ b/web-client/src/components/admin/AdminPlayers.tsx
@@ -8,15 +8,20 @@
 import { useEffect, useState } from 'react'
 import type React from 'react'
 import {
+  type AdminGamesPage,
   type AdminUserDetail,
   type AdminUserSummary,
   fetchUserDetail,
+  fetchUserGames,
   fetchUsers,
   setUserAdmin,
 } from '@/api/adminUsers'
 import type { AdminAuth } from '@/api/adminAuth'
-import { colorLabel } from './statFormat'
+import { colorForIdentity, colorLabel } from './statFormat'
 import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle } from './adminUi'
+import { AdminDeckModal, AdminSavedDecks } from './AdminPlayerDecks'
+
+const GAMES_PAGE_SIZE = 10
 
 export function AdminPlayers({ auth, onBack }: { auth: AdminAuth; onBack: () => void }) {
   const [users, setUsers] = useState<AdminUserSummary[]>([])
@@ -108,6 +113,9 @@ function PlayerDetail({
   const [detail, setDetail] = useState<AdminUserDetail | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [updating, setUpdating] = useState(false)
+  const [games, setGames] = useState<AdminGamesPage>({ entries: [], total: 0 })
+  const [gamesPage, setGamesPage] = useState(0)
+  const [deckModal, setDeckModal] = useState<{ gameId: string; opponent: string } | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -118,6 +126,19 @@ function PlayerDetail({
       cancelled = true
     }
   }, [auth, id])
+
+  useEffect(() => {
+    let cancelled = false
+    fetchUserGames(auth, id, GAMES_PAGE_SIZE, gamesPage * GAMES_PAGE_SIZE)
+      .then((p) => !cancelled && setGames(p))
+      .catch(() => !cancelled && setGames({ entries: [], total: 0 }))
+    return () => {
+      cancelled = true
+    }
+  }, [auth, id, gamesPage])
+
+  /** Open a finished game's replay in a new tab so the admin keeps their place on this screen. */
+  const watchReplay = (gameId: string) => window.open(`/replay/${gameId}`, '_blank', 'noopener')
 
   const toggleAdmin = async () => {
     if (!detail) return
@@ -230,24 +251,89 @@ function PlayerDetail({
             </Panel>
           )}
 
-          {detail.recentGames.length > 0 && (
-            <Panel title="Recent games">
-              <Table head={['Date', 'Mode', 'Colors', 'Opponent', 'Result']}>
-                {detail.recentGames.map((g, i) => (
-                  <tr key={`${g.endedAt}-${i}`}>
+          {games.total > 0 && (
+            <Panel title={`Games · ${games.total}`}>
+              <Table head={['Date', 'Mode', 'Colors', 'Opponent', 'Result', 'Deck', 'Replay']}>
+                {games.entries.map((g, i) => (
+                  <tr key={`${g.gameId}-${i}`}>
                     <td style={cellStyle.td}>{g.endedAt.slice(0, 10)}</td>
                     <td style={cellStyle.td}>{prettyMode(g.gameMode)}</td>
-                    <td style={cellStyle.td}>{g.colors ? colorLabel(g.colors) : '—'}</td>
+                    <td style={cellStyle.td}>
+                      {g.colors ? (
+                        <span style={styles.colorsCell}>
+                          <span style={{ ...styles.colorDot, backgroundColor: colorForIdentity(g.colors) }} />
+                          {colorLabel(g.colors)}
+                        </span>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
                     <td style={cellStyle.td}>{g.opponents ?? '—'}</td>
                     <td style={{ ...cellStyle.tdNum, color: g.won ? adminTheme.good : adminTheme.bad }}>
                       {g.won ? 'Win' : 'Loss'}
                     </td>
+                    <td style={cellStyle.tdNum}>
+                      <button
+                        type="button"
+                        style={styles.rowLink}
+                        onClick={() => setDeckModal({ gameId: g.gameId, opponent: g.opponents ?? 'opponent' })}
+                      >
+                        View
+                      </button>
+                    </td>
+                    <td style={cellStyle.tdNum}>
+                      {g.hasReplay ? (
+                        <button type="button" style={styles.rowLink} onClick={() => watchReplay(g.gameId)}>
+                          Watch
+                        </button>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
                   </tr>
                 ))}
               </Table>
+              {games.total > GAMES_PAGE_SIZE && (
+                <div style={styles.pager}>
+                  <button
+                    type="button"
+                    style={{ ...styles.pagerBtn, ...(gamesPage === 0 ? styles.pagerBtnDisabled : {}) }}
+                    disabled={gamesPage === 0}
+                    onClick={() => setGamesPage((p) => Math.max(0, p - 1))}
+                  >
+                    ← Newer
+                  </button>
+                  <span style={cellStyle.muted}>
+                    Page {gamesPage + 1} of {Math.max(1, Math.ceil(games.total / GAMES_PAGE_SIZE))}
+                  </span>
+                  <button
+                    type="button"
+                    style={{
+                      ...styles.pagerBtn,
+                      ...((gamesPage + 1) * GAMES_PAGE_SIZE >= games.total ? styles.pagerBtnDisabled : {}),
+                    }}
+                    disabled={(gamesPage + 1) * GAMES_PAGE_SIZE >= games.total}
+                    onClick={() => setGamesPage((p) => p + 1)}
+                  >
+                    Older →
+                  </button>
+                </div>
+              )}
             </Panel>
           )}
+
+          <AdminSavedDecks auth={auth} userId={id} />
         </>
+      )}
+
+      {deckModal && (
+        <AdminDeckModal
+          auth={auth}
+          userId={id}
+          gameId={deckModal.gameId}
+          opponentLabel={deckModal.opponent}
+          onClose={() => setDeckModal(null)}
+        />
       )}
     </AdminScreen>
   )
@@ -333,4 +419,18 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 13,
     cursor: 'pointer',
   },
+  colorsCell: { display: 'inline-flex', alignItems: 'center', gap: 6 },
+  colorDot: { width: 9, height: 9, borderRadius: 999, display: 'inline-block' },
+  rowLink: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 13, padding: 0 },
+  pager: { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 14, marginTop: 12 },
+  pagerBtn: {
+    background: 'none',
+    border: `1px solid ${adminTheme.border}`,
+    borderRadius: 8,
+    color: adminTheme.textSecondary,
+    cursor: 'pointer',
+    fontSize: 13,
+    padding: '6px 12px',
+  },
+  pagerBtnDisabled: { color: adminTheme.textMuted, cursor: 'default', borderColor: adminTheme.borderSoft },
 }

--- a/web-client/src/components/admin/GeoMap.tsx
+++ b/web-client/src/components/admin/GeoMap.tsx
@@ -1,0 +1,141 @@
+/**
+ * World map of where players connect from, for the admin dashboard. The server resolves raw IPs to
+ * coarse locations server-side and sends only aggregated {@link GeoBucket}s (country/region/city +
+ * game count) — this draws them on an actual map instead of a long table: a muted Natural-Earth
+ * basemap (world-atlas TopoJSON) with a proportional bubble per country, sized by games and placed at
+ * the country's centroid (world-countries lat/long, keyed by ISO alpha-2). A compact ranked list sits
+ * beside it for the precise numbers the bubbles only approximate; locations with no resolvable country
+ * (e.g. "Local network") fall to that list rather than vanishing.
+ */
+import { useMemo, useState } from 'react'
+import type React from 'react'
+import { geoNaturalEarth1, geoPath } from 'd3-geo'
+import { feature } from 'topojson-client'
+import countriesData from 'world-countries'
+import worldTopology from 'world-atlas/countries-110m.json'
+import type { GeoBucket } from '@/api/adminStats'
+import { adminTheme } from './adminUi'
+
+const WIDTH = 760
+const HEIGHT = 380
+
+/** ISO alpha-2 → [longitude, latitude] centroid, from the world-countries dataset. */
+const CENTROIDS: Record<string, [number, number]> = Object.fromEntries(
+  (countriesData as unknown as Array<{ cca2: string; latlng: [number, number] }>).map((c) => [
+    c.cca2,
+    // world-countries stores [lat, lng]; d3 projections want [lng, lat].
+    [c.latlng[1], c.latlng[0]] as [number, number],
+  ]),
+)
+
+interface CountryAgg {
+  code: string | null
+  country: string
+  games: number
+}
+
+/** Sum games per resolved country; rows without a country code are folded into one "unknown" entry. */
+function aggregateByCountry(buckets: GeoBucket[]): CountryAgg[] {
+  const byCode = new Map<string, CountryAgg>()
+  for (const b of buckets) {
+    const key = b.countryCode ?? '∅'
+    const existing = byCode.get(key)
+    if (existing) existing.games += b.games
+    else byCode.set(key, { code: b.countryCode, country: b.country ?? 'Unknown / local', games: b.games })
+  }
+  return [...byCode.values()].sort((a, b) => b.games - a.games)
+}
+
+export function GeoMap({ buckets }: { buckets: GeoBucket[] }) {
+  const [hover, setHover] = useState<{ label: string; x: number; y: number } | null>(null)
+
+  const { paths, markers, ranked, maxGames } = useMemo(() => {
+    const fc = feature(
+      worldTopology as never,
+      (worldTopology as { objects: { countries: unknown } }).objects.countries as never,
+    ) as unknown as { features: unknown[] }
+    const projection = geoNaturalEarth1().fitSize([WIDTH, HEIGHT], fc as never)
+    const pathGen = geoPath(projection)
+    const countryPaths = fc.features.map((f) => pathGen(f as never) ?? '')
+
+    const ranked = aggregateByCountry(buckets)
+    const maxGames = Math.max(1, ...ranked.map((r) => r.games))
+    const markers = ranked
+      .filter((r) => r.code && CENTROIDS[r.code])
+      .map((r) => {
+        const [x, y] = projection(CENTROIDS[r.code!]!) ?? [0, 0]
+        // Area-proportional radius (sqrt), clamped to a readable range.
+        const radius = 4 + (Math.sqrt(r.games) / Math.sqrt(maxGames)) * 20
+        return { ...r, x, y, radius }
+      })
+      .sort((a, b) => b.radius - a.radius) // big bubbles first so small ones stay clickable on top
+    return { paths: countryPaths, markers, ranked, maxGames }
+  }, [buckets])
+
+  return (
+    <div style={styles.wrap}>
+      <div style={styles.mapBox}>
+        <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} style={styles.svg} role="img" aria-label="Player connection map">
+          <g>
+            {paths.map((d, i) => (
+              <path key={i} d={d} fill={adminTheme.panelAlt} stroke={adminTheme.border} strokeWidth={0.4} />
+            ))}
+          </g>
+          <g>
+            {markers.map((m) => (
+              <circle
+                key={m.code}
+                cx={m.x}
+                cy={m.y}
+                r={m.radius}
+                fill={adminTheme.accentSolid}
+                fillOpacity={0.5}
+                stroke={adminTheme.accent}
+                strokeWidth={1}
+                style={{ cursor: 'default' }}
+                onMouseEnter={() => setHover({ label: `${m.country} · ${m.games}`, x: m.x, y: m.y })}
+                onMouseLeave={() => setHover(null)}
+              >
+                <title>{`${m.country}: ${m.games} game${m.games === 1 ? '' : 's'}`}</title>
+              </circle>
+            ))}
+          </g>
+          {hover && (
+            <g transform={`translate(${hover.x}, ${hover.y - 12})`} pointerEvents="none">
+              <text textAnchor="middle" style={styles.hoverText}>
+                {hover.label}
+              </text>
+            </g>
+          )}
+        </svg>
+      </div>
+
+      <div style={styles.list}>
+        <div style={styles.listHead}>Top locations</div>
+        {ranked.slice(0, 12).map((r) => (
+          <div key={r.code ?? r.country} style={styles.listRow}>
+            <span style={styles.listName}>{r.country}</span>
+            <span style={styles.listBarTrack}>
+              <span style={{ ...styles.listBar, width: `${(r.games / maxGames) * 100}%` }} />
+            </span>
+            <span style={styles.listCount}>{r.games}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  wrap: { display: 'grid', gridTemplateColumns: 'minmax(0, 2fr) minmax(180px, 1fr)', gap: 18, alignItems: 'start' },
+  mapBox: { backgroundColor: adminTheme.bg, border: `1px solid ${adminTheme.borderSoft}`, borderRadius: 12, padding: 8 },
+  svg: { width: '100%', height: 'auto', display: 'block' },
+  hoverText: { fill: adminTheme.text, fontSize: 11, fontWeight: 700, paintOrder: 'stroke', stroke: adminTheme.bg, strokeWidth: 3 },
+  list: { display: 'flex', flexDirection: 'column', gap: 8 },
+  listHead: { color: adminTheme.textMuted, fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.6 },
+  listRow: { display: 'grid', gridTemplateColumns: '1fr 56px auto', alignItems: 'center', gap: 8, fontSize: 12 },
+  listName: { color: adminTheme.textSecondary, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' },
+  listBarTrack: { height: 6, borderRadius: 999, backgroundColor: adminTheme.panelAlt, overflow: 'hidden' },
+  listBar: { display: 'block', height: '100%', backgroundColor: adminTheme.accentSolid, borderRadius: 999 },
+  listCount: { color: adminTheme.text, fontVariantNumeric: 'tabular-nums', minWidth: 28, textAlign: 'right' },
+}

--- a/web-client/src/components/deck/GameDeckView.tsx
+++ b/web-client/src/components/deck/GameDeckView.tsx
@@ -1,0 +1,222 @@
+/**
+ * Shared, polished renderer for a recorded/saved deck — the single deck UI reused by the player's
+ * recent-games deck modal and the admin player view. It takes the registry-enriched card lines the
+ * server sends ({@link GameDeckCard}: copies + cmc + types + colours) and renders them the way the
+ * deckbuilder does: cards grouped by type with running counts, a stacked-by-colour mana curve and
+ * colour pips (both from the deckbuilder's {@link DeckSummary} helpers), and a cursor-following card
+ * image on hover ({@link HoverCardPreview}). Nothing here is admin- or profile-specific, so both
+ * surfaces — and any future deck viewer — share exactly one look.
+ */
+import { useState } from 'react'
+import type React from 'react'
+import type { GameDeckCard, GameDeckParticipant } from '@/api/account'
+import {
+  COLOR_DOT,
+  ManaCurveBars,
+  computeDeckStats,
+  type DeckStatsCard,
+} from '@/components/ui/DeckSummary'
+import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
+import { colorLabel } from '@/components/admin/statFormat'
+
+// Primary-type buckets, in the order the deckbuilder lists them. A card is filed under the first of
+// these its type set matches (so an artifact creature counts as a Creature); anything else is Other.
+const TYPE_ORDER = ['CREATURE', 'PLANESWALKER', 'INSTANT', 'SORCERY', 'ARTIFACT', 'ENCHANTMENT', 'LAND'] as const
+const TYPE_LABEL: Record<string, string> = {
+  CREATURE: 'Creatures',
+  PLANESWALKER: 'Planeswalkers',
+  INSTANT: 'Instants',
+  SORCERY: 'Sorceries',
+  ARTIFACT: 'Artifacts',
+  ENCHANTMENT: 'Enchantments',
+  LAND: 'Lands',
+  OTHER: 'Other',
+}
+
+interface TypeGroup {
+  key: string
+  label: string
+  cards: GameDeckCard[]
+  count: number
+}
+
+function primaryType(card: GameDeckCard): string {
+  for (const t of TYPE_ORDER) if (card.cardTypes.includes(t)) return t
+  return 'OTHER'
+}
+
+function groupByType(cards: GameDeckCard[]): TypeGroup[] {
+  const buckets = new Map<string, GameDeckCard[]>()
+  for (const card of cards) {
+    const key = primaryType(card)
+    const list = buckets.get(key)
+    if (list) list.push(card)
+    else buckets.set(key, [card])
+  }
+  const order = [...TYPE_ORDER, 'OTHER']
+  return order
+    .filter((k) => buckets.has(k))
+    .map((k) => {
+      const groupCards = buckets
+        .get(k)!
+        .slice()
+        .sort((a, b) => a.cmc - b.cmc || a.cardName.localeCompare(b.cardName))
+      return {
+        key: k,
+        label: TYPE_LABEL[k] ?? k,
+        cards: groupCards,
+        count: groupCards.reduce((sum, c) => sum + c.copies, 0),
+      }
+    })
+}
+
+type HoverState = { name: string; pos: { x: number; y: number } } | null
+
+/**
+ * The body of a single deck: colour pips, mana curve, and the cards grouped by type. Used standalone
+ * for a saved deck and inside {@link SeatDeckColumn} for a game seat. Manages its own hover preview.
+ */
+export function DeckCardBody({ cards }: { cards: GameDeckCard[] }) {
+  const [hover, setHover] = useState<HoverState>(null)
+
+  if (cards.length === 0) return <p style={styles.muted}>Deck not recorded.</p>
+
+  // Reuse the deckbuilder's stats helper — GameDeckCard satisfies DeckStatsCard structurally.
+  const deckRecord: Record<string, number> = {}
+  const cardMeta: Record<string, DeckStatsCard> = {}
+  for (const c of cards) {
+    deckRecord[c.cardName] = c.copies
+    cardMeta[c.cardName] = { cmc: c.cmc, colors: c.colors, cardTypes: c.cardTypes }
+  }
+  const stats = computeDeckStats(deckRecord, cardMeta)
+  const groups = groupByType(cards)
+
+  return (
+    <div style={styles.body}>
+      {stats.colorCounts.length > 0 && (
+        <div style={styles.pips}>
+          {stats.colorCounts.map(([color, n]) => (
+            <span key={color} style={styles.pip} title={`${color}: ${Math.round(n)}`}>
+              <span style={{ ...styles.pipDot, background: COLOR_DOT[color] ?? '#888' }} />
+              {Math.round(n)}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {stats.curve.some((n) => n > 0) && (
+        <div style={styles.curve}>
+          <ManaCurveBars curve={stats.curve} curveByColor={stats.curveByColor} />
+        </div>
+      )}
+
+      <div style={styles.groups}>
+        {groups.map((g) => (
+          <div key={g.key}>
+            <div style={styles.groupTitle}>
+              {g.label} <span style={styles.groupCount}>{g.count}</span>
+            </div>
+            <ul style={styles.cardList}>
+              {g.cards.map((c) => (
+                <li
+                  key={c.cardName}
+                  style={styles.cardRow}
+                  onMouseEnter={(e) => setHover({ name: c.cardName, pos: { x: e.clientX, y: e.clientY } })}
+                  onMouseMove={(e) => setHover({ name: c.cardName, pos: { x: e.clientX, y: e.clientY } })}
+                  onMouseLeave={() => setHover(null)}
+                >
+                  <span style={styles.copies}>{c.copies}</span>
+                  <span style={styles.cardName}>{c.cardName}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {hover && <HoverCardPreview name={hover.name} imageUri={null} pos={hover.pos} />}
+    </div>
+  )
+}
+
+/** One seat in a game's deck view: a header (name / result / colours) above its {@link DeckCardBody}. */
+export function SeatDeckColumn({ p }: { p: GameDeckParticipant }) {
+  const total = p.cards.reduce((sum, c) => sum + c.copies, 0)
+  return (
+    <div style={styles.col}>
+      <div style={styles.colHead}>
+        <span style={styles.colName}>
+          {p.isSelf ? 'You' : p.playerName}
+          {p.isAi ? <span style={styles.aiTag}> AI</span> : null}
+        </span>
+        <span style={{ ...styles.resultTag, color: p.won ? '#5bd16e' : '#e15b6e' }}>{p.won ? 'Win' : 'Loss'}</span>
+      </div>
+      <div style={styles.colMeta}>
+        <span>{p.colors ? colorLabel(p.colors) : 'Colourless'}</span>
+        <span style={styles.dim}>· {total} cards</span>
+      </div>
+      <DeckCardBody cards={p.cards} />
+    </div>
+  )
+}
+
+/** Both seats' decks side by side — the body of the recent-games / admin deck modal. */
+export function GameDeckColumns({ participants }: { participants: GameDeckParticipant[] }) {
+  return (
+    <div style={styles.columns}>
+      {participants.map((p, i) => (
+        <SeatDeckColumn key={`${p.playerName}-${i}`} p={p} />
+      ))}
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  muted: { margin: '6px 0 0', color: '#888', fontSize: 13 },
+  columns: { display: 'flex', gap: 16, flexWrap: 'wrap' },
+  col: {
+    flex: '1 1 320px',
+    minWidth: 0,
+    backgroundColor: '#171723',
+    border: '1px solid #2a2a3e',
+    borderRadius: 12,
+    padding: '14px 16px',
+  },
+  colHead: { display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 8 },
+  colName: { color: '#fff', fontSize: 15, fontWeight: 600 },
+  resultTag: { fontSize: 12, fontWeight: 700 },
+  aiTag: { color: '#888', fontSize: 11 },
+  colMeta: { display: 'flex', alignItems: 'center', gap: 6, color: '#bbb', fontSize: 12, margin: '6px 0 4px' },
+  dim: { color: '#777' },
+  body: { display: 'flex', flexDirection: 'column', gap: 12, marginTop: 8 },
+  pips: { display: 'flex', flexWrap: 'wrap', gap: 10 },
+  pip: { display: 'inline-flex', alignItems: 'center', gap: 5, color: '#cdd', fontSize: 12, fontVariantNumeric: 'tabular-nums' },
+  pipDot: { width: 11, height: 11, borderRadius: 999, display: 'inline-block', border: '1px solid #00000055' },
+  curve: { marginTop: 2 },
+  groups: { display: 'flex', flexDirection: 'column', gap: 12 },
+  groupTitle: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: 8,
+    color: '#9aa0b5',
+    fontSize: 12,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  groupCount: { color: '#666', fontWeight: 600 },
+  cardList: { listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 1 },
+  cardRow: {
+    display: 'flex',
+    gap: 8,
+    alignItems: 'baseline',
+    fontSize: 13,
+    color: '#d6d9e6',
+    padding: '2px 6px',
+    borderRadius: 6,
+    cursor: 'default',
+  },
+  copies: { color: '#8b9bff', fontVariantNumeric: 'tabular-nums', minWidth: 18, textAlign: 'right', fontWeight: 600 },
+  cardName: { color: '#d6d9e6' },
+}

--- a/web-client/src/components/profile/DeckViewModal.tsx
+++ b/web-client/src/components/profile/DeckViewModal.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useState } from 'react'
 import type React from 'react'
 import { type GameDecks, fetchGameDecks } from '@/api/account'
-import { colorForIdentity, colorLabel } from '@/components/admin/statFormat'
+import { GameDeckColumns } from '@/components/deck/GameDeckView'
 
 export function DeckViewModal({
   gameId,
@@ -50,47 +50,11 @@ export function DeckViewModal({
         ) : decks.participants.length === 0 ? (
           <p style={styles.muted}>No decklist was recorded for this game.</p>
         ) : (
-          <div style={styles.columns}>
-            {decks.participants.map((p, i) => (
-              <DeckColumn key={`${p.playerName}-${i}`} p={p} />
-            ))}
+          <div style={styles.columnsWrap}>
+            <GameDeckColumns participants={decks.participants} />
           </div>
         )}
       </div>
-    </div>
-  )
-}
-
-function DeckColumn({ p }: { p: GameDecks['participants'][number] }) {
-  const total = p.cards.reduce((sum, c) => sum + c.copies, 0)
-  return (
-    <div style={styles.col}>
-      <div style={styles.colHead}>
-        <span style={styles.colName}>
-          {p.isSelf ? 'You' : p.playerName}
-          {p.isAi ? <span style={styles.aiTag}> AI</span> : null}
-        </span>
-        <span style={{ ...styles.resultTag, color: p.won ? '#5bd16e' : '#e15b6e' }}>
-          {p.won ? 'Win' : 'Loss'}
-        </span>
-      </div>
-      <div style={styles.colMeta}>
-        <span style={{ ...styles.colorDot, backgroundColor: colorForIdentity(p.colors) }} />
-        <span>{colorLabel(p.colors)}</span>
-        <span style={styles.dim}>· {total} cards</span>
-      </div>
-      {p.cards.length === 0 ? (
-        <p style={styles.muted}>Deck not recorded.</p>
-      ) : (
-        <ul style={styles.cardList}>
-          {p.cards.map((c) => (
-            <li key={c.cardName} style={styles.cardRow}>
-              <span style={styles.copies}>{c.copies}×</span>
-              <span style={styles.cardName}>{c.cardName}</span>
-            </li>
-          ))}
-        </ul>
-      )}
     </div>
   )
 }
@@ -107,7 +71,7 @@ const styles: Record<string, React.CSSProperties> = {
     zIndex: 1000,
   },
   modal: {
-    width: 'min(760px, 100%)',
+    width: 'min(820px, 100%)',
     maxHeight: '85vh',
     overflowY: 'auto',
     backgroundColor: '#12121e',
@@ -120,24 +84,5 @@ const styles: Record<string, React.CSSProperties> = {
   close: { background: 'none', border: 'none', color: '#999', cursor: 'pointer', fontSize: 18 },
   muted: { margin: '4px 0 0', color: '#888', fontSize: 13 },
   error: { margin: '8px 0 0', color: '#ff6b6b', fontSize: 13 },
-  columns: { display: 'flex', gap: 16, marginTop: 14, flexWrap: 'wrap' },
-  col: {
-    flex: '1 1 300px',
-    minWidth: 0,
-    backgroundColor: '#171723',
-    border: '1px solid #2a2a3e',
-    borderRadius: 10,
-    padding: '12px 14px',
-  },
-  colHead: { display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 8 },
-  colName: { color: '#fff', fontSize: 15, fontWeight: 600 },
-  resultTag: { fontSize: 12, fontWeight: 700 },
-  aiTag: { color: '#888', fontSize: 11 },
-  colMeta: { display: 'flex', alignItems: 'center', gap: 6, color: '#bbb', fontSize: 12, margin: '6px 0 10px' },
-  colorDot: { width: 10, height: 10, borderRadius: 999, display: 'inline-block' },
-  dim: { color: '#777' },
-  cardList: { listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 2 },
-  cardRow: { display: 'flex', gap: 8, fontSize: 13, color: '#cdd' },
-  copies: { color: '#8b9bff', fontVariantNumeric: 'tabular-nums', minWidth: 24 },
-  cardName: { color: '#cdd' },
+  columnsWrap: { marginTop: 14 },
 }

--- a/web-client/src/vendor.d.ts
+++ b/web-client/src/vendor.d.ts
@@ -1,0 +1,7 @@
+/** Ambient typing for the bundled world-atlas TopoJSON basemap (admin GeoMap). The shape is an
+ * opaque TopoJSON Topology; consumers pass it straight to topojson-client's `feature()`. Typed as
+ * `unknown` so importing the large JSON doesn't balloon type-checking with its literal type. */
+declare module 'world-atlas/countries-110m.json' {
+  const topology: unknown
+  export default topology
+}


### PR DESCRIPTION
Makes the admin dashboard more polished and useful, completes player information, and unifies how decks are displayed by reusing the deckbuilder's visual language. Nothing here touches the engine/SDK — it's server-orchestration + client UI.

![Admin dashboard map + shared deck view](https://raw.githubusercontent.com/wingedsheep/argentum-engine/admin-dashboard-polish-screenshots/admin-dashboard-polish.png)
*(Rendered from sample data — the admin/profile views need an accounts-enabled Postgres server with recorded games to populate live. The screenshot branch is throwaway.)*

## Admin dashboard (Stats)
- **Most-played / highest-win-rate cards are no longer an endless list** — they show the top 12 with a `Show all (N)` / `Show top 12` toggle.
- **Both global card stats now exclude basic lands** (server-side, mirroring the existing per-user `topCards` filter) so the metagame view isn't drowned in Forests/Islands.
- **"Where players connect from" is now an actual map** — a Natural-Earth basemap (`world-atlas`) with a proportional bubble per country placed at its centroid (`world-countries`, keyed by ISO alpha-2), plus a compact ranked **Top locations** list for the precise numbers the bubbles only approximate. Locations with no resolvable country (e.g. "Local network") fall to the list instead of vanishing. The server still resolves raw IPs server-side and only sends aggregated buckets.

## Player information (admin player detail)
- **Games panel** (paginated) with per-game **View** (decks) and **Watch** (replay — opens `/replay/{id}` in a new tab so the admin keeps their place).
- **Saved decks panel** listing the account's decks, each openable into the deck viewer.
- New endpoints: `GET /api/admin/users/{id}/games` (+ `X-Total-Count`), `GET /api/admin/users/{id}/games/{gameId}/decks`, `GET /api/admin/users/{id}/decks`.

## Shared, polished deck view (don't reinvent the wheel)
- New `GameDeckView` (`GameDeckColumns` / `DeckCardBody`) renders a deck the way the deckbuilder does: **cards grouped by type** with running counts, a **stacked-by-colour mana curve** and **colour pips** (reusing `DeckSummary`'s `computeDeckStats` / `ManaCurveBars`), and a **hover card image** (reusing `HoverCardPreview`).
- The player's recent-games `DeckViewModal` (previously a flat, image-less list) and **both** admin deck viewers now use this one component — so the past-games deck display matches the rest of the app.
- Recorded/saved deck card lines are **enriched server-side** with cmc / types / colours (`GameDeckCard`) so the viewer needs no card catalog.

## New dependencies (client, admin-route chunk only)
`d3-geo`, `topojson-client`, `world-atlas`, `world-countries` (+ dev `@types/*`). The map lives on the lazy-loaded `AdminPage` chunk, so normal players never download it.

## Verification
- `npm run build` + `npm run typecheck` (web-client) green.
- `:game-server:compileKotlin` green.
- Headline UI rendered via Playwright (screenshot above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)