### PR TITLE
Load deck-viewer card previews from the CDN, not slow Scryfall name lookups

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.gameserver.stats
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.registry.PrintingRegistry
 import com.wingedsheep.sdk.core.CardType
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.jdbc.core.JdbcTemplate
@@ -39,9 +40,9 @@ data class DeckCardEntry(val cardName: String, val copies: Int)
 
 /**
  * One card line enriched with the registry metadata the client needs to render a deck the polished
- * way (group by type, draw a mana curve, colour the pips) — so the deck viewer doesn't have to load
- * the full card catalog just to know a card's cost/type/colour. Field names match the client's
- * `DeckStatsCard` shape so `computeDeckStats` consumes them directly.
+ * way (group by type, draw a mana curve, colour the pips, show the art on hover) — so the deck viewer
+ * doesn't have to load the full card catalog just to know a card's cost/type/colour/image. Field names
+ * match the client's `DeckStatsCard` shape so `computeDeckStats` consumes them directly.
  */
 data class GameDeckCard(
     val cardName: String,
@@ -52,6 +53,12 @@ data class GameDeckCard(
     val cardTypes: List<String>,
     /** The card's own colours as enum names (e.g. ["WHITE","BLUE"]); empty = colourless/unresolved. */
     val colors: List<String>,
+    /**
+     * Direct CDN art URL for the card's default printing, resolved the same way as the deckbuilder
+     * catalog ([CardsController]). `null` when the card can't be resolved, in which case the client
+     * falls back to a Scryfall name lookup — slower and rate-limited, so we send this up front.
+     */
+    val imageUri: String?,
 )
 
 /** One seat's recorded deck within a finished game, for the recent-games deck viewer. */
@@ -143,6 +150,7 @@ class StatsQueryService(
     private val jdbc: JdbcTemplate,
     private val deckProfiler: DeckProfiler,
     private val cardRegistry: CardRegistry,
+    private val printingRegistry: PrintingRegistry,
 ) {
 
     // ---- Per-user ----------------------------------------------------------------------------
@@ -454,6 +462,11 @@ class StatsQueryService(
                     cmc = card?.cmc ?: 0,
                     cardTypes = card?.typeLine?.cardTypes?.map { it.name } ?: emptyList(),
                     colors = card?.colors?.map { it.name } ?: emptyList(),
+                    // Prefer the default printing's art (mirrors CardsController), falling back to the
+                    // canonical metadata image — so the deck viewer loads from the CDN directly.
+                    imageUri = card?.let {
+                        printingRegistry.defaultPrinting(it.name)?.imageUri ?: it.metadata.imageUri
+                    },
                 )
             }
 

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -263,6 +263,11 @@ export interface GameDeckCard {
   readonly cardTypes: string[]
   /** The card's own colours as enum names, e.g. `["WHITE","BLUE"]`; empty = colourless. */
   readonly colors: string[]
+  /**
+   * Direct CDN art URL for the card's default printing, resolved server-side (like the deckbuilder
+   * catalog). `null` when unresolved, in which case the preview falls back to a Scryfall name lookup.
+   */
+  readonly imageUri: string | null
 }
 
 /** One seat's recorded deck within a finished game. */

--- a/web-client/src/components/deck/GameDeckView.tsx
+++ b/web-client/src/components/deck/GameDeckView.tsx
@@ -70,7 +70,7 @@ function groupByType(cards: GameDeckCard[]): TypeGroup[] {
     })
 }
 
-type HoverState = { name: string; pos: { x: number; y: number } } | null
+type HoverState = { name: string; imageUri: string | null; pos: { x: number; y: number } } | null
 
 /**
  * The body of a single deck: colour pips, mana curve, and the cards grouped by type. Used standalone
@@ -121,8 +121,8 @@ export function DeckCardBody({ cards }: { cards: GameDeckCard[] }) {
                 <li
                   key={c.cardName}
                   style={styles.cardRow}
-                  onMouseEnter={(e) => setHover({ name: c.cardName, pos: { x: e.clientX, y: e.clientY } })}
-                  onMouseMove={(e) => setHover({ name: c.cardName, pos: { x: e.clientX, y: e.clientY } })}
+                  onMouseEnter={(e) => setHover({ name: c.cardName, imageUri: c.imageUri, pos: { x: e.clientX, y: e.clientY } })}
+                  onMouseMove={(e) => setHover({ name: c.cardName, imageUri: c.imageUri, pos: { x: e.clientX, y: e.clientY } })}
                   onMouseLeave={() => setHover(null)}
                 >
                   <span style={styles.copies}>{c.copies}</span>
@@ -134,7 +134,7 @@ export function DeckCardBody({ cards }: { cards: GameDeckCard[] }) {
         ))}
       </div>
 
-      {hover && <HoverCardPreview name={hover.name} imageUri={null} pos={hover.pos} />}
+      {hover && <HoverCardPreview name={hover.name} imageUri={hover.imageUri} pos={hover.pos} />}
     </div>
   )
 }


### PR DESCRIPTION
## Problem

Card previews in the **stats / profile** sections load noticeably worse than in the deckbuilder.

The shared deck view (`GameDeckView.tsx`) — reused by the recent-games deck modal (stats/profile) and the admin player view — rendered its hover previews with `imageUri={null}`:

```tsx
{hover && <HoverCardPreview name={hover.name} imageUri={null} pos={hover.pos} />}
```

With no `imageUri`, `getCardImageUrl` falls back to `getScryfallFallbackUrl`, which hits:

```
https://api.scryfall.com/cards/named?exact=<name>&format=image&version=large
```

That's the Scryfall **API** endpoint — a name lookup that issues a redirect to the real image for *every card, every time*. It's slower than a direct image fetch and is rate-limited. The deckbuilder, by contrast, already has the direct `cards.scryfall.io` **CDN** URL (served as `imageUri` in `/api/sets`), so its previews load instantly and reliably.

The server already enriches these deck cards with cmc / type / colour so the viewer doesn't need the full catalog — it just never included the image URI.

## Fix

Carry the image URI the same way the deckbuilder catalog does, end to end:

- **Server** (`StatsQueryService`): add `imageUri` to `GameDeckCard`, resolved via `PrintingRegistry.defaultPrinting(name).imageUri` (mirrors `CardsController`), falling back to the canonical metadata image. Injected `PrintingRegistry`.
- **Client** (`account.ts`): add `imageUri` to the `GameDeckCard` type.
- **Client** (`GameDeckView.tsx`): carry `imageUri` in the hover state and pass it to `HoverCardPreview` instead of `null`.

Previews now load from the CDN directly, matching the deckbuilder. Unresolvable cards still fall back to the Scryfall lookup (`imageUri` is null), so nothing regresses.

## Testing

- `:game-server:compileKotlin` — BUILD SUCCESSFUL.
- `web-client` typecheck clean for the changed files (`account.ts`, `GameDeckView.tsx`). The three pre-existing `GeoMap.tsx` `d3-geo`/`topojson-client`/`world-countries` errors are unrelated to this change and present on `main`.

No screenshot: the affected view only appears with recorded game history in the DB (logged-in account + finished games), which isn't reproducible in a throwaway local stack. The change is a URL-source swap with the existing preview component, verified by tracing both code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)