### PR TITLE
Add three Final Fantasy cards (Stuck in Summoner's Sanctum, Reno and Rude, Blitzball)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2216,12 +2216,16 @@ work for abilities-on-stack (which carry no `CardComponent`).
   payoffs that target/choose/sacrifice/return "a creature that crewed/saddled it this turn" (Giant
   Beaver, Rambling Possum, The Gitrog, Calamity). For the *count* of those creatures use
   `DynamicAmount.CreaturesThatCrewedOrSaddledThisTurn` instead.
-- `IsAttachedToBySource` (filter builder `notAttachedToBySource()`, which wraps it in a negation) —
+- `IsAttachedToBySource` (positive filter builder `attachedToBySource()`; negated builder
+  `notAttachedToBySource()`) —
   source-relative: matches the permanent the effect's source is attached to, read from the source's
   `AttachedToComponent.targetId`. Used negated for "other than enchanted/equipped creature"
   exclusions on Aura/Equipment edicts — Sporogenic Infection: "target player sacrifices a creature of
   their choice other than enchanted creature" via
-  `Effects.Sacrifice(GameObjectFilter.Creature.notAttachedToBySource(), 1, targetPlayer)`. Resolves
+  `Effects.Sacrifice(GameObjectFilter.Creature.notAttachedToBySource(), 1, targetPlayer)`. Used
+  positively to scope a static ability on an Aura/Equipment to just its host — Stuck in Summoner's
+  Sanctum: "enchanted permanent's activated abilities can't be activated" via
+  `PreventActivatedAbilities(GameObjectFilter.Permanent.attachedToBySource())`. Resolves
   against `PredicateContext.sourceId`; inert with no source / unattached source, and never matches in
   group-static projection or trigger-gating contexts (no source there).
 - `HasGreatestPower` (filter builder `hasGreatestPower()`) / `HasLeastPower` (filter builder
@@ -5148,6 +5152,11 @@ of `AddMana`. The engine empties pools at end of turn, so:
 - `LIFE_LOST` — life lost this turn.
 - `PLAYER_ATTACKED` — whether/how many times you attacked.
 - `DEALT_COMBAT_DAMAGE` — combat damage dealt.
+- `DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE` — indicator (0/1) that the player was dealt combat
+  damage by a legendary creature this turn (recorded in `CombatDamageManager`, cleared at end of
+  turn). Powers "an opponent was dealt combat damage by a legendary creature this turn" — Blitzball —
+  via `Compare(TurnTracking(EachOpponent, DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE), GTE, 1)`
+  (facade `Conditions.AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn`).
 - `COUNTERS_PUT_ON_CREATURE` — counters placed.
 - `LANDS_PLAYED` — lands the player explicitly played this turn (from-hand land drops only,
   derived from `LandDropsComponent`).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1120,6 +1120,17 @@ object Conditions {
     val OpponentLostLifeThisTurn: ConditionInterface =
         trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_LOST, player = Player.EachOpponent)
 
+    /**
+     * If an opponent was dealt combat damage by a legendary creature this turn.
+     * Used for cards like Blitzball: "Activate only if an opponent was dealt combat damage by a
+     * legendary creature this turn."
+     */
+    val AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn: ConditionInterface =
+        trackerAtLeast(
+            com.wingedsheep.sdk.scripting.values.TurnTracker.DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE,
+            player = Player.EachOpponent,
+        )
+
     // =========================================================================
     // Candidate-player target restrictions (CR 115)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -663,6 +663,16 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must BE the permanent the effect's source is attached to (its enchanted/equipped
+     * permanent). Source-relative — scopes a static ability on an Aura/Equipment to just its
+     * host, e.g. Stuck in Summoner's Sanctum's "enchanted permanent's activated abilities can't
+     * be activated" via [com.wingedsheep.sdk.scripting.PreventActivatedAbilities].
+     */
+    fun attachedToBySource() = copy(
+        statePredicates = statePredicates + StatePredicate.IsAttachedToBySource
+    )
+
+    /**
      * Must be attached to a permanent matching [hostFilter] (general form of attachment matching —
      * the host filter may carry a controller predicate, e.g. "a creature you control"). Used by
      * Stolen Uniform's reflexive "if it's attached to a creature you control" guard.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/values/DynamicAmount.kt
@@ -45,6 +45,13 @@ enum class TurnTracker {
     PLAYER_ATTACKED,
     /** Indicator (0 or 1) that the player was dealt combat damage this turn. */
     DEALT_COMBAT_DAMAGE,
+    /**
+     * Indicator (0 or 1) that the player was dealt combat damage by a legendary creature this
+     * turn. Backed by `WasDealtCombatDamageByLegendaryCreatureThisTurnComponent`, set when a
+     * legendary creature deals combat damage to the player and cleared at end of turn. Powers
+     * "if an opponent was dealt combat damage by a legendary creature this turn" (Blitzball).
+     */
+    DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE,
     /** Indicator (0 or 1) that the player put one or more counters on a creature this turn. */
     COUNTERS_PUT_ON_CREATURE,
     /** Number of land cards the player played this turn (derived from `LandDropsComponent`). */
@@ -101,6 +108,8 @@ enum class TurnTracker {
         LIFE_LOST -> "whether ${player.description} lost life this turn"
         PLAYER_ATTACKED -> "whether ${player.description} attacked this turn"
         DEALT_COMBAT_DAMAGE -> "whether ${player.description} were dealt combat damage this turn"
+        DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE ->
+            "whether ${player.description} were dealt combat damage by a legendary creature this turn"
         COUNTERS_PUT_ON_CREATURE -> "whether ${player.description} put a counter on a creature this turn"
         LANDS_PLAYED -> "the number of lands ${player.description} played this turn"
         LANDS_ENTERED_UNDER_CONTROL -> "the number of lands that entered the battlefield under ${player.possessive} control this turn"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Blitzball.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Blitzball.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Blitzball
+ * {3}
+ * Artifact
+ *
+ * {T}: Add one mana of any color.
+ * GOOOOAAAALLL! — {T}, Sacrifice this artifact: Draw two cards. Activate only if an
+ * opponent was dealt combat damage by a legendary creature this turn.
+ *
+ * The mana ability is the standard `AddAnyColorMana` rock. The draw ability gates on a new
+ * per-turn tracker — [Conditions.AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn],
+ * backed by `DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE` — recorded in `CombatDamageManager`
+ * whenever a legendary creature deals combat damage to a player and cleared at end of turn.
+ */
+val Blitzball = card("Blitzball") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add one mana of any color.\n" +
+        "GOOOOAAAALLL! — {T}, Sacrifice this artifact: Draw two cards. Activate only if an " +
+        "opponent was dealt combat damage by a legendary creature this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.DrawCards(2)
+        description = "GOOOOAAAALLL! — Draw two cards. Activate only if an opponent was dealt " +
+            "combat damage by a legendary creature this turn."
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(
+                Conditions.AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "254"
+        artist = "Gas1"
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/92f4ad73-42bf-45c0-8bb6-0b44043c81ef.jpg?1748706744"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RenoAndRude.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RenoAndRude.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Reno and Rude
+ * {1}{B}
+ * Legendary Creature — Human Assassin
+ * 2/1
+ *
+ * Menace
+ * Whenever Reno and Rude deals combat damage to a player, exile the top card of
+ * that player's library. Then you may sacrifice another creature or artifact. If
+ * you do, you may play the exiled card this turn, and mana of any type can be
+ * spent to cast it.
+ *
+ * Resolution-time chain over existing pipeline primitives:
+ *   1. exile the top card of the *damaged* player's library ([Player.TriggeringPlayer]
+ *      is the player dealt combat damage; the card stays owned by them in exile),
+ *   2. an [OptionalCostEffect] models "you may sacrifice another creature or artifact.
+ *      If you do, ...": the sacrifice is the optional cost (`excludeSource` makes it
+ *      "another"), and only paying it grants the play permission,
+ *   3. the reward is a [GrantMayPlayFromExileEffect] with `withAnyManaType` for
+ *      "mana of any type can be spent to cast it", expiring at end of turn.
+ */
+val RenoAndRude = card("Reno and Rude") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Assassin"
+    power = 2
+    toughness = 1
+    oracleText = "Menace\n" +
+        "Whenever Reno and Rude deals combat damage to a player, exile the top card of " +
+        "that player's library. Then you may sacrifice another creature or artifact. If you " +
+        "do, you may play the exiled card this turn, and mana of any type can be spent to cast it."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(
+                        DynamicAmount.Fixed(1),
+                        player = Player.TriggeringPlayer,
+                    ),
+                    storeAs = "exiled",
+                ),
+                MoveCollectionEffect(
+                    from = "exiled",
+                    destination = CardDestination.ToZone(Zone.EXILE, player = Player.TriggeringPlayer),
+                ),
+                OptionalCostEffect(
+                    cost = SacrificeEffect(
+                        filter = GameObjectFilter.CreatureOrArtifact,
+                        count = 1,
+                        excludeSource = true,
+                    ),
+                    ifPaid = GrantMayPlayFromExileEffect(
+                        from = "exiled",
+                        expiry = MayPlayExpiry.EndOfTurn,
+                        withAnyManaType = true,
+                    ),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "113"
+        artist = "Maji"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5eb0064-c7c4-4e3e-add2-b86269de3fb9.jpg?1748706185"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/StuckInSummonersSanctum.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/StuckInSummonersSanctum.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Stuck in Summoner's Sanctum
+ * {2}{U}
+ * Enchantment — Aura
+ *
+ * Flash
+ * Enchant artifact or creature
+ * When this Aura enters, tap enchanted permanent.
+ * Enchanted permanent doesn't untap during its controller's untap step and its
+ * activated abilities can't be activated.
+ *
+ * Charmed Sleep's lock generalised to any permanent (artifact or creature). The
+ * untap restriction reuses [AbilityFlag.DOESNT_UNTAP] on the host (granted via the
+ * default `attachedCreature()` group filter, which scopes to any attached permanent).
+ * The activation lock uses [PreventActivatedAbilities] scoped with
+ * `attachedToBySource()` so it forbids only this Aura's host — the who/when-blind
+ * Cursed Totem static read at activation-legality time, narrowed to the enchanted
+ * permanent.
+ */
+val StuckInSummonersSanctum = card("Stuck in Summoner's Sanctum") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant artifact or creature\n" +
+        "When this Aura enters, tap enchanted permanent.\n" +
+        "Enchanted permanent doesn't untap during its controller's untap step and its " +
+        "activated abilities can't be activated."
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.CreatureOrArtifact
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Tap(EffectTarget.EnchantedPermanent)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(AbilityFlag.DOESNT_UNTAP.name)
+    }
+
+    staticAbility {
+        ability = PreventActivatedAbilities(
+            filter = GameObjectFilter.Permanent.attachedToBySource(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Susumu Kuroi"
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/6678501e-6349-4e37-ab4c-a31a3d408d52.jpg?1748706046"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1795,6 +1795,67 @@
     ]
 }
 
+// Blitzball
+{
+    "name": "Blitzball",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add one mana of any color.\nGOOOOAAAALLL! — {T}, Sacrifice this artifact: Draw two cards. Activate only if an opponent was dealt combat damage by a legendary creature this turn.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "TurnTracking",
+                                "player": "EachOpponent",
+                                "tracker": "DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                ],
+                "descriptionOverride": "GOOOOAAAALLL! — Draw two cards. Activate only if an opponent was dealt combat damage by a legendary creature this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "254",
+        "artist": "Gas1",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/92f4ad73-42bf-45c0-8bb6-0b44043c81ef.jpg?1748706744"
+    },
+    "colorIdentityOverride": []
+}
+
 // Blitzball Shot
 {
     "name": "Blitzball Shot",
@@ -11748,6 +11809,84 @@
     ]
 }
 
+// Reno and Rude
+{
+    "name": "Reno and Rude",
+    "manaCost": "{1}{B}",
+    "typeLine": "Legendary Creature — Human Assassin",
+    "oracleText": "Menace\nWhenever Reno and Rude deals combat damage to a player, exile the top card of that player's library. Then you may sacrifice another creature or artifact. If you do, you may play the exiled card this turn, and mana of any type can be spent to cast it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": "TriggeringPlayer"
+                            },
+                            "storeAs": "exiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile",
+                                "player": "TriggeringPlayer"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.MayPay",
+                                "cost": {
+                                    "type": "Sacrifice",
+                                    "filter": "creature|artifact",
+                                    "excludeSource": true
+                                }
+                            },
+                            "then": {
+                                "type": "GrantMayPlayFromExile",
+                                "from": "exiled",
+                                "withAnyManaType": true
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "rarity": "UNCOMMON",
+        "artist": "Maji",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5eb0064-c7c4-4e3e-add2-b86269de3fb9.jpg?1748706185"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Resentful Revelation
 {
     "name": "Resentful Revelation",
@@ -14282,6 +14421,63 @@
         "rarity": "UNCOMMON",
         "artist": "Chris Rallis",
         "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d80c511-2f4d-4f77-8143-7b49b2b19fae.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Stuck in Summoner's Sanctum
+{
+    "name": "Stuck in Summoner's Sanctum",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant artifact or creature\nWhen this Aura enters, tap enchanted permanent.\nEnchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "EnchantedPermanent"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "DOESNT_UNTAP"
+            },
+            {
+                "type": "PreventActivatedAbilities",
+                "filter": {
+                    "cardPredicates": [
+                        "IsPermanent"
+                    ],
+                    "statePredicates": [
+                        "IsAttachedToBySource"
+                    ]
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature|artifact"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Susumu Kuroi",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/6678501e-6349-4e37-ab4c-a31a3d408d52.jpg?1748706046"
     },
     "colorIdentityOverride": [
         "BLUE"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -55,6 +55,7 @@ import com.wingedsheep.engine.state.components.player.LifeLostThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PutCounterOnCreatureThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.SacrificedFoodThisTurnComponent
+import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageByLegendaryCreatureThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
@@ -715,6 +716,9 @@ class CleanupPhaseManager(
                 }
                 if (result.has<WasDealtCombatDamageThisTurnComponent>()) {
                     result = result.without<WasDealtCombatDamageThisTurnComponent>()
+                }
+                if (result.has<WasDealtCombatDamageByLegendaryCreatureThisTurnComponent>()) {
+                    result = result.without<WasDealtCombatDamageByLegendaryCreatureThisTurnComponent>()
                 }
                 result
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -464,6 +464,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CardsDrawnThisTurnComponent::class)
         subclass(EquipActivationsThisTurnComponent::class)
         subclass(WasDealtCombatDamageThisTurnComponent::class)
+        subclass(WasDealtCombatDamageByLegendaryCreatureThisTurnComponent::class)
         subclass(AdditionalPhasesComponent::class)
         subclass(InAdditionalCombatPhaseComponent::class)
         subclass(AdditionalUpkeepStepsComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/DynamicAmountEvaluator.kt
@@ -427,6 +427,10 @@ class DynamicAmountEvaluator(
                         state.getEntity(playerId)
                             ?.has<com.wingedsheep.engine.state.components.player.WasDealtCombatDamageThisTurnComponent>() == true
                     }
+                    TurnTracker.DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE -> playerIds.count { playerId ->
+                        state.getEntity(playerId)
+                            ?.has<com.wingedsheep.engine.state.components.player.WasDealtCombatDamageByLegendaryCreatureThisTurnComponent>() == true
+                    }
                     TurnTracker.COUNTERS_PUT_ON_CREATURE -> playerIds.count { playerId ->
                         state.getEntity(playerId)
                             ?.has<com.wingedsheep.engine.state.components.player.PutCounterOnCreatureThisTurnComponent>() == true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -15,6 +15,7 @@ import com.wingedsheep.engine.state.components.battlefield.DealtCombatDamageToPl
 import com.wingedsheep.engine.state.components.battlefield.HasDealtCombatDamageToPlayerComponent
 import com.wingedsheep.engine.state.components.battlefield.HasDealtDamageComponent
 import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTurnComponent
+import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageByLegendaryCreatureThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.combat.AttackerOrderComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
@@ -908,6 +909,12 @@ internal class CombatDamageManager(
         newState = newState.updateEntity(targetId) { container ->
             container.with(WasDealtCombatDamageThisTurnComponent)
         }
+        // Track when the damaging source is a legendary creature (Blitzball etc.)
+        if (state.projectedState.isCreature(sourceId) && state.projectedState.isLegendary(sourceId)) {
+            newState = newState.updateEntity(targetId) { container ->
+                container.with(WasDealtCombatDamageByLegendaryCreatureThisTurnComponent)
+            }
+        }
 
         val sourceName = state.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Creature"
         events.add(DamageDealtEvent(sourceId, targetId, effectiveAmount, true,
@@ -1053,6 +1060,12 @@ internal class CombatDamageManager(
             // Track that player was dealt combat damage this turn
             newState = newState.updateEntity(targetId) { container ->
                 container.with(WasDealtCombatDamageThisTurnComponent)
+            }
+            // Track when the damaging source is a legendary creature (Blitzball etc.)
+            if (projected.isCreature(sourceId) && projected.isLegendary(sourceId)) {
+                newState = newState.updateEntity(targetId) { container ->
+                    container.with(WasDealtCombatDamageByLegendaryCreatureThisTurnComponent)
+                }
             }
             val sourceName = newState.getEntity(sourceId)?.get<CardComponent>()?.name ?: "Creature"
             events.add(DamageDealtEvent(sourceId, targetId, amount, true,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -1021,6 +1021,15 @@ data object PutCounterOnCreatureThisTurnComponent : Component
 data object WasDealtCombatDamageThisTurnComponent : Component
 
 /**
+ * Marks a player as having been dealt combat damage by a legendary creature this turn.
+ * Cleared at end of turn by CleanupPhaseManager.
+ * Backs the DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE turn tracker
+ * (AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn condition — Blitzball).
+ */
+@Serializable
+data object WasDealtCombatDamageByLegendaryCreatureThisTurnComponent : Component
+
+/**
  * Component indicating that a player should skip their entire next [turns] turns.
  * Applied by effects like Last Chance (which gives the opponent an "extra turn" by skipping the
  * other player's turn in a 2-player game) and Ral Zarek, Guest Lecturer's ultimate (skip several

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlitzballScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlitzballScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Blitzball (FIN #254) — {3} Artifact.
+ *
+ * "{T}: Add one mana of any color.
+ *  GOOOOAAAALLL! — {T}, Sacrifice this artifact: Draw two cards. Activate only if an opponent
+ *  was dealt combat damage by a legendary creature this turn."
+ *
+ * Exercises the new DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE turn tracker
+ * (AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn): the GOOOOAAAALLL ability is gated
+ * off until a legendary creature deals combat damage to an opponent, then becomes available.
+ */
+class BlitzballScenarioTest : ScenarioTestBase() {
+
+    private val goalAbilityId =
+        cardRegistry.getCard("Blitzball")!!.script.activatedAbilities[1].id
+
+    init {
+        test("GOOOOAAAALLL is not activatable before any legendary combat damage") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Blitzball", tapped = false, summoningSickness = false)
+                .withCardOnBattlefield(1, "Yargle, Glutton of Urborg", summoningSickness = false)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val blitzball = game.findPermanent("Blitzball")!!
+            val goal = game.getLegalActions(1).find {
+                val a = it.action
+                a is ActivateAbility && a.sourceId == blitzball && a.abilityId == goalAbilityId
+            }
+            withClue("GOOOOAAAALLL should be unavailable until a legendary deals combat damage") {
+                goal shouldBe null
+            }
+        }
+
+        test("GOOOOAAAALLL becomes activatable after a legendary creature deals combat damage to an opponent") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Blitzball", tapped = false, summoningSickness = false)
+                .withCardOnBattlefield(1, "Yargle, Glutton of Urborg", tapped = false, summoningSickness = false)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val blitzball = game.findPermanent("Blitzball")!!
+
+            // Attack P2 with the legendary Yargle (9/3) and let combat damage resolve.
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Yargle, Glutton of Urborg" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+            withClue("P2 should have taken 9 combat damage from Yargle") {
+                game.getLifeTotal(2) shouldBe 11
+            }
+
+            val goal = game.getLegalActions(1).find {
+                val a = it.action
+                a is ActivateAbility && a.sourceId == blitzball && a.abilityId == goalAbilityId
+            }
+            withClue("GOOOOAAAALLL should now be available after a legendary dealt combat damage") {
+                (goal != null) shouldBe true
+            }
+
+            val activation = game.execute(
+                ActivateAbility(
+                    playerId = game.player1Id,
+                    sourceId = blitzball,
+                    abilityId = goalAbilityId,
+                )
+            )
+            withClue("Activating GOOOOAAAALLL should succeed: ${activation.error}") {
+                activation.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("Blitzball was sacrificed as part of the cost") {
+                game.findPermanent("Blitzball") shouldBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StuckInSummonersSanctumScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StuckInSummonersSanctumScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Stuck in Summoner's Sanctum (FIN #76) — {2}{U} Enchantment — Aura.
+ *
+ * "Flash
+ *  Enchant artifact or creature
+ *  When this Aura enters, tap enchanted permanent.
+ *  Enchanted permanent doesn't untap during its controller's untap step and its activated
+ *  abilities can't be activated."
+ *
+ * Focuses on the new behavior: the activation lock scoped to just the Aura's host via
+ * `PreventActivatedAbilities(GameObjectFilter.Permanent.attachedToBySource())`. The
+ * "doesn't untap" half reuses the engine's DOESNT_UNTAP flag (covered by Charmed Sleep).
+ */
+class StuckInSummonersSanctumScenarioTest : ScenarioTestBase() {
+
+    private val elvesManaAbilityId =
+        cardRegistry.getCard("Llanowar Elves")!!.script.activatedAbilities.first().id
+
+    init {
+        test("enchanted permanent's activated abilities can't be activated") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(2, "Llanowar Elves", summoningSickness = false)
+                .withCardAttachedTo(1, "Stuck in Summoner's Sanctum", "Llanowar Elves")
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val elves = game.findPermanent("Llanowar Elves")!!
+            val elvesActivation = game.getLegalActions(2).find {
+                val a = it.action
+                a is ActivateAbility && a.sourceId == elves && a.abilityId == elvesManaAbilityId
+            }
+            withClue("Stuck in Summoner's Sanctum should lock the enchanted creature's mana ability") {
+                elvesActivation shouldBe null
+            }
+        }
+
+        test("the same creature's ability is available when not enchanted (control)") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(2, "Llanowar Elves", summoningSickness = false)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val elves = game.findPermanent("Llanowar Elves")!!
+            val elvesActivation = game.getLegalActions(2).find {
+                val a = it.action
+                a is ActivateAbility && a.sourceId == elves && a.abilityId == elvesManaAbilityId
+            }
+            withClue("Without the Aura, Llanowar Elves' mana ability should be available") {
+                (elvesActivation != null) shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of unimplemented **Final Fantasy (FIN)** cards via the `add-card` flow. Two compose existing primitives; one adds a small, reusable engine feature.

## Cards

### Stuck in Summoner's Sanctum — `{2}{U}` Enchantment — Aura (common, #76)
> Flash · Enchant artifact or creature · When this Aura enters, tap enchanted permanent. · Enchanted permanent doesn't untap during its controller's untap step and its activated abilities can't be activated.

Reuses the Charmed Sleep lock (`DOESNT_UNTAP` on the host). The activation lock reuses `PreventActivatedAbilities`, scoped to just the Aura's host via a new positive filter helper **`GameObjectFilter.attachedToBySource()`** (twin of the existing `notAttachedToBySource()`, backed by the existing `StatePredicate.IsAttachedToBySource`).

### Reno and Rude — `{1}{B}` Legendary Creature — Human Assassin, 2/1 (uncommon, #113)
> Menace · Whenever Reno and Rude deals combat damage to a player, exile the top card of that player's library. Then you may sacrifice another creature or artifact. If you do, you may play the exiled card this turn, and mana of any type can be spent to cast it.

Pure composition: exile the top of the *damaged* player's library (`Player.TriggeringPlayer`), then an `OptionalCostEffect` (sacrifice another creature/artifact, `excludeSource`) gates a `GrantMayPlayFromExileEffect(withAnyManaType = true)`.

### Blitzball — `{3}` Artifact (common, #254)
> {T}: Add one mana of any color. · GOOOOAAAALLL! — {T}, Sacrifice this artifact: Draw two cards. Activate only if an opponent was dealt combat damage by a legendary creature this turn.

Adds a new **`DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE`** turn tracker — a per-player component recorded in `CombatDamageManager` when a legendary creature deals combat damage to a player, cleared at end of turn — exposed via `Conditions.AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn` and used as an `ActivationRestriction.OnlyIfCondition` gate.

## New SDK / engine building blocks
- `GameObjectFilter.attachedToBySource()` — scope a static ability to its Aura/Equipment host.
- `TurnTracker.DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE` + `WasDealtCombatDamageByLegendaryCreatureThisTurnComponent` (set in `CombatDamageManager`, read in `DynamicAmountEvaluator`, cleared in `CleanupPhaseManager`, registered in `Serialization`).
- `Conditions.AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn`.

## Tests
- `BlitzballScenarioTest` — GOOOOAAAALLL gated off until a legendary (Yargle, 9/3) deals combat damage to an opponent, then activatable (and sacrifices Blitzball).
- `StuckInSummonersSanctumScenarioTest` — enchanted creature's mana ability is locked; available again without the Aura (control).
- FIN card snapshot reblessed (adds only the 3 new cards; no other card's tree changed).
- SDK reference (`docs/card-sdk-language-reference.md`) updated for all three new building blocks.
- Combat/aura/activation regression suites pass (`*Combat*`, `*Lifelink*`, `*Trample*`, `*FirstStrike*`, Cursed Totem, Sleep Magic, Kotis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)