### PR TITLE
Show number of friends online on the Friends element

### DIFF
--- a/web-client/src/components/auth/AuthWidget.tsx
+++ b/web-client/src/components/auth/AuthWidget.tsx
@@ -22,6 +22,7 @@ export function AuthWidget() {
   const user = useAuthStore((s) => s.user)
   const logout = useAuthStore((s) => s.logout)
   const incomingCount = useFriendsStore((s) => s.incoming.length)
+  const onlineCount = useFriendsStore((s) => s.friends.filter((f) => f.online).length)
   const loadFriends = useFriendsStore((s) => s.load)
   const resetFriends = useFriendsStore((s) => s.reset)
   const [loginOpen, setLoginOpen] = useState(false)
@@ -64,6 +65,33 @@ export function AuthWidget() {
             style={{ position: 'relative' }}
           >
             Friends
+            {onlineCount > 0 && (
+              <span
+                aria-label={`${onlineCount} friends online`}
+                title={`${onlineCount} online`}
+                style={{
+                  marginLeft: 6,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: '#5bd16e',
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  style={{
+                    display: 'inline-block',
+                    width: 7,
+                    height: 7,
+                    borderRadius: 999,
+                    backgroundColor: '#5bd16e',
+                  }}
+                />
+                {onlineCount}
+              </span>
+            )}
             {incomingCount > 0 && (
               <span
                 aria-label={`${incomingCount} pending friend requests`}

--- a/web-client/src/pages/FriendsPage.tsx
+++ b/web-client/src/pages/FriendsPage.tsx
@@ -23,6 +23,7 @@ export function FriendsPage() {
   const patchUser = useAuthStore((s) => s.patchUser)
 
   const friends = useFriendsStore((s) => s.friends)
+  const onlineFriendCount = friends.filter((f) => f.online).length
   const incoming = useFriendsStore((s) => s.incoming)
   const outgoing = useFriendsStore((s) => s.outgoing)
   const loading = useFriendsStore((s) => s.loading)
@@ -200,7 +201,13 @@ export function FriendsPage() {
           {/* Friends list */}
           <div style={styles.sectionBlock}>
             <h2 style={styles.section}>
-              Your friends {friends.length > 0 && <span style={styles.muted}>({friends.length})</span>}
+              Your friends{' '}
+              {friends.length > 0 && (
+                <span style={styles.muted}>
+                  ({friends.length}
+                  {onlineFriendCount > 0 && <span style={{ color: '#5bd16e' }}> · {onlineFriendCount} online</span>})
+                </span>
+              )}
             </h2>
             {storeError && <p style={styles.error}>{storeError}</p>}
             {friends.length === 0 ? (


### PR DESCRIPTION
## What

Surfaces a live **online friends count** on the friends UI:

- **Friends nav button** (`AuthWidget`) — a small green dot + count appears next to "Friends" whenever one or more friends are online. It sits before the existing red incoming-request badge, so the two read as distinct signals (green = friends online, red = pending requests).
- **Friends page header** — `Your friends (N)` becomes `Your friends (N · M online)`, with the online part in the same green used for the per-friend status dots.

## How

The friends list is already kept populated app-wide once signed in (the `AuthWidget` effect calls `friendsStore.load()` on auth, and presence stays live via the WebSocket `applyPresence` push). So the count is just a derived `friends.filter(f => f.online).length` — no new fetches, no new state, and it updates in real time as friends come online/offline.

Both badges are gated on `> 0` so nothing renders when no friends are online.

## Notes on screenshots

A live screenshot would require a signed-in account with at least one *online* friend (two authenticated, presence-broadcasting sessions against a running stack), which isn't practical to stage here. The change is a small, self-contained derived badge; `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)