### PR TITLE
Add four Final Fantasy cards (Prima Vista, Gold Saucer, Eden, Jenova)

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -325,3 +325,34 @@ Deferred (need `add-feature`, not pure authoring):
   `lastKnownSourceCounters` capture (snapshot the self-sacrificed source's P/T, or add a
   `DynamicAmount.LastKnownSourcePower`). Note: **Cinder Shade (INV)** and **Ghitu Fire-Eater (ULG)**
   share this latent gap.
+
+## Implementation pass — 2026-06-28 (add-card batch)
+
+Implemented (all pure authoring, no engine change):
+- **The Prima Vista** (#64) — Vehicle; Flying + Crew 2 + "whenever you cast a noncreature spell, if
+  at least four mana was spent, this becomes an artifact creature until end of turn"
+  (`Triggers.YouCastNoncreature` + `Conditions.TriggeringSpellManaSpentAtLeast(4)` intervening-if →
+  `Effects.BecomeCreature(Self, 5/3, EndOfTurn)`).
+- **The Gold Saucer** (#279) — `Land — Town`; taps for {C}; "{2},{T}: flip a coin, on a win create a
+  Treasure" (`FlipCoinEffect(wonEffect = Effects.CreateTreasure(1))`); "{3},{T}, Sacrifice two
+  artifacts: Draw a card" (`Costs.SacrificeMultiple(2, GameObjectFilter.Artifact)`).
+- **Eden, Seat of the Sanctum** (#277) — `Land — Town`; taps for {C}; "{5},{T}: Mill two, then you may
+  sacrifice Eden. When you do, return another target permanent card from your graveyard to your hand"
+  (`ReflexiveTriggerEffect` with `optional = true`; the reflexive target is chosen after the sacrifice,
+  so `excludeSelf = true` models "another").
+- **Jenova, Ancient Calamity** (#228) — combat trigger puts +1/+1 counters equal to its power on up to
+  one other target creature, which becomes a Mutant (`AddDynamicCountersEffect` + `Effects.AddCreatureType`);
+  "whenever a Mutant you control dies during your turn, draw cards equal to its power"
+  (`Triggers.leavesBattlefield` filtered to Mutants + `Conditions.IsYourTurn` + `DynamicAmounts.triggeringPower`).
+
+Deferred (needs `add-feature`, not pure authoring):
+- **The Lunar Whale** (#60) — Vehicle; Flying/Crew 1 + "you may look at the top card" + "as long as it
+  attacked this turn, you may play the top card of your library." The look-at-top and the conditional
+  *cast* permission compose today via `LookAtTopOfLibrary` and
+  `ConditionalStaticAbility(PlayFromTopOfLibrary, Conditions.SourceAttackedThisTurn)`, **but playing a
+  *land* from the top is blocked**: `PlayLandHandler.hasPlayFromTopOfLibrary` only matches a bare
+  `PlayFromTopOfLibrary` static and never unwraps `ConditionalStaticAbility` (it special-cases only
+  `MayPlayLandsFromGraveyard`). Fix is a small reusable engine change — unwrap
+  `ConditionalStaticAbility` around `PlayFromTopOfLibrary`/`PlayLandsAndCastFilteredFromTopOfLibrary`
+  in `PlayLandHandler` (and mirror in `CastPermissionUtils.hasPlayFromTopOfLibrary`), evaluating the
+  gating condition — exactly like the existing graveyard-play conditional handling.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/EdenSeatOfTheSanctum.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/EdenSeatOfTheSanctum.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Eden, Seat of the Sanctum
+ * Land — Town
+ * {T}: Add {C}.
+ * {5}, {T}: Mill two cards. Then you may sacrifice this land. When you do, return another
+ *   target permanent card from your graveyard to your hand.
+ *
+ * The second ability mills two, then composes a [ReflexiveTriggerEffect] for the optional
+ * "sacrifice this land. When you do, …" follow-up: the action sacrifices Eden itself
+ * ([Effects.SacrificeTarget] of [EffectTarget.Self]), and the reflexive "when you do" returns
+ * a permanent card from your graveyard to your hand. Its target is chosen *after* the sacrifice
+ * resolves (reflexive trigger targeting), so Eden is already in the graveyard by then;
+ * `excludeSelf = true` on the target filter models the "another" restriction by excluding the
+ * ability's source (Eden) from the legal returnable cards.
+ */
+val EdenSeatOfTheSanctum = card("Eden, Seat of the Sanctum") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land — Town"
+    oracleText = "{T}: Add {C}.\n" +
+        "{5}, {T}: Mill two cards. Then you may sacrifice this land. When you do, return another " +
+        "target permanent card from your graveyard to your hand."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap)
+        effect = Effects.Composite(
+            Patterns.Library.mill(2),
+            ReflexiveTriggerEffect(
+                action = Effects.SacrificeTarget(EffectTarget.Self),
+                optional = true,
+                reflexiveEffect = Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+                reflexiveTargetRequirements = listOf(
+                    TargetObject(
+                        filter = TargetFilter(
+                            baseFilter = GameObjectFilter.Permanent.ownedByYou(),
+                            zone = Zone.GRAVEYARD,
+                            excludeSelf = true,
+                        )
+                    )
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "277"
+        artist = "Leon Tukker"
+        flavorText = "This city, Cocoon's capital, shares its name with its fal'Cie patron."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e28eac1e-adc7-4f8d-b206-bef09ba07d38.jpg?1748706821"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JenovaAncientCalamity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/JenovaAncientCalamity.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.AddDynamicCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Jenova, Ancient Calamity — Final Fantasy #228
+ * {2}{B}{G}
+ * Legendary Creature — Alien
+ * 1/5
+ *
+ * At the beginning of combat on your turn, put a number of +1/+1 counters equal to Jenova's
+ * power on up to one other target creature. That creature becomes a Mutant in addition to its
+ * other types.
+ * Whenever a Mutant you control dies during your turn, you draw cards equal to its power.
+ *
+ * The combat trigger uses [Triggers.BeginCombat]; the target is "up to one other target
+ * creature" — an optional single [TargetCreature] over [TargetFilter.OtherCreature]
+ * (excludeSelf), so the whole effect no-ops when no target is chosen (cf. Ardyn, the Usurper).
+ * The counter amount is [DynamicAmounts.sourcePower] (Jenova's current power) and the type
+ * grant is a permanent [Effects.AddCreatureType] ("in addition to its other types").
+ *
+ * The dies payoff mirrors Rakdos Joins Up: a [Triggers.leavesBattlefield] (… to GRAVEYARD)
+ * over Mutant creatures you control, gated to "during your turn" via
+ * triggerCondition = [Conditions.IsYourTurn]. The draw amount is [DynamicAmounts.triggeringPower],
+ * which resolves via last-known information for the just-died creature.
+ */
+val JenovaAncientCalamity = card("Jenova, Ancient Calamity") {
+    manaCost = "{2}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Alien"
+    power = 1
+    toughness = 5
+    oracleText = "At the beginning of combat on your turn, put a number of +1/+1 counters equal to " +
+        "Jenova's power on up to one other target creature. That creature becomes a Mutant in addition " +
+        "to its other types.\n" +
+        "Whenever a Mutant you control dies during your turn, you draw cards equal to its power."
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        // "Up to one other target" — both the counters and the type grant no-op if no target
+        // is chosen, which faithfully matches "up to one".
+        val t = target(
+            "up to one other target creature",
+            TargetCreature(optional = true, filter = TargetFilter.OtherCreature)
+        )
+        effect = Effects.Composite(listOf(
+            AddDynamicCountersEffect(Counters.PLUS_ONE_PLUS_ONE, DynamicAmounts.sourcePower(), t),
+            Effects.AddCreatureType("Mutant", t)
+        ))
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype("Mutant").youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        triggerCondition = Conditions.IsYourTurn
+        effect = Effects.DrawCards(DynamicAmounts.triggeringPower())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Ignatius Budi"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/534f98ee-7bc2-44d6-b49f-f57c051807d5.jpg?1748706622"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheGoldSaucer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheGoldSaucer.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.FlipCoinEffect
+
+
+/**
+ * The Gold Saucer
+ * Land — Town
+ * {T}: Add {C}.
+ * {2}, {T}: Flip a coin. If you win the flip, create a Treasure token.
+ * {3}, {T}, Sacrifice two artifacts: Draw a card.
+ */
+val TheGoldSaucer = card("The Gold Saucer") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land — Town"
+    oracleText = "{T}: Add {C}.\n" +
+        "{2}, {T}: Flip a coin. If you win the flip, create a Treasure token.\n" +
+        "{3}, {T}, Sacrifice two artifacts: Draw a card."
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = FlipCoinEffect(wonEffect = Effects.CreateTreasure(1))
+    }
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}"),
+            Costs.Tap,
+            Costs.SacrificeMultiple(2, GameObjectFilter.Artifact)
+        )
+        effect = Effects.DrawCards(1)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "279"
+        artist = "Anthony Devine"
+        flavorText = "After relaxing at Costa del Sol, stop by the Gold Saucer. It's a rich and exciting place to play!"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/5363c881-443d-43df-afd8-f81e1a1741a2.jpg?1748706827"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ThePrimaVista.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ThePrimaVista.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Prima Vista
+ * {4}{U}
+ * Legendary Artifact — Vehicle
+ * 5/3
+ * Flying
+ * Whenever you cast a noncreature spell, if at least four mana was spent to cast it, The Prima
+ * Vista becomes an artifact creature until end of turn.
+ * Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes
+ * an artifact creature until end of turn.)
+ *
+ * "If at least four mana was spent to cast it" is an intervening-if on the cast trigger (CR 603.4),
+ * modeled by [Conditions.TriggeringSpellManaSpentAtLeast] reading the triggering spell's recorded
+ * total mana paid (so {X} spells that paid four or more qualify, while a four-mana-value spell cast
+ * for less does not). The payoff animates the source via [Effects.BecomeCreature] on
+ * [EffectTarget.Self] with `Duration.EndOfTurn`: it keeps its Artifact type and Vehicle subtype and
+ * simply gains the CREATURE type with its printed 5/3 — the same animation Crew produces.
+ */
+val ThePrimaVista = card("The Prima Vista") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Artifact — Vehicle"
+    oracleText = "Flying\n" +
+        "Whenever you cast a noncreature spell, if at least four mana was spent to cast it, The " +
+        "Prima Vista becomes an artifact creature until end of turn.\n" +
+        "Crew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle " +
+        "becomes an artifact creature until end of turn.)"
+    power = 5
+    toughness = 3
+    keywords(Keyword.FLYING)
+
+    // Whenever you cast a noncreature spell, if at least four mana was spent to cast it,
+    // The Prima Vista becomes an artifact creature until end of turn.
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        triggerCondition = Conditions.TriggeringSpellManaSpentAtLeast(4)
+        effect = Effects.BecomeCreature(
+            target = EffectTarget.Self,
+            power = 5,
+            toughness = 3,
+            duration = Duration.EndOfTurn,
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(2))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "64"
+        artist = "Leon Tukker"
+        imageUri = "https://cards.scryfall.io/normal/front/e/3/e3998132-5746-4dde-9529-97d3ad7d7361.jpg?1748705994"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -4727,6 +4727,109 @@
     ]
 }
 
+// Eden, Seat of the Sanctum
+{
+    "name": "Eden, Seat of the Sanctum",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "{T}: Add {C}.\n{5}, {T}: Mill two cards. Then you may sacrifice this land. When you do, return another target permanent card from your graveyard to your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "ReflexiveTrigger",
+                            "action": {
+                                "type": "SacrificeTarget",
+                                "target": "Self"
+                            },
+                            "reflexiveEffect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Hand"
+                            },
+                            "reflexiveTargetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "permanent own:you",
+                                        "zone": "Graveyard",
+                                        "excludeSelf": true
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "277",
+        "rarity": "UNCOMMON",
+        "artist": "Leon Tukker",
+        "flavorText": "This city, Cocoon's capital, shares its name with its fal'Cie patron.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e28eac1e-adc7-4f8d-b206-bef09ba07d38.jpg?1748706821"
+    },
+    "colorIdentityOverride": []
+}
+
 // Eject
 {
     "name": "Eject",
@@ -7593,6 +7696,94 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Jenova, Ancient Calamity
+{
+    "name": "Jenova, Ancient Calamity",
+    "manaCost": "{2}{B}{G}",
+    "typeLine": "Legendary Creature — Alien",
+    "oracleText": "At the beginning of combat on your turn, put a number of +1/+1 counters equal to Jenova's power on up to one other target creature. That creature becomes a Mutant in addition to its other types.\nWhenever a Mutant you control dies during your turn, you draw cards equal to its power.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "+1/+1",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": "Power"
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one other target creature"
+                            }
+                        },
+                        {
+                            "type": "AddCreatureType",
+                            "subtype": "Mutant",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one other target creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature",
+                        "excludeSelf": true
+                    },
+                    "id": "up to one other target creature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Mutant ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": "Power"
+                    }
+                },
+                "triggerCondition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Ignatius Budi",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/534f98ee-7bc2-44d6-b49f-f57c051807d5.jpg?1748706622"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }
 
@@ -15968,6 +16159,156 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// The Gold Saucer
+{
+    "name": "The Gold Saucer",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "{T}: Add {C}.\n{2}, {T}: Flip a coin. If you win the flip, create a Treasure token.\n{3}, {T}, Sacrifice two artifacts: Draw a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "FlipCoin",
+                    "wonEffect": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Treasure"
+                    }
+                }
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "279",
+        "rarity": "UNCOMMON",
+        "artist": "Anthony Devine",
+        "flavorText": "After relaxing at Costa del Sol, stop by the Gold Saucer. It's a rich and exciting place to play!",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/5363c881-443d-43df-afd8-f81e1a1741a2.jpg?1748706827"
+    },
+    "colorIdentityOverride": []
+}
+
+// The Prima Vista
+{
+    "name": "The Prima Vista",
+    "manaCost": "{4}{U}",
+    "typeLine": "Legendary Artifact — Vehicle",
+    "oracleText": "Flying\nWhenever you cast a noncreature spell, if at least four mana was spent to cast it, The Prima Vista becomes an artifact creature until end of turn.\nCrew 2 (Tap any number of creatures you control with total power 2 or more: This Vehicle becomes an artifact creature until end of turn.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "BecomeCreature",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "triggerCondition": {
+                    "type": "TriggeringSpellManaSpentAtLeast",
+                    "amount": 4
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "64",
+        "rarity": "UNCOMMON",
+        "artist": "Leon Tukker",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/3/e3998132-5746-4dde-9529-97d3ad7d7361.jpg?1748705994"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EdenSeatOfTheSanctumScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EdenSeatOfTheSanctumScenarioTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.EdenSeatOfTheSanctum
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Eden, Seat of the Sanctum (FIN #277) — Land — Town.
+ * {T}: Add {C}.
+ * {5}, {T}: Mill two cards. Then you may sacrifice this land. When you do, return another
+ *   target permanent card from your graveyard to your hand.
+ *
+ * Verifies: (1) the mana ability adds {C}; (2) the {5},{T} ability mills two and, when the
+ * controller opts to sacrifice Eden, returns a chosen permanent card from the graveyard to
+ * hand; (3) declining the sacrifice leaves Eden on the battlefield and returns nothing.
+ */
+class EdenSeatOfTheSanctumScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + EdenSeatOfTheSanctum)
+        // A 30-card library so milling two has cards to move.
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("mana ability taps for {C}") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val eden = driver.putPermanentOnBattlefield(me, "Eden, Seat of the Sanctum")
+        driver.untapPermanent(eden)
+
+        val manaAbility = EdenSeatOfTheSanctum.activatedAbilities[0].id
+        driver.submit(
+            ActivateAbility(playerId = me, sourceId = eden, abilityId = manaAbility)
+        ).isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(me)?.get<ManaPoolComponent>()!!
+        pool.colorless shouldBe 1
+    }
+
+    test("{5},{T}: mills two, then sacrificing Eden returns a chosen permanent card to hand") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // A permanent (creature) card seeded in the graveyard to be returned.
+        val bear = driver.putCardInGraveyard(me, "Grizzly Bears")
+
+        val eden = driver.putPermanentOnBattlefield(me, "Eden, Seat of the Sanctum")
+        driver.untapPermanent(eden)
+        driver.giveColorlessMana(me, 5)
+
+        val graveyardBefore = driver.getGraveyard(me).size
+        val handBefore = driver.getHandSize(me)
+
+        val ability = EdenSeatOfTheSanctum.activatedAbilities[1].id
+        driver.submit(
+            ActivateAbility(playerId = me, sourceId = eden, abilityId = ability)
+        ).isSuccess shouldBe true
+        // Resolve the activated ability (mill two), pausing on the optional-sacrifice decision.
+        while (!driver.isPaused && driver.stackSize > 0) driver.bothPass()
+
+        // Two cards milled from the library into the graveyard.
+        driver.getGraveyard(me).size shouldBe graveyardBefore + 2
+
+        // "Then you may sacrifice this land." — accept.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+
+        // The "when you do" reflexive trigger goes on the stack; pick the card to return.
+        driver.submitTargetSelection(me, listOf(bear))
+        while (driver.stackSize > 0) driver.bothPass() // resolve the reflexive return-to-hand
+
+        // Eden was sacrificed; the chosen permanent card is back in hand.
+        driver.getPermanents(me).contains(eden) shouldBe false
+        driver.getGraveyard(me).contains(eden) shouldBe true
+        driver.getHand(me).contains(bear) shouldBe true
+        driver.getGraveyard(me).contains(bear) shouldBe false
+        // Mill two minus the returned card; hand gains exactly the returned card.
+        driver.getHandSize(me) shouldBe handBefore + 1
+    }
+
+    test("declining the sacrifice keeps Eden and returns nothing") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val bear = driver.putCardInGraveyard(me, "Grizzly Bears")
+
+        val eden = driver.putPermanentOnBattlefield(me, "Eden, Seat of the Sanctum")
+        driver.untapPermanent(eden)
+        driver.giveColorlessMana(me, 5)
+
+        val ability = EdenSeatOfTheSanctum.activatedAbilities[1].id
+        driver.submit(
+            ActivateAbility(playerId = me, sourceId = eden, abilityId = ability)
+        ).isSuccess shouldBe true
+        // Resolve the activated ability (mill two), pausing on the optional-sacrifice decision.
+        while (!driver.isPaused && driver.stackSize > 0) driver.bothPass()
+
+        // Decline the optional sacrifice.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, false)
+
+        // Eden stays on the battlefield; the graveyard card is not returned.
+        driver.getPermanents(me).contains(eden) shouldBe true
+        driver.getHand(me).contains(bear) shouldBe false
+        driver.getGraveyard(me).contains(bear) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JenovaAncientCalamityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JenovaAncientCalamityScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.JenovaAncientCalamity
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Jenova, Ancient Calamity (FIN).
+ *
+ * - At the beginning of combat on your turn, put a number of +1/+1 counters equal to Jenova's
+ *   power on up to one other target creature. That creature becomes a Mutant in addition to its
+ *   other types.
+ * - Whenever a Mutant you control dies during your turn, you draw cards equal to its power.
+ *
+ * Test 1 drives the combat trigger: a chosen other creature gains Jenova's power (1) in +1/+1
+ * counters and the Mutant subtype (asserted via projected subtypes).
+ *
+ * Test 2 drives the dies payoff: the creature made a Mutant in test 1 is then destroyed on the
+ * controller's turn, and the controller draws cards equal to that creature's last-known power.
+ */
+class JenovaAncientCalamityScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(JenovaAncientCalamity))
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // Player 1 may not be active at game start (random turn order) — advance until it is.
+    fun GameTestDriver.advanceToPlayer1(targetStep: Step) {
+        passPriorityUntil(targetStep)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(targetStep)
+            safety++
+        }
+    }
+
+    test("beginning of combat: target other creature gets Jenova's power in counters and becomes a Mutant") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(driver.player1, "Jenova, Ancient Calamity")
+
+        driver.advanceToPlayer1(Step.BEGIN_COMBAT)
+
+        // The combat trigger asks for "up to one other target creature".
+        val targetDecision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(driver.player1, listOf(bear))
+        driver.bothPass()
+
+        // Jenova's power is 1, so one +1/+1 counter is placed on the chosen creature.
+        plusOneCounters(driver, bear) shouldBe 1
+
+        // The creature becomes a Mutant in addition to its other types (projected subtype grant).
+        val projected = projector.project(driver.state)
+        projected.getSubtypes(bear).any { it.equals("Mutant", ignoreCase = true) } shouldBe true
+        // Still a Bear ("in addition to").
+        projected.getSubtypes(bear).any { it.equals("Bear", ignoreCase = true) } shouldBe true
+    }
+
+    test("a Mutant you control dying during your turn draws cards equal to its power") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(driver.player1, "Jenova, Ancient Calamity")
+
+        driver.advanceToPlayer1(Step.BEGIN_COMBAT)
+
+        // Make the Bear a Mutant (and give it +1/+1, so it is a 3/3) via Jenova's combat trigger.
+        val targetDecision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(driver.player1, listOf(bear))
+        driver.bothPass()
+        plusOneCounters(driver, bear) shouldBe 1
+
+        // Advance to the controller's main phase so they can cast Doom Blade ("during your turn").
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+        driver.activePlayer shouldBe driver.player1
+
+        val handBefore = driver.getHandSize(driver.player1)
+
+        // Destroy the Mutant for real so its dies trigger fires with last-known power (3).
+        val doomBlade = driver.putCardInHand(driver.player1, "Doom Blade")
+        driver.giveMana(driver.player1, Color.BLACK, 2)
+        driver.castSpell(driver.player1, doomBlade, targets = listOf(bear)).isSuccess shouldBe true
+        driver.bothPass() // resolve Doom Blade -> Bear is destroyed, queuing the dies trigger
+        driver.state.getBattlefield().contains(bear) shouldBe false
+        driver.bothPass() // resolve Jenova's "Mutant you control dies" draw trigger
+
+        // The Bear was a 3/3 Mutant (2/2 base + one +1/+1 counter), so the controller drew 3 cards.
+        driver.getHandSize(driver.player1) shouldBe handBefore + 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheGoldSaucerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheGoldSaucerScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Gold Saucer (FIN #279) — Land — Town.
+ *
+ *  - {T}: Add {C}.
+ *  - {2}, {T}: Flip a coin. If you win the flip, create a Treasure token.
+ *  - {3}, {T}, Sacrifice two artifacts: Draw a card.
+ *
+ * All three abilities are built from existing SDK primitives (AddColorlessMana, FlipCoinEffect,
+ * SacrificeMultiple cost + DrawCards), so these tests exercise the wiring end-to-end. The coin
+ * flip is random, so its test only asserts that the ability activates and resolves cleanly.
+ */
+class TheGoldSaucerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Gold Saucer") {
+
+            test("{T}: Add {C} fills the mana pool with one colorless mana") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Gold Saucer", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val saucer = game.findPermanent("The Gold Saucer")!!
+                val manaAbility = cardRegistry.getCard("The Gold Saucer")!!
+                    .activatedAbilities[0].id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = saucer,
+                        abilityId = manaAbility,
+                    )
+                )
+                withClue("Activating the mana ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("The mana ability adds one colorless mana") {
+                    pool?.colorless shouldBe 1
+                }
+            }
+
+            test("{2}, {T}: Flip a coin activates and resolves") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Gold Saucer", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Wastes", 2) // pays {2}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val saucer = game.findPermanent("The Gold Saucer")!!
+                val flipAbility = cardRegistry.getCard("The Gold Saucer")!!
+                    .activatedAbilities[1].id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = saucer,
+                        abilityId = flipAbility,
+                    )
+                )
+                withClue("Activating the coin-flip ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                // The flip is random; just assert it resolves cleanly off the stack. A Treasure
+                // is created on a win and not on a loss, so we only check 0..1 Treasures exist.
+                game.resolveStack()
+                withClue("At most one Treasure is created (depending on the flip)") {
+                    (game.findAllPermanents("Treasure").size in 0..1) shouldBe true
+                }
+            }
+
+            test("{3}, {T}, Sacrifice two artifacts: Draw a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "The Gold Saucer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Ornithopter", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Ornithopter", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Wastes", 3) // pays {3}
+                    .withCardInLibrary(1, "Grizzly Bears") // a card to draw
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val saucer = game.findPermanent("The Gold Saucer")!!
+                val artifacts = game.findAllPermanents("Ornithopter")
+                withClue("Two artifacts are on the battlefield to sacrifice") {
+                    artifacts.size shouldBe 2
+                }
+                val drawAbility = cardRegistry.getCard("The Gold Saucer")!!
+                    .activatedAbilities[2].id
+
+                val handBefore = game.state.getHand(game.player1Id).size
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = saucer,
+                        abilityId = drawAbility,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = artifacts),
+                    )
+                )
+                withClue("Activating the draw ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                withClue("Both artifacts were sacrificed as a cost") {
+                    game.findAllPermanents("Ornithopter").size shouldBe 0
+                }
+                game.resolveStack()
+
+                withClue("The ability draws exactly one card") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThePrimaVistaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThePrimaVistaScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for The Prima Vista (FIN #64).
+ *
+ * The Prima Vista {4}{U} Legendary Artifact — Vehicle 5/3
+ * Flying
+ * Whenever you cast a noncreature spell, if at least four mana was spent to cast it, The Prima
+ * Vista becomes an artifact creature until end of turn.
+ * Crew 2.
+ *
+ * Exercises the [com.wingedsheep.sdk.dsl.Conditions.TriggeringSpellManaSpentAtLeast] intervening-if
+ * on the [com.wingedsheep.sdk.dsl.Triggers.YouCastNoncreature] cast trigger: a 4-mana noncreature
+ * spell animates the Vehicle into an artifact creature until end of turn; a 1-mana one does not.
+ */
+class ThePrimaVistaScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("casting a 4-mana noncreature spell makes The Prima Vista an artifact creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val prima = driver.putPermanentOnBattlefield(active, "The Prima Vista")
+
+        withClue("the Vehicle starts as a noncreature artifact") {
+            driver.state.projectedState.isCreature(prima) shouldBe false
+        }
+
+        // Cast Stoke the Flames ({2}{R}{R}, a 4-mana instant) targeting the opponent, paying full mana.
+        val stoke = driver.putCardInHand(active, "Stoke the Flames")
+        driver.giveMana(active, Color.RED, 2)
+        driver.giveColorlessMana(active, 2)
+        driver.castSpellWithTargets(
+            active,
+            stoke,
+            listOf(entityIdToChosenTarget(driver.state, opponent)),
+        ).isSuccess shouldBe true
+        // Resolve The Prima Vista's trigger (on top of the stack), then the spell.
+        driver.bothPass()
+        driver.bothPass()
+
+        withClue("four mana was spent, so The Prima Vista is now an artifact creature") {
+            driver.state.projectedState.isCreature(prima) shouldBe true
+        }
+        withClue("printed 5/3") {
+            driver.state.projectedState.getPower(prima) shouldBe 5
+            driver.state.projectedState.getToughness(prima) shouldBe 3
+        }
+    }
+
+    test("casting a sub-4-mana noncreature spell does not animate The Prima Vista") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val prima = driver.putPermanentOnBattlefield(active, "The Prima Vista")
+
+        // Lightning Bolt ({R}) is a 1-mana noncreature spell — below the four-mana threshold.
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.giveMana(active, Color.RED, 1)
+        driver.castSpellWithTargets(
+            active,
+            bolt,
+            listOf(entityIdToChosenTarget(driver.state, opponent)),
+        ).isSuccess shouldBe true
+        driver.bothPass()
+        driver.bothPass()
+
+        withClue("fewer than four mana was spent, so the Vehicle stays a noncreature artifact") {
+            driver.state.projectedState.isCreature(prima) shouldBe false
+        }
+    }
+})


### PR DESCRIPTION
Implements a handful of pure-authoring **Final Fantasy (FIN)** cards via the `add-card` workflow — no engine/SDK changes. Each reuses existing primitives, ships a `rules-engine` scenario test, and the FIN card-snapshot golden is re-blessed.

## Cards

| Card | # | What it does |
|------|---|--------------|
| **The Prima Vista** | 64 | Legendary Artifact — Vehicle 5/3. Flying; Crew 2; *whenever you cast a noncreature spell, if at least four mana was spent, becomes an artifact creature until end of turn* (`Triggers.YouCastNoncreature` + `Conditions.TriggeringSpellManaSpentAtLeast(4)` intervening-if → `Effects.BecomeCreature(Self, 5/3, EndOfTurn)`). |
| **The Gold Saucer** | 279 | Land — Town. `{T}: Add {C}`; `{2},{T}:` flip a coin, on a win create a Treasure (`FlipCoinEffect(wonEffect = …)`); `{3},{T}, Sacrifice two artifacts: Draw a card` (`Costs.SacrificeMultiple(2, Artifact)`). |
| **Eden, Seat of the Sanctum** | 277 | Land — Town. `{T}: Add {C}`; `{5},{T}:` mill two, then you *may* sacrifice Eden and on doing so return another target permanent card from your graveyard to hand (`ReflexiveTriggerEffect`, `optional = true`; `excludeSelf = true` models "another"). |
| **Jenova, Ancient Calamity** | 228 | Legendary Creature — Alien 1/5. Beginning-of-combat: put +1/+1 counters equal to its power on up to one other target creature, which becomes a Mutant; whenever a Mutant you control dies during your turn, draw cards equal to its power (`DynamicAmounts.sourcePower`/`triggeringPower`, `Effects.AddCreatureType`, `Conditions.IsYourTurn`). |

## Tests
- 9 new scenario tests across the 4 cards — all pass.
- `CardLintTest` passes; `CardDefinitionSnapshotTest` re-blessed (FIN golden: +4 cards, no other card changed).

## Deferred: The Lunar Whale (#60)
Scoped in but **not** shipped — it needs a small engine change, so it belongs in `add-feature`, not `add-card`. "As long as it attacked this turn, you may play the top card of your library" works for casting *spells* but **not for playing a *land*** from the top: `PlayLandHandler.hasPlayFromTopOfLibrary` only matches a bare `PlayFromTopOfLibrary` static and never unwraps `ConditionalStaticAbility` (it special-cases only `MayPlayLandsFromGraveyard`). The fix — unwrap the conditional wrapper around `PlayFromTopOfLibrary` in the land-play permission check, evaluating its gating condition — is documented in `backlog/fin-engine-gaps.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)