### PR TITLE
Fix: free-cast Auras from exile must prompt for their enchant target

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
@@ -90,11 +90,19 @@ class CastFromCollectionWithoutPayingCostExecutor(
         val cardComponent = newState.getEntity(cardId)?.get<CardComponent>()
         val cardDef = cardComponent?.let { cardRegistry.getCard(it.cardDefinitionId) }
         val isModalSpell = cardDef?.script?.spellEffect is ModalEffect
-        val targetRequirements = cardDef?.script?.targetRequirements.orEmpty()
+        // Include the aura's enchant target: an Aura carries its target in `auraTarget`, not in
+        // `targetRequirements`, so a free-cast Aura (Pacifism) would otherwise reach CastSpellHandler
+        // with no target — which it rejects ("No valid targets available"), stranding the card in
+        // exile. Mirror CastSpellHandler's own `targetRequirements + auraTarget` union here.
+        val targetRequirements = buildList {
+            addAll(cardDef?.script?.targetRequirements.orEmpty())
+            cardDef?.script?.auraTarget?.let { add(it) }
+        }
 
         // Modal spells route through CastSpellHandler's own target-pause flow after mode
-        // selection. Non-modal targeted spells need us to surface a ChooseTargetsDecision
-        // first because CastSpellHandler.validate rejects `targets = []` for required slots.
+        // selection. Non-modal targeted spells (including Auras) need us to surface a
+        // ChooseTargetsDecision first because CastSpellHandler.validate rejects `targets = []`
+        // for required slots.
         if (!isModalSpell && targetRequirements.isNotEmpty()) {
             val legalTargetsMap = mutableMapOf<Int, List<EntityId>>()
             val requirementInfos = targetRequirements.mapIndexed { index, requirement ->

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreOfClanStoutarmTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BreOfClanStoutarmTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.core.ManaCost
@@ -185,6 +186,41 @@ class BreOfClanStoutarmTest : ScenarioTestBase() {
                 }
                 withClue("Tiny Bolt went to its owner's graveyard after resolving") {
                     game.isInGraveyard(1, "Tiny Bolt") shouldBe true
+                }
+            }
+
+            test("mana value ≤ life gained: an Aura can be cast for free and select its enchant target") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bre of Clan Stoutarm")
+                    .withCardInHand(1, "Healing Salve")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Pacifism")    // an Aura — targets via auraTarget, not targetRequirements
+                    .withCardOnBattlefield(2, "Cheap Ogre") // the creature Pacifism will enchant
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Healing Salve").error shouldBe null
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+                // Accept the free cast, then pick what Pacifism enchants (the opponent's Cheap Ogre).
+                game.answerYesNo(true)
+                val ogre = game.findPermanent("Cheap Ogre")
+                    ?: error("Cheap Ogre should be on the battlefield as an enchant target")
+                game.selectTargets(listOf(ogre))
+                game.resolveStack()
+
+                withClue("Pacifism was cast for free and entered the battlefield") {
+                    game.isOnBattlefield("Pacifism") shouldBe true
+                }
+                withClue("Pacifism is attached to the chosen creature") {
+                    val pacifism = game.findPermanent("Pacifism")
+                        ?: error("Pacifism should be on the battlefield")
+                    game.state.getEntity(pacifism)?.get<AttachedToComponent>()?.targetId shouldBe ogre
                 }
             }
 


### PR DESCRIPTION
## Summary

Follow-up to the Bre of Clan Stoutarm work (#1095): casting an **Aura** for free from exile (e.g. **Pacifism** off Bre's end step) gave no target-selection step and the card was silently stranded in exile.

### Root cause
Auras carry their target in `CardScript.auraTarget`, **not** in `targetRequirements`. `CastFromCollectionWithoutPayingCostExecutor` only inspected `targetRequirements`, so for an Aura it surfaced no `ChooseTargetsDecision` and called `CastSpellHandler` with no target. The handler treats `auraTarget` as a required target and rejects the cast (*"No valid targets available"*); the executor swallows that error as a no-op — so the Aura never gets cast and stays in exile.

(Instants/sorceries were fine because their targets live in `targetRequirements`, which the executor already checked.)

### Fix
Build the target decision from the **union** `targetRequirements + auraTarget`, mirroring what `CastSpellHandler` itself does:

```kotlin
val targetRequirements = buildList {
    addAll(cardDef?.script?.targetRequirements.orEmpty())
    cardDef?.script?.auraTarget?.let { add(it) }
}
```

Now an Aura surfaces a normal `ChooseTargetsDecision`, the player picks what to enchant, and it attaches on resolution. Non-aura cards are unaffected (`auraTarget` is null). This also covers the `CastAnyNumberFromCollection` loop, which casts each chosen card through the same effect/executor.

This is an engine-layer fix, so it benefits **every** card that free-casts an Aura from exile, not just Bre.

## Tests
- New regression test: casts **Pacifism** for free off Bre's end step, picks the opponent's creature, and asserts Pacifism is on the battlefield **attached to that creature** (`AttachedToComponent.targetId`). Fails before the fix, passes after.
- All Bre end-step tests pass (creature / instant / sorcery / aura / hand-fallback / decline).
- **Full `rules-engine` suite passes** — no regression to other cards sharing this executor (Cruelclaw, the Dragonstorm "…storm" enchantments, cascade-style casts, Kaervek, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)