### PR TITLE
Fix: aura bonus mana counts toward mana-spent gates (Shimmerwilds Growth + Deceit)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastPaymentProcessor.kt
@@ -374,6 +374,19 @@ class CastPaymentProcessor(
                 }
             }
 
+            // Aura bonus mana (Shimmerwilds Growth, Fertile Ground, …) spent on the cost is not in
+            // `manaProduced`; fold it in so "if {B}{B} was spent" gates (Deceit) see it. See
+            // [ManaSolution.bonusManaSpentByColor].
+            for ((color, amount) in solution.bonusManaSpentByColor) {
+                when (color) {
+                    Color.WHITE -> whiteSpent += amount
+                    Color.BLUE -> blueSpent += amount
+                    Color.BLACK -> blackSpent += amount
+                    Color.RED -> redSpent += amount
+                    Color.GREEN -> greenSpent += amount
+                }
+            }
+
             // Add only the bonus mana that wasn't consumed by the solver to the floating pool.
             // Bonus mana from a restricted ability keeps its restriction so the player can't
             // launder e.g. Steelswarm Operator's artifact-only mana into unrestricted blue.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -196,7 +196,14 @@ data class ManaSolution(
      * when the cost has no X restriction. The cast/ability payment path adds this to the
      * mana-spent-on-X accumulator that backs `DynamicAmount.ManaSpentOnX`.
      */
-    val xRestrictedManaSpent: Map<Color, Int> = emptyMap()
+    val xRestrictedManaSpent: Map<Color, Int> = emptyMap(),
+    /**
+     * Per-color count of genuinely-extra aura bonus mana (Shimmerwilds Growth, Fertile Ground, …)
+     * the solver consumed to pay colored/hybrid pips or generic. This mana is NOT in [manaProduced]
+     * (which only tracks the printed mana of tapped sources), so the cast/ability payment path must
+     * add it to the per-color mana-spent tally that backs `Conditions.ManaSpentToCastIncludes`.
+     */
+    val bonusManaSpentByColor: Map<Color, Int> = emptyMap()
 )
 
 /**
@@ -220,6 +227,15 @@ data class BonusManaEntry(
      * a colored pip; [color] is an unused placeholder and the entry floats back as colorless.
      */
     val colorless: Boolean = false,
+    /**
+     * True when this entry is genuinely-extra mana from an aura tap-bonus (Shimmerwilds Growth,
+     * Fertile Ground, Wild Growth, …) that is NOT already reflected in [ManaSolution.manaProduced].
+     * Consuming such an entry to pay a pip therefore contributes its color to the mana-spent tally
+     * (so "if {B}{B} was spent" gates like Deceit's see the bonus black mana). It is false for
+     * multi-mana excess (e.g. a 3-green source), whose full amount the solver already records in
+     * [manaProduced] — counting that again would double the spend.
+     */
+    val countsTowardSpent: Boolean = false,
 )
 
 /**
@@ -342,6 +358,11 @@ class ManaSolver(
         // mana retains its restriction when it lands in the player's pool.
         val bonusManaPool = mutableListOf<BonusManaEntry>()
 
+        // Per-color tally of aura bonus mana (entries flagged [BonusManaEntry.countsTowardSpent])
+        // actually spent on the cost. Reported via [ManaSolution.bonusManaSpentByColor] so callers
+        // fold it into the mana-spent-to-cast tally — see [BonusManaEntry.countsTowardSpent].
+        val bonusManaSpentByColor = mutableMapOf<Color, Int>()
+
         // Helper to update available counts when a source is used
         fun useSource(source: ManaSource, colorUsed: Color?) {
             usedSources.add(source)
@@ -376,6 +397,8 @@ class ManaSolver(
                         amount = source.bonusManaPerTap,
                         restriction = null,
                         anyColor = source.bonusManaIsAnyColor,
+                        // Genuinely-extra mana, not in `manaProduced` — count it when spent.
+                        countsTowardSpent = true,
                     )
                 )
             }
@@ -397,6 +420,12 @@ class ManaSolver(
             if (idx < 0) return false
             val entry = bonusManaPool[idx]
             bonusManaPool[idx] = entry.copy(amount = entry.amount - 1)
+            // A colored pip paid from genuinely-extra aura bonus mana contributes its color to the
+            // mana-spent tally. The mana produced is exactly `color` (a fixed-color entry matches it;
+            // an any-color entry produces the demanded color).
+            if (entry.countsTowardSpent) {
+                bonusManaSpentByColor[color] = (bonusManaSpentByColor[color] ?: 0) + 1
+            }
             return true
         }
 
@@ -407,6 +436,12 @@ class ManaSolver(
             if (idx < 0) return false
             val entry = bonusManaPool[idx]
             bonusManaPool[idx] = entry.copy(amount = entry.amount - 1)
+            // Generic paid from extra aura bonus mana counts its fixed color (mirroring
+            // ManaPool.payPartial, where colored mana spent on generic still tracks as that color).
+            // An any-color bonus has no color committed at solve time, so it stays uncounted here.
+            if (entry.countsTowardSpent && !entry.anyColor && !entry.colorless) {
+                bonusManaSpentByColor[entry.color] = (bonusManaSpentByColor[entry.color] ?: 0) + 1
+            }
             return true
         }
 
@@ -454,6 +489,8 @@ class ManaSolver(
                     amount = source.bonusManaPerTap,
                     restriction = null,
                     anyColor = source.bonusManaIsAnyColor,
+                    // Genuinely-extra mana, not in `manaProduced` — count it when spent.
+                    countsTowardSpent = true,
                 )
             )
             return spendBonusMana(color)
@@ -687,7 +724,8 @@ class ManaSolver(
             manaProduced,
             bonusManaPool.filter { it.amount > 0 },
             consumedRiders,
-            xRestrictedManaSpent = xRestrictedSpent
+            xRestrictedManaSpent = xRestrictedSpent,
+            bonusManaSpentByColor = bonusManaSpentByColor
         )
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeceitHybridManaSpentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeceitHybridManaSpentTest.kt
@@ -1,0 +1,179 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CastRecordComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.basicLand
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bug repro: Deceit's black gate ({B}{B} spent) must trigger when its two {U/B}
+ * hybrid symbols are paid with black mana — including black mana produced by a
+ * Mountain enchanted with Shimmerwilds Growth (chosen color Black).
+ */
+class DeceitHybridManaSpentTest : FunSpec({
+
+    fun deceitPermanent(driver: GameTestDriver) =
+        driver.state.getBattlefield().first { id ->
+            driver.state.getEntity(id)?.get<CardComponent>()?.name == "Deceit"
+        }
+
+    test("paying both {U/B} symbols with pooled black mana records {B}{B} spent") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val deceit = driver.putCardInHand(activePlayer, "Deceit")
+        // {4}{U/B}{U/B}: 4 generic + two black for the hybrids.
+        driver.giveColorlessMana(activePlayer, 4)
+        driver.giveMana(activePlayer, Color.BLACK, 2)
+
+        driver.castSpell(activePlayer, deceit)
+        driver.bothPass()
+
+        val record = driver.state.getEntity(deceitPermanent(driver))!!.get<CastRecordComponent>()!!
+        record.blackSpent shouldBe 2
+        record.blueSpent shouldBe 0
+    }
+
+    test("black gate fires when {B}{B} spent: opponent reveals hand and discards a nonland card") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.state.getOpponents(activePlayer).first()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent holds exactly one nonland card to be discarded.
+        val victim = driver.putCardInHand(opponent, "Shimmerwilds Growth")
+
+        val deceit = driver.putCardInHand(activePlayer, "Deceit")
+        driver.giveColorlessMana(activePlayer, 4)
+        driver.giveMana(activePlayer, Color.BLACK, 2)
+
+        driver.castSpell(activePlayer, deceit)
+
+        // Resolve Deceit, then resolve the black-gate trigger it puts on the stack.
+        // Target the opponent and choose their nonland card to discard.
+        var guard = 0
+        while (guard++ < 60) {
+            when (val d = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(d.playerId, listOf(opponent))
+                is SelectCardsDecision -> driver.submitCardSelection(d.playerId, d.options.take(d.minSelections))
+                null -> {
+                    if (driver.state.priorityPlayerId == null) break
+                    driver.bothPass()
+                }
+                else -> driver.autoResolveDecision()
+            }
+            if (driver.getGraveyard(opponent).contains(victim)) break
+        }
+
+        driver.getGraveyard(opponent) shouldBe listOf(victim)
+    }
+
+    test("Mountain enchanted with Shimmerwilds Growth (Black) pays Deceit's hybrids as black") {
+        val TestMountain = basicLand("Mountain") {}
+        val mountainManaAbilityId = TestMountain.activatedAbilities[0].id
+
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TestMountain))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mountain = driver.putPermanentOnBattlefield(activePlayer, "Mountain")
+        val growth = driver.putCardInHand(activePlayer, "Shimmerwilds Growth")
+        driver.giveMana(activePlayer, Color.GREEN, 2)
+        driver.castSpell(activePlayer, growth, listOf(mountain))
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as ChooseColorDecision
+        driver.submitDecision(activePlayer, ColorChosenResponse(decision.id, Color.BLACK))
+
+        // Tap the enchanted Mountain: produces {B} (overridden) + {B} (bonus) = {B}{B}.
+        driver.submit(
+            ActivateAbility(playerId = activePlayer, sourceId = mountain, abilityId = mountainManaAbilityId)
+        ).isSuccess shouldBe true
+        val pool = driver.state.getEntity(activePlayer)!!.get<ManaPoolComponent>()!!
+        pool.black shouldBe 2
+
+        // 4 generic for the {4}, the two black for {U/B}{U/B}.
+        driver.giveColorlessMana(activePlayer, 4)
+
+        val deceit = driver.putCardInHand(activePlayer, "Deceit")
+        driver.castSpell(activePlayer, deceit)
+        driver.bothPass()
+
+        val record = driver.state.getEntity(deceitPermanent(driver))!!.get<CastRecordComponent>()!!
+        record.blackSpent shouldBe 2
+        record.blueSpent shouldBe 0
+    }
+
+    test("auto-pay: bonus black from Shimmerwilds Growth counts toward {B}{B} spent (the bug)") {
+        // The user's report: tapping an enchanted Mountain (chosen Black) for its {B} + bonus {B}
+        // and casting Deceit. Through the auto-pay / mana-solver path, the aura's BONUS mana lives
+        // in the solver's bonus pool and was never folded into the per-color "mana spent" tally,
+        // so only 1 black registered and the {B}{B} gate silently failed.
+        val TestMountain = basicLand("Mountain") {}
+
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TestMountain))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.state.getOpponents(activePlayer).first()
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = driver.putCardInHand(opponent, "Shimmerwilds Growth")
+
+        val mountain = driver.putPermanentOnBattlefield(activePlayer, "Mountain")
+        val growth = driver.putCardInHand(activePlayer, "Shimmerwilds Growth")
+        driver.giveMana(activePlayer, Color.GREEN, 2)
+        driver.castSpell(activePlayer, growth, listOf(mountain))
+        driver.bothPass()
+        val colorDecision = driver.pendingDecision as ChooseColorDecision
+        driver.submitDecision(activePlayer, ColorChosenResponse(colorDecision.id, Color.BLACK))
+
+        // Four Forests cover the {4}; the enchanted Mountain alone produces {B}{B} for the hybrids.
+        // No floating mana, so the cast routes through auto-pay / the mana solver.
+        repeat(4) { driver.putPermanentOnBattlefield(activePlayer, "Forest") }
+
+        val deceit = driver.putCardInHand(activePlayer, "Deceit")
+        driver.castSpell(activePlayer, deceit)
+
+        var guard = 0
+        while (guard++ < 60) {
+            when (val d = driver.pendingDecision) {
+                is ChooseTargetsDecision -> driver.submitTargetSelection(d.playerId, listOf(opponent))
+                is SelectCardsDecision -> driver.submitCardSelection(d.playerId, d.options.take(d.minSelections))
+                null -> {
+                    if (driver.state.priorityPlayerId == null) break
+                    driver.bothPass()
+                }
+                else -> driver.autoResolveDecision()
+            }
+            if (driver.getGraveyard(opponent).contains(victim)) break
+        }
+
+        val record = driver.state.getEntity(deceitPermanent(driver))!!.get<CastRecordComponent>()!!
+        record.blackSpent shouldBe 2
+        driver.getGraveyard(opponent) shouldBe listOf(victim)
+    }
+})


### PR DESCRIPTION
## The bug

Repro (from the report): enchant a Mountain with **Shimmerwilds Growth** and choose **Black**, so it taps for `{B}` + a bonus `{B}`. Cast **Deceit** (`{4}{U/B}{U/B}`) paying the two `{U/B}` hybrids with that black mana. Deceit's second ability — *"if `{B}{B}` was spent to cast it, target opponent reveals their hand…"* — **never fired.**

## Root cause

`Conditions.ManaSpentToCastIncludes` reads a per-color "mana spent to cast" tally stamped onto the permanent (`CastRecordComponent`). In the **auto-pay / mana-solver** path that tally is built only from `ManaSolution.manaProduced`, which records the *printed* mana of each tapped source.

An aura's **bonus** mana (Shimmerwilds Growth, Fertile Ground, Wild Growth, …) lives in the solver's separate `bonusManaPool` and is spent via `spendBonusMana`. That consumption was never folded into the spent-color tally, so paying the second `{U/B}` with the Mountain's bonus black recorded only **1** black instead of 2, and the `{B}{B}` gate silently failed.

The pay-from-floating-pool path (`ManaPool.payPartial`) was already correct — it inspects the real pool before/after — so the bug only manifested through auto-pay (which also backs the client's explicit mana-source-selection cast, since `explicitPay` delegates to `autoPay`).

## Fix

- `ManaSolver` now reports `ManaSolution.bonusManaSpentByColor` for aura bonus mana actually spent on the cost, and `CastPaymentProcessor.autoPay` folds it into the per-color tally.
- A new `BonusManaEntry.countsTowardSpent` flag distinguishes genuinely-extra **aura bonus** mana (not in `manaProduced`) from **multi-mana excess** (e.g. a 3-green source, whose full amount is already in `manaProduced`), so the spend is never double-counted.

No SDK/DSL surface change — purely internal mana-solver accounting.

## Tests

New `DeceitHybridManaSpentTest` (rules-engine):
- pay both `{U/B}` from a pre-tapped pool → records `{B}{B}` (pool path baseline)
- enchanted Mountain pays Deceit's hybrids as black
- black gate fires → opponent discards a nonland card
- **auto-pay: bonus black from Shimmerwilds Growth counts toward `{B}{B}` spent** — fails on `main`, passes with the fix (verified by reverting the fold)

Full `just test-rules` suite passes.