### PR TITLE
Fix Room cards in sealed/draft deckbuilder: rotate preview + real mana cost

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -663,11 +663,27 @@ class ConnectionHandler(
         /** Minimum seconds a player must be disconnected before they can be kicked */
         const val KICK_MINIMUM_DISCONNECT_SECONDS = 120
 
+        /**
+         * Mana cost string for the sealed/draft deckbuilder. A split card (Rooms, fused split
+         * cards) has no single printed cost — its top-level [CardDefinition.manaCost] is empty —
+         * so we join each face's cost with " // " (e.g. "{U} // {4}{U}"). The client renders that
+         * with a slash separator, and its mana-curve / land-suggestion logic sums the pips across
+         * both halves (a split card's mana value while not on the stack is the combined mana value
+         * of its halves). Null when the card has no printed cost at all (e.g. lands).
+         */
+        private fun sealedManaCost(card: com.wingedsheep.sdk.model.CardDefinition): String? {
+            if (card.layout == com.wingedsheep.sdk.model.CardLayout.SPLIT && card.cardFaces.isNotEmpty()) {
+                return card.cardFaces.joinToString(" // ") { it.manaCost.toString() }
+                    .takeIf { it.isNotBlank() }
+            }
+            return if (card.manaCost.symbols.isEmpty()) null else card.manaCost.toString()
+        }
+
         fun cardToSealedCardInfo(card: com.wingedsheep.sdk.model.CardDefinition): ServerMessage.SealedCardInfo {
             val backFace = card.backFace
             return ServerMessage.SealedCardInfo(
                 name = card.name,
-                manaCost = if (card.manaCost.symbols.isEmpty()) null else card.manaCost.toString(),
+                manaCost = sealedManaCost(card),
                 typeLine = card.typeLine.toString(),
                 rarity = card.metadata.rarity.name,
                 imageUri = card.metadata.imageUri,
@@ -682,7 +698,8 @@ class ConnectionHandler(
                 backFaceImageUri = backFace?.metadata?.imageUri,
                 colorIdentity = card.colorIdentity.map { it.name },
                 setCode = card.setCode,
-                collectorNumber = card.metadata.collectorNumber
+                collectorNumber = card.metadata.collectorNumber,
+                layout = card.layout.name
             )
         }
     }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -339,7 +339,13 @@ sealed interface ServerMessage {
         // player saves a drafted/sealed deck to their library (otherwise the save falls back to
         // the card's default printing). Either may be null for test cards lacking metadata.
         val setCode: String? = null,
-        val collectorNumber: String? = null
+        val collectorNumber: String? = null,
+        /**
+         * Printed layout (`NORMAL`, `SPLIT`, `ADVENTURE`, …). Lets the sealed/draft deckbuilder
+         * rotate split cards (Rooms like Unholy Annex // Ritual Chamber, Pain // Suffering) to
+         * landscape in the hover preview, since their single image is printed sideways.
+         */
+        val layout: String = "NORMAL"
     )
 
     /**

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -25,7 +25,7 @@ import { ManaCost, ManaSymbol } from '@/components/ui/ManaSymbols'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
 import { useDfcHoverFlip } from '@/components/ui/useDfcHoverFlip'
 import { SetIcon } from '@/components/ui/SetIcon'
-import { getCardImageUrl, getScryfallArtCropUrl } from '@/utils/cardImages'
+import { getCardImageUrl, getScryfallArtCropUrl, splitImageRotateDeg } from '@/utils/cardImages'
 import { rarityColor } from '@/components/draft/RarityBadge'
 import {
   parseQuery,
@@ -3823,15 +3823,6 @@ function CardTextFallback({ card }: { card: CardSummary }) {
 
 function resolveImageUrl(card: CardSummary): string {
   return getCardImageUrl(card.name, card.imageUri ?? null, 'normal')
-}
-
-/**
- * Split-layout cards (Pain // Suffering, Rooms like Unholy Annex // Ritual Chamber) have a
- * single image that's printed sideways, so the hover preview rotates it 90° to read landscape.
- * Mirrors the game-board treatment in CardPreview.tsx.
- */
-function splitImageRotateDeg(card: { layout?: string } | null | undefined): 0 | 90 {
-  return card?.layout === 'SPLIT' ? 90 : 0
 }
 
 /**

--- a/web-client/src/components/draft/DraftPickOverlay.tsx
+++ b/web-client/src/components/draft/DraftPickOverlay.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useGameStore, type DraftState } from '@/store/gameStore.ts'
 import type { SealedCardInfo, LobbySettings } from '@/types'
 import { useResponsive } from '@/hooks/useResponsive.ts'
-import { getCardImageUrl } from '@/utils/cardImages.ts'
+import { getCardImageUrl, splitImageRotateDeg } from '@/utils/cardImages.ts'
 import { ManaCost } from '../ui/ManaSymbols'
 import { HoverCardPreview } from '../ui/HoverCardPreview'
 import { useDfcHoverFlip } from '../ui/useDfcHoverFlip'
@@ -500,6 +500,7 @@ function DraftPicker({ draftState, settings }: { draftState: DraftState; setting
           pos={hoverPos}
           rulings={hoveredCard.rulings}
           overlay={dfc.hint}
+          imageRotateDeg={splitImageRotateDeg(hoveredCard)}
         />
       )}
     </div>

--- a/web-client/src/components/draft/GridDraftOverlay.tsx
+++ b/web-client/src/components/draft/GridDraftOverlay.tsx
@@ -3,7 +3,7 @@ import { useGameStore } from '@/store/gameStore.ts'
 import type { GridDraftState } from '@/store/slices'
 import type { SealedCardInfo, LobbySettings } from '@/types'
 import { useResponsive } from '@/hooks/useResponsive.ts'
-import { getCardImageUrl } from '@/utils/cardImages.ts'
+import { getCardImageUrl, splitImageRotateDeg } from '@/utils/cardImages.ts'
 import { ManaCost } from '../ui/ManaSymbols'
 import { HoverCardPreview } from '../ui/HoverCardPreview'
 import { useDfcHoverFlip } from '../ui/useDfcHoverFlip'
@@ -862,6 +862,7 @@ function GridDrafter({ gridState, settings }: { gridState: GridDraftState; setti
           pos={hoverPos}
           rulings={hoveredCard.rulings}
           overlay={dfc.hint}
+          imageRotateDeg={splitImageRotateDeg(hoveredCard)}
         />
       )}
 

--- a/web-client/src/components/draft/WinstonDraftOverlay.tsx
+++ b/web-client/src/components/draft/WinstonDraftOverlay.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { useGameStore, type WinstonDraftState } from '@/store/gameStore.ts'
 import type { SealedCardInfo, LobbySettings } from '@/types'
 import { useResponsive } from '@/hooks/useResponsive.ts'
-import { getCardImageUrl } from '@/utils/cardImages.ts'
+import { getCardImageUrl, splitImageRotateDeg } from '@/utils/cardImages.ts'
 import { ManaCost } from '../ui/ManaSymbols'
 import { HoverCardPreview } from '../ui/HoverCardPreview'
 import { useDfcHoverFlip } from '../ui/useDfcHoverFlip'
@@ -717,6 +717,7 @@ function WinstonDrafter({ winstonState, settings }: { winstonState: WinstonDraft
           pos={hoverPos}
           rulings={hoveredCard.rulings}
           overlay={dfc.hint}
+          imageRotateDeg={splitImageRotateDeg(hoveredCard)}
         />
       )}
 

--- a/web-client/src/components/sealed/DeckBuilderOverlay.tsx
+++ b/web-client/src/components/sealed/DeckBuilderOverlay.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useGameStore, type DeckBuildingState } from '@/store/gameStore.ts'
 import type { SealedCardInfo } from '@/types'
 import { useResponsive } from '@/hooks/useResponsive.ts'
-import { getCardImageUrl } from '@/utils/cardImages.ts'
+import { getCardImageUrl, splitImageRotateDeg } from '@/utils/cardImages.ts'
 import { playableWithinColors } from '@/utils/manaCost.ts'
 import { ManaSymbol, ManaCost } from '../ui/ManaSymbols'
 import { HoverCardPreview } from '../ui/HoverCardPreview'
@@ -1377,6 +1377,7 @@ function DeckBuilder({ state }: { state: DeckBuildingState }) {
           pos={hoverPos}
           rulings={hoveredCard.rulings}
           overlay={dfc.hint}
+          imageRotateDeg={splitImageRotateDeg(hoveredCard)}
         />
       )}
 

--- a/web-client/src/components/ui/ManaSymbols.tsx
+++ b/web-client/src/components/ui/ManaSymbols.tsx
@@ -68,15 +68,27 @@ export function ManaSymbol({ symbol, size = 14 }: { symbol: string; size?: numbe
 export function ManaCost({ cost, size = 14, gap = 1 }: { cost: string | null; size?: number; gap?: number }) {
   if (!cost) return null
 
-  const symbols = cost.match(/\{([^}]+)\}/g)
-  if (!symbols || symbols.length === 0) return null
+  // Split cards (Rooms, fused split cards) carry both halves' costs joined by "//"
+  // (e.g. "{U} // {4}{U}"). Render each half's symbols with a slash divider between them.
+  const halves = cost
+    .split('//')
+    .map((half) => half.match(/\{([^}]+)\}/g) ?? [])
+    .filter((symbols) => symbols.length > 0)
+  if (halves.length === 0) return null
 
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap }}>
-      {symbols.map((match, i) => {
-        const inner = match.slice(1, -1)
-        return <ManaSymbol key={i} symbol={inner} size={size} />
-      })}
+      {halves.map((symbols, hi) => (
+        <span key={hi} style={{ display: 'inline-flex', alignItems: 'center', gap }}>
+          {hi > 0 && (
+            <span style={{ opacity: 0.6, margin: '0 2px', fontSize: Math.round(size * 0.85) }}>//</span>
+          )}
+          {symbols.map((match, i) => {
+            const inner = match.slice(1, -1)
+            return <ManaSymbol key={i} symbol={inner} size={size} />
+          })}
+        </span>
+      ))}
     </span>
   )
 }

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1135,6 +1135,12 @@ export interface SealedCardInfo {
    */
   readonly setCode?: string | null
   readonly collectorNumber?: string | null
+  /**
+   * Printed layout code ('NORMAL', 'SPLIT', 'ADVENTURE', …). Split cards (Pain // Suffering,
+   * Rooms like Unholy Annex // Ritual Chamber) are 'SPLIT' — the deckbuilder rotates their
+   * hover preview 90° to landscape since the single image is printed sideways.
+   */
+  readonly layout?: string
 }
 
 /**

--- a/web-client/src/utils/cardImages.ts
+++ b/web-client/src/utils/cardImages.ts
@@ -19,6 +19,15 @@ export const MANIFEST_FACE_DOWN_IMAGE_URL = 'https://cards.scryfall.io/normal/fr
 export const CARD_BACK_IMAGE_URL = 'https://backs.scryfall.io/normal/2/2/222b7a3b-2321-4d4c-af19-19338b134971.jpg?1677416389'
 
 /**
+ * Degrees to rotate a card's hover preview image. Split-layout cards (Pain // Suffering, Rooms
+ * like Unholy Annex // Ritual Chamber — CR 709.5) are printed sideways, so their single portrait
+ * image is rotated 90° to landscape. Everything else stays upright.
+ */
+export function splitImageRotateDeg(card: { layout?: string } | null | undefined): 0 | 90 {
+  return card?.layout === 'SPLIT' ? 90 : 0
+}
+
+/**
  * Get the image URL for a card.
  *
  * Uses the provided imageUri if available (from card metadata),


### PR DESCRIPTION
## Problem

In the **sealed / draft deckbuilder**, Room cards (split-layout cards like *Unholy Annex // Ritual Chamber*) were broken in two ways:

1. **Hover preview was upright** — Rooms are printed sideways on a single image, so the preview was unreadable (the constructed deckbuilder and game board already rotate these 90°, but the sealed/draft flow did not).
2. **Shown as costing 0 mana** — a split card has no single top-level mana cost, so `SealedCardInfo.manaCost` was `null`. That made Rooms count as 0-drops in the mana curve, the colour distribution, the card rows, and the basic-land suggestions.

## Fix

**Rotation.** `SealedCardInfo` now carries `layout` (mirroring the constructed catalog's `CardSummary.layout`). The `splitImageRotateDeg` helper moved to `utils/cardImages` and is now applied in the sealed deckbuilder **and all three draft overlays** (booster / grid / winston), so `SPLIT` cards rotate to landscape everywhere a preview is shown.

**Mana cost.** `cardToSealedCardInfo` builds a split card's cost by joining each face's cost with `//` (e.g. `{1}{B} // {4}{B}{B}`). The existing client mana-curve / land-suggestion logic then sums the pips across both halves — a split card's mana value while not on the stack is the combined mana value of its halves — and the shared `ManaCost` component renders the two halves with a slash divider.

## Scope of preview locations checked

All hover-preview sites now rotate Rooms: sealed `DeckBuilderOverlay`, `DraftPickOverlay`, `GridDraftOverlay`, `WinstonDraftOverlay`, and (already) the constructed `DeckbuilderPage` and game-board `CardPreview`.

> Note: the *constructed* deckbuilder catalog (`CardsController` → `CardSummary`) has the same latent 0-mana issue for Rooms but is out of scope here (its `cmc` field feeds `cmc:` search/sort, so changing it is a separate behaviour decision). This PR is limited to the sealed/draft flow as requested.

## Screenshots

Room hover preview, now rotated to landscape and readable:

![rotated room preview](https://raw.githubusercontent.com/wingedsheep/argentum-engine/rooms-preview-screenshots/room-hover-rotated.png)

Deck row + curve: the Room now shows its combined cost `{1}{B} // {4}{B}{B}` and lands in the 7+ curve bucket instead of 0:

![deck row mana cost](https://raw.githubusercontent.com/wingedsheep/argentum-engine/rooms-preview-screenshots/deck-with-room-manacost.png)

*(Screenshots hosted on the throwaway `rooms-preview-screenshots` branch.)*

## Testing

- `just test-server` — passes (server compiles; DTO change is backward-compatible with a default).
- `npm run typecheck` (web-client) — passes.
- Verified end-to-end in the running deckbuilder via a crafted sealed pool containing a real DSK Room (screenshots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)