### PR TITLE
Show delirium progress per-card instead of always on the graveyard

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -391,6 +391,16 @@ data class ClientCard(
      */
     val thresholdInfo: ClientThresholdInfo? = null,
 
+    /**
+     * For cards that care about Delirium (a condition gated on "four or more card types among
+     * cards in your graveyard"). Present only when the card's definition actually references
+     * delirium — wherever it appears (static/triggered/activated ability, spell effect, cost
+     * reduction, replacement effect) — so the badge shows up exactly on the relevant cards
+     * rather than on every graveyard. `current` is the distinct card-type count in the card
+     * controller's graveyard; `required` is the printed threshold (always 4 in practice).
+     */
+    val deliriumInfo: ClientDeliriumInfo? = null,
+
     /** Whether this is a double-faced card (DFC). */
     val isDoubleFaced: Boolean = false,
 
@@ -506,6 +516,20 @@ data class ClientThresholdInfo(
 )
 
 /**
+ * Per-card Delirium progress (CR — four or more card types among cards in your graveyard).
+ *
+ * - [current]: distinct card types in the card controller's graveyard.
+ * - [required]: the delirium threshold the card gates on (4 for printed delirium).
+ * - [active]: whether [current] has reached [required].
+ */
+@Serializable
+data class ClientDeliriumInfo(
+    val current: Int,
+    val required: Int,
+    val active: Boolean
+)
+
+/**
  * Zone information for client display.
  */
 @Serializable
@@ -543,13 +567,6 @@ data class ClientPlayer(
     val maxHandSize: Int? = 7,
     val librarySize: Int,
     val graveyardSize: Int,
-
-    /**
-     * Number of distinct card types among cards in this player's graveyard (CR — the Delirium count;
-     * Delirium is active at 4+). Drives the delirium tracker the client renders on the graveyard
-     * pile so the threshold is visible at a glance.
-     */
-    val graveyardCardTypes: Int = 0,
     val exileSize: Int,
     val landsPlayedThisTurn: Int,
     val hasLost: Boolean,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -37,6 +37,11 @@ import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.imageOverrideFor
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.sdk.model.CardDefinition
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import com.wingedsheep.sdk.scripting.LookAtFaceDownCreatures
 import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
 import com.wingedsheep.sdk.scripting.OpponentsPlayWithHandsRevealed
@@ -1102,6 +1107,22 @@ class ClientStateTransformer(
             }
         }
 
+        // Delirium progress badge: shown only on cards whose definition actually gates on
+        // delirium ("four or more card types among cards in your graveyard"), detected by
+        // walking the card's serialized tree so the badge appears wherever delirium lives
+        // (static/triggered/activated ability, spell effect, cost reduction, replacement).
+        // Unlike threshold, this counts distinct card types, not raw graveyard size.
+        val deliriumInfo = cardDef?.let { def ->
+            findDeliriumThreshold(def)?.let { required ->
+                val current = distinctGraveyardCardTypes(state, controllerId)
+                ClientDeliriumInfo(
+                    current = current,
+                    required = required,
+                    active = current >= required
+                )
+            }
+        }
+
         // Modal DFC (CR 712) back face for display/flip preview (it lives in `cardFaces`, not `backFace`).
         val modalBackFace = if (cardDef?.layout == com.wingedsheep.sdk.model.CardLayout.MODAL_DFC) {
             cardDef.cardFaces.firstOrNull()
@@ -1181,6 +1202,7 @@ class ClientStateTransformer(
             classLevel = container.get<com.wingedsheep.engine.state.components.battlefield.ClassLevelComponent>()?.currentLevel,
             classMaxLevel = cardDef?.maxClassLevel,
             thresholdInfo = thresholdInfo,
+            deliriumInfo = deliriumInfo,
             stackText = if (zoneKey.zoneType == Zone.STACK && spellOnStack != null && cardDef != null) {
                 when {
                     spellOnStack.castFaceDown -> "Cast as a face-down 2/2 creature"
@@ -1601,15 +1623,6 @@ class ClientStateTransformer(
         val graveyardSize = state.getGraveyard(playerId).size
         val exileSize = state.getExile(playerId).size
 
-        // Distinct card types in the graveyard — the Delirium count (active at 4+). Mirrors the
-        // engine's Aggregation.DISTINCT_TYPES so the client tracker matches what gates delirium
-        // abilities. Graveyard is a non-battlefield zone, so base card types are correct here.
-        val graveyardCardTypes = state.getGraveyard(playerId)
-            .flatMapTo(mutableSetOf()) { entityId ->
-                state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.cardTypes?.map { it.name } ?: emptyList()
-            }
-            .size
-
         // Effective maximum hand size (CR 402.2): 7 by default, smaller/larger when an effect set
         // it, null when unlimited (Reliquary Tower). Shared source of truth with cleanup.
         val maxHandSize = com.wingedsheep.engine.core.MaximumHandSize.effective(
@@ -1667,7 +1680,6 @@ class ClientStateTransformer(
             maxHandSize = maxHandSize,
             librarySize = librarySize,
             graveyardSize = graveyardSize,
-            graveyardCardTypes = graveyardCardTypes,
             exileSize = exileSize,
             landsPlayedThisTurn = landsPlayed,
             hasLost = hasLost,
@@ -2803,6 +2815,107 @@ class ClientStateTransformer(
                 if (isYourGraveyardCount(left) && right is DynamicAmount.Fixed) right.amount + 1 else null
             ComparisonOperator.LT ->
                 if (isYourGraveyardCount(right) && left is DynamicAmount.Fixed) left.amount + 1 else null
+            else -> null
+        }
+    }
+
+    /**
+     * Distinct card types among cards in [playerId]'s graveyard — the Delirium count (CR; active
+     * at 4+). Mirrors the engine's `Aggregation.DISTINCT_TYPES`. Graveyard is a non-battlefield
+     * zone, so base card types are correct here (no projection needed).
+     */
+    private fun distinctGraveyardCardTypes(state: GameState, playerId: EntityId): Int =
+        state.getGraveyard(playerId)
+            .flatMapTo(mutableSetOf()) { entityId ->
+                state.getEntity(entityId)?.get<CardComponent>()?.typeLine?.cardTypes?.map { it.name } ?: emptyList()
+            }
+            .size
+
+    /**
+     * The delirium threshold a card gates on, or null if the card doesn't care about delirium.
+     *
+     * Delirium gates can sit anywhere in a card's script — a static ability, an activated/triggered
+     * ability, a spell effect, a cost reduction, or a replacement effect — so rather than
+     * enumerate every container we walk the card's serialized JSON tree (the same coverage
+     * strategy as `CardLinter`) for a `distinct graveyard card types <comparison> N` shape.
+     * Result is memoized per card name: card definitions are immutable and shared, and this runs
+     * for every card in every client view.
+     */
+    private fun findDeliriumThreshold(cardDef: CardDefinition): Int? =
+        deliriumThresholdCache.computeIfAbsent(cardDef.name) { detectDeliriumThreshold(cardDef) ?: 0 }
+            .takeIf { it > 0 }
+
+    /** Cache of card name → delirium threshold; `0` is the sentinel for "no delirium gate". */
+    private val deliriumThresholdCache = java.util.concurrent.ConcurrentHashMap<String, Int>()
+
+    /**
+     * Card encoder with defaults materialized (same trick as `CardLinter`): the shared
+     * `CardSerialization.json` encodes with `encodeDefaults = false`, which would drop the
+     * default-valued discriminators we match on (`player = You`, `filter = Any`), so encode them.
+     */
+    private val deliriumDetectJson = kotlinx.serialization.json.Json(
+        from = com.wingedsheep.sdk.serialization.CardSerialization.json
+    ) { encodeDefaults = true }
+
+    private fun detectDeliriumThreshold(cardDef: CardDefinition): Int? {
+        val tree = deliriumDetectJson.encodeToJsonElement(CardDefinition.serializer(), cardDef)
+        val thresholds = mutableListOf<Int>()
+        collectDeliriumThresholds(tree, thresholds)
+        return thresholds.minOrNull()
+    }
+
+    private fun collectDeliriumThresholds(element: JsonElement, out: MutableList<Int>) {
+        when (element) {
+            is JsonObject -> {
+                if (element.content("type") == "Compare") {
+                    deliriumThresholdOf(element)?.let { out.add(it) }
+                }
+                element.values.forEach { collectDeliriumThresholds(it, out) }
+            }
+            is JsonArray -> element.forEach { collectDeliriumThresholds(it, out) }
+            else -> {}
+        }
+    }
+
+    /** A primitive string field's content, or null if the key is absent or holds a non-primitive. */
+    private fun JsonObject.content(key: String): String? =
+        (this[key] as? JsonPrimitive)?.contentOrNull
+
+    /**
+     * Matches a `Compare` whose one side counts distinct card types in *your* graveyard
+     * (`AggregateZone(You, Graveyard, DISTINCT_TYPES)`) and whose other side is a fixed number,
+     * returning the threshold at which delirium turns on. Mirrors [matchYourGraveyardAtLeast] but
+     * on the serialized tree and for the distinct-types aggregation.
+     */
+    private fun deliriumThresholdOf(compare: JsonObject): Int? {
+        // `Player.You` serializes polymorphically as {"type":"You"}; tolerate a bare "You" too.
+        fun isYou(operand: JsonElement?): Boolean = when (operand) {
+            is JsonPrimitive -> operand.contentOrNull == "You"
+            is JsonObject -> operand.content("type") == "You"
+            else -> false
+        }
+
+        fun isDistinctGraveyardTypes(operand: JsonElement?): Boolean {
+            val o = operand as? JsonObject ?: return false
+            return o.content("type") == "AggregateZone" &&
+                isYou(o["player"]) &&
+                o.content("zone") == "Graveyard" &&
+                o.content("aggregation") == "DISTINCT_TYPES"
+        }
+
+        fun fixedAmount(operand: JsonElement?): Int? {
+            val o = operand as? JsonObject ?: return null
+            if (o.content("type") != "Fixed") return null
+            return o.content("amount")?.toIntOrNull()
+        }
+
+        val left = compare["left"]
+        val right = compare["right"]
+        return when (compare.content("operator")) {
+            "GTE" -> if (isDistinctGraveyardTypes(left)) fixedAmount(right) else null
+            "LTE" -> if (isDistinctGraveyardTypes(right)) fixedAmount(left) else null
+            "GT" -> if (isDistinctGraveyardTypes(left)) fixedAmount(right)?.plus(1) else null
+            "LT" -> if (isDistinctGraveyardTypes(right)) fixedAmount(left)?.plus(1) else null
             else -> null
         }
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlayerStatusClientViewTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PlayerStatusClientViewTest.kt
@@ -4,17 +4,23 @@ import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.sdk.model.EntityId
 import io.kotest.assertions.withClue
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 /**
- * The client view exposes two per-player status numbers the player otherwise has to track in their
- * head: the Delirium count (distinct card types in the graveyard, active at 4+) and the effective
- * maximum hand size (CR 402.2). Both ride on [com.wingedsheep.engine.view.ClientPlayer] and the
- * client renders them as the graveyard delirium tracker and the hand-limit badge respectively.
+ * The client view exposes status the player otherwise has to track in their head: per-card Delirium
+ * progress (distinct card types in the controller's graveyard, active at 4+) and the effective
+ * maximum hand size (CR 402.2).
  *
- * The max-hand-size value comes from the shared [com.wingedsheep.engine.core.MaximumHandSize] source
- * of truth, so what the badge shows is exactly what cleanup will enforce (see CursedRackScenarioTest
- * for the cleanup-side discard behavior).
+ * Delirium rides on [com.wingedsheep.engine.view.ClientCard.deliriumInfo] and is populated only on
+ * cards whose definition actually gates on delirium — detected by walking the card's serialized
+ * tree, so it works wherever the gate lives (static ability, activated/triggered ability, spell
+ * effect, cost reduction, replacement effect), not just static abilities. The client renders it as
+ * a per-card badge so the count shows up only on the cards it matters for.
+ *
+ * Max hand size rides on [com.wingedsheep.engine.view.ClientPlayer] and comes from the shared
+ * [com.wingedsheep.engine.core.MaximumHandSize] source of truth, so what the badge shows is exactly
+ * what cleanup will enforce (see CursedRackScenarioTest for the cleanup-side discard behavior).
  */
 class PlayerStatusClientViewTest : ScenarioTestBase() {
 
@@ -24,36 +30,72 @@ class PlayerStatusClientViewTest : ScenarioTestBase() {
     private fun viewSelf(state: com.wingedsheep.engine.state.GameState) =
         transformer.transform(state, p1).players.first { it.playerId == p1 }
 
+    private fun cardNamed(state: com.wingedsheep.engine.state.GameState, name: String) =
+        transformer.transform(state, p1).cards.values.first { it.name == name }
+
     init {
-        test("graveyardCardTypes counts distinct card types, not raw cards") {
-            // Two creatures + one instant = two distinct types (Creature, Instant), not three cards.
+        test("a delirium card shows its progress toward the four-card-type threshold") {
+            // Two distinct types in the graveyard (Creature, Instant) — delirium not yet active.
             val game = scenario()
                 .withPlayers("Player1", "Player2")
-                .withCardInGraveyard(1, "Grizzly Bears")
-                .withCardInGraveyard(1, "Grizzly Bears")
-                .withCardInGraveyard(1, "Lightning Bolt")
+                .withCardOnBattlefield(1, "Winter, Misanthropic Guide")
+                .withCardInGraveyard(1, "Grizzly Bears")   // Creature
+                .withCardInGraveyard(1, "Grizzly Bears")   // Creature (same type — counts once)
+                .withCardInGraveyard(1, "Lightning Bolt")  // Instant
                 .build()
 
-            val player = viewSelf(game.state)
-            player.graveyardSize shouldBe 3
-            player.graveyardCardTypes shouldBe 2
+            val info = cardNamed(game.state, "Winter, Misanthropic Guide").deliriumInfo
+            info.shouldNotBeNull()
+            info.current shouldBe 2
+            info.required shouldBe 4
+            info.active shouldBe false
         }
 
-        test("delirium count reaches four with four distinct card types") {
+        test("a delirium card's badge turns active at four distinct card types") {
             val game = scenario()
                 .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Winter, Misanthropic Guide")
                 .withCardInGraveyard(1, "Grizzly Bears")   // Creature
                 .withCardInGraveyard(1, "Lightning Bolt")  // Instant
                 .withCardInGraveyard(1, "Pacifism")        // Enchantment
                 .withCardInGraveyard(1, "Divination")      // Sorcery
                 .build()
 
-            viewSelf(game.state).graveyardCardTypes shouldBe 4
+            val info = cardNamed(game.state, "Winter, Misanthropic Guide").deliriumInfo
+            info.shouldNotBeNull()
+            info.current shouldBe 4
+            info.active shouldBe true
         }
 
-        test("an empty graveyard reports zero card types") {
-            val game = scenario().withPlayers("Player1", "Player2").build()
-            viewSelf(game.state).graveyardCardTypes shouldBe 0
+        test("cards that don't care about delirium carry no delirium badge") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withCardInGraveyard(1, "Lightning Bolt")
+                .withCardInGraveyard(1, "Pacifism")
+                .build()
+
+            withClue("Grizzly Bears has no delirium-gated ability") {
+                cardNamed(game.state, "Grizzly Bears").deliriumInfo.shouldBeNull()
+            }
+        }
+
+        test("delirium is detected outside static abilities (spell effect and activated ability)") {
+            // Demonic Counsel gates a *spell effect* on delirium; Balustrade Wurm gates an
+            // *activated ability* on it. Neither is a static ability, so this proves the
+            // full-tree detection rather than a static-ability-only scan.
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Demonic Counsel")
+                .withCardInGraveyard(1, "Balustrade Wurm")
+                .build()
+
+            withClue("Demonic Counsel's delirium gate lives in its spell effect") {
+                cardNamed(game.state, "Demonic Counsel").deliriumInfo.shouldNotBeNull()
+            }
+            withClue("Balustrade Wurm's delirium gate lives in an activated ability") {
+                cardNamed(game.state, "Balustrade Wurm").deliriumInfo.shouldNotBeNull()
+            }
         }
 
         test("maximum hand size is the default seven with no effect in play") {

--- a/web-client/src/components/game/OpponentRail.tsx
+++ b/web-client/src/components/game/OpponentRail.tsx
@@ -1121,7 +1121,6 @@ function chipTitle(opponent: ClientPlayer): string {
   if (handLimitSuffix(opponent.maxHandSize)) {
     lines.push(`Max hand size ${opponent.maxHandSize ?? '∞ (no maximum)'}`)
   }
-  if ((opponent.graveyardCardTypes ?? 0) >= 4) lines.push('Delirium active (4+ card types)')
   if (opponent.poisonCounters > 0) lines.push(`Poison ${opponent.poisonCounters}/10`)
   for (const e of opponent.commanderDamage ?? []) {
     lines.push(`⚔ ${e.commanderName}: ${e.amount}/${e.threshold}`)

--- a/web-client/src/components/game/board/ZonePiles.tsx
+++ b/web-client/src/components/game/board/ZonePiles.tsx
@@ -163,12 +163,6 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
           {player.graveyardSize > 0 && (
             <div style={{ ...styles.pileCount, fontSize: responsive.fontSize.small }}>{player.graveyardSize}</div>
           )}
-          {/* Delirium tracker (CR — 4+ card types in your graveyard). Always shown while the
-              graveyard has cards so the progress toward — and reaching of — delirium is visible
-              at a glance, for both players. */}
-          {player.graveyardSize > 0 && (player.graveyardCardTypes ?? 0) > 0 && (
-            <DeliriumTracker types={player.graveyardCardTypes ?? 0} pileWidth={effectivePileWidth} />
-          )}
           {/* Show targeted cards fanned out when a spell is targeting cards in this graveyard */}
           {targetedGraveyardCards.map((card, index) => {
             const fanOffset = targetedGraveyardCards.length > 1
@@ -279,62 +273,6 @@ export function ZonePile({ player, isOpponent = false }: { player: ClientPlayer;
           onClose={() => setBrowsingLibrary(false)}
         />
       )}
-    </div>
-  )
-}
-
-/** Delirium activates at 4+ distinct card types in the graveyard (CR). */
-const DELIRIUM_THRESHOLD = 4
-
-/**
- * Compact delirium tracker overlaid on the top edge of the graveyard pile: a row of four pips that
- * fill as distinct card types accumulate, glowing gold once the fourth lands (delirium active).
- * The exact count lives in the tooltip — the pile is often only ~30px wide, too narrow for a
- * legible numeral, so the pips carry the at-a-glance signal and the tooltip the precise number.
- */
-function DeliriumTracker({ types, pileWidth }: { types: number; pileWidth: number }) {
-  const active = types >= DELIRIUM_THRESHOLD
-  const filled = Math.min(types, DELIRIUM_THRESHOLD)
-  // Scale pips to the pile width so four-plus-gaps always fit, even at the 28px minimum.
-  const pip = Math.max(3, Math.round(pileWidth / 9))
-  const gold = '#f5d76e'
-  return (
-    <div
-      title={
-        active
-          ? `Delirium active — ${types} card types in graveyard (4+ needed)`
-          : `Delirium: ${types}/${DELIRIUM_THRESHOLD} card types in graveyard`
-      }
-      style={{
-        position: 'absolute',
-        top: 3,
-        left: '50%',
-        transform: 'translateX(-50%)',
-        display: 'flex',
-        alignItems: 'center',
-        gap: Math.max(2, Math.round(pip / 2)),
-        padding: '2px 4px',
-        borderRadius: 999,
-        background: 'rgba(0, 0, 0, 0.7)',
-        border: `1px solid ${active ? gold : 'rgba(255,255,255,0.18)'}`,
-        boxShadow: active ? `0 0 7px ${gold}aa` : 'none',
-        pointerEvents: 'none',
-        zIndex: 6,
-      }}
-    >
-      {Array.from({ length: DELIRIUM_THRESHOLD }).map((_, i) => (
-        <span
-          key={i}
-          style={{
-            width: pip,
-            height: pip,
-            borderRadius: '50%',
-            background: i < filled ? gold : 'transparent',
-            border: `1px solid ${i < filled ? gold : 'rgba(255,255,255,0.35)'}`,
-            boxShadow: active && i < filled ? `0 0 4px ${gold}` : 'none',
-          }}
-        />
-      ))}
     </div>
   )
 }

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1443,6 +1443,13 @@ function GameCardImpl({
         </div>
       )}
 
+      {/* Delirium progress badge (cards gated on "4+ card types in your graveyard"). Carries over
+          the gold-pip motif from the old graveyard-pile tracker, now shown only on the cards that
+          actually care about delirium. The exact count lives in the tooltip. */}
+      {card.deliriumInfo && (
+        <DeliriumBadge info={card.deliriumInfo} pip={responsive.badges.counterIconFontSize} />
+      )}
+
       {/* Banding (CR 702.22): band-membership badge, color-coded per band */}
       {isBanded && bandColor && (
         <div style={{ ...styles.bandBadge, backgroundColor: bandColor.base }}>
@@ -2696,6 +2703,62 @@ function GameCardImpl({
   }
 
   return <RenderProfiler id={profilerId}>{cardElement}</RenderProfiler>
+}
+
+/**
+ * Delirium progress badge: a compact row of pips (one per card type needed) that fill gold as
+ * distinct card types accumulate in the controller's graveyard, glowing once delirium is active.
+ * Rendered only on cards that gate on delirium. The exact count rides in the tooltip — a card
+ * corner is too small for a legible numeral, so the pips carry the at-a-glance signal.
+ */
+function DeliriumBadge({
+  info,
+  pip,
+}: {
+  info: { current: number; required: number; active: boolean }
+  pip: number
+}) {
+  const gold = '#f5d76e'
+  const pipSize = Math.max(3, Math.round(pip))
+  const filled = Math.min(info.current, info.required)
+  return (
+    <div
+      title={
+        info.active
+          ? `Delirium active — ${info.current} card types in graveyard (${info.required}+ needed)`
+          : `Delirium: ${info.current}/${info.required} card types in graveyard`
+      }
+      style={{
+        position: 'absolute',
+        bottom: 2,
+        left: 2,
+        display: 'flex',
+        alignItems: 'center',
+        gap: Math.max(2, Math.round(pipSize / 2)),
+        padding: '2px 4px',
+        borderRadius: 999,
+        background: 'rgba(0, 0, 0, 0.72)',
+        border: `1px solid ${info.active ? gold : 'rgba(255,255,255,0.25)'}`,
+        boxShadow: info.active ? `0 0 6px ${gold}aa` : '0 1px 2px rgba(0,0,0,0.5)',
+        pointerEvents: 'none',
+        zIndex: 3,
+      }}
+    >
+      {Array.from({ length: info.required }).map((_, i) => (
+        <span
+          key={i}
+          style={{
+            width: pipSize,
+            height: pipSize,
+            borderRadius: '50%',
+            background: i < filled ? gold : 'transparent',
+            border: `1px solid ${i < filled ? gold : 'rgba(255,255,255,0.4)'}`,
+            boxShadow: info.active && i < filled ? `0 0 4px ${gold}` : 'none',
+          }}
+        />
+      ))}
+    </div>
+  )
 }
 
 // Memoized so a parent re-render (e.g. BattlefieldContent reacting to a

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -367,6 +367,18 @@ export interface ClientCard {
   } | null
 
   /**
+   * Delirium progress: present only on cards whose definition cares about delirium ("four or
+   * more card types among cards in your graveyard"). Lets the UI render a badge showing the
+   * distinct card-type count (`current`) out of the threshold (`required`, 4 in practice) for
+   * the card's controller. Absent on cards that don't reference delirium.
+   */
+  readonly deliriumInfo?: {
+    readonly current: number
+    readonly required: number
+    readonly active: boolean
+  } | null
+
+  /**
    * For planeswalkers on the battlefield: the complete set of loyalty abilities,
    * in declaration order. The UI renders the full list and grays out any ability
    * whose `abilityId` isn't present in the legal actions for this card.
@@ -456,11 +468,6 @@ export interface ClientPlayer {
   readonly maxHandSize?: number | null
   readonly librarySize: number
   readonly graveyardSize: number
-  /**
-   * Distinct card types among cards in this player's graveyard — the Delirium count (active at 4+).
-   * Drives the delirium tracker on the graveyard pile.
-   */
-  readonly graveyardCardTypes?: number
   readonly exileSize: number
   readonly landsPlayedThisTurn: number
   readonly hasLost: boolean


### PR DESCRIPTION
## Why

[PR #1094](https://github.com/wingedsheep/argentum-engine/pull/1094) added a delirium pip tracker on **every** graveyard pile (plus an opponent-rail tooltip line), regardless of whether any card in the game cares about delirium. With no delirium cards in play, the count is just noise.

This moves delirium where it's actually relevant: a **per-card badge**, mirroring the existing threshold badge — so the count shows up only on the cards that gate on delirium.

## What

- `ClientCard` gains `deliriumInfo { current, required, active }`. The per-player `graveyardCardTypes` field, the graveyard-pile `DeliriumTracker`, and the opponent-rail delirium line are removed.
- Relevance is detected by walking the card's **serialized definition tree** (same coverage strategy as `CardLinter`) for a `distinct graveyard card types >= N` comparison. This means the badge appears wherever the gate lives — static ability, activated/triggered ability, spell effect, cost reduction, or replacement effect — not just static abilities. The result is memoized per card name.
- The client reuses the gold-pip visual language from #1094, now rendered as a compact badge in the card's bottom-left corner (count in the tooltip). Active state glows gold.

## Result

The badge shows the distinct card-type count toward delirium on the relevant card, and nothing on cards that don't care. Below: Winter, Misanthropic Guide (delirium) beside Grizzly Bears (vanilla) — only Winter carries the badge.

**Progress (3 of 4 card types in graveyard):**

![Delirium badge — partial progress, 3 of 4](https://raw.githubusercontent.com/wingedsheep/argentum-engine/delirium-screenshots/delirium-partial.png)

**Active (4 card types — pips fill and glow gold):**

![Delirium badge — active, 4 of 4](https://raw.githubusercontent.com/wingedsheep/argentum-engine/delirium-screenshots/delirium-active.png)

<details>
<summary>Full board context</summary>

![Full board](https://raw.githubusercontent.com/wingedsheep/argentum-engine/delirium-screenshots/delirium-full.png)
</details>

> Screenshots are hosted on the throwaway `delirium-screenshots` branch (not committed to this PR).

## Tests

`PlayerStatusClientViewTest` now asserts the per-card badge, including **detection outside static abilities** — Demonic Counsel's delirium-gated spell effect and Balustrade Wurm's delirium-gated activated ability both surface `deliriumInfo`, while a vanilla card (Grizzly Bears) does not. `just test-rules` and `just test-server` green; web-client `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)