### PR TITLE
Show delirium count and changed max hand size in the client

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -4,7 +4,6 @@ import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.AbilityActivatedThisTurnComponent
-import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
 import com.wingedsheep.engine.state.components.battlefield.CrewSaddleContributorsComponent
 import com.wingedsheep.engine.state.components.battlefield.SaddledComponent
 import com.wingedsheep.engine.state.components.battlefield.AbilityResolutionCountThisTurnComponent
@@ -68,7 +67,6 @@ import com.wingedsheep.engine.state.components.player.OpponentCreaturesExiledThi
 import com.wingedsheep.engine.state.components.player.PlayerEffectRemoval
 import com.wingedsheep.engine.state.components.player.MayCastCreaturesFromGraveyardWithForageComponent
 import com.wingedsheep.engine.state.components.player.PlayerHexproofComponent
-import com.wingedsheep.engine.state.components.player.PlayerNoMaximumHandSizeComponent
 import com.wingedsheep.engine.state.components.player.PlayerShroudComponent
 import com.wingedsheep.engine.state.components.player.SpellsCantBeCounteredComponent
 import com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponent
@@ -77,12 +75,8 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
-import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.Duration
-import com.wingedsheep.sdk.scripting.NoMaximumHandSize
 import com.wingedsheep.sdk.scripting.PreventManaPoolEmptying
-import com.wingedsheep.sdk.scripting.SetMaximumHandSize
-import com.wingedsheep.sdk.scripting.references.Player
 
 /**
  * Handles all end-of-turn cleanup: discard to hand size, damage removal,
@@ -93,11 +87,8 @@ class CleanupPhaseManager(
     private val decisionHandler: DecisionHandler
 ) {
 
-    /** Default maximum hand size (CR 402.2), absent any effect that sets or removes it. */
-    private val defaultMaxHandSize = 7
-
     // Stateless evaluators (default projection) used to read SetMaximumHandSize abilities and
-    // their ConditionalStaticAbility gates at cleanup time.
+    // their ConditionalStaticAbility gates at cleanup time (delegated to [MaximumHandSize]).
     private val conditionEvaluator = ConditionEvaluator()
     private val dynamicAmountEvaluator = DynamicAmountEvaluator(conditionEvaluator)
 
@@ -117,7 +108,9 @@ class CleanupPhaseManager(
         // Check if player needs to discard
         val handKey = ZoneKey(activePlayer, Zone.HAND)
         val hand = newState.getZone(handKey)
-        val maxHandSize = maximumHandSize(newState, activePlayer)
+        val maxHandSize = MaximumHandSize.effective(
+            newState, activePlayer, cardRegistry, conditionEvaluator, dynamicAmountEvaluator
+        )
         val cardsToDiscard = if (maxHandSize == null) 0 else hand.size - maxHandSize
 
         if (cardsToDiscard > 0) {
@@ -365,103 +358,6 @@ class CleanupPhaseManager(
         } else {
             state
         }
-    }
-
-    /**
-     * The effective maximum hand size for [playerId] at cleanup, or `null` when they have no
-     * maximum (Reliquary Tower / Wisdom of Ages — [hasNoMaximumHandSize]).
-     *
-     * Starts from [defaultMaxHandSize] (CR 402.2) and applies every [SetMaximumHandSize] static
-     * ability on the battlefield whose [SetMaximumHandSize.player] scope (resolved relative to the
-     * source's controller) includes [playerId], taking the most restrictive (smallest) value. A
-     * [ConditionalStaticAbility] wrapper is unwrapped and its condition evaluated against the
-     * source's controller, so "as long as …" gates (Winter's Delirium) are honored.
-     */
-    private fun maximumHandSize(state: GameState, playerId: EntityId): Int? {
-        if (hasNoMaximumHandSize(state, playerId)) return null
-        var max = defaultMaxHandSize
-        val registry = cardRegistry
-        val projected = state.projectedState
-        for (permanentId in state.getBattlefield()) {
-            val card = state.getEntity(permanentId)?.get<CardComponent>() ?: continue
-            val cardDef = registry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.isEmpty()) continue
-            val controllerId = projected.getController(permanentId) ?: continue
-            val context = EffectContext(sourceId = permanentId, controllerId = controllerId)
-            for (raw in cardDef.script.staticAbilities) {
-                val setAbility = activeSetMaximumHandSize(state, raw, context) ?: continue
-                if (!playerScopeIncludes(setAbility.player, playerId, controllerId, state, permanentId)) continue
-                val value = dynamicAmountEvaluator.evaluate(state, setAbility.amount, context)
-                    .coerceAtLeast(0)
-                max = minOf(max, value)
-            }
-        }
-        return max
-    }
-
-    /**
-     * Unwrap [raw] to a live [SetMaximumHandSize] if it is one (directly or behind a
-     * [ConditionalStaticAbility] whose condition holds), else `null`.
-     */
-    private fun activeSetMaximumHandSize(
-        state: GameState,
-        raw: com.wingedsheep.sdk.scripting.StaticAbility,
-        context: EffectContext
-    ): SetMaximumHandSize? = when (raw) {
-        is SetMaximumHandSize -> raw
-        is ConditionalStaticAbility -> {
-            val inner = raw.ability as? SetMaximumHandSize
-            if (inner != null && conditionEvaluator.evaluate(state, raw.condition, context)) inner else null
-        }
-        else -> null
-    }
-
-    /**
-     * Whether a [SetMaximumHandSize.player] scope, resolved relative to [controllerId] (the
-     * source's controller), includes [playerId]. Mirrors the player-scope switch in
-     * [com.wingedsheep.engine.handlers.effects.DamageUtils.isLifeGainPrevented].
-     */
-    private fun playerScopeIncludes(
-        scope: Player,
-        playerId: EntityId,
-        controllerId: EntityId,
-        state: GameState,
-        sourceId: EntityId
-    ): Boolean =
-        when (scope) {
-            Player.You -> playerId == controllerId
-            Player.EachOpponent -> playerId != controllerId
-            Player.Each, Player.Any, Player.ActivePlayerFirst -> true
-            // The opponent durably chosen as the source entered (Cursed Rack), read from the
-            // source's CastChoicesComponent[OPPONENT].
-            Player.ChosenOpponent -> state.getEntity(sourceId)?.chosenOpponent() == playerId
-            else -> false
-        }
-
-    /**
-     * Check if [playerId] has no maximum hand size — either from a permanent they control with the
-     * [NoMaximumHandSize] static ability (Thought Vessel, Reliquary Tower) or from a player-scoped
-     * rest-of-game effect ([PlayerNoMaximumHandSizeComponent], conferred by Wisdom of Ages).
-     */
-    private fun hasNoMaximumHandSize(state: GameState, playerId: EntityId): Boolean {
-        if (state.getEntity(playerId)?.has<PlayerNoMaximumHandSizeComponent>() == true) {
-            return true
-        }
-        val registry = cardRegistry
-        val projected = state.projectedState
-        for (permanentId in projected.getBattlefieldControlledBy(playerId)) {
-            val container = state.getEntity(permanentId) ?: continue
-            val card = container.get<CardComponent>() ?: continue
-            val cardDef = registry.getCard(card.cardDefinitionId) ?: continue
-            // Routed through RoomFaceStatics so a Room face's "You have no maximum hand size"
-            // (e.g. Steaming Sauna) counts only while that door is unlocked (CR 709.5).
-            if (com.wingedsheep.engine.state.components.identity.RoomFaceStatics
-                    .activeStaticAbilities(container, cardDef).any { it is NoMaximumHandSize }
-            ) {
-                return true
-            }
-        }
-        return false
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/MaximumHandSize.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/MaximumHandSize.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.engine.core
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceStatics
+import com.wingedsheep.engine.state.components.player.PlayerNoMaximumHandSizeComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.NoMaximumHandSize
+import com.wingedsheep.sdk.scripting.SetMaximumHandSize
+import com.wingedsheep.sdk.scripting.StaticAbility
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * The single source of truth for a player's effective maximum hand size (CR 402.2).
+ *
+ * Used in two places that must agree: the cleanup step ([CleanupPhaseManager]), which discards down
+ * to this value, and the client view ([com.wingedsheep.engine.view.ClientStateTransformer]), which
+ * surfaces it so the player can see when an effect has changed their limit. Keeping one
+ * implementation guarantees the badge the player reads matches the number cleanup enforces.
+ *
+ * Stateless — the caller supplies the evaluators so projection stays cached on the immutable
+ * [GameState] (no evaluator allocation per call).
+ */
+object MaximumHandSize {
+
+    /** Default maximum hand size (CR 402.2), absent any effect that sets or removes it. */
+    const val DEFAULT = 7
+
+    /**
+     * The effective maximum hand size for [playerId], or `null` when they have no maximum
+     * (Reliquary Tower / Wisdom of Ages — [hasNoMaximum]).
+     *
+     * Starts from [DEFAULT] (CR 402.2) and applies every [SetMaximumHandSize] static ability on the
+     * battlefield whose [SetMaximumHandSize.player] scope (resolved relative to the source's
+     * controller) includes [playerId], taking the most restrictive (smallest) value. A
+     * [ConditionalStaticAbility] wrapper is unwrapped and its condition evaluated against the
+     * source's controller, so "as long as …" gates (Winter's Delirium) are honored.
+     */
+    fun effective(
+        state: GameState,
+        playerId: EntityId,
+        cardRegistry: CardRegistry,
+        conditionEvaluator: ConditionEvaluator,
+        dynamicAmountEvaluator: DynamicAmountEvaluator,
+    ): Int? {
+        if (hasNoMaximum(state, playerId, cardRegistry)) return null
+        var max = DEFAULT
+        val projected = state.projectedState
+        for (permanentId in state.getBattlefield()) {
+            val card = state.getEntity(permanentId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            if (cardDef.script.staticAbilities.isEmpty()) continue
+            val controllerId = projected.getController(permanentId) ?: continue
+            val context = EffectContext(sourceId = permanentId, controllerId = controllerId)
+            for (raw in cardDef.script.staticAbilities) {
+                val setAbility = activeSetMaximumHandSize(state, raw, context, conditionEvaluator) ?: continue
+                if (!playerScopeIncludes(setAbility.player, playerId, controllerId, state, permanentId)) continue
+                val value = dynamicAmountEvaluator.evaluate(state, setAbility.amount, context)
+                    .coerceAtLeast(0)
+                max = minOf(max, value)
+            }
+        }
+        return max
+    }
+
+    /**
+     * Unwrap [raw] to a live [SetMaximumHandSize] if it is one (directly or behind a
+     * [ConditionalStaticAbility] whose condition holds), else `null`.
+     */
+    private fun activeSetMaximumHandSize(
+        state: GameState,
+        raw: StaticAbility,
+        context: EffectContext,
+        conditionEvaluator: ConditionEvaluator,
+    ): SetMaximumHandSize? = when (raw) {
+        is SetMaximumHandSize -> raw
+        is ConditionalStaticAbility -> {
+            val inner = raw.ability as? SetMaximumHandSize
+            if (inner != null && conditionEvaluator.evaluate(state, raw.condition, context)) inner else null
+        }
+        else -> null
+    }
+
+    /**
+     * Whether a [SetMaximumHandSize.player] scope, resolved relative to [controllerId] (the
+     * source's controller), includes [playerId]. Mirrors the player-scope switch in
+     * [com.wingedsheep.engine.handlers.effects.DamageUtils.isLifeGainPrevented].
+     */
+    private fun playerScopeIncludes(
+        scope: Player,
+        playerId: EntityId,
+        controllerId: EntityId,
+        state: GameState,
+        sourceId: EntityId,
+    ): Boolean =
+        when (scope) {
+            Player.You -> playerId == controllerId
+            Player.EachOpponent -> playerId != controllerId
+            Player.Each, Player.Any, Player.ActivePlayerFirst -> true
+            // The opponent durably chosen as the source entered (Cursed Rack), read from the
+            // source's CastChoicesComponent[OPPONENT].
+            Player.ChosenOpponent -> state.getEntity(sourceId)?.chosenOpponent() == playerId
+            else -> false
+        }
+
+    /**
+     * Check if [playerId] has no maximum hand size — either from a permanent they control with the
+     * [NoMaximumHandSize] static ability (Thought Vessel, Reliquary Tower) or from a player-scoped
+     * rest-of-game effect ([PlayerNoMaximumHandSizeComponent], conferred by Wisdom of Ages).
+     */
+    fun hasNoMaximum(state: GameState, playerId: EntityId, cardRegistry: CardRegistry): Boolean {
+        if (state.getEntity(playerId)?.has<PlayerNoMaximumHandSizeComponent>() == true) {
+            return true
+        }
+        val projected = state.projectedState
+        for (permanentId in projected.getBattlefieldControlledBy(playerId)) {
+            val container = state.getEntity(permanentId) ?: continue
+            val card = container.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            // Routed through RoomFaceStatics so a Room face's "You have no maximum hand size"
+            // (e.g. Steaming Sauna) counts only while that door is unlocked (CR 709.5).
+            if (RoomFaceStatics.activeStaticAbilities(container, cardDef).any { it is NoMaximumHandSize }) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -532,8 +532,24 @@ data class ClientPlayer(
     val life: Int,
     val poisonCounters: Int,
     val handSize: Int,
+
+    /**
+     * This player's effective maximum hand size (CR 402.2) — the limit cleanup discards down to,
+     * shared with [com.wingedsheep.engine.core.MaximumHandSize] so the displayed badge matches what
+     * cleanup enforces. `7` by default; a smaller/larger value when an effect set it (Cursed Rack);
+     * `null` when the player has no maximum (Reliquary Tower, Thought Vessel). The client shows a
+     * badge only when this differs from the default 7 (or is unlimited).
+     */
+    val maxHandSize: Int? = 7,
     val librarySize: Int,
     val graveyardSize: Int,
+
+    /**
+     * Number of distinct card types among cards in this player's graveyard (CR — the Delirium count;
+     * Delirium is active at 4+). Drives the delirium tracker the client renders on the graveyard
+     * pile so the threshold is visible at a glance.
+     */
+    val graveyardCardTypes: Int = 0,
     val exileSize: Int,
     val landsPlayedThisTurn: Int,
     val hasLost: Boolean,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -67,6 +67,9 @@ class ClientStateTransformer(
 ) {
 
     private val conditionEvaluator = com.wingedsheep.engine.handlers.ConditionEvaluator()
+    // Reused (with conditionEvaluator + cardRegistry) to surface each player's effective maximum
+    // hand size via the shared com.wingedsheep.engine.core.MaximumHandSize source of truth.
+    private val dynamicAmountEvaluator = DynamicAmountEvaluator(conditionEvaluator)
 
 
     /**
@@ -1598,6 +1601,21 @@ class ClientStateTransformer(
         val graveyardSize = state.getGraveyard(playerId).size
         val exileSize = state.getExile(playerId).size
 
+        // Distinct card types in the graveyard — the Delirium count (active at 4+). Mirrors the
+        // engine's Aggregation.DISTINCT_TYPES so the client tracker matches what gates delirium
+        // abilities. Graveyard is a non-battlefield zone, so base card types are correct here.
+        val graveyardCardTypes = state.getGraveyard(playerId)
+            .flatMapTo(mutableSetOf()) { entityId ->
+                state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.cardTypes?.map { it.name } ?: emptyList()
+            }
+            .size
+
+        // Effective maximum hand size (CR 402.2): 7 by default, smaller/larger when an effect set
+        // it, null when unlimited (Reliquary Tower). Shared source of truth with cleanup.
+        val maxHandSize = com.wingedsheep.engine.core.MaximumHandSize.effective(
+            state, playerId, cardRegistry, conditionEvaluator, dynamicAmountEvaluator
+        )
+
         // Determine lands played this turn
         val landsPlayed = if (landDropsComponent != null) {
             landDropsComponent.maxPerTurn - landDropsComponent.remaining
@@ -1646,8 +1664,10 @@ class ClientStateTransformer(
             life = displayedLife ?: 20,
             poisonCounters = container?.get<CountersComponent>()?.getCount(CounterType.POISON) ?: 0,
             handSize = handSize,
+            maxHandSize = maxHandSize,
             librarySize = librarySize,
             graveyardSize = graveyardSize,
+            graveyardCardTypes = graveyardCardTypes,
             exileSize = exileSize,
             landsPlayedThisTurn = landsPlayed,
             hasLost = hasLost,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlayerStatusClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlayerStatusClientViewTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * The client view exposes two per-player status numbers the player otherwise has to track in their
+ * head: the Delirium count (distinct card types in the graveyard, active at 4+) and the effective
+ * maximum hand size (CR 402.2). Both ride on [com.wingedsheep.engine.view.ClientPlayer] and the
+ * client renders them as the graveyard delirium tracker and the hand-limit badge respectively.
+ *
+ * The max-hand-size value comes from the shared [com.wingedsheep.engine.core.MaximumHandSize] source
+ * of truth, so what the badge shows is exactly what cleanup will enforce (see CursedRackScenarioTest
+ * for the cleanup-side discard behavior).
+ */
+class PlayerStatusClientViewTest : ScenarioTestBase() {
+
+    private val transformer = com.wingedsheep.engine.view.ClientStateTransformer(cardRegistry)
+    private val p1 = EntityId.of("player-1")
+
+    private fun viewSelf(state: com.wingedsheep.engine.state.GameState) =
+        transformer.transform(state, p1).players.first { it.playerId == p1 }
+
+    init {
+        test("graveyardCardTypes counts distinct card types, not raw cards") {
+            // Two creatures + one instant = two distinct types (Creature, Instant), not three cards.
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withCardInGraveyard(1, "Grizzly Bears")
+                .withCardInGraveyard(1, "Lightning Bolt")
+                .build()
+
+            val player = viewSelf(game.state)
+            player.graveyardSize shouldBe 3
+            player.graveyardCardTypes shouldBe 2
+        }
+
+        test("delirium count reaches four with four distinct card types") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInGraveyard(1, "Grizzly Bears")   // Creature
+                .withCardInGraveyard(1, "Lightning Bolt")  // Instant
+                .withCardInGraveyard(1, "Pacifism")        // Enchantment
+                .withCardInGraveyard(1, "Divination")      // Sorcery
+                .build()
+
+            viewSelf(game.state).graveyardCardTypes shouldBe 4
+        }
+
+        test("an empty graveyard reports zero card types") {
+            val game = scenario().withPlayers("Player1", "Player2").build()
+            viewSelf(game.state).graveyardCardTypes shouldBe 0
+        }
+
+        test("maximum hand size is the default seven with no effect in play") {
+            val game = scenario().withPlayers("Player1", "Player2").build()
+            viewSelf(game.state).maxHandSize shouldBe 7
+        }
+
+        test("Reliquary Tower reports no maximum hand size (null = unlimited)") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Reliquary Tower")
+                .build()
+
+            withClue("Reliquary Tower grants 'You have no maximum hand size'") {
+                viewSelf(game.state).maxHandSize.shouldBeNull()
+            }
+        }
+
+        test("an opponent's Reliquary Tower does not lift the viewing player's maximum") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(2, "Reliquary Tower")
+                .build()
+
+            viewSelf(game.state).maxHandSize shouldBe 7
+        }
+    }
+}

--- a/web-client/src/components/game/GameBoard.tsx
+++ b/web-client/src/components/game/GameBoard.tsx
@@ -578,6 +578,8 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
                 spectatorMode={spectatorMode}
                 poisonCounters={effectiveOpponent.poisonCounters}
                 commanderDamage={effectiveOpponent.commanderDamage ?? []}
+                handSize={effectiveOpponent.handSize}
+                maxHandSize={effectiveOpponent.maxHandSize}
                 {...(isMulti ? { seatColor: viewedSeatColor.base } : {})}
                 {...(isViewedOpponentAlly ? { isAlly: true } : {})}
               />
@@ -657,7 +659,7 @@ export function GameBoard({ spectatorMode = false, topOffset = 0 }: GameBoardPro
         <div style={{ ...styles.centerLifeSection, ...styles.centerLifeSectionRight }}>
           {effectiveViewingPlayer && (
             <>
-              <LifeDisplay life={effectiveViewingPlayer.life} isPlayer playerId={effectiveViewingPlayer.playerId} playerName={effectiveViewingPlayer.name} spectatorMode={spectatorMode} poisonCounters={effectiveViewingPlayer.poisonCounters} commanderDamage={effectiveViewingPlayer.commanderDamage ?? []} {...(isMulti ? { seatColor: selfSeatColor.base } : {})} />
+              <LifeDisplay life={effectiveViewingPlayer.life} isPlayer playerId={effectiveViewingPlayer.playerId} playerName={effectiveViewingPlayer.name} spectatorMode={spectatorMode} poisonCounters={effectiveViewingPlayer.poisonCounters} commanderDamage={effectiveViewingPlayer.commanderDamage ?? []} handSize={effectiveViewingPlayer.handSize} maxHandSize={effectiveViewingPlayer.maxHandSize} {...(isMulti ? { seatColor: selfSeatColor.base } : {})} />
               {!responsive.isMobile && <ActiveEffectsBadges effects={effectiveViewingPlayer.activeEffects} />}
               {!responsive.isMobile && effectiveViewingPlayer.manaPool && <ManaPool manaPool={effectiveViewingPlayer.manaPool} />}
             </>

--- a/web-client/src/components/game/OpponentRail.tsx
+++ b/web-client/src/components/game/OpponentRail.tsx
@@ -450,11 +450,14 @@ function SelfRailChip({ self }: { self: ClientPlayer }) {
               fontSize: sz.hand,
               fontWeight: 700,
               fontVariantNumeric: 'tabular-nums',
-              color: '#9fb0d0',
+              color: handLimitSuffix(self.maxHandSize) ? '#f0d488' : '#9fb0d0',
             }}
+            title={handLimitSuffix(self.maxHandSize)
+              ? `Hand ${self.handSize} · maximum hand size ${self.maxHandSize ?? '∞'}`
+              : undefined}
           >
-            <HandCountIcon />
-            {self.handSize}
+            <HandCountIcon color={handLimitSuffix(self.maxHandSize) ? '#f0d488' : '#8899bb'} />
+            {self.handSize}{handLimitSuffix(self.maxHandSize)}
           </span>
         )}
 
@@ -500,6 +503,19 @@ function SelfRailChip({ self }: { self: ClientPlayer }) {
       </div>
     </div>
   )
+}
+
+/** Default maximum hand size (CR 402.2) — no "/max" suffix is shown while the limit is unchanged. */
+const DEFAULT_MAX_HAND_SIZE = 7
+
+/**
+ * Suffix appended to a rail chip's hand count when this player's maximum hand size has changed from
+ * the default 7: "/∞" for no maximum (Reliquary Tower) or "/N" for a finite cap (Cursed Rack). An
+ * empty string when the limit is the normal 7 (or absent), so the chip stays uncluttered.
+ */
+function handLimitSuffix(maxHandSize?: number | null): string {
+  if (maxHandSize === undefined || maxHandSize === DEFAULT_MAX_HAND_SIZE) return ''
+  return maxHandSize === null ? '/∞' : `/${maxHandSize}`
 }
 
 /** Tiny card-back glyph for the hand count (cross-platform safe, unlike 🂠). */
@@ -885,11 +901,14 @@ function RailChip({
               fontSize: sz.hand,
               fontWeight: 700,
               fontVariantNumeric: 'tabular-nums',
-              color: '#9fb0d0',
+              color: handLimitSuffix(opponent.maxHandSize) ? '#f0d488' : '#9fb0d0',
             }}
+            title={handLimitSuffix(opponent.maxHandSize)
+              ? `Hand ${opponent.handSize} · maximum hand size ${opponent.maxHandSize ?? '∞'}`
+              : undefined}
           >
-            <HandCountIcon />
-            {opponent.handSize}
+            <HandCountIcon color={handLimitSuffix(opponent.maxHandSize) ? '#f0d488' : '#8899bb'} />
+            {opponent.handSize}{handLimitSuffix(opponent.maxHandSize)}
           </span>
         )}
 
@@ -1099,6 +1118,10 @@ function chipTitle(opponent: ClientPlayer): string {
     opponent.name,
     `Life ${opponent.life} · Hand ${opponent.handSize} · Library ${opponent.librarySize} · Graveyard ${opponent.graveyardSize}`,
   ]
+  if (handLimitSuffix(opponent.maxHandSize)) {
+    lines.push(`Max hand size ${opponent.maxHandSize ?? '∞ (no maximum)'}`)
+  }
+  if ((opponent.graveyardCardTypes ?? 0) >= 4) lines.push('Delirium active (4+ card types)')
   if (opponent.poisonCounters > 0) lines.push(`Poison ${opponent.poisonCounters}/10`)
   for (const e of opponent.commanderDamage ?? []) {
     lines.push(`⚔ ${e.commanderName}: ${e.amount}/${e.threshold}`)

--- a/web-client/src/components/game/board/ZonePiles.tsx
+++ b/web-client/src/components/game/board/ZonePiles.tsx
@@ -163,6 +163,12 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
           {player.graveyardSize > 0 && (
             <div style={{ ...styles.pileCount, fontSize: responsive.fontSize.small }}>{player.graveyardSize}</div>
           )}
+          {/* Delirium tracker (CR — 4+ card types in your graveyard). Always shown while the
+              graveyard has cards so the progress toward — and reaching of — delirium is visible
+              at a glance, for both players. */}
+          {player.graveyardSize > 0 && (player.graveyardCardTypes ?? 0) > 0 && (
+            <DeliriumTracker types={player.graveyardCardTypes ?? 0} pileWidth={effectivePileWidth} />
+          )}
           {/* Show targeted cards fanned out when a spell is targeting cards in this graveyard */}
           {targetedGraveyardCards.map((card, index) => {
             const fanOffset = targetedGraveyardCards.length > 1
@@ -273,6 +279,62 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
           onClose={() => setBrowsingLibrary(false)}
         />
       )}
+    </div>
+  )
+}
+
+/** Delirium activates at 4+ distinct card types in the graveyard (CR). */
+const DELIRIUM_THRESHOLD = 4
+
+/**
+ * Compact delirium tracker overlaid on the top edge of the graveyard pile: a row of four pips that
+ * fill as distinct card types accumulate, glowing gold once the fourth lands (delirium active).
+ * The exact count lives in the tooltip — the pile is often only ~30px wide, too narrow for a
+ * legible numeral, so the pips carry the at-a-glance signal and the tooltip the precise number.
+ */
+function DeliriumTracker({ types, pileWidth }: { types: number; pileWidth: number }) {
+  const active = types >= DELIRIUM_THRESHOLD
+  const filled = Math.min(types, DELIRIUM_THRESHOLD)
+  // Scale pips to the pile width so four-plus-gaps always fit, even at the 28px minimum.
+  const pip = Math.max(3, Math.round(pileWidth / 9))
+  const gold = '#f5d76e'
+  return (
+    <div
+      title={
+        active
+          ? `Delirium active — ${types} card types in graveyard (4+ needed)`
+          : `Delirium: ${types}/${DELIRIUM_THRESHOLD} card types in graveyard`
+      }
+      style={{
+        position: 'absolute',
+        top: 3,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: Math.max(2, Math.round(pip / 2)),
+        padding: '2px 4px',
+        borderRadius: 999,
+        background: 'rgba(0, 0, 0, 0.7)',
+        border: `1px solid ${active ? gold : 'rgba(255,255,255,0.18)'}`,
+        boxShadow: active ? `0 0 7px ${gold}aa` : 'none',
+        pointerEvents: 'none',
+        zIndex: 6,
+      }}
+    >
+      {Array.from({ length: DELIRIUM_THRESHOLD }).map((_, i) => (
+        <span
+          key={i}
+          style={{
+            width: pip,
+            height: pip,
+            borderRadius: '50%',
+            background: i < filled ? gold : 'transparent',
+            border: `1px solid ${i < filled ? gold : 'rgba(255,255,255,0.35)'}`,
+            boxShadow: active && i < filled ? `0 0 4px ${gold}` : 'none',
+          }}
+        />
+      ))}
     </div>
   )
 }

--- a/web-client/src/components/game/overlay/LifeDisplay.tsx
+++ b/web-client/src/components/game/overlay/LifeDisplay.tsx
@@ -19,6 +19,8 @@ export function LifeDisplay({
   commanderDamage,
   seatColor,
   isAlly = false,
+  handSize,
+  maxHandSize,
 }: {
   life: number
   isPlayer?: boolean
@@ -27,6 +29,13 @@ export function LifeDisplay({
   spectatorMode?: boolean
   poisonCounters?: number
   commanderDamage?: readonly ClientCommanderDamage[]
+  /** Current hand size — paired with [maxHandSize] to show the hand-limit badge when it changed. */
+  handSize?: number | undefined
+  /**
+   * Effective maximum hand size (CR 402.2). A badge appears only when this differs from the default
+   * 7 — a finite cap (Cursed Rack) or `null` for no maximum (Reliquary Tower).
+   */
+  maxHandSize?: number | null | undefined
   /**
    * Multiplayer: the player's seat-identity color — tints the orb border and
    * name so the viewed opponent's orb visibly matches their rail chip.
@@ -412,7 +421,73 @@ export function LifeDisplay({
           POISON {poisonCounters}/10
         </div>
       )}
+      <MaxHandSizeBadge handSize={handSize} maxHandSize={maxHandSize} />
       <CommanderDamageBadges entries={commanderDamage ?? []} />
+    </div>
+  )
+}
+
+/** Default maximum hand size (CR 402.2). No badge is shown while the limit is unchanged. */
+const DEFAULT_MAX_HAND_SIZE = 7
+
+/**
+ * Hand-limit badge under the life orb — visible only when this player's maximum hand size has been
+ * changed from the default 7: a finite cap (Cursed Rack → "HAND 5/4", amber when over the limit and
+ * a discard looms) or no maximum at all (Reliquary Tower → "HAND ∞"). When the limit is the normal
+ * 7, nothing renders, so the badge stays a signal that something is affecting the hand.
+ */
+export function MaxHandSizeBadge({
+  handSize,
+  maxHandSize,
+}: {
+  handSize?: number | undefined
+  maxHandSize?: number | null | undefined
+}) {
+  // `undefined` = field absent (older payload); only the explicit default 7 is "unchanged".
+  if (maxHandSize === undefined || maxHandSize === DEFAULT_MAX_HAND_SIZE) return null
+
+  const unlimited = maxHandSize === null
+  const over = !unlimited && handSize !== undefined && handSize > maxHandSize
+  const color = unlimited ? '#7ad0ff' : over ? '#ffb86b' : '#cdb4f0'
+  const borderColor = unlimited
+    ? 'rgba(122, 208, 255, 0.55)'
+    : over
+      ? 'rgba(255, 184, 107, 0.6)'
+      : 'rgba(205, 180, 240, 0.5)'
+  const bgColor = unlimited
+    ? 'rgba(10, 28, 40, 0.92)'
+    : over
+      ? 'rgba(46, 30, 10, 0.92)'
+      : 'rgba(26, 18, 40, 0.92)'
+  const label = unlimited
+    ? 'HAND ∞'
+    : handSize !== undefined
+      ? `HAND ${handSize}/${maxHandSize}`
+      : `HAND MAX ${maxHandSize}`
+  const title = unlimited
+    ? 'No maximum hand size — this player never discards to hand size'
+    : `Maximum hand size ${maxHandSize}${over ? ` — must discard down to ${maxHandSize} in cleanup` : ''}`
+
+  return (
+    <div
+      title={title}
+      style={{
+        marginTop: 4,
+        minHeight: 18,
+        padding: '2px 7px',
+        borderRadius: 4,
+        border: `1px solid ${borderColor}`,
+        backgroundColor: bgColor,
+        color,
+        fontSize: 11,
+        fontWeight: 800,
+        lineHeight: '14px',
+        letterSpacing: '0.3px',
+        fontVariantNumeric: 'tabular-nums',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
     </div>
   )
 }

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -448,8 +448,19 @@ export interface ClientPlayer {
   readonly life: number
   readonly poisonCounters: number
   readonly handSize: number
+  /**
+   * Effective maximum hand size (CR 402.2): 7 by default, a different number when an effect set it
+   * (Cursed Rack), or `null` when the player has no maximum (Reliquary Tower). The UI surfaces a
+   * badge only when this differs from the default 7 (or is unlimited).
+   */
+  readonly maxHandSize?: number | null
   readonly librarySize: number
   readonly graveyardSize: number
+  /**
+   * Distinct card types among cards in this player's graveyard — the Delirium count (active at 4+).
+   * Drives the delirium tracker on the graveyard pile.
+   */
+  readonly graveyardCardTypes?: number
   readonly exileSize: number
   readonly landsPlayedThisTurn: number
   readonly hasLost: boolean


### PR DESCRIPTION
## What

Surfaces two per-player status numbers the engine already tracks but never showed the player:

- **Delirium count** — distinct card types in your graveyard (delirium is active at 4+, CR).
- **Max hand size** — the effective maximum hand size (CR 402.2), when an effect has changed it (Cursed Rack, Reliquary Tower, Winter Misanthropic Guide, …).

## How

**Engine / DTO**
- Extracted the effective-max-hand-size computation out of `CleanupPhaseManager` into a shared, stateless `MaximumHandSize` object, so the cleanup step (which discards down to it) and the client view use **one source of truth** — the badge shows exactly what cleanup enforces.
- Added `ClientPlayer.maxHandSize` (`null` = unlimited) and `ClientPlayer.graveyardCardTypes` (mirrors the engine's `Aggregation.DISTINCT_TYPES`), populated in `ClientStateTransformer`.

**Client**
- **Graveyard pile** → a delirium tracker: four pips that fill as distinct card types accumulate and glow gold once delirium is active. Exact count in the tooltip (the pile is often ~30px wide). Shown for both players, in every layout.
- **`LifeDisplay`** → a hand-limit badge, shown **only when the max differs from the default 7**: a finite cap like `HAND 5/4` (amber when over the limit and a discard looms) or `HAND ∞` for no maximum.
- **`OpponentRail`** chips append `/N` or `/∞` to the hand count when the limit changed, plus delirium/limit notes in the chip tooltip.

No new SDK primitive — this is a client-view surface over existing engine state, so no `card-sdk-language-reference.md` change.

## Tests

- New `PlayerStatusClientViewTest`: distinct-type count (not raw cards), the 4-type delirium threshold, the default-7 case, and Reliquary Tower (own vs. opponent).
- Existing `CursedRackScenarioTest`, `WinterMisanthropicGuideTest`, `RoaringFurnaceSteamingSaunaTest`, `SosBatchKillianWisdomScenarioTest` still pass through the refactored shared helper.
- `tsc --noEmit` and `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)