### PR TITLE
Add a batch of Final Fantasy cards (Fenrir, Torgal, Water Crystal, Raubahn, Quina)

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -238,11 +238,14 @@ so a land // spell Adventure offers *both* "play the land" (PlayLandEnumerator) 
   DFC-combine mechanic. Needs a meld layout + the "exile both, return the combined back face" flow. *(Ragnarok itself
   is castable/returnable today; only the meld path is missing.)*
 - **"Damage you'd deal is doubled" / stagger** (Lightning, Army of One; Kuja's Flare Star; The Earth Crystal counter
-  doubling; The Wind Crystal lifegain doubling; The Water Crystal mill doubling) — replacement effects that **scale
-  outgoing damage / counters / life / mill by ×2**. The counter-doubling and damage-doubling one-shots exist; confirm
+  doubling; The Wind Crystal lifegain doubling) — replacement effects that **scale
+  outgoing damage / counters / life / mill**. The counter-doubling and damage-doubling one-shots exist; confirm
   a *continuous* "your sources deal double damage to a tagged player until your next turn" replacement (Lightning's
   Stagger) and the various ×2 static replacements compose, else add the missing replacement variants. *(Mirrors the
-  TLA "damage-amplification replacement" gap.)*
+  TLA "damage-amplification replacement" gap.)* **The Water Crystal is now implemented** — its "an opponent
+  mills that many cards plus four instead" is the additive `ModifyMillAmount` replacement (twin of `ModifyDrawAmount`),
+  applied at the mill announcement in `GatherCardsExecutor` via the new `CardSource.TopOfLibrary.isMill` flag +
+  `EventPattern.MillEvent`.
 - **Y'shtola / Gogo copy-an-ability** — Gogo, Master of Mimicry ("Copy target activated or triggered ability you
   control X times") needs ability-on-stack copying with X. Verify `CopyAbility` support; likely a gap for the
   targeted-ability-copy-X-times shape.

--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -46,7 +46,12 @@ Verified against source (file:line). These appear across the remaining FIN cards
   Shantotto, Vivi (the whole "magic-counter" sub-theme).
 - **Equip** — `equipAbility("{N}")` (`CardBuilder.kt:515`) + `AttachEquipmentExecutor`; **attach-to-target as a
   spell/triggered effect** — `Effects.AttachTargetEquipmentToCreature(...)` (`Effects.kt:3048`,
-  `AttachTargetEquipmentToCreatureExecutor`), covering Raubahn, Weapons Vendor, Beatrix, Gilgamesh, Zack Fair.
+  `AttachTargetEquipmentToCreatureExecutor`), covering Weapons Vendor, Beatrix, Gilgamesh, Zack Fair.
+  **Raubahn, Bull of Ala Mhigo is implemented** (attack trigger reuses that effect; "up to one target Equipment"
+  is an optional target, declining/illegal attach is a no-op).
+- **Dynamic ward cost ("Ward—Pay life equal to ~")** — `KeywordAbility.wardLife(DynamicAmount)` →
+  `WardCost.DynamicLife`, resolved at ward-trigger resolution (CR 702.21b) with last-known power if the source
+  has left (CR 112.7a). Implemented for Raubahn, Bull of Ala Mhigo.
   **Equip cost reduction** — `ActivatedAbility.genericCostReduction` (`ActivatedAbility.kt:58`). **`Filters.EquippedCreature`**
   for equipped-creature static buffs (`Filters.kt:137`).
 - **Affinity for a subtype** — `KeywordAbility.AffinityForSubtype` (`KeywordAbility.kt:217`) → Bartz and Boko

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5561,6 +5561,19 @@ replacementEffect {
   use a source-relative condition instead. Use for "if you would draw one or more cards, you draw
   that many cards plus N instead" (Quantum Riddler:
   `ModifyDrawAmount(modifier = 1, restrictions = listOf(Conditions.CardsInHandAtMost(1)), appliesTo = DrawEvent(player = Player.You))`).
+- `ModifyMillAmount(modifier, restrictions, appliesTo)` — modify the number of cards a *mill* announces
+  by a fixed amount (the mill twin of `ModifyDrawAmount`): a player who would mill N instead mills
+  `N + modifier`, clamped to ≥ 0. `appliesTo` is an `EventPattern.MillEvent` whose `player` filter
+  (`Player.You` / `Player.EachOpponent` / `Player.Each`) gates which players' mills are affected,
+  relative to the source's controller. `restrictions` (a `List<Condition>`, ALL must hold, evaluated
+  against the milling player as controller) gates *when* it applies. Applied **once** per mill
+  instruction at the announcement site (`GatherCardsExecutor`'s `CardSource.TopOfLibrary(isMill = true)`
+  branch, which only the `Patterns.Library.mill(...)` pipeline sets — scry / surveil / exile-top /
+  look-at-top gathers leave `isMill = false` and are never affected), so a paused-and-resumed mill
+  never double-modifies. A base mill of 0 is left untouched ("would mill one or more cards"). Multiple
+  instances sum. Use for "if an opponent would mill one or more cards, they mill that many cards plus
+  four instead" (The Water Crystal:
+  `ModifyMillAmount(modifier = 4, appliesTo = EventPattern.MillEvent(player = Player.EachOpponent))`).
 - `ModifyLifeGain(multiplier, modifier, appliesTo, restrictions)` — modify life gain by a multiplicative *and/or*
   additive factor: `gained = (original * multiplier) + modifier`, clamped to ≥ 0. `appliesTo` is a `LifeGainEvent`
   whose `player` filter (default `Player.Each`) gates which players the replacement applies to. `restrictions`

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -727,6 +727,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   resolution rather than a fixed integer, pass `dynamicCount = <DynamicAmount>` instead of `count` — the executor
   evaluates it (coerced to ≥ 0) and creates that many tokens (Lobelia Sackville-Baggins, LTR: "create X Treasure
   tokens, where X is the exiled card's power", via `DynamicAmount.EntityProperty(Target(0), Power)`).
+  **Colored** predefined tokens (a token has no mana cost, so its printed color is a color indicator, CR 204):
+  set `colorIdentity = "<symbols>"` on the token's `CardDefinition` — both predefined-token executors read
+  `colorIdentityOverride ?: colors` for the token's color (a bare `colors` is mana-cost-derived and would be
+  colorless). Example: the `Frog` token (`PredefinedTokens.Frog`, a 1/1 green Frog created by Quina, Qu Gourmet).
   For an *inline* token (not a registered `CardDefinition`) that has its own abilities, the raw
   `CreateTokenEffect` constructor exposes `staticAbilities`, `triggeredAbilities`, **and**
   `activatedAbilities` — each list is granted to every created token at resolution (permanent
@@ -5544,7 +5548,8 @@ replacementEffect {
   creation event, and the extra tokens are added once per qualifying event, not once per token. The added
   tokens bypass the same replacement pass so a Map added for an artifact-token event does not recursively
   trigger itself. Used by Worldwalker Helm (`TokenCreationEvent(You, Artifact)`, add `Map`, `inheritTapped = true`)
-  and Peregrin Took (`additionalTokenType = "Food"`, "those tokens plus an additional Food token are created instead").
+  and Peregrin Took (`additionalTokenType = "Food"`, "those tokens plus an additional Food token are created instead")
+  and Quina, Qu Gourmet (`additionalTokenType = "Frog"`, default `appliesTo` = any token you create, adds a 1/1 green Frog).
 - `EntersAsCopy(optional, copyFilter, copyFromZone, filterByTotalManaSpent, additionalSubtypes, additionalKeywords, nameOverride, powerOverride, toughnessOverride, exileCopiedCard)` —
   "enter as a copy of …". As the permanent resolves, the controller picks an object matching
   `copyFilter` and the permanent enters as a copy (Rule 707 copiable values), with any overrides

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3856,7 +3856,8 @@ composite abilities).
 **Parameterized `KeywordAbility.*`**
 
 - `Ward(amount)` — opponent pays a mana cost to target this (CR 702.21). Non-mana costs use
-  `KeywordAbility.Ward(WardCost.X)`: `WardCost.Mana`, `WardCost.Life(n)`, `WardCost.Discard(n, random, filter)`,
+  `KeywordAbility.Ward(WardCost.X)`: `WardCost.Mana`, `WardCost.Life(n)`, `WardCost.DynamicLife(amount)`,
+  `WardCost.Discard(n, random, filter)`,
   and `WardCost.Sacrifice(filter, count = 1)` ("Ward—Sacrifice a Food", Ygra; "Ward—Sacrifice three
   nonland permanents" with `count = 3`, Valgavoth, Terror Eater, via `KeywordAbility.wardSacrifice(filter, count)`).
   For sacrifice ward, the opponent chooses which `count` matching permanent(s) they control to sacrifice
@@ -3872,6 +3873,13 @@ composite abilities).
   `GameObjectFilter`: when set, only matching hand cards count toward the can-pay check and only matching
   cards are offered for discard — e.g. Saruman of Many Colors' "Ward—Discard an enchantment, instant, or
   sorcery card" (`wardDiscard(filter = Enchantment or Instant or Sorcery)`).
+  `WardCost.DynamicLife(amount)` (built via `KeywordAbility.wardLife(amount: DynamicAmount)`) is a life
+  cost whose amount is a `DynamicAmount` read when the ward trigger *resolves* (CR 702.21b) — e.g.
+  Raubahn, Bull of Ala Mhigo's "Ward—Pay life equal to Raubahn's power"
+  (`wardLife(DynamicAmounts.sourcePower())`), which reads the source's projected power then, or its
+  last-known power if the source has left the battlefield (CR 112.7a, via `EntityReference.Source`'s
+  last-known-information policy). It resolves down to a fixed `WardCost.Life` in the executor, so it
+  composes inside `WardCost.Composite` and uses the same pay-or-counter prompt.
 - `Protection(color)` — protection from a single color.
 - `ProtectionFrom(set)` — protection from a set of colors/types.
 - `Protection(ProtectionScope.Supertype("Legendary"))` / `KeywordAbility.protectionFromSupertype("Legendary")` — protection from a supertype, e.g. "protection from legendary creatures" (Tsabo Tavoc). Enforced across targeting, blocking, and combat damage via projected `PROTECTION_FROM_SUPERTYPE_<X>` keywords.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -626,7 +626,7 @@ object LibraryPatterns {
         return CompositeEffect(
             listOf(
                 GatherCardsEffect(
-                    source = CardSource.TopOfLibrary(count, player),
+                    source = CardSource.TopOfLibrary(count, player, isMill = true),
                     storeAs = "milled"
                 ),
                 MoveCollectionEffect(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -254,6 +254,20 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
+     * When a player would mill one or more cards (CR 701.13). Used by
+     * [com.wingedsheep.sdk.scripting.ModifyMillAmount] to adjust the count at the mill
+     * announcement (e.g. The Water Crystal: "If an opponent would mill one or more cards,
+     * they mill that many cards plus four instead").
+     */
+    @SerialName("MillEvent")
+    @Serializable
+    data class MillEvent(
+        val player: Player = Player.You
+    ) : EventPattern {
+        override val description: String = "${player.description} would mill one or more cards"
+    }
+
+    /**
      * Fires on a `CardsDrawnEvent` when the drawing player's per-turn draw count
      * crosses the specified threshold (CR 121.2 — each card drawn is an individual
      * draw, so a single multi-card draw fires at most once when the Nth card lands

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordAbility.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.costs.PayCost
 import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import com.wingedsheep.sdk.dsl.firebending
@@ -83,6 +84,7 @@ sealed interface KeywordAbility {
         override val description: String = when (cost) {
             is WardCost.Mana -> "Ward ${cost.manaCost}"
             is WardCost.Life -> "Ward—Pay ${cost.amount} life"
+            is WardCost.DynamicLife -> "Ward—Pay life equal to ${cost.amount.description}"
             is WardCost.Discard -> "Ward—Discard ${cost.description}"
             is WardCost.Sacrifice -> "Ward—Sacrifice ${cost.description}"
             is WardCost.Composite -> "Ward—${cost.description}"
@@ -715,9 +717,16 @@ sealed interface KeywordAbility {
         fun ward(cost: String): KeywordAbility = Ward(WardCost.Mana(cost))
 
         /**
-         * Create Ward with life cost.
+         * Create Ward with a fixed life cost.
          */
         fun wardLife(amount: Int): KeywordAbility = Ward(WardCost.Life(amount))
+
+        /**
+         * Create Ward with a [DynamicAmount] life cost — "Ward—Pay life equal to ~"
+         * (e.g. Raubahn, Bull of Ala Mhigo with [com.wingedsheep.sdk.dsl.DynamicAmounts.sourcePower]).
+         * The amount is evaluated when the ward triggered ability resolves.
+         */
+        fun wardLife(amount: DynamicAmount): KeywordAbility = Ward(WardCost.DynamicLife(amount))
 
         /**
          * Create Ward with discard cost. When [filter] is non-null the discarded

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/KeywordStaticAbilities.kt
@@ -82,6 +82,7 @@ data class GrantWard(
     override val description: String = when (cost) {
         is WardCost.Mana -> "${filter.description} have ward ${cost.manaCost}"
         is WardCost.Life -> "${filter.description} have \"Ward—Pay ${cost.amount} life.\""
+        is WardCost.DynamicLife -> "${filter.description} have \"Ward—Pay life equal to ${cost.amount.description}.\""
         is WardCost.Discard -> "${filter.description} have \"Ward—Discard ${cost.description}.\""
         is WardCost.Sacrifice -> "${filter.description} have \"Ward—Sacrifice ${cost.description}.\""
         is WardCost.Composite -> "${filter.description} have \"Ward—${cost.description}.\""

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -605,6 +605,47 @@ data class ModifyDrawAmount(
 }
 
 /**
+ * Modify how many cards a player mills (CR 701.13). Additive: a [modifier] of `+4` makes a
+ * player who would mill N instead mill `N + 4`; negative values reduce the mill (clamped to ≥ 0
+ * by the caller). Applied at the mill announcement, once per mill instruction, exactly like
+ * [ModifyDrawAmount] — so a paused-and-resumed mill never double-modifies.
+ *
+ * The [appliesTo] [EventPattern.MillEvent] gates which player's mills are affected relative to
+ * the source's controller (`Player.You` / `Player.EachOpponent` / `Player.Each`). [restrictions]
+ * are additional [Condition]s evaluated against the milling player as controller; ALL must hold.
+ *
+ * Example — The Water Crystal: "If an opponent would mill one or more cards, they mill that many
+ * cards plus four instead" → `ModifyMillAmount(4, appliesTo = MillEvent(Player.EachOpponent))`.
+ */
+@SerialName("ModifyMillAmount")
+@Serializable
+data class ModifyMillAmount(
+    val modifier: Int,
+    val restrictions: List<Condition> = emptyList(),
+    override val appliesTo: EventPattern = EventPattern.MillEvent()
+) : ReplacementEffect {
+    override val description: String = buildString {
+        val restrictionDesc = restrictions.joinToString(" and ") { it.description.removePrefix("if ") }
+        if (restrictionDesc.isNotEmpty()) {
+            append(restrictionDesc.replaceFirstChar { it.uppercase() })
+            append(", if ")
+        } else {
+            append("If ")
+        }
+        append(appliesTo.description)
+        append(", they mill that many cards plus $modifier instead")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        val newRestrictions = restrictions.map { it.applyTextReplacement(replacer) }
+        val anyChanged = newAppliesTo !== appliesTo ||
+            newRestrictions.zip(restrictions).any { (n, o) -> n !== o }
+        return if (anyChanged) copy(appliesTo = newAppliesTo, restrictions = newRestrictions) else this
+    }
+}
+
+/**
  * Replace drawing with another effect.
  * Example: Underrealm Lich (look at 3, put 1 in hand, rest in graveyard)
  */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PipelineEffects.kt
@@ -28,12 +28,19 @@ sealed interface CardSource {
 
     /**
      * Top N cards of a player's library.
+     *
+     * [isMill] marks this gather as the library half of a *mill* (top N → graveyard), so the
+     * count site applies `ModifyMillAmount` replacement effects (CR 701.13 "mill that many plus
+     * four instead"). Only the `Patterns.Library.mill(...)` pipeline sets this; other top-N
+     * gathers (scry, surveil, exile-top, look-at-top) leave it `false` so they are never affected
+     * by mill-amount replacements.
      */
     @SerialName("TopOfLibrary")
     @Serializable
     data class TopOfLibrary(
         val count: DynamicAmount,
-        val player: Player = Player.You
+        val player: Player = Player.You,
+        val isMill: Boolean = false
     ) : CardSource {
         override val description: String = "the top ${count.description} cards of ${player.possessive} library"
     }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/StackEffects.kt
@@ -331,6 +331,22 @@ sealed interface WardCost {
     }
 
     /**
+     * Ward with a life cost whose amount is a game-state-dependent [DynamicAmount] — e.g.
+     * Raubahn, Bull of Ala Mhigo's "Ward—Pay life equal to Raubahn's power"
+     * ([com.wingedsheep.sdk.dsl.DynamicAmounts.sourcePower]). The amount is evaluated when the
+     * ward triggered ability *resolves* (CR 702.21b), reading the source's power at that time,
+     * or its last-known value if the source has left the battlefield (CR 112.7a) — both handled
+     * by [com.wingedsheep.sdk.scripting.values.EntityReference.Source]'s last-known-information
+     * fallback. The fixed-Int [Life] stays the common case; this variant covers only costs that
+     * read live game state.
+     */
+    @SerialName("WardCost.DynamicLife")
+    @Serializable
+    data class DynamicLife(val amount: DynamicAmount) : WardCost {
+        override val description: String = "pay life equal to ${amount.description}"
+    }
+
+    /**
      * Ward with a discard cost — e.g. Ward—Discard a card.
      *
      * When [filter] is non-null the discarded card(s) must match it — e.g.
@@ -399,6 +415,7 @@ data class WardCounterEffect(
     override val description: String = when (cost) {
         is WardCost.Mana -> "Counter it unless its controller pays ${cost.manaCost}"
         is WardCost.Life -> "Counter it unless its controller pays ${cost.amount} life"
+        is WardCost.DynamicLife -> "Counter it unless its controller pays life equal to ${cost.amount.description}"
         is WardCost.Discard -> "Counter it unless its controller discards ${cost.description}"
         is WardCost.Sacrifice -> "Counter it unless its controller sacrifices ${cost.description}"
         is WardCost.Composite -> "Counter it unless its controller pays ${cost.description}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/QuinaQuGourmet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/QuinaQuGourmet.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CreateAdditionalToken
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Quina, Qu Gourmet
+ * {2}{G}
+ * Legendary Creature — Qu
+ * 2/3
+ *
+ * If one or more tokens would be created under your control, those tokens plus a
+ * 1/1 green Frog creature token are created instead.
+ * {2}, Sacrifice a Frog: Put a +1/+1 counter on Quina.
+ *
+ * The token-creation clause is a replacement effect (CR 614) that fires once per
+ * token-creation event under your control, regardless of how many or what kind of
+ * tokens the event makes (Scryfall rulings 2025-06-06: you must be the one creating
+ * the tokens, but you needn't control the source). It is self-limiting (CR 614.5):
+ * the added Frog is created directly and does not itself re-enter the replacement
+ * pipeline, so it never recurses on its own Frog. The added Frog also gains none of
+ * the original tokens' abilities (ruling), though it does inherit the original
+ * creation's "tapped" rider via [CreateAdditionalToken.inheritTapped].
+ */
+val QuinaQuGourmet = card("Quina, Qu Gourmet") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Qu"
+    power = 2
+    toughness = 3
+    oracleText = "If one or more tokens would be created under your control, those tokens plus a 1/1 green Frog creature token are created instead.\n" +
+        "{2}, Sacrifice a Frog: Put a +1/+1 counter on Quina."
+
+    // "those tokens plus a 1/1 green Frog creature token are created instead." The engine
+    // creates the extra Frog directly after the primary tokens, without re-entering the
+    // token-creation replacement pipeline, so it never recurses on its own added Frog
+    // (CR 614.5). The default appliesTo (You / any token) matches every token created
+    // under your control.
+    replacementEffect(CreateAdditionalToken(additionalTokenType = "Frog"))
+
+    // "{2}, Sacrifice a Frog: Put a +1/+1 counter on Quina."
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.Sacrifice(GameObjectFilter.Creature.withSubtype("Frog"))
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "194"
+        artist = "Fajareka Setiawan"
+        flavorText = "\"World only have two things: Things you can eat and things you no can eat.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f352b5e-9731-4a8e-b872-db5d3bf32211.jpg?1748706489"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RaubahnBullOfAlaMhigo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RaubahnBullOfAlaMhigo.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Raubahn, Bull of Ala Mhigo
+ * {1}{R}
+ * Legendary Creature — Human Warrior
+ * 2/2
+ * Ward—Pay life equal to Raubahn's power.
+ * Whenever Raubahn attacks, attach up to one target Equipment you control to target attacking
+ *   creature.
+ *
+ * The ward cost is a dynamic life cost: [KeywordAbility.wardLife] with
+ * [DynamicAmounts.sourcePower] models "Pay life equal to Raubahn's power". The amount is read
+ * when the ward trigger resolves (CR 702.21b) — Raubahn's projected power then, or his
+ * last-known power if he has already left the battlefield (CR 112.7a; Scryfall ruling
+ * 2025-06-06). See [com.wingedsheep.sdk.scripting.effects.WardCost.DynamicLife].
+ *
+ * The attack trigger reuses [Effects.AttachTargetEquipmentToCreature]: the Equipment is "up to
+ * one target" (optional — declining or an illegal attach is a no-op, Scryfall ruling
+ * 2025-06-06), the attacking creature is a required target and may be Raubahn himself.
+ */
+val RaubahnBullOfAlaMhigo = card("Raubahn, Bull of Ala Mhigo") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "Ward—Pay life equal to Raubahn's power.\n" +
+        "Whenever Raubahn attacks, attach up to one target Equipment you control to target " +
+        "attacking creature."
+
+    keywords(Keyword.WARD)
+    keywordAbility(KeywordAbility.wardLife(DynamicAmounts.sourcePower()))
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val equipment = target(
+            "up to one target Equipment you control",
+            TargetPermanent(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT).youControl()
+                ),
+                optional = true
+            )
+        )
+        val creature = target("target attacking creature", Targets.AttackingCreature)
+        effect = Effects.AttachTargetEquipmentToCreature(equipment, creature)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "151"
+        artist = "Julia Vasilyeva"
+        flavorText = "\"Come, then! Who will be next to die on my steel!?\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/0/7035d11b-525f-4120-8dcb-610095196681.jpg?1748706327"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonFenrir.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonFenrir.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Summon: Fenrir
+ * {2}{G}
+ * Enchantment Creature — Saga Wolf
+ * 3/2
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Crescent Fang — Search your library for a basic land card, put it onto the battlefield
+ *     tapped, then shuffle.
+ * II — Heavenward Howl — When you next cast a creature spell this turn, that creature enters
+ *     with an additional +1/+1 counter on it.
+ * III — Ecliptic Growl — Draw a card if you control the creature with the greatest power or
+ *     tied for the greatest power.
+ *
+ * Chapter II installs a one-shot, end-of-turn delayed triggered ability whose
+ * `SpellCastEvent` filter matches any creature spell you cast. When the next such spell is
+ * cast that turn, the trigger adds a +1/+1 counter to the spell on the stack via
+ * `EffectTarget.TriggeringEntity`; the counter travels with the spell to the battlefield as
+ * it resolves, satisfying "enters with an additional +1/+1 counter on it" naturally. Same
+ * primitive as Long List of the Ents, minus the noted-type filter (here it's any creature).
+ *
+ * Chapter III's "you control the creature with the greatest power or tied for the greatest
+ * power" ≡ you control a creature AND your max creature-power >= the global max
+ * creature-power. The `ControlCreature` conjunct excludes the 0-vs-0 case when no creatures
+ * exist (same condition shape as Thickest in the Thicket).
+ */
+val SummonFenrir = card("Summon: Fenrir") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment Creature — Saga Wolf"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Crescent Fang — Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\n" +
+        "II — Heavenward Howl — When you next cast a creature spell this turn, that creature enters with an additional +1/+1 counter on it.\n" +
+        "III — Ecliptic Growl — Draw a card if you control the creature with the greatest power or tied for the greatest power."
+    power = 3
+    toughness = 2
+
+    sagaChapter(1) {
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.BasicLand,
+            count = 1,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true,
+        )
+    }
+
+    sagaChapter(2) {
+        effect = CreateDelayedTriggerEffect(
+            trigger = TriggerSpec(
+                event = EventPattern.SpellCastEvent(
+                    spellFilter = GameObjectFilter.Creature,
+                    player = Player.You,
+                ),
+            ),
+            fireOnce = true,
+            expiry = DelayedTriggerExpiry.EndOfTurn,
+            effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.TriggeringEntity),
+        )
+    }
+
+    sagaChapter(3) {
+        effect = ConditionalEffect(
+            condition = Conditions.All(
+                Conditions.ControlCreature,
+                Compare(
+                    DynamicAmounts.battlefield(Player.You, GameObjectFilter.Creature).maxPower(),
+                    ComparisonOperator.GTE,
+                    DynamicAmounts.battlefield(Player.Each, GameObjectFilter.Creature).maxPower(),
+                ),
+            ),
+            effect = Effects.DrawCards(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "203"
+        artist = "Chun Lo"
+        flavorText = "\"Who dares summon me from the darkness?\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/93feb9d5-d004-4598-a448-b3488c869c05.jpg?1748706522"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheWaterCrystal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheWaterCrystal.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyMillAmount
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Water Crystal
+ * {2}{U}{U}
+ * Legendary Artifact
+ *
+ * Blue spells you cast cost {1} less to cast.
+ * If an opponent would mill one or more cards, they mill that many cards plus four instead.
+ * {4}{U}{U}, {T}: Each opponent mills cards equal to the number of cards in your hand.
+ *
+ * Notes:
+ *  - The cost reduction reduces only generic mana in the total cost of blue spells you cast
+ *    (Scryfall ruling 2025-06-06); modeled with [CostModification.ReduceGeneric], exactly like
+ *    its cycle siblings (The Wind Crystal, etc.).
+ *  - "they mill that many cards plus four instead" is the mill twin of The Wind Crystal's
+ *    [com.wingedsheep.sdk.scripting.ModifyLifeGain]: a [ModifyMillAmount] additive replacement
+ *    scoped to mills by an opponent ([EventPattern.MillEvent] with [Player.EachOpponent]).
+ *    Applied at the mill announcement, so it boosts *any* source's opponent mill — not just this
+ *    card's activated ability. Two copies add eight, three add twelve, etc. (Scryfall ruling
+ *    2025-06-06), because each is a separate replacement summed in turn. A base mill of zero is
+ *    untouched ("would mill one or more cards").
+ *  - The activated ability mills each opponent. The amount is the number of cards in *your* hand,
+ *    so the count is `DynamicAmount.Count(Player.You, HAND)` evaluated in the ability's own
+ *    context and the mill target is `Player.EachOpponent` — the gather fans out across every
+ *    opponent's library, and each milled card goes to its owner's graveyard. (Using a
+ *    Player.You–anchored count rather than wrapping in ForEachPlayer keeps "your hand" pointing
+ *    at the controller, not at each opponent.)
+ */
+val TheWaterCrystal = card("The Water Crystal") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Artifact"
+    oracleText = "Blue spells you cast cost {1} less to cast.\n" +
+        "If an opponent would mill one or more cards, they mill that many cards plus four instead.\n" +
+        "{4}{U}{U}, {T}: Each opponent mills cards equal to the number of cards in your hand."
+
+    // Blue spells you cast cost {1} less to cast.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.BLUE)),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    // If an opponent would mill one or more cards, they mill that many cards plus four instead.
+    replacementEffect(
+        ModifyMillAmount(
+            modifier = 4,
+            appliesTo = EventPattern.MillEvent(player = Player.EachOpponent),
+        )
+    )
+
+    // {4}{U}{U}, {T}: Each opponent mills cards equal to the number of cards in your hand.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{U}{U}"), Costs.Tap)
+        effect = Patterns.Library.mill(
+            DynamicAmounts.cardsInYourHand(),
+            EffectTarget.PlayerRef(Player.EachOpponent),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "85"
+        artist = "Pablo Mendoza"
+        flavorText = "\"Crystal of water, may you regain your light.\"\n—Aria Benett"
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0af8436-797b-4e1f-b21a-d8e93701c3c9.jpg?1748706080"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TorgalAFineHound.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TorgalAFineHound.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Torgal, A Fine Hound
+ * {1}{G}
+ * Legendary Creature — Wolf
+ * 2/2
+ *
+ * Whenever you cast your first Human creature spell each turn, that creature enters with an
+ * additional +1/+1 counter on it for each Dog and/or Wolf you control.
+ * {T}: Add one mana of any color.
+ *
+ * Implementation notes:
+ *  - "your first Human creature spell each turn" = a [Triggers.youCastSpell] trigger filtered to
+ *    Human creature spells (`GameObjectFilter.Creature.withSubtype("Human")`) with
+ *    `oncePerTurn = true`, so it fires on the first such spell you cast each turn and not again.
+ *  - The counter is placed on the triggering spell while it is still on the stack
+ *    ([EffectTarget.TriggeringEntity]); it travels with the spell to the battlefield as it
+ *    resolves, satisfying "that creature enters with an additional +1/+1 counter on it"
+ *    naturally — the same primitive Summon: Fenrir's chapter II uses, here with a dynamic count.
+ *  - "for each Dog and/or Wolf you control" is a dynamic amount counting permanents you control
+ *    that are Dogs or Wolves (`withAnySubtype("Dog", "Wolf")`, OR logic). Counting zero is fine —
+ *    the spell still resolves; it just enters with no extra counters. (Torgal himself is a Wolf,
+ *    so unless he has left the battlefield the count is at least 1.)
+ *  - "{T}: Add one mana of any color" is a standard mana ability (`manaAbility = true`).
+ */
+val TorgalAFineHound = card("Torgal, A Fine Hound") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Wolf"
+    oracleText = "Whenever you cast your first Human creature spell each turn, that creature " +
+        "enters with an additional +1/+1 counter on it for each Dog and/or Wolf you control.\n" +
+        "{T}: Add one mana of any color."
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Creature.withSubtype("Human"),
+        )
+        oncePerTurn = true
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Creature.withAnySubtype("Dog", "Wolf"),
+            ).count(),
+            EffectTarget.TriggeringEntity,
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "208"
+        artist = "Narendra Bintara Adi"
+        flavorText = "\"Thank you, Torgal. For never giving up.\"\n—Clive Rosfield"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f5725aa-42bb-4dfd-9c15-135b38b33da3.jpg?1748706543"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -492,6 +492,26 @@ object PredefinedTokens {
     }
 
     /**
+     * Frog token — a vanilla 1/1 green creature (Quina, Qu Gourmet).
+     *
+     * Its green color comes from a color indicator (CR 204), stored here via the
+     * `colorIdentity` DSL setter → `colorIdentityOverride`. Tokens have no mana cost,
+     * so the token-creation executors read the override for the printed color (a plain
+     * `CardDefinition.colors` would be empty/colorless without a mana cost).
+     */
+    val Frog = card("Frog") {
+        typeLine = "Creature — Frog"
+        colorIdentity = "G"
+        power = 1
+        toughness = 1
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/e/3/e3c84944-23b8-40d7-9b25-c746b08b4dc4.jpg?1748704089"
+            artist = "Daniel Correia"
+        }
+    }
+
+    /**
      * All predefined token definitions.
      * Register these in the CardRegistry so token abilities are resolved.
      */
@@ -513,6 +533,7 @@ object PredefinedTokens {
         Drone,
         Everywhere,
         Munitions,
-        Mutagen
+        Mutagen,
+        Frog
     )
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -2302,7 +2302,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -4285,7 +4285,8 @@
                                     "count": {
                                         "type": "Fixed",
                                         "amount": 2
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -10943,7 +10944,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 4
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -15708,7 +15710,8 @@
                                         "player": {
                                             "type": "ContextPlayer",
                                             "index": 0
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -21907,7 +21910,8 @@
                                     "count": {
                                         "type": "Fixed",
                                         "amount": 3
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -3031,7 +3031,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -5761,7 +5762,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -12797,7 +12799,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -12859,7 +12862,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -14663,7 +14667,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -14856,7 +14861,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/DSK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DSK.json
@@ -8471,7 +8471,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -13938,7 +13939,8 @@
                                     "count": {
                                         "type": "Fixed",
                                         "amount": 1
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -15570,7 +15572,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -15728,7 +15731,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -15770,7 +15774,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -17573,7 +17578,8 @@
                                             "count": {
                                                 "type": "Fixed",
                                                 "amount": 2
-                                            }
+                                            },
+                                            "isMill": true
                                         },
                                         "storeAs": "milled"
                                     },
@@ -17632,7 +17638,8 @@
                                             "count": {
                                                 "type": "Fixed",
                                                 "amount": 2
-                                            }
+                                            },
+                                            "isMill": true
                                         },
                                         "storeAs": "milled"
                                     },
@@ -17691,7 +17698,8 @@
                                             "count": {
                                                 "type": "Fixed",
                                                 "amount": 2
-                                            }
+                                            },
+                                            "isMill": true
                                         },
                                         "storeAs": "milled"
                                     },

--- a/mtg-sets/src/test/resources/snapshots/cards/ECL.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ECL.json
@@ -4800,7 +4800,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -15320,7 +15321,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -18773,7 +18775,8 @@
                                         "count": {
                                             "type": "Fixed",
                                             "amount": 3
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -18828,7 +18831,8 @@
                                         "count": {
                                             "type": "Fixed",
                                             "amount": 3
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -18918,7 +18922,8 @@
                                             "count": {
                                                 "type": "Fixed",
                                                 "amount": 3
-                                            }
+                                            },
+                                            "isMill": true
                                         },
                                         "storeAs": "milled"
                                     },

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -5417,7 +5417,8 @@
                                         "count": {
                                             "type": "Fixed",
                                             "amount": 3
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -7420,7 +7421,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 1
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -13582,7 +13584,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -13941,7 +13944,8 @@
                                     "player": {
                                         "type": "ContextPlayer",
                                         "index": 0
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -14454,7 +14458,8 @@
                         "player": {
                             "type": "ContextPlayer",
                             "index": 0
-                        }
+                        },
+                        "isMill": true
                     },
                     "storeAs": "milled"
                 },
@@ -14554,7 +14559,8 @@
                                     "type": "Fixed",
                                     "amount": 4
                                 },
-                                "player": "DefendingPlayer"
+                                "player": "DefendingPlayer",
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -11226,6 +11226,66 @@
     ]
 }
 
+// Quina, Qu Gourmet
+{
+    "name": "Quina, Qu Gourmet",
+    "manaCost": "{2}{G}",
+    "typeLine": "Legendary Creature — Qu",
+    "oracleText": "If one or more tokens would be created under your control, those tokens plus a 1/1 green Frog creature token are created instead.\n{2}, Sacrifice a Frog: Put a +1/+1 counter on Quina.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "creature Frog"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "CreateAdditionalToken",
+                "additionalTokenType": "Frog"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "UNCOMMON",
+        "artist": "Fajareka Setiawan",
+        "flavorText": "\"World only have two things: Things you can eat and things you no can eat.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f352b5e-9731-4a8e-b872-db5d3bf32211.jpg?1748706489"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Quistis Trepe
 {
     "name": "Quistis Trepe",

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -4837,7 +4837,8 @@
                                         "count": {
                                             "type": "Fixed",
                                             "amount": 2
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -6950,7 +6951,8 @@
                                     "player": "You",
                                     "tracker": "LIFE_GAINED"
                                 },
-                                "player": "EachOpponent"
+                                "player": "EachOpponent",
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -7914,7 +7916,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -13888,7 +13891,8 @@
                                         "count": {
                                             "type": "Fixed",
                                             "amount": 3
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -15813,7 +15817,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 5
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -16721,6 +16726,95 @@
         "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc420e79-c483-474f-97cd-e9c6a636c306.jpg?1748706782"
     },
     "colorIdentityOverride": []
+}
+
+// The Water Crystal
+{
+    "name": "The Water Crystal",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Blue spells you cast cost {1} less to cast.\nIf an opponent would mill one or more cards, they mill that many cards plus four instead.\n{4}{U}{U}, {T}: Each opponent mills cards equal to the number of cards in your hand.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{U}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Count",
+                                    "player": "You",
+                                    "zone": "Hand"
+                                },
+                                "player": "EachOpponent",
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard",
+                                "player": "EachOpponent"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "blue"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "ModifyMillAmount",
+                "modifier": 4,
+                "appliesTo": {
+                    "type": "MillEvent",
+                    "player": "EachOpponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "rarity": "RARE",
+        "artist": "Pablo Mendoza",
+        "flavorText": "\"Crystal of water, may you regain your light.\"\n—Aria Benett",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0af8436-797b-4e1f-b21a-d8e93701c3c9.jpg?1748706080"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // The Wind Crystal

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -11518,6 +11518,80 @@
     ]
 }
 
+// Raubahn, Bull of Ala Mhigo
+{
+    "name": "Raubahn, Bull of Ala Mhigo",
+    "manaCost": "{1}{R}",
+    "typeLine": "Legendary Creature — Human Warrior",
+    "oracleText": "Ward—Pay life equal to Raubahn's power.\nWhenever Raubahn attacks, attach up to one target Equipment you control to target attacking creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.DynamicLife",
+                "amount": {
+                    "type": "EntityProperty",
+                    "entity": "Source",
+                    "numericProperty": "Power"
+                }
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AttachTargetEquipmentToCreature",
+                    "equipmentTarget": {
+                        "type": "BoundVariable",
+                        "name": "up to one target Equipment you control"
+                    },
+                    "creatureTarget": {
+                        "type": "BoundVariable",
+                        "name": "target attacking creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "artifact Equipment ctrl:you"
+                    },
+                    "id": "up to one target Equipment you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking"
+                        },
+                        "id": "target attacking creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "151",
+        "rarity": "RARE",
+        "artist": "Julia Vasilyeva",
+        "flavorText": "\"Come, then! Who will be next to die on my steel!?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/0/7035d11b-525f-4120-8dcb-610095196681.jpg?1748706327"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Reach the Horizon
 {
     "name": "Reach the Horizon",

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -15045,6 +15045,139 @@
     ]
 }
 
+// Summon: Fenrir
+{
+    "name": "Summon: Fenrir",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment Creature — Saga Wolf",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Crescent Fang — Search your library for a basic land card, put it onto the battlefield tapped, then shuffle.\nII — Heavenward Howl — When you next cast a creature spell this turn, that creature enters with an additional +1/+1 counter on it.\nIII — Ecliptic Growl — Draw a card if you control the creature with the greatest power or tied for the greatest power.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "basicland"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        "ShuffleLibrary"
+                    ]
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "TriggeringEntity"
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "SpellCastEvent",
+                            "spellFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ]
+                            }
+                        }
+                    },
+                    "fireOnce": true
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "All",
+                            "conditions": [
+                                {
+                                    "type": "Exists",
+                                    "player": "You",
+                                    "zone": "Battlefield",
+                                    "filter": "creature"
+                                },
+                                {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "creature",
+                                        "aggregation": "MAX",
+                                        "property": "POWER"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "Each",
+                                        "filter": "creature",
+                                        "aggregation": "MAX",
+                                        "property": "POWER"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "203",
+        "rarity": "UNCOMMON",
+        "artist": "Chun Lo",
+        "flavorText": "\"Who dares summon me from the darkness?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/93feb9d5-d004-4598-a448-b3488c869c05.jpg?1748706522"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Summon: G.F. Ifrit
 {
     "name": "Summon: G.F. Ifrit",

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -17302,6 +17302,67 @@
     ]
 }
 
+// Torgal, A Fine Hound
+{
+    "name": "Torgal, A Fine Hound",
+    "manaCost": "{1}{G}",
+    "typeLine": "Legendary Creature — Wolf",
+    "oracleText": "Whenever you cast your first Human creature spell each turn, that creature enters with an additional +1/+1 counter on it for each Dog and/or Wolf you control.\n{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Human"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Dog|Wolf"
+                    },
+                    "target": "TriggeringEntity"
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "UNCOMMON",
+        "artist": "Narendra Bintara Adi",
+        "flavorText": "\"Thank you, Torgal. For never giving up.\"\n—Clive Rosfield",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f5725aa-42bb-4dfd-9c15-135b38b33da3.jpg?1748706543"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Town Greeter
 {
     "name": "Town Greeter",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -164,7 +164,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 4
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -3159,7 +3160,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/JUD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JUD.json
@@ -1055,7 +1055,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -716,7 +716,8 @@
                                     "count": {
                                         "type": "Fixed",
                                         "amount": 1
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -8813,7 +8814,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -10764,7 +10766,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -10792,7 +10795,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1156,7 +1156,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -2551,7 +2552,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/LGN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LGN.json
@@ -2096,7 +2096,8 @@
                                     "player": "TriggeringPlayer",
                                     "zone": "Hand"
                                 },
-                                "player": "TriggeringPlayer"
+                                "player": "TriggeringPlayer",
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -12374,7 +12374,8 @@
                                             "entity": "RingBearer",
                                             "numericProperty": "Power"
                                         },
-                                        "player": "Each"
+                                        "player": "Each",
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -12686,7 +12687,8 @@
                                                                 "name": "influence"
                                                             }
                                                         }
-                                                    }
+                                                    },
+                                                    "isMill": true
                                                 },
                                                 "storeAs": "milled"
                                             },
@@ -12787,7 +12789,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -14745,7 +14748,8 @@
                                         "type": "Fixed",
                                         "amount": 2
                                     },
-                                    "player": "EachOpponent"
+                                    "player": "EachOpponent",
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -17198,7 +17202,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -17849,7 +17854,8 @@
                                         "player": {
                                             "type": "ContextPlayer",
                                             "index": 0
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/MKM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MKM.json
@@ -250,7 +250,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/OTJ.json
@@ -4669,7 +4669,8 @@
                                     "count": {
                                         "type": "Fixed",
                                         "amount": 3
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -4871,7 +4872,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -18670,7 +18672,8 @@
                                         "count": {
                                             "type": "Fixed",
                                             "amount": 2
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -19795,7 +19798,8 @@
                                             "player": {
                                                 "type": "ContextPlayer",
                                                 "index": 0
-                                            }
+                                            },
+                                            "isMill": true
                                         },
                                         "storeAs": "milled"
                                     },

--- a/mtg-sets/src/test/resources/snapshots/cards/SCG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SCG.json
@@ -790,7 +790,8 @@
                         "player": {
                             "type": "ContextPlayer",
                             "index": 0
-                        }
+                        },
+                        "isMill": true
                     },
                     "storeAs": "milled"
                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/SOS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SOS.json
@@ -5149,7 +5149,8 @@
                                     "player": {
                                         "type": "ContextPlayer",
                                         "index": 0
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -5181,7 +5182,8 @@
                                     "player": {
                                         "type": "ContextPlayer",
                                         "index": 0
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -8346,7 +8348,8 @@
                                         "count": {
                                             "type": "Fixed",
                                             "amount": 1
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },

--- a/mtg-sets/src/test/resources/snapshots/cards/SPM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/SPM.json
@@ -4784,7 +4784,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -1314,7 +1314,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -6354,7 +6355,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -8810,7 +8812,8 @@
                                         "player": "You",
                                         "zone": "Battlefield",
                                         "filter": "land"
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -11405,7 +11408,8 @@
                                     "count": {
                                         "type": "Fixed",
                                         "amount": 3
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },
@@ -15192,7 +15196,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -18180,7 +18185,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -18564,7 +18570,8 @@
                                         "player": {
                                             "type": "ContextPlayer",
                                             "index": 0
-                                        }
+                                        },
+                                        "isMill": true
                                     },
                                     "storeAs": "milled"
                                 },
@@ -19180,7 +19187,8 @@
                                     "count": {
                                         "type": "Fixed",
                                         "amount": 4
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -30,7 +30,8 @@
                                 "player": {
                                     "type": "ContextPlayer",
                                     "index": 0
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },

--- a/mtg-sets/src/test/resources/snapshots/cards/TMT.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMT.json
@@ -1923,7 +1923,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 2
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -4475,7 +4476,8 @@
                         "player": {
                             "type": "ContextPlayer",
                             "index": 0
-                        }
+                        },
+                        "isMill": true
                     },
                     "storeAs": "milled"
                 },
@@ -8128,7 +8130,8 @@
                                 "count": {
                                     "type": "Fixed",
                                     "amount": 3
-                                }
+                                },
+                                "isMill": true
                             },
                             "storeAs": "milled"
                         },
@@ -11728,7 +11731,8 @@
                                     "count": {
                                         "type": "Fixed",
                                         "amount": 4
-                                    }
+                                    },
+                                    "isMill": true
                                 },
                                 "storeAs": "milled"
                             },

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/Keywords.kt
@@ -68,8 +68,9 @@ internal fun BridgeBuilder.keywords() {
     // (`Ward—Discard a card`, `Ward {2}`, `Ward—Pay N life`, `Ward—Sacrifice <filter>`). Like Saddle,
     // it must be `supported`, not `keyword`: a bare `keywords(Keyword.WARD)` would drop the cost. The
     // emitter's `rname == "Ward"` branch renders `keywordAbility(KeywordAbility.ward(...)/wardDiscard()/
-    // wardLife(N)/wardSacrifice(filter))` for the cost shapes it can express; richer/compound costs
-    // decline -> SCAFFOLD. This entry only marks the capability covered (never blocking).
+    // wardLife(N)/wardLife(DynamicAmounts.sourcePower())/wardSacrifice(filter))` for the cost shapes it
+    // can express ("Ward—Pay life equal to ~'s power", Raubahn, renders the dynamic form); richer/compound
+    // costs decline -> SCAFFOLD. This entry only marks the capability covered (never blocking).
     supported("Ward", "keyword ability: Ward—<cost> (CR 702.21) -> keywordAbility(KeywordAbility.ward(...)/wardDiscard()/wardLife(N)/wardSacrifice(filter))")
 
     composed("Landwalk", "specific *WALK keywords (SWAMPWALK, FORESTWALK, ...)")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -232,6 +232,17 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     supported("WouldPutACardOrTokenInAPlayersGraveyardFromAnywhere", "replaceable event: any card/token to any graveyard from anywhere")
     supported("ExileItInstead", "replacement action: exile instead of going to the graveyard")
 
+    // "If one or more tokens would be created under your control, those tokens plus a <token>
+    // are created instead" (Peregrin Took, Worldwalker Helm, Quina, Qu Gourmet). Maps to the
+    // CreateAdditionalToken replacement. Capability-only — the emitter declines (SCAFFOLD)
+    // because the IR describes the added token inline (P/T/color/subtype) while the SDK
+    // references a predefined token by name, a card-specific mapping we won't render lossily.
+    composed(
+        "ReplaceAnyNumberOfTokensWouldBeCreated",
+        "CreateAdditionalToken (those tokens plus an extra named token)",
+        composes = listOf("CreateAdditionalToken"),
+    )
+
     // "You have no maximum hand size for the rest of the game" (Wisdom of Ages) — the nested
     // _PlayerEffect of a CreatePlayerEffect(You) resolution action. Renders to the one-shot
     // player-scoped `RemoveMaximumHandSize` effect (distinct from the battlefield-only

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.tooling.coverage.Local
 import com.wingedsheep.tooling.coverage.RawLine
 import com.wingedsheep.tooling.coverage.Stmt
 import com.wingedsheep.tooling.coverage.Sub
+import com.wingedsheep.tooling.coverage.amountNode
 import com.wingedsheep.tooling.coverage.arg
 import com.wingedsheep.tooling.coverage.argWordsTagged
 import com.wingedsheep.tooling.coverage.asArr
@@ -3258,9 +3259,18 @@ internal fun EmitCtx.wardKeywordLine(rule: JsonObject): List<Stmt>? {
         "DiscardACard" -> call("KeywordAbility.wardDiscard")
         "DiscardACardAtRandom" -> call("KeywordAbility.wardDiscard", arg("random", "true"))
         "PayLife" -> {
-            // Only a fixed integer life cost renders; dynamic life (PowerOfPermanent, X) declines.
-            val n = (cost["args"].asInt()) ?: ((cost["args"] as? JsonObject)?.get("args").asInt()) ?: return null
-            call("KeywordAbility.wardLife", arg("$n"))
+            // A fixed integer life cost renders to wardLife(N). A dynamic life cost renders to
+            // wardLife(<DynamicAmount>) only for the source-power shape it recognizes — Raubahn,
+            // Bull of Ala Mhigo's "Ward—Pay life equal to ~'s power" maps PowerOfPermanent(ThisPermanent)
+            // to DynamicAmounts.sourcePower(). Any other dynamic shape (X, another permanent's power)
+            // still declines -> SCAFFOLD rather than emit an inexact cost.
+            val n = (cost["args"].asInt()) ?: ((cost["args"] as? JsonObject)?.get("args").asInt())
+            if (n != null) {
+                call("KeywordAbility.wardLife", arg("$n"))
+            } else {
+                val dynamic = dynamicAmountExpr(amountNode(cost.field("args"))) ?: return null
+                call("KeywordAbility.wardLife", arg(dynamic))
+            }
         }
         "SacrificeAPermanent" -> {
             val filter = gameObjectFilterDsl(cost.field("args")) ?: return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -92,6 +92,9 @@ class TriggerMatcher(
             is EventPattern.DrawEvent -> {
                 event is CardsDrawnEvent && matchesPlayer(trigger.player, event.playerId, controllerId)
             }
+            // MillEvent is a replacement-only pattern (ModifyMillAmount); it never matches a
+            // triggered ability. Applied at the mill announcement by MillAmountModifier.
+            is EventPattern.MillEvent -> false
             is EventPattern.NthCardDrawnEvent -> {
                 // Fires on CardsDrawnEvent when the drawing player's per-turn draw count
                 // crosses the threshold inside this batch. The component is incremented

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/GatherCardsExecutor.kt
@@ -52,7 +52,14 @@ class GatherCardsExecutor : EffectExecutor<GatherCardsEffect> {
                 val playerIds = resolvePlayers(source.player, context, state)
                     ?: return EffectResult.error(state, "Could not resolve player for GatherCards")
                 playerIds.flatMap { playerId ->
-                    state.getZone(ZoneKey(playerId, Zone.LIBRARY)).take(count)
+                    // For a mill, apply ModifyMillAmount replacement effects to the announced
+                    // count per milling player (CR 701.13 — "mill that many plus four instead").
+                    val effectiveCount = if (source.isMill) {
+                        MillAmountModifier.apply(state, playerId, count)
+                    } else {
+                        count
+                    }
+                    state.getZone(ZoneKey(playerId, Zone.LIBRARY)).take(effectiveCount)
                 }
             }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MillAmountModifier.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MillAmountModifier.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ModifyMillAmount
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Applies [ModifyMillAmount] replacement effects to an announced mill count (CR 701.13 / CR 616 —
+ * the "mill N" instruction is modified by replacement effects that refer to the number of cards
+ * milled, before any individual card moves). Called once at the mill announcement site
+ * ([GatherCardsExecutor]'s `CardSource.TopOfLibrary(isMill = true)` branch), NOT per moved card,
+ * so a paused-and-resumed mill pipeline never double-modifies.
+ *
+ * This is the mill twin of `DrawReplacementDispatcher.applyDrawAmountModifier`: it scans every
+ * battlefield permanent's replacement effects, gates each by the [EventPattern.MillEvent]'s
+ * `player` filter relative to [playerId] and the source's controller, checks `restrictions`, sums
+ * the modifier, and clamps the result to `≥ 0`. A base mill of 0 is left untouched ("would mill
+ * one or more cards" only fires when at least one card would be milled).
+ */
+object MillAmountModifier {
+
+    fun apply(
+        state: GameState,
+        playerId: EntityId,
+        originalCount: Int
+    ): Int {
+        if (originalCount <= 0) return originalCount
+        val conditionEvaluator = ConditionEvaluator()
+        var adjusted = originalCount
+        for (entityId in state.getBattlefield()) {
+            val container = state.getEntity(entityId) ?: continue
+            val replacementSource = container.get<ReplacementEffectSourceComponent>() ?: continue
+            val sourceControllerId = container.get<ControllerComponent>()?.playerId
+
+            for (effect in replacementSource.replacementEffects) {
+                if (effect !is ModifyMillAmount) continue
+                val millEvent = effect.appliesTo as? EventPattern.MillEvent ?: continue
+
+                val matchesPlayer = when (millEvent.player) {
+                    Player.Each -> true
+                    Player.You -> sourceControllerId != null && playerId == sourceControllerId
+                    Player.EachOpponent ->
+                        sourceControllerId != null && playerId != sourceControllerId
+                    else -> false
+                }
+                if (!matchesPlayer) continue
+
+                val effectContext = EffectContext(
+                    sourceId = entityId,
+                    controllerId = playerId,
+                )
+                val restrictionsHold = effect.restrictions.all { restriction ->
+                    conditionEvaluator.evaluate(state, restriction, effectContext)
+                }
+                if (!restrictionsHold) continue
+
+                adjusted += effect.modifier
+            }
+        }
+        return adjusted.coerceAtLeast(0)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/attachments/AttachTargetEquipmentToCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/attachments/AttachTargetEquipmentToCreatureExecutor.kt
@@ -13,6 +13,12 @@ import kotlin.reflect.KClass
  * Executor for [AttachTargetEquipmentToCreatureEffect].
  * Attaches a targeted Equipment to a targeted creature.
  * Both the Equipment and creature are explicit targets (not the source).
+ *
+ * Either target may be declared optional ("up to one target"). When either resolves to nothing —
+ * the player declined an optional target, or a required target became illegal before resolution
+ * (CR 608.2c) — there is nothing to attach, so the effect is a graceful no-op (Raubahn, Bull of
+ * Ala Mhigo attaches "up to one target Equipment"; Blacksmith's Talent attaches to "up to one
+ * target creature").
  */
 class AttachTargetEquipmentToCreatureExecutor : EffectExecutor<AttachTargetEquipmentToCreatureEffect> {
 
@@ -24,11 +30,12 @@ class AttachTargetEquipmentToCreatureExecutor : EffectExecutor<AttachTargetEquip
         effect: AttachTargetEquipmentToCreatureEffect,
         context: EffectContext
     ): EffectResult {
+        // "up to one" / fizzled target — nothing to attach, so this is a no-op (not an error).
         val equipmentId = context.resolveTarget(effect.equipmentTarget, state)
-            ?: return EffectResult.error(state, "No valid equipment target for attach")
+            ?: return EffectResult.success(state)
 
         val creatureId = context.resolveTarget(effect.creatureTarget, state)
-            ?: return EffectResult.success(state) // "up to one" — no creature target is OK
+            ?: return EffectResult.success(state)
 
         var newState = state
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/stack/WardCounterEffectExecutor.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.engine.core.ManaSourceOption
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
@@ -82,10 +83,17 @@ class WardCounterEffectExecutor(
             ?: container.get<TriggeredAbilityOnStackComponent>()?.controllerId
             ?: return EffectResult.success(state)
 
+        // Resolve any DynamicLife component to a fixed Life amount at ward-resolution time
+        // (CR 702.21b): "Ward—Pay life equal to ~" reads the live value now — e.g. Raubahn's
+        // power, using last-known information if Raubahn has left the battlefield (handled by
+        // EntityReference.Source's LkiPolicy). All downstream payment / continuation machinery
+        // then operates on a plain WardCost.Life, so no other branch needs to change.
+        val resolvedCost = resolveDynamicLife(state, effect.cost, context)
+
         return chargeWardCost(
             state = state,
             cardRegistry = cardRegistry,
-            cost = effect.cost,
+            cost = resolvedCost,
             remainingParts = emptyList(),
             spellEntityId = spellEntityId,
             container = container,
@@ -93,6 +101,23 @@ class WardCounterEffectExecutor(
             wardSourceId = context.sourceId,
             controllerId = context.controllerId
         )
+    }
+
+    /**
+     * Replace every [WardCost.DynamicLife] (including those nested in a [WardCost.Composite])
+     * with a fixed [WardCost.Life] by evaluating its [com.wingedsheep.sdk.scripting.values.DynamicAmount]
+     * against the current state, clamped to >= 0. Other cost shapes pass through unchanged.
+     */
+    private fun resolveDynamicLife(
+        state: GameState,
+        cost: WardCost,
+        context: EffectContext
+    ): WardCost = when (cost) {
+        is WardCost.DynamicLife ->
+            WardCost.Life(DynamicAmountEvaluator().evaluate(state, cost.amount, context).coerceAtLeast(0))
+        is WardCost.Composite ->
+            WardCost.Composite(cost.parts.map { resolveDynamicLife(state, it, context) })
+        else -> cost
     }
 
     companion object {
@@ -141,6 +166,13 @@ class WardCounterEffectExecutor(
                         spellEntityId, container, payingPlayerId, wardSourceId, controllerId
                     )
                 }
+                // The dynamic life amount is resolved to a fixed WardCost.Life by execute()'s
+                // resolveDynamicLife before any cost reaches here (including inside a Composite),
+                // so this branch is unreachable; charge a 0-life cost defensively if it ever isn't.
+                is WardCost.DynamicLife -> handleLifeCost(
+                    state, cardRegistry, spellEntityId, container, payingPlayerId,
+                    0, remainingParts, wardSourceId, controllerId
+                )
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
@@ -84,7 +84,10 @@ class CreatePredefinedTokenExecutor(
                 typeLine = cardDef.typeLine,
                 baseStats = cardDef.creatureStats,
                 baseKeywords = cardDef.keywords,
-                colors = cardDef.colors,
+                // Tokens have no mana cost, so a colored token's printed color lives in its
+                // color indicator (CR 204), stored on the definition as colorIdentityOverride.
+                // Fall back to the mana-cost-derived colors for tokens without an override.
+                colors = cardDef.colorIdentityOverride ?: cardDef.colors,
                 ownerId = tokenControllerId,
                 imageUri = cardDef.metadata.imageUri
             )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -193,7 +193,10 @@ object TokenCreationReplacementHelper {
                         typeLine = cardDef.typeLine,
                         baseStats = cardDef.creatureStats,
                         baseKeywords = cardDef.keywords,
-                        colors = cardDef.colors,
+                        // Tokens have no mana cost, so a colored token's printed color lives in
+                        // its color indicator (CR 204), stored as colorIdentityOverride. Fall
+                        // back to mana-cost-derived colors for tokens without an override.
+                        colors = cardDef.colorIdentityOverride ?: cardDef.colors,
                         ownerId = tokenControllerId,
                         imageUri = cardDef.metadata.imageUri
                     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -924,6 +924,8 @@ class StaticAbilityHandler(
             is com.wingedsheep.sdk.scripting.PreventDraw,
             is com.wingedsheep.sdk.scripting.ReplaceDrawWithEffect,
             is com.wingedsheep.sdk.scripting.ModifyDrawAmount,
+            // Mill:
+            is com.wingedsheep.sdk.scripting.ModifyMillAmount,
             // Counter placement:
             is com.wingedsheep.sdk.scripting.ModifyCounterPlacement,
             is com.wingedsheep.sdk.scripting.DoubleCounterPlacement,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuinaQuGourmetScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuinaQuGourmetScenarioTest.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Quina, Qu Gourmet (FIN #194, {2}{G}, 2/3 Legendary Qu).
+ *
+ *   If one or more tokens would be created under your control, those tokens plus a
+ *   1/1 green Frog creature token are created instead.
+ *     ([com.wingedsheep.sdk.scripting.CreateAdditionalToken] with additionalTokenType = "Frog")
+ *   {2}, Sacrifice a Frog: Put a +1/+1 counter on Quina.
+ *
+ * These tests pin: (1) the replacement adds exactly one Frog per creation event regardless
+ * of token count, (2) the added Frog is a 1/1 GREEN creature (its color comes from the
+ * token definition's color indicator, since tokens have no mana cost), (3) the added Frog
+ * does not itself loop (CR 614.5), and (4) the sacrifice-a-Frog ability puts a +1/+1
+ * counter on Quina.
+ */
+class QuinaQuGourmetScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Quina, Qu Gourmet") {
+
+            test("creating two tokens yields the two tokens plus exactly one green Frog") {
+                // Rally at the Hornburg ({1}{R}) creates two 1/1 white Human Soldier tokens. With
+                // Quina out, that single creation event is replaced to also create one Frog.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Quina, Qu Gourmet")
+                    .withCardInHand(1, "Rally at the Hornburg")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Rally at the Hornburg")
+                game.resolveStack()
+
+                withClue("Rally at the Hornburg makes two Human Soldiers") {
+                    game.findPermanents("Human Soldier Token").size shouldBe 2
+                }
+                withClue("Quina adds exactly one Frog (fires once per event, not per token)") {
+                    game.findPermanents("Frog").size shouldBe 1
+                }
+
+                val frogId = game.findPermanents("Frog").single()
+                val frog = game.state.getEntity(frogId)?.get<CardComponent>()!!
+                withClue("The Frog is green") { frog.colors shouldBe setOf(Color.GREEN) }
+                withClue("The Frog is a 1/1") {
+                    frog.baseStats?.basePower shouldBe 1
+                    frog.baseStats?.baseToughness shouldBe 1
+                }
+            }
+
+            test("a token-making source yields exactly one Frog — the added Frog does not loop (CR 614.5)") {
+                // Raise the Alarm ({1}{W}) creates two 1/1 white Soldier tokens. Proves no runaway
+                // loop: the source's tokens + exactly one Frog, and that added Frog (itself a token)
+                // does NOT re-enter the replacement to make a second Frog.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Quina, Qu Gourmet")
+                    .withCardInHand(1, "Raise the Alarm")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Raise the Alarm")
+                game.resolveStack()
+
+                withClue("Exactly one Frog — the added Frog does not itself re-enter the replacement") {
+                    game.findPermanents("Frog").size shouldBe 1
+                }
+            }
+
+            test("{2}, Sacrifice a Frog: Put a +1/+1 counter on Quina") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Quina, Qu Gourmet")
+                    .withCardOnBattlefield(1, "Frog", isToken = true)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val quina = game.findPermanent("Quina, Qu Gourmet")!!
+                val frog = game.findPermanents("Frog").single()
+                val ability = cardRegistry.getCard("Quina, Qu Gourmet")!!.script.activatedAbilities[0]
+
+                val act = game.execute(
+                    ActivateAbility(
+                        game.player1Id,
+                        quina,
+                        ability.id,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(frog))
+                    )
+                )
+                withClue("Activating the ability should succeed: ${act.error}") { act.error shouldBe null }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+                while (game.hasPendingDecision()) game.resolveStack()
+
+                withClue("The Frog is sacrificed to pay the cost") {
+                    game.findPermanents("Frog").size shouldBe 0
+                }
+                withClue("Quina gets a +1/+1 counter") {
+                    game.state.getEntity(quina)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RaubahnBullOfAlaMhigoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RaubahnBullOfAlaMhigoScenarioTest.kt
@@ -1,0 +1,180 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Raubahn, Bull of Ala Mhigo (FIN #151).
+ *
+ * Raubahn, Bull of Ala Mhigo {1}{R} Legendary Creature — Human Warrior 2/2
+ * Ward—Pay life equal to Raubahn's power.
+ * Whenever Raubahn attacks, attach up to one target Equipment you control to target attacking
+ * creature.
+ *
+ * The ward cost is a dynamic life cost (`WardCost.DynamicLife(DynamicAmounts.sourcePower())`):
+ * the amount is Raubahn's power read when the ward trigger resolves (CR 702.21b / Scryfall
+ * ruling 2025-06-06). These tests prove the base-power amount, the *modified*-power amount (a
+ * Glorious Anthem makes the cost 3), the can't-pay immediate counter, and the attack-trigger
+ * attach (with and without choosing the optional Equipment target).
+ */
+class RaubahnBullOfAlaMhigoScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        test("ward cost equals Raubahn's base power (2) — paying lets the spell resolve") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Raubahn, Bull of Ala Mhigo")
+                .withCardInHand(2, "Lightning Bolt")
+                .withLandsOnBattlefield(2, "Mountain", 1)
+                .withLifeTotal(2, 20)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val raubahn = game.findPermanent("Raubahn, Bull of Ala Mhigo")!!
+
+            // Opponent (player 2) targets Raubahn → ward triggers, resolves, prompts the caster.
+            game.castSpell(2, "Lightning Bolt", raubahn).error shouldBe null
+            game.resolveStack()
+
+            val decision = game.getPendingDecision()
+            withClue("ward prompts the caster to pay life") {
+                (decision is YesNoDecision) shouldBe true
+            }
+            decision!!.playerId shouldBe game.player2Id
+
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+
+            withClue("paid 2 life (Raubahn's power), Bolt resolves and kills the 2/2") {
+                game.getLifeTotal(2) shouldBe 18
+                game.findPermanent("Raubahn, Bull of Ala Mhigo") shouldBe null
+            }
+        }
+
+        test("ward cost tracks Raubahn's MODIFIED power — anthem makes it 3 life") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Raubahn, Bull of Ala Mhigo")
+                .withCardOnBattlefield(1, "Glorious Anthem")   // +1/+1 → Raubahn is 3/3
+                .withCardInHand(2, "Lightning Bolt")
+                .withLandsOnBattlefield(2, "Mountain", 1)
+                .withLifeTotal(2, 20)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val raubahn = game.findPermanent("Raubahn, Bull of Ala Mhigo")!!
+            withClue("anthem makes Raubahn 3/3") {
+                stateProjector.project(game.state).getPower(raubahn) shouldBe 3
+            }
+
+            game.castSpell(2, "Lightning Bolt", raubahn).error shouldBe null
+            game.resolveStack()
+
+            (game.getPendingDecision() is YesNoDecision) shouldBe true
+            game.answerYesNo(true).error shouldBe null
+            game.resolveStack()
+
+            withClue("paid 3 life (Raubahn's modified power)") {
+                game.getLifeTotal(2) shouldBe 17
+            }
+        }
+
+        test("ward counters immediately when the caster can't pay the dynamic life cost") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Raubahn, Bull of Ala Mhigo")
+                .withCardOnBattlefield(1, "Glorious Anthem")   // Raubahn 3/3 → ward costs 3 life
+                .withCardInHand(2, "Lightning Bolt")
+                .withLandsOnBattlefield(2, "Mountain", 1)
+                .withLifeTotal(2, 2)                            // can't pay 3
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val raubahn = game.findPermanent("Raubahn, Bull of Ala Mhigo")!!
+
+            game.castSpell(2, "Lightning Bolt", raubahn).error shouldBe null
+            game.resolveStack()
+
+            withClue("no decision — 2 life < 3, ward counters the Bolt immediately") {
+                game.hasPendingDecision() shouldBe false
+            }
+            withClue("Raubahn survives, no life paid") {
+                game.findPermanent("Raubahn, Bull of Ala Mhigo") shouldNotBe null
+                game.getLifeTotal(2) shouldBe 2
+            }
+        }
+
+        test("attack trigger attaches the chosen Equipment to the chosen attacking creature") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Raubahn, Bull of Ala Mhigo", summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // second attacker
+                .withCardOnBattlefield(1, "Buster Sword")   // Equipment to move (+3/+2)
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val sword = game.findPermanent("Buster Sword")!!
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Raubahn, Bull of Ala Mhigo" to 2, "Grizzly Bears" to 2)).error shouldBe null
+            game.resolveStack()
+
+            val decision = game.getPendingDecision()
+            withClue("attack trigger pauses to choose Equipment (slot 0) + attacking creature (slot 1)") {
+                decision shouldNotBe null
+            }
+            game.submitDecision(TargetsResponse(decision!!.id, mapOf(0 to listOf(sword), 1 to listOf(bears))))
+            game.resolveStack()
+
+            withClue("Buster Sword now attached to Grizzly Bears (2/2 +3/+2 = 5/4)") {
+                stateProjector.project(game.state).getPower(bears) shouldBe 5
+                stateProjector.project(game.state).getToughness(bears) shouldBe 4
+            }
+        }
+
+        test("attack trigger is a no-op when the optional Equipment target is declined") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Raubahn, Bull of Ala Mhigo", summoningSickness = false)
+                .withCardOnBattlefield(1, "Buster Sword")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val raubahn = game.findPermanent("Raubahn, Bull of Ala Mhigo")!!
+            val sword = game.findPermanent("Buster Sword")!!
+
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Raubahn, Bull of Ala Mhigo" to 2)).error shouldBe null
+            game.resolveStack()
+
+            val decision = game.getPendingDecision()
+            withClue("attack trigger still pauses to choose targets") {
+                decision shouldNotBe null
+            }
+            // Decline the "up to one" Equipment (slot 0 empty); required attacking creature = Raubahn.
+            game.submitDecision(TargetsResponse(decision!!.id, mapOf(0 to emptyList(), 1 to listOf(raubahn))))
+            game.resolveStack()
+
+            withClue("no attach happened — Buster Sword stays unattached, Raubahn stays 2/2") {
+                stateProjector.project(game.state).getPower(raubahn) shouldBe 2
+                stateProjector.project(game.state).getToughness(raubahn) shouldBe 2
+                game.findPermanent("Buster Sword") shouldNotBe null
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonFenrirScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonFenrirScenarioTest.kt
@@ -1,0 +1,146 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonFenrir
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Summon: Fenrir — {2}{G} Enchantment Creature — Saga Wolf, 3/2 (FIN).
+ *
+ *   I  — Crescent Fang — Search your library for a basic land card, put it onto the battlefield
+ *        tapped, then shuffle.
+ *   II — Heavenward Howl — When you next cast a creature spell this turn, that creature enters
+ *        with an additional +1/+1 counter on it.
+ *   III — Ecliptic Growl — Draw a card if you control the creature with the greatest power or
+ *        tied for the greatest power.
+ *
+ * Generic saga-creature machinery (lore accrual, chapter triggers, sacrifice after the final
+ * chapter) is covered by CreatureSagaTest; this pins Fenrir's three chapter effects in isolation.
+ */
+class SummonFenrirScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.loreCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LORE) ?: 0
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SummonFenrir))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveAll() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard++ < 50) {
+            val pd = state.pendingDecision
+            if (pd != null) autoResolveDecision() else bothPass()
+        }
+    }
+
+    fun GameTestDriver.castFenrir(me: EntityId): EntityId {
+        val spell = putCardInHand(me, "Summon: Fenrir")
+        giveColorlessMana(me, 2)
+        giveMana(me, Color.GREEN, 1)
+        castSpell(me, spell)
+        return spell
+    }
+
+    /** Advance turns (auto-resolving decisions / passing priority) until [predicate] holds. */
+    fun GameTestDriver.advanceUntil(maxSteps: Int = 2000, predicate: GameTestDriver.() -> Boolean) {
+        var guard = 0
+        while (guard++ < maxSteps && !predicate()) {
+            val pd = state.pendingDecision
+            when {
+                pd != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+        }
+    }
+
+    test("chapter I — search for a basic land and put it onto the battlefield tapped") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val landsBefore = driver.getLands(me).size
+
+        driver.castFenrir(me)
+        // Resolve the Saga ETB; chapter I trigger then resolves into a library search decision.
+        var guard = 0
+        while (driver.state.pendingDecision == null && guard++ < 30) driver.bothPass()
+
+        val decision = driver.state.pendingDecision
+        (decision is SelectCardsDecision) shouldBe true
+        decision as SelectCardsDecision
+        driver.submitDecision(me, CardsSelectedResponse(decision.id, decision.options.take(1)))
+        driver.resolveAll()
+
+        val lands = driver.getLands(me)
+        lands.size shouldBe landsBefore + 1
+        // The fetched land entered tapped.
+        lands.any { driver.isTapped(it) } shouldBe true
+    }
+
+    test("chapter II — next creature spell enters with an extra +1/+1 counter") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.castFenrir(me)
+        driver.resolveAll()
+
+        // Advance until the Saga has its second lore counter (chapter II resolved).
+        driver.advanceUntil {
+            val s = findPermanent(me, "Summon: Fenrir") ?: return@advanceUntil true
+            loreCounters(s) >= 2
+        }
+        driver.findPermanent(me, "Summon: Fenrir") shouldNotBe null
+        driver.resolveAll()
+
+        // Cast a creature spell; the delayed trigger gives it one +1/+1 counter as it enters.
+        val bears = driver.putCardInHand(me, "Centaur Courser")
+        driver.giveColorlessMana(me, 2)
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.castSpell(me, bears)
+        driver.resolveAll()
+
+        val perm = driver.findPermanent(me, "Centaur Courser")!!
+        driver.plusOneCounters(perm) shouldBe 1
+        // 3/3 base + a +1/+1 counter = 4/4.
+        projector.project(driver.state).getPower(perm) shouldBe 4
+        projector.project(driver.state).getToughness(perm) shouldBe 4
+    }
+
+    test("chapter III — draw a card when you control the greatest-power creature") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.castFenrir(me)
+        driver.resolveAll()
+
+        // Fenrir is a 3/2; in a mirror with no opposing creatures I always control the
+        // greatest-power creature, so chapter III resolves the conditional draw and then the
+        // Saga is sacrificed after its final chapter — completing without error.
+        driver.advanceUntil {
+            findPermanent(me, "Summon: Fenrir") == null
+        }
+        driver.findPermanent(me, "Summon: Fenrir") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheWaterCrystalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheWaterCrystalScenarioTest.kt
@@ -1,0 +1,179 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Water Crystal (FIN #85).
+ *
+ * {2}{U}{U} Legendary Artifact
+ *  - Blue spells you cast cost {1} less to cast.
+ *  - If an opponent would mill one or more cards, they mill that many cards plus four instead.
+ *  - {4}{U}{U}, {T}: Each opponent mills cards equal to the number of cards in your hand.
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.ModifyMillAmount] mill-amount replacement
+ * (the +4 boost on opponent mills, including stacking and the "would mill one or more" gate) and
+ * the activated ability (each opponent mills equal to *your* hand size). The {1}-less cost
+ * reduction reuses the existing ModifySpellCost primitive (covered by The Wind Crystal), so it
+ * isn't re-exercised here.
+ */
+class TheWaterCrystalScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Water Crystal") {
+
+            test("opponent who would mill 2 mills 6 instead (Millstone + the +4 replacement)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Water Crystal")
+                    // Millstone targets the opponent to mill exactly two.
+                    .withCardOnBattlefield(1, "Millstone")
+                    .withLandsOnBattlefield(1, "Island", 2) // pays Millstone's {2}
+                    // Opponent's library: enough to absorb 2 + 4 = 6.
+                    .also { b -> repeat(8) { b.withCardInLibrary(2, "Forest") } }
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val millstoneId = game.findPermanent("Millstone")!!
+                val ability = cardRegistry.getCard("Millstone")!!.script.activatedAbilities[0]
+
+                val libBefore = game.librarySize(2)
+                val graveBefore = game.graveyardSize(2)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = millstoneId,
+                        abilityId = ability.id,
+                        targets = listOf(entityIdToChosenTarget(game.state, game.player2Id)),
+                    )
+                )
+                withClue("Activating Millstone should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Millstone's 2-card mill is boosted to 6 by The Water Crystal") {
+                    game.graveyardSize(2) shouldBe graveBefore + 6
+                    game.librarySize(2) shouldBe libBefore - 6
+                }
+            }
+
+            test("the +4 boost does NOT apply to the controller's own mills") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Water Crystal")
+                    // Millstone targets the controller (player 1) — the replacement is opponent-only.
+                    .withCardOnBattlefield(1, "Millstone")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .also { b -> repeat(8) { b.withCardInLibrary(1, "Plains") } }
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val millstoneId = game.findPermanent("Millstone")!!
+                val ability = cardRegistry.getCard("Millstone")!!.script.activatedAbilities[0]
+
+                val graveBefore = game.graveyardSize(1)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = millstoneId,
+                        abilityId = ability.id,
+                        targets = listOf(entityIdToChosenTarget(game.state, game.player1Id)),
+                    )
+                )
+                withClue("Activating Millstone should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Your own mill is unmodified — only opponents get the +4") {
+                    game.graveyardSize(1) shouldBe graveBefore + 2
+                }
+            }
+
+            test("two copies of The Water Crystal stack: opponent's 2-card mill becomes 2 + 4 + 4 = 10") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    // Two crystals, each contributing its own +4 replacement (Scryfall ruling).
+                    .withCardOnBattlefield(1, "The Water Crystal")
+                    .withCardOnBattlefield(1, "The Water Crystal")
+                    .withCardOnBattlefield(1, "Millstone")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .also { b -> repeat(15) { b.withCardInLibrary(2, "Forest") } }
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.findPermanents("The Water Crystal").size shouldBe 2
+
+                val millstoneId = game.findPermanent("Millstone")!!
+                val ability = cardRegistry.getCard("Millstone")!!.script.activatedAbilities[0]
+
+                val graveBefore = game.graveyardSize(2)
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = millstoneId,
+                        abilityId = ability.id,
+                        targets = listOf(entityIdToChosenTarget(game.state, game.player2Id)),
+                    )
+                )
+                result.error shouldBe null
+                game.resolveStack()
+
+                withClue("Two crystals add 4 each: 2 + 4 + 4 = 10") {
+                    game.graveyardSize(2) shouldBe graveBefore + 10
+                }
+            }
+
+            test("{4}{U}{U}, {T}: each opponent mills equal to your hand size (3 in hand -> 7 milled with the +4)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Water Crystal", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 6) // pays {4}{U}{U}
+                    // Three cards in the controller's hand → base mill of 3.
+                    .withCardInHand(1, "Island")
+                    .withCardInHand(1, "Island")
+                    .withCardInHand(1, "Island")
+                    .also { b -> repeat(12) { b.withCardInLibrary(2, "Forest") } }
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crystal = game.findPermanent("The Water Crystal")!!
+                val abilityId = cardRegistry.getCard("The Water Crystal")!!
+                    .script.activatedAbilities[0].id
+
+                val graveBefore = game.graveyardSize(2)
+
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crystal,
+                        abilityId = abilityId,
+                    )
+                )
+                withClue("Activating The Water Crystal should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                if (game.getPendingDecision() is com.wingedsheep.engine.core.SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("Base mill = your hand size (3), boosted by the opponent +4 to 7") {
+                    game.graveyardSize(2) shouldBe graveBefore + 7
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TorgalAFineHoundScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TorgalAFineHoundScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonFenrir
+import com.wingedsheep.mtg.sets.definitions.fin.cards.TorgalAFineHound
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Torgal, A Fine Hound — {1}{G} Legendary Creature — Wolf, 2/2 (FIN).
+ *
+ *   Whenever you cast your first Human creature spell each turn, that creature enters with an
+ *   additional +1/+1 counter on it for each Dog and/or Wolf you control.
+ *   {T}: Add one mana of any color.
+ *
+ * The trigger is `oncePerTurn`, so only the *first* Human creature spell each turn benefits; the
+ * counter rides onto the resolving spell via [EffectTarget.TriggeringEntity]; the count scales with
+ * Dogs/Wolves you control. These tests pin all three behaviours plus the "Human only" filter.
+ */
+class TorgalAFineHoundScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + listOf(TorgalAFineHound, SummonFenrir)
+        )
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveAll() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard++ < 50) {
+            val pd = state.pendingDecision
+            if (pd != null) autoResolveDecision() else bothPass()
+        }
+    }
+
+    fun GameTestDriver.castHuman(me: EntityId, name: String): EntityId {
+        val spell = putCardInHand(me, name)
+        giveColorlessMana(me, 2)
+        giveMana(me, Color.RED, 1)
+        giveMana(me, Color.WHITE, 1)
+        castSpell(me, spell)
+        resolveAll()
+        return findPermanent(me, name)!!
+    }
+
+    test("first Human creature spell enters with +1/+1 per Dog/Wolf you control (Torgal alone = 1)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(me, "Torgal, A Fine Hound")
+
+        // Only Torgal (a Wolf) is on the battlefield -> exactly one +1/+1 counter.
+        val human = driver.castHuman(me, "Blade of the Ninth Watch")
+        driver.plusOneCounters(human) shouldBe 1
+        // 2/1 base + one +1/+1 counter = 3/2.
+        projector.project(driver.state).getPower(human) shouldBe 3
+        projector.project(driver.state).getToughness(human) shouldBe 2
+    }
+
+    test("count scales with Dogs/Wolves you control (Torgal + Fenrir = 2 Wolves)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(me, "Torgal, A Fine Hound")
+        // Summon: Fenrir is an Enchantment Creature — Saga Wolf, so it counts as a Wolf.
+        driver.putPermanentOnBattlefield(me, "Summon: Fenrir")
+
+        val human = driver.castHuman(me, "Blade of the Ninth Watch")
+        driver.plusOneCounters(human) shouldBe 2
+    }
+
+    test("only the FIRST Human creature spell each turn triggers (oncePerTurn)") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(me, "Torgal, A Fine Hound")
+
+        val first = driver.castHuman(me, "Blade of the Ninth Watch")
+        driver.plusOneCounters(first) shouldBe 1
+
+        // A second Human creature spell the same turn gets no counter.
+        val second = driver.castHuman(me, "First Strike Knight")
+        driver.plusOneCounters(second) shouldBe 0
+    }
+
+    test("non-Human creature spells do not trigger") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(me, "Torgal, A Fine Hound")
+
+        // Llanowar Elves is an Elf Druid — not a Human, so no counter.
+        val elf = driver.putCardInHand(me, "Llanowar Elves")
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.castSpell(me, elf)
+        driver.resolveAll()
+        driver.plusOneCounters(driver.findPermanent(me, "Llanowar Elves")!!) shouldBe 0
+    }
+})


### PR DESCRIPTION
Implements a handful of missing **Final Fantasy (FIN)** cards. Each was built via the `add-card` skill — Scryfall-faithful data, canonical placement verified with `just check-card-printing`, a Kotest scenario test per card, and the per-set card-snapshot golden re-blessed.

## Cards

| Card | Cost | What it does | New SDK? |
|------|------|--------------|----------|
| **Summon: Fenrir** | {2}{G} | Saga Wolf 3/2 — fetch a basic land tapped; next creature spell enters with a +1/+1 counter; conditional draw if you control the greatest power | No — pure composition |
| **Torgal, A Fine Hound** | {1}{G} | Wolf 2/2 — first Human creature spell each turn enters with +1/+1 per Dog/Wolf you control; {T}: any color | No — composition |
| **The Water Crystal** | {2}{U}{U} | Legendary Artifact — blue spells cost {1} less; opponents mill +4; {4}{U}{U},{T}: each opp mills = your hand size | **Yes** — general `ModifyMillAmount` replacement |
| **Raubahn, Bull of Ala Mhigo** | {1}{R} | Human Warrior 2/2 — Ward—pay life = its power; on attack, attach an Equipment to an attacker | **Yes** — `WardCost.DynamicLife(DynamicAmount)` |
| **Quina, Qu Gourmet** | {2}{G} | Qu 2/3 — when tokens would be created, also make a Frog; {2}, sac a Frog: +1/+1 on Quina | No — reuses `CreateAdditionalToken`; adds first colored predefined token |

## New / extended SDK building blocks (general & reusable, fully wired)

- **`ModifyMillAmount`** replacement effect (modeled on `ModifyDrawAmount`): per-player mill-amount modifier as a `DynamicAmount`, gated by an `EventPattern.MillEvent(player)` filter. Applied at the mill announcement in `GatherCardsExecutor`; an `isMill` flag on `CardSource.TopOfLibrary` (set only by `Patterns.Library.mill`) keeps scry/surveil/exile-top unaffected. Executor + facade + classification in `isRuntimeReplacementEffect` + docs §15 + scenario test.
- **`WardCost.DynamicLife(amount)`** — Ward cost read from live game state; resolves to a fixed life cost at trigger resolution using the source's projected power (last-known if it has left). Executor collapses it before charging so downstream payment is unchanged. Facade `wardLife(DynamicAmount)` + docs + scenario test. mtgish emitter now renders this shape instead of declining.
- **Colored predefined tokens** — token executors honor `colorIdentityOverride`; the 1/1 green Frog is the first colored predefined token.

## Notes

- The cross-set snapshot golden churn is **only** `"isMill": true` added to existing mill pipeline steps (the new flag) — no other card tree changed; verified line-by-line.
- mtgish bridge entries added for the new mechanics; emitters render where lossless, otherwise deliberately tier SCAFFOLD (decline-don't-widen). `coverage-verify POR` stays 158/158, 0 mismatch.
- `just build` green across all modules (rebased on current `main`).

## Test plan

- [x] Per-card scenario tests pass (Fenrir 3, Torgal 4, Water Crystal 4, Raubahn 5, Quina 3)
- [x] `just build` (full check incl. snapshots, card lint, facade-boundary) SUCCESSFUL
- [x] `check-card-printing` confirms FIN canonical placement for all five
- [x] mtgish `coverage-verify POR` 158/158, 0 mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
