### PR TITLE
Add five Final Fantasy cards (Fat Chocobo, Primal Odin, Gabranth, Unexpected Request, Clash of the Eikons)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ClashOfTheEikons.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ClashOfTheEikons.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Clash of the Eikons
+ * {G}
+ * Sorcery
+ * Choose one or more —
+ * • Target creature you control fights target creature an opponent controls.
+ * • Remove a lore counter from target Saga you control. (Removing lore counters doesn't cause
+ *   chapter abilities to trigger.)
+ * • Put a lore counter on target Saga you control.
+ *
+ * A choose-one-or-more modal spell ([modal] with `chooseCount = 3, minChooseCount = 1`), each mode
+ * carrying its own independent targets. Adding a lore counter advances the targeted Saga normally
+ * (its chapter ability triggers, per CR 714); removing one never triggers a chapter. Both reuse the
+ * generic [Effects.AddCounters] / [Effects.RemoveCounters] over the [Counters.LORE] type.
+ */
+val ClashOfTheEikons = card("Clash of the Eikons") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or more —\n" +
+        "• Target creature you control fights target creature an opponent controls.\n" +
+        "• Remove a lore counter from target Saga you control. (Removing lore counters doesn't " +
+        "cause chapter abilities to trigger.)\n" +
+        "• Put a lore counter on target Saga you control."
+
+    spell {
+        modal(chooseCount = 3, minChooseCount = 1) {
+            mode("Target creature you control fights target creature an opponent controls") {
+                val yourCreature = target(
+                    "creature you control",
+                    TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.youControl()))
+                )
+                val theirCreature = target(
+                    "creature an opponent controls",
+                    TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.opponentControls()))
+                )
+                effect = Effects.Fight(yourCreature, theirCreature)
+            }
+            mode("Remove a lore counter from target Saga you control") {
+                val saga = target(
+                    "Saga you control",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Enchantment.withSubtype(Subtype.SAGA).youControl()))
+                )
+                effect = Effects.RemoveCounters(Counters.LORE, 1, saga)
+            }
+            mode("Put a lore counter on target Saga you control") {
+                val saga = target(
+                    "Saga you control",
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Enchantment.withSubtype(Subtype.SAGA).youControl()))
+                )
+                effect = Effects.AddCounters(Counters.LORE, 1, saga)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "180"
+        artist = "Gal Or"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75c18134-f517-4a68-8640-0426b3cd4f6c.jpg?1748706434"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JudgeMagisterGabranth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JudgeMagisterGabranth.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Judge Magister Gabranth
+ * {W}{B}
+ * Legendary Creature — Human Advisor Knight
+ * 2/2
+ * Menace
+ * Whenever another creature or artifact you control dies, put a +1/+1 counter on Judge Magister
+ *   Gabranth.
+ *
+ * The dies trigger uses [Triggers.leavesBattlefield] with `to = GRAVEYARD` and
+ * [TriggerBinding.OTHER] ("another") over the [GameObjectFilter.CreatureOrArtifact] you control, so
+ * Gabranth's own death never triggers it.
+ */
+val JudgeMagisterGabranth = card("Judge Magister Gabranth") {
+    manaCost = "{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Human Advisor Knight"
+    power = 2
+    toughness = 2
+    oracleText = "Menace\n" +
+        "Whenever another creature or artifact you control dies, put a +1/+1 counter on Judge Magister Gabranth."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.CreatureOrArtifact.youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "230"
+        artist = "Josu Hernaiz"
+        flavorText = "\"I slew your king. I slew your country. Do these deeds not demand vengeance?\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/9/f9e64cb6-48f7-41d3-99e7-4b0bc3b33fd7.jpg?1748706634"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonFatChocobo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonFatChocobo.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Summon: Fat Chocobo
+ * {4}{G}
+ * Enchantment Creature — Saga Bird
+ * 4/4
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+ * I — Wark — Create a 2/2 green Bird creature token with "Whenever a land you control enters,
+ *   this token gets +1/+0 until end of turn."
+ * II, III, IV — Kerplunk — Creatures you control gain trample until end of turn.
+ *
+ * Four-chapter Saga (sacrifice after IV; the engine derives the final chapter from the highest
+ * declared chapter, matching Summon: G.F. Ifrit). Chapter I creates the Chocobo Bird token, which
+ * carries its own land-enters trigger giving it +1/+0 until end of turn — the same token Call the
+ * Mountain Chocobo makes. Chapters II–IV grant trample to creatures you control until end of turn
+ * via [Patterns.Group.grantKeywordToAll].
+ */
+val SummonFatChocobo = card("Summon: Fat Chocobo") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment Creature — Saga Bird"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\n" +
+        "I — Wark — Create a 2/2 green Bird creature token with \"Whenever a land you control enters, " +
+        "this token gets +1/+0 until end of turn.\"\n" +
+        "II, III, IV — Kerplunk — Creatures you control gain trample until end of turn."
+    power = 4
+    toughness = 4
+
+    // I — Wark — create the 2/2 green Bird token with a land-enters self-pump trigger.
+    val wark = CreateTokenEffect(
+        power = 2,
+        toughness = 2,
+        colors = setOf(Color.GREEN),
+        creatureTypes = setOf("Bird"),
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1fbc471d-5948-47fc-b7cc-81cc13a4cd15.jpg?1748704082",
+        triggeredAbilities = listOf(
+            TriggeredAbility.create(
+                trigger = Triggers.entersBattlefield(
+                    filter = GameObjectFilter.Land.youControl(),
+                    binding = TriggerBinding.ANY
+                ).event,
+                binding = Triggers.entersBattlefield(
+                    filter = GameObjectFilter.Land.youControl(),
+                    binding = TriggerBinding.ANY
+                ).binding,
+                effect = Effects.ModifyStats(1, 0, EffectTarget.Self)
+            )
+        )
+    )
+
+    // II, III, IV — Kerplunk — creatures you control gain trample until end of turn.
+    val kerplunk = Patterns.Group.grantKeywordToAll(Keyword.TRAMPLE, Filters.Group.creaturesYouControl)
+
+    sagaChapter(1) { effect = wark }
+    sagaChapter(2) { effect = kerplunk }
+    sagaChapter(3) { effect = kerplunk }
+    sagaChapter(4) { effect = kerplunk }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "202"
+        artist = "Joseph Weston"
+        flavorText = "A pleasingly plump summon."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/32eb192b-de6b-4814-8077-628d343d014e.jpg?1748706518"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonPrimalOdin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonPrimalOdin.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Summon: Primal Odin
+ * {4}{B}{B}
+ * Enchantment Creature — Saga Knight
+ * 5/3
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Gungnir — Destroy target creature an opponent controls.
+ * II — Zantetsuken — This creature gains "Whenever this creature deals combat damage to a player,
+ *   that player loses the game."
+ * III — Hall of Sorrow — Draw two cards. Each player loses 2 life.
+ *
+ * Three-chapter Saga (sacrifice after III; derived from the highest declared chapter). Chapter II
+ * permanently grants the Saga creature itself the Phage-style "deals combat damage to a player →
+ * that player loses the game" trigger via [GrantTriggeredAbilityEffect] (SELF, [Duration.Permanent]),
+ * reusing [Triggers.DealsCombatDamageToPlayer] + [Effects.LoseGame] on the damaged player. Chapter
+ * III draws two and drains every player for 2 ([Player.Each]).
+ */
+val SummonPrimalOdin = card("Summon: Primal Odin") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment Creature — Saga Knight"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Gungnir — Destroy target creature an opponent controls.\n" +
+        "II — Zantetsuken — This creature gains \"Whenever this creature deals combat damage to a " +
+        "player, that player loses the game.\"\n" +
+        "III — Hall of Sorrow — Draw two cards. Each player loses 2 life."
+    power = 5
+    toughness = 3
+
+    // I — Gungnir — Destroy target creature an opponent controls.
+    sagaChapter(1) {
+        val victim = target("creature", TargetObject(filter = TargetFilter.CreatureOpponentControls))
+        effect = Effects.Destroy(victim)
+    }
+
+    // II — Zantetsuken — grant this creature the "combat damage to a player → that player loses" trigger.
+    sagaChapter(2) {
+        effect = GrantTriggeredAbilityEffect(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.DealsCombatDamageToPlayer.event,
+                binding = Triggers.DealsCombatDamageToPlayer.binding,
+                effect = Effects.LoseGame(
+                    target = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+                    message = "Summon: Primal Odin's Zantetsuken dealt combat damage"
+                )
+            ),
+            target = EffectTarget.Self,
+            duration = Duration.Permanent
+        )
+    }
+
+    // III — Hall of Sorrow — Draw two cards. Each player loses 2 life.
+    sagaChapter(3) {
+        effect = Effects.DrawCards(2) then
+            Effects.LoseLife(2, EffectTarget.PlayerRef(Player.Each))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "121"
+        artist = "Nino Is"
+        flavorText = "The elder primal Odin has returned to Eorzea."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8b1b5f06-e34d-44a3-976e-5157c4b7a0f4.jpg?1748706216"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/UnexpectedRequest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/UnexpectedRequest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Unexpected Request
+ * {2}{R}
+ * Sorcery
+ * Gain control of target creature until end of turn. Untap that creature. It gains haste until end
+ *   of turn. You may attach an Equipment you control to that creature. If you do, unattach it at the
+ *   beginning of the next end step.
+ *
+ * A "threaten" with an optional Equipment rider, composed from existing primitives (no monolithic
+ * executor):
+ *  - [Effects.GainControl] of the target creature for [Duration.EndOfTurn], then [Effects.Untap]
+ *    and a [Duration.EndOfTurn] haste grant — the standard borrow-and-swing package.
+ *  - The Equipment to move is an *optional* second target (you may decline by choosing none). A
+ *    [ConditionalEffect] gates the attach on an Equipment actually having been chosen
+ *    ([Conditions.EntityMatches] resolves to `false` when the optional slot is empty), so the "if
+ *    you do" clause is honored — no attach, no scheduled unattach when you decline.
+ *  - When an Equipment is chosen, [Effects.AttachTargetEquipmentToCreature] moves it onto the
+ *    borrowed creature and a [CreateDelayedTriggerEffect] at [Step.END] unattaches it at the
+ *    beginning of the next end step. The Equipment never changes controller, so it remains yours
+ *    when the borrowed creature reverts at cleanup.
+ */
+val UnexpectedRequest = card("Unexpected Request") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Gain control of target creature until end of turn. Untap that creature. It gains " +
+        "haste until end of turn. You may attach an Equipment you control to that creature. If you " +
+        "do, unattach it at the beginning of the next end step."
+
+    spell {
+        // creature = ContextTarget(0), equipment = ContextTarget(1) (declaration order).
+        val creature = target("target creature", Targets.Creature)
+        val equipment = target(
+            "an Equipment you control",
+            TargetPermanent(
+                filter = TargetFilter(GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).youControl()),
+                optional = true
+            )
+        )
+        effect = Effects.Composite(
+            Effects.GainControl(creature, Duration.EndOfTurn),
+            Effects.Untap(creature),
+            Effects.GrantKeyword(Keyword.HASTE, creature, Duration.EndOfTurn),
+            ConditionalEffect(
+                // "If you do" — the ConditionEvaluator only dispatches ContextTarget (not the
+                // bound-variable handle), so gate on the equipment's positional slot.
+                condition = Conditions.EntityMatches(
+                    EffectTarget.ContextTarget(1),
+                    GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT)
+                ),
+                effect = Effects.Composite(
+                    Effects.AttachTargetEquipmentToCreature(
+                        equipmentTarget = equipment,
+                        creatureTarget = creature
+                    ),
+                    CreateDelayedTriggerEffect(
+                        step = Step.END,
+                        effect = Effects.UnattachEquipment(equipment)
+                    )
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "167"
+        artist = "Ignatius Budi"
+        flavorText = "\"I shall hereby do my best to kidnap you!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/0265fd20-a85d-49ce-b338-4c40843a5b18.jpg?1748706387"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -2937,6 +2937,104 @@
     ]
 }
 
+// Clash of the Eikons
+{
+    "name": "Clash of the Eikons",
+    "manaCost": "{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or more —\n• Target creature you control fights target creature an opponent controls.\n• Remove a lore counter from target Saga you control. (Removing lore counters doesn't cause chapter abilities to trigger.)\n• Put a lore counter on target Saga you control.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Fight",
+                        "target1": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        },
+                        "target2": {
+                            "type": "BoundVariable",
+                            "name": "creature an opponent controls"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "creature you control"
+                        },
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:opponent"
+                            },
+                            "id": "creature an opponent controls"
+                        }
+                    ],
+                    "description": "Target creature you control fights target creature an opponent controls"
+                },
+                {
+                    "effect": {
+                        "type": "RemoveCounters",
+                        "counterType": "lore",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "Saga you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment Saga ctrl:you"
+                            },
+                            "id": "Saga you control"
+                        }
+                    ],
+                    "description": "Remove a lore counter from target Saga you control"
+                },
+                {
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "lore",
+                        "count": 1,
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "Saga you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment Saga ctrl:you"
+                            },
+                            "id": "Saga you control"
+                        }
+                    ],
+                    "description": "Put a lore counter on target Saga you control"
+                }
+            ],
+            "chooseCount": 3,
+            "minChooseCount": 1
+        }
+    },
+    "metadata": {
+        "collectorNumber": "180",
+        "rarity": "UNCOMMON",
+        "artist": "Gal Or",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75c18134-f517-4a68-8640-0426b3cd4f6c.jpg?1748706434"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Clive's Hideaway
 {
     "name": "Clive's Hideaway",
@@ -7740,6 +7838,52 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Judge Magister Gabranth
+{
+    "name": "Judge Magister Gabranth",
+    "manaCost": "{W}{B}",
+    "typeLine": "Legendary Creature — Human Advisor Knight",
+    "oracleText": "Menace\nWhenever another creature or artifact you control dies, put a +1/+1 counter on Judge Magister Gabranth.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature|artifact ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"I slew your king. I slew your country. Do these deeds not demand vengeance?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/9/f9e64cb6-48f7-41d3-99e7-4b0bc3b33fd7.jpg?1748706634"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
     ]
 }
 
@@ -14400,6 +14544,120 @@
     ]
 }
 
+// Summon: Fat Chocobo
+{
+    "name": "Summon: Fat Chocobo",
+    "manaCost": "{4}{G}",
+    "typeLine": "Enchantment Creature — Saga Bird",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)\nI — Wark — Create a 2/2 green Bird creature token with \"Whenever a land you control enters, this token gets +1/+0 until end of turn.\"\nII, III, IV — Kerplunk — Creatures you control gain trample until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Bird"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/f/1fbc471d-5948-47fc-b7cc-81cc13a4cd15.jpg?1748704082",
+                    "triggeredAbilities": [
+                        {
+                            "id": "ability_1",
+                            "trigger": {
+                                "type": "ZoneChangeEvent",
+                                "filter": "land ctrl:you",
+                                "to": "Battlefield"
+                            },
+                            "binding": "ANY",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                }
+            },
+            {
+                "chapter": 4,
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "GrantKeyword",
+                        "keyword": "TRAMPLE",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "202",
+        "artist": "Joseph Weston",
+        "flavorText": "A pleasingly plump summon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/32eb192b-de6b-4814-8077-628d343d014e.jpg?1748706518"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Summon: G.F. Ifrit
 {
     "name": "Summon: G.F. Ifrit",
@@ -14811,6 +15069,101 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Summon: Primal Odin
+{
+    "name": "Summon: Primal Odin",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Enchantment Creature — Saga Knight",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Gungnir — Destroy target creature an opponent controls.\nII — Zantetsuken — This creature gains \"Whenever this creature deals combat damage to a player, that player loses the game.\"\nIII — Hall of Sorrow — Draw two cards. Each player loses 2 life.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature"
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "GrantTriggeredAbility",
+                    "ability": {
+                        "id": "ability_1",
+                        "trigger": {
+                            "type": "DealsDamageEvent",
+                            "damageType": "DamageCombat",
+                            "recipient": "AnyPlayer"
+                        },
+                        "effect": {
+                            "type": "LoseGame",
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "TriggeringPlayer"
+                            },
+                            "message": "Summon: Primal Odin's Zantetsuken dealt combat damage"
+                        }
+                    },
+                    "target": "Self",
+                    "duration": "Permanent"
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "Each"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "121",
+        "rarity": "RARE",
+        "artist": "Nino Is",
+        "flavorText": "The elder primal Odin has returned to Eorzea.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8b1b5f06-e34d-44a3-976e-5157c4b7a0f4.jpg?1748706216"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -16791,6 +17144,113 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Unexpected Request
+{
+    "name": "Unexpected Request",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. You may attach an Equipment you control to that creature. If you do, unattach it at the beginning of the next end step.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 1
+                            },
+                            "filter": "artifact Equipment"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AttachTargetEquipmentToCreature",
+                                "equipmentTarget": {
+                                    "type": "BoundVariable",
+                                    "name": "an Equipment you control"
+                                },
+                                "creatureTarget": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                }
+                            },
+                            {
+                                "type": "CreateDelayedTrigger",
+                                "step": "END",
+                                "effect": {
+                                    "type": "UnattachEquipment",
+                                    "target": {
+                                        "type": "BoundVariable",
+                                        "name": "an Equipment you control"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "artifact Equipment ctrl:you"
+                },
+                "id": "an Equipment you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "167",
+        "rarity": "UNCOMMON",
+        "artist": "Ignatius Budi",
+        "flavorText": "\"I shall hereby do my best to kidnap you!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/0265fd20-a85d-49ce-b338-4c40843a5b18.jpg?1748706387"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClashOfTheEikonsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClashOfTheEikonsScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.ClashOfTheEikons
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonFatChocobo
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Clash of the Eikons — {G} Sorcery (FIN).
+ *
+ * Choose one or more —
+ * • Target creature you control fights target creature an opponent controls.
+ * • Remove a lore counter from target Saga you control.
+ * • Put a lore counter on target Saga you control.
+ */
+class ClashOfTheEikonsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ClashOfTheEikons, SummonFatChocobo))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.lore(saga: EntityId): Int =
+        state.getEntity(saga)?.get<CountersComponent>()?.getCount(CounterType.LORE) ?: 0
+
+    test("fight mode — my creature fights and kills the opponent's") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // 3/3 fights 1/1: the Lions takes 3 (dies); the Courser takes 1 (survives).
+        val courser = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3
+        val lions = driver.putCreatureOnBattlefield(opp, "Savannah Lions")    // 1/1
+
+        driver.giveMana(me, Color.GREEN, 1)
+        val spell = driver.putCardInHand(me, "Clash of the Eikons")
+
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(courser), ChosenTarget.Permanent(lions)),
+                chosenModes = listOf(0),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(courser), ChosenTarget.Permanent(lions))
+                )
+            )
+        ).error shouldBe null
+        driver.bothPass()
+
+        driver.findPermanent(opp, "Savannah Lions") shouldBe null
+        driver.findPermanent(me, "Centaur Courser") shouldBe courser
+    }
+
+    test("add-lore mode — puts a lore counter on a Saga I control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val saga = driver.putPermanentOnBattlefield(me, "Summon: Fat Chocobo")
+        val loreBefore = driver.lore(saga)
+
+        driver.giveMana(me, Color.GREEN, 1)
+        val spell = driver.putCardInHand(me, "Clash of the Eikons")
+
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(saga)),
+                chosenModes = listOf(2),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(saga)))
+            )
+        ).error shouldBe null
+        // Resolve the spell and any chapter trigger that the added lore counter sets off.
+        var guard = 0
+        while ((driver.state.stack.isNotEmpty() || driver.state.pendingDecision != null) && guard++ < 50) {
+            val pd = driver.state.pendingDecision
+            if (pd != null) driver.autoResolveDecision() else driver.bothPass()
+        }
+
+        // A lore counter was added (chapter I fired; the Saga is still around at lore 1 of IV).
+        driver.lore(driver.findPermanent(me, "Summon: Fat Chocobo")!!) shouldBe (loreBefore + 1)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JudgeMagisterGabranthScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JudgeMagisterGabranthScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.JudgeMagisterGabranth
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Judge Magister Gabranth — {W}{B} 2/2 Legendary Creature — Human Advisor Knight (FIN).
+ *
+ * Menace.
+ * Whenever another creature or artifact you control dies, put a +1/+1 counter on Gabranth.
+ */
+class JudgeMagisterGabranthScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(JudgeMagisterGabranth))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Swamp" to 20), startingLife = 20)
+        return driver
+    }
+
+    test("has menace") {
+        val driver = createDriver()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val gabranth = driver.putCreatureOnBattlefield(me, "Judge Magister Gabranth")
+        projector.project(driver.state).hasKeyword(gabranth, Keyword.MENACE) shouldBe true
+    }
+
+    test("another creature I control dying puts a +1/+1 counter on Gabranth") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val gabranth = driver.putCreatureOnBattlefield(me, "Judge Magister Gabranth")
+        // A 1/1 of mine that will die in combat.
+        val lions = driver.putCreatureOnBattlefield(me, "Savannah Lions")
+        driver.removeSummoningSickness(lions)
+        // A 3/3 blocker for the opponent.
+        val courser = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        projector.project(driver.state).getPower(gabranth) shouldBe 2
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(lions), opp)
+        driver.bothPass()
+        driver.declareBlockers(opp, mapOf(courser to listOf(lions)))
+        // Drive priority through combat damage (auto-resolving the damage board) and let the dies
+        // trigger resolve.
+        var guard = 0
+        while (guard++ < 60) {
+            val pd = driver.state.pendingDecision
+            when {
+                pd != null -> driver.autoResolveDecision()
+                driver.findPermanent(me, "Savannah Lions") == null && driver.state.stack.isEmpty() -> break
+                driver.state.priorityPlayerId != null -> driver.passPriority(driver.state.priorityPlayerId!!)
+                else -> break
+            }
+        }
+
+        // Savannah Lions died (3 >= 1 toughness); Gabranth grew to 3/3.
+        driver.findPermanent(me, "Savannah Lions") shouldBe null
+        projector.project(driver.state).getPower(driver.findPermanent(me, "Judge Magister Gabranth")!!) shouldBe 3
+    }
+
+    test("an opponent's creature dying does NOT trigger Gabranth") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val gabranth = driver.putCreatureOnBattlefield(me, "Judge Magister Gabranth")
+        // My 3/3 attacker kills the opponent's 1/1 blocker.
+        val courser = driver.putCreatureOnBattlefield(me, "Centaur Courser")
+        driver.removeSummoningSickness(courser)
+        val lions = driver.putCreatureOnBattlefield(opp, "Savannah Lions")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(courser), opp)
+        driver.bothPass()
+        driver.declareBlockers(opp, mapOf(lions to listOf(courser)))
+        var guard = 0
+        while (guard++ < 60) {
+            val pd = driver.state.pendingDecision
+            when {
+                pd != null -> driver.autoResolveDecision()
+                driver.findPermanent(opp, "Savannah Lions") == null && driver.state.stack.isEmpty() -> break
+                driver.state.priorityPlayerId != null -> driver.passPriority(driver.state.priorityPlayerId!!)
+                else -> break
+            }
+        }
+
+        // The opponent's Lions died, but it isn't a creature I control — Gabranth stays 2/2.
+        driver.findPermanent(opp, "Savannah Lions") shouldBe null
+        projector.project(driver.state).getPower(gabranth) shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonFatChocoboScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonFatChocoboScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonFatChocobo
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Summon: Fat Chocobo — {4}{G} Enchantment Creature — Saga Bird, 4/4 (FIN).
+ *
+ *   I — Wark — Create a 2/2 green Bird creature token with "Whenever a land you control enters,
+ *       this token gets +1/+0 until end of turn."
+ *   II, III, IV — Kerplunk — Creatures you control gain trample until end of turn.
+ *
+ * The generic saga-creature machinery (lore accrual, chapter triggers, sacrifice after the final
+ * chapter) is covered by CreatureSagaTest; this pins Fat Chocobo's chapter I token — its body, type,
+ * and embedded land-enters self-pump trigger — and the chapter II–IV trample grant.
+ */
+class SummonFatChocoboScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SummonFatChocobo))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveAll() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard++ < 50) {
+            val pd = state.pendingDecision
+            if (pd != null) autoResolveDecision() else bothPass()
+        }
+    }
+
+    fun GameTestDriver.castChocobo(me: EntityId): EntityId {
+        val spell = putCardInHand(me, "Summon: Fat Chocobo")
+        giveColorlessMana(me, 4)
+        giveMana(me, com.wingedsheep.sdk.core.Color.GREEN, 1)
+        castSpell(me, spell)
+        resolveAll()
+        return spell
+    }
+
+    test("chapter I creates a 2/2 green Bird token") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.castChocobo(me)
+
+        val saga = driver.findPermanent(me, "Summon: Fat Chocobo")!!
+        // The token is the creature I control that isn't the Saga itself.
+        val token = driver.getCreatures(me).firstOrNull { it != saga }
+        token shouldNotBe null
+
+        val projected = projector.project(driver.state)
+        projected.getPower(token!!) shouldBe 2
+        projected.getToughness(token) shouldBe 2
+        projected.hasType(token, "Bird") shouldBe true
+    }
+
+    test("the chapter I token gets +1/+0 when a land enters under my control") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.castChocobo(me)
+        val saga = driver.findPermanent(me, "Summon: Fat Chocobo")!!
+        val token = driver.getCreatures(me).first { it != saga }
+
+        projector.project(driver.state).getPower(token) shouldBe 2
+
+        // Play a land: the token's "whenever a land you control enters" trigger fires for +1/+0.
+        val land = driver.putCardInHand(me, "Forest")
+        driver.playLand(me, land)
+        driver.resolveAll()
+
+        projector.project(driver.state).getPower(driver.getCreatures(me).first { it != saga }) shouldBe 3
+    }
+
+    test("chapter II grants creatures I control trample") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val saga = driver.castChocobo(me)
+        val sagaId = driver.findPermanent(me, "Summon: Fat Chocobo")!!
+
+        // Advance turns until the Saga has accrued a second lore counter (chapter II resolves).
+        var guard = 0
+        while (guard++ < 1000) {
+            val token = driver.getCreatures(me).firstOrNull { it != sagaId }
+            if (token != null && projector.project(driver.state).hasKeyword(token, Keyword.TRAMPLE)) break
+            if (driver.findPermanent(me, "Summon: Fat Chocobo") == null) {
+                throw AssertionError("Saga was sacrificed before chapter II granted trample")
+            }
+            val pd = driver.state.pendingDecision
+            when {
+                pd != null -> driver.autoResolveDecision()
+                driver.state.priorityPlayerId != null -> {
+                    driver.autoSubmitCombatDeclarationIfNeeded()
+                    driver.passPriority(driver.state.priorityPlayerId!!)
+                }
+            }
+        }
+
+        val token = driver.getCreatures(me).first { it != sagaId }
+        projector.project(driver.state).hasKeyword(token, Keyword.TRAMPLE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonPrimalOdinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonPrimalOdinScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonPrimalOdin
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Summon: Primal Odin — {4}{B}{B} Enchantment Creature — Saga Knight, 5/3 (FIN).
+ *
+ *   I — Gungnir — Destroy target creature an opponent controls.
+ *   II — Zantetsuken — This creature gains "Whenever this creature deals combat damage to a
+ *        player, that player loses the game."
+ *   III — Hall of Sorrow — Draw two cards. Each player loses 2 life.
+ *
+ * Generic saga machinery is covered by CreatureSagaTest; this pins chapter I's targeted destroy and
+ * chapter III's draw-two / drain-each-player.
+ */
+class SummonPrimalOdinScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SummonPrimalOdin))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.castOdin(me: EntityId): EntityId {
+        val spell = putCardInHand(me, "Summon: Primal Odin")
+        giveColorlessMana(me, 4)
+        giveMana(me, com.wingedsheep.sdk.core.Color.BLACK, 2)
+        castSpell(me, spell)
+        return spell
+    }
+
+    /** Resolve the whole stack, supplying [chooseTargets] for any target prompt. */
+    fun GameTestDriver.resolveStack(chooseTargets: () -> List<EntityId> = { emptyList() }) {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard++ < 100) {
+            val pd = state.pendingDecision
+            when {
+                pd is ChooseTargetsDecision -> submitTargetSelection(pd.playerId, chooseTargets())
+                pd != null -> autoResolveDecision()
+                else -> bothPass()
+            }
+        }
+    }
+
+    test("chapter I destroys the targeted opponent creature") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val courser = driver.putCreatureOnBattlefield(opp, "Centaur Courser") // 3/3
+
+        driver.castOdin(me)
+        driver.resolveStack(chooseTargets = { listOf(courser) })
+
+        driver.findPermanent(opp, "Centaur Courser") shouldBe null
+        // The Saga itself is still on the battlefield at lore I of III.
+        (driver.findPermanent(me, "Summon: Primal Odin") != null) shouldBe true
+    }
+
+    test("chapter III draws two and drains each player for two") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        // No opponent creatures, so chapter I has no legal target and simply does nothing —
+        // advancing never pauses on a mandatory target it cannot satisfy.
+        driver.castOdin(me)
+        driver.resolveStack()
+
+        val saga = driver.findPermanent(me, "Summon: Primal Odin")!!
+
+        // Advance turns until chapter III has resolved (both players drained to 18).
+        var guard = 0
+        while (guard++ < 1000) {
+            if (driver.getLifeTotal(me) <= 18 && driver.getLifeTotal(opp) <= 18) break
+            if (driver.state.gameOver) throw AssertionError("Game ended before chapter III resolved")
+            val pd = driver.state.pendingDecision
+            when {
+                pd is ChooseTargetsDecision -> driver.submitTargetSelection(pd.playerId, emptyList())
+                pd != null -> driver.autoResolveDecision()
+                driver.state.priorityPlayerId != null -> {
+                    driver.autoSubmitCombatDeclarationIfNeeded()
+                    driver.passPriority(driver.state.priorityPlayerId!!)
+                }
+            }
+        }
+
+        driver.getLifeTotal(me) shouldBe 18
+        driver.getLifeTotal(opp) shouldBe 18
+        // After its final chapter, the Saga is sacrificed.
+        driver.findPermanent(me, "Summon: Primal Odin") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnexpectedRequestScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnexpectedRequestScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.UnexpectedRequest
+import com.wingedsheep.mtg.sets.definitions.mrd.cards.Bonesplitter
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unexpected Request — {2}{R} Sorcery (FIN).
+ *
+ * Gain control of target creature until end of turn. Untap that creature. It gains haste until end
+ * of turn. You may attach an Equipment you control to that creature. If you do, unattach it at the
+ * beginning of the next end step.
+ *
+ * The until-end-of-turn control change is a continuous effect, so control is read from the
+ * projected state (cf. StolenUniformScenarioTest), not the base [getController].
+ */
+class UnexpectedRequestScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(UnexpectedRequest, Bonesplitter))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("gains control of the target creature until end of turn and grants it haste") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val courser = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        driver.giveMana(me, Color.RED, 3)
+        val spell = driver.putCardInHand(me, "Unexpected Request")
+        driver.castSpell(me, spell, targets = listOf(courser)).error shouldBe null
+        driver.bothPass()
+
+        val projected = projector.project(driver.state)
+        projected.getController(courser) shouldBe me
+        projected.hasKeyword(courser, Keyword.HASTE) shouldBe true
+    }
+
+    test("optionally attaches a chosen Equipment to the borrowed creature") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val courser = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val bonesplitter = driver.putPermanentOnBattlefield(me, "Bonesplitter")
+
+        driver.giveMana(me, Color.RED, 3)
+        val spell = driver.putCardInHand(me, "Unexpected Request")
+        driver.castSpellWithTargets(
+            me, spell,
+            listOf(ChosenTarget.Permanent(courser), ChosenTarget.Permanent(bonesplitter))
+        ).error shouldBe null
+        driver.bothPass()
+
+        projector.project(driver.state).getController(courser) shouldBe me
+        driver.state.getEntity(bonesplitter)?.get<AttachedToComponent>()?.targetId shouldBe courser
+    }
+
+    test("declining the Equipment attaches nothing but still steals the creature") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val courser = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val bonesplitter = driver.putPermanentOnBattlefield(me, "Bonesplitter")
+
+        driver.giveMana(me, Color.RED, 3)
+        val spell = driver.putCardInHand(me, "Unexpected Request")
+        // Provide only the creature target; the optional Equipment slot is left empty.
+        driver.castSpell(me, spell, targets = listOf(courser)).error shouldBe null
+        driver.bothPass()
+
+        projector.project(driver.state).getController(courser) shouldBe me
+        driver.state.getEntity(bonesplitter)?.get<AttachedToComponent>() shouldBe null
+    }
+})


### PR DESCRIPTION
## Summary

Implements five missing **Final Fantasy (FIN)** cards via the `add-card` skill. Every card composes existing SDK primitives — **no new engine mechanics** — so there are no SDK-reference or engine changes, only card definitions, scenario tests, and the re-blessed snapshot.

| Card | What it does |
|------|--------------|
| **Summon: Fat Chocobo** | 4-chapter Saga. I — Wark: create the 2/2 green Bird token with its "whenever a land you control enters, +1/+0 until EOT" trigger. II–IV — Kerplunk: creatures you control gain trample until EOT. |
| **Summon: Primal Odin** | 3-chapter Saga. I — destroy target opponent creature. II — grant itself the Phage-style "deals combat damage to a player → that player loses the game" trigger. III — draw two, each player loses 2 life. |
| **Judge Magister Gabranth** | `{W}{B}` 2/2 Menace. Whenever **another** creature or artifact you control dies (`TriggerBinding.OTHER`), put a +1/+1 counter on it. |
| **Unexpected Request** | `{2}{R}` Sorcery — threaten (gain control until EOT + untap + haste) with an optional Equipment attach gated on "if you do", unattached at the beginning of the next end step. |
| **Clash of the Eikons** | `{G}` Sorcery — choose **one or more**: fight (your creature vs an opponent's), remove a lore counter from a target Saga you control, or put a lore counter on one. |

## Implementation notes

- **Reuse over new types**: sagas (`sagaChapter`), modal-spell DSL (`modal(chooseCount, minChooseCount)`), `GrantTriggeredAbilityEffect`, `Effects.GainControl`/`AttachTargetEquipmentToCreature` + delayed end-step trigger, `Triggers.leavesBattlefield(binding = OTHER)`, `Patterns.Group.grantKeywordToAll`, `Effects.Fight`, `Effects.Add/RemoveCounters` over `Counters.LORE`.
- Coliseum Behemoth and A Realm Reborn (originally scoped) turned out to be already implemented; swapped in Gabranth and Primal Odin.

## Testing

- 13 new rules-engine scenario tests (one suite per card) covering the key behaviors — saga chapters, the dies trigger (positive + negative "opponent's creature" case), threaten + optional attach + decline, and the modal fight / lore-counter modes.
- FIN card-definition snapshot re-blessed (adds only these 5 cards; no other card moved).
- `just build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)