### PR TITLE
Fix "any target" / planeswalker targeting to read projected types

### DIFF
--- a/manual-scenarios/cards/c/cat-gator-earthbend-target.json
+++ b/manual-scenarios/cards/c/cat-gator-earthbend-target.json
@@ -1,0 +1,41 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Cat-Gator", "Earthbending Lesson"],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Swamp", "Forest", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Badgermole"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Forest", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -193,10 +193,13 @@ class TargetFinder(
         val battlefield = state.getBattlefield()
         for (entityId in battlefield) {
             val container = state.getEntity(entityId) ?: continue
-            val cardComponent = container.get<CardComponent>() ?: continue
+            if (!container.has<CardComponent>()) continue
             val entityController = container.get<ControllerComponent>()?.playerId
 
-            if (!cardComponent.isPlaneswalker) continue
+            // Read the PROJECTED type line, not the printed one, so a permanent that
+            // becomes a planeswalker via a continuous effect is offered (CR 115.4 /
+            // projection rule), consistent with findAnyTargets.
+            if (!projected.isPlaneswalker(entityId)) continue
 
             // Check hexproof/shroud
             if (projected.hasKeyword(entityId, Keyword.HEXPROOF) && entityController != controllerId) continue
@@ -229,10 +232,13 @@ class TargetFinder(
         val battlefield = state.getBattlefield()
         for (entityId in battlefield) {
             val container = state.getEntity(entityId) ?: continue
-            val cardComponent = container.get<CardComponent>() ?: continue
+            if (!container.has<CardComponent>()) continue
             val entityController = container.get<ControllerComponent>()?.playerId
 
-            if (!cardComponent.isPlaneswalker) continue
+            // Read the PROJECTED type line, not the printed one, so a permanent that
+            // becomes a planeswalker via a continuous effect is offered (CR 115.4 /
+            // projection rule), consistent with findAnyTargets.
+            if (!projected.isPlaneswalker(entityId)) continue
 
             // Check hexproof/shroud
             if (projected.hasKeyword(entityId, Keyword.HEXPROOF) && entityController != controllerId) continue

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/TargetFinder.kt
@@ -318,11 +318,13 @@ class TargetFinder(
         val battlefield = state.getBattlefield()
         for (entityId in battlefield) {
             val container = state.getEntity(entityId) ?: continue
-            val cardComponent = container.get<CardComponent>() ?: continue
+            if (!container.has<CardComponent>()) continue
             val entityController = container.get<ControllerComponent>()?.playerId
 
-            // Only creatures and planeswalkers for "any target"
-            if (!cardComponent.typeLine.isCreature && !cardComponent.isPlaneswalker) {
+            // Only creatures and planeswalkers for "any target". Read the PROJECTED
+            // type line, not the printed one, so animated lands (Earthbend) and
+            // face-down 2/2 creatures are valid targets (CR 115.4 / projection rule).
+            if (!projected.isCreature(entityId) && !projected.isPlaneswalker(entityId)) {
                 continue
             }
 
@@ -378,11 +380,13 @@ class TargetFinder(
 
         return battlefield.filter { entityId ->
             val container = state.getEntity(entityId) ?: return@filter false
-            val cardComponent = container.get<CardComponent>() ?: return@filter false
+            if (!container.has<CardComponent>()) return@filter false
             val entityController = container.get<ControllerComponent>()?.playerId
 
-            // Must be creature or planeswalker
-            if (!cardComponent.typeLine.isCreature && !cardComponent.isPlaneswalker) {
+            // Must be creature or planeswalker. Read the PROJECTED type line, not the
+            // printed one, so animated lands (Earthbend) and face-down 2/2 creatures
+            // are valid targets (projection rule, see CR 115.4).
+            if (!projected.isCreature(entityId) && !projected.isPlaneswalker(entityId)) {
                 return@filter false
             }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CatGatorEarthbendTargetingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CatGatorEarthbendTargetingTest.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.TargetFinder
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression: "any target" must read the PROJECTED type line, not the printed one.
+ *
+ * An Earthbend land (e.g. via Earthbending Lesson) becomes a 0/0 land *creature*
+ * via an [AnimateLandEffect] floating layer — the CREATURE type lives in the
+ * projected state, not on the card's printed type line, which still says "Land".
+ *
+ * Cat-Gator's ETB ("deals damage … to any target") uses [AnyTarget]. The bug:
+ * [TargetFinder.findAnyTargets] filtered candidates with the printed
+ * `cardComponent.typeLine.isCreature`, so an animated land was never offered as a
+ * legal target — Cat-Gator could not deal damage to an earthbended land.
+ */
+class CatGatorEarthbendTargetingTest : FunSpec({
+
+    val targetFinder = TargetFinder()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + AvatarTheLastAirbenderSet.cards)
+        return driver
+    }
+
+    test("an earthbended land is a legal \"any target\"") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putLandOnBattlefield(you, "Forest")
+
+        // Before animation: a plain Forest is NOT a legal "any target".
+        targetFinder.findLegalTargets(driver.state, AnyTarget(), controllerId = you)
+            .contains(forest) shouldBe false
+
+        // Earthbend the Forest into a creature-land.
+        val lesson = driver.putCardInHand(you, "Earthbending Lesson")
+        driver.giveMana(you, Color.GREEN, 4)
+        driver.castSpell(you, lesson, listOf(forest)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // After animation: the Forest is a creature in projection, so "any target"
+        // (Cat-Gator's ETB) can now legally target it.
+        targetFinder.findLegalTargets(driver.state, AnyTarget(), controllerId = you)
+            .contains(forest) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CatGatorEarthbendTargetingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CatGatorEarthbendTargetingTest.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreatureOrPlaneswalker
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -42,8 +43,11 @@ class CatGatorEarthbendTargetingTest : FunSpec({
 
         val forest = driver.putLandOnBattlefield(you, "Forest")
 
-        // Before animation: a plain Forest is NOT a legal "any target".
+        // Before animation: a plain Forest is NOT a legal "any target",
+        // nor a legal "target creature or planeswalker".
         targetFinder.findLegalTargets(driver.state, AnyTarget(), controllerId = you)
+            .contains(forest) shouldBe false
+        targetFinder.findLegalTargets(driver.state, TargetCreatureOrPlaneswalker(), controllerId = you)
             .contains(forest) shouldBe false
 
         // Earthbend the Forest into a creature-land.
@@ -52,9 +56,11 @@ class CatGatorEarthbendTargetingTest : FunSpec({
         driver.castSpell(you, lesson, listOf(forest)).isSuccess shouldBe true
         driver.bothPass()
 
-        // After animation: the Forest is a creature in projection, so "any target"
-        // (Cat-Gator's ETB) can now legally target it.
+        // After animation: the Forest is a creature in projection, so both "any target"
+        // (Cat-Gator's ETB) and "target creature or planeswalker" can now legally target it.
         targetFinder.findLegalTargets(driver.state, AnyTarget(), controllerId = you)
+            .contains(forest) shouldBe true
+        targetFinder.findLegalTargets(driver.state, TargetCreatureOrPlaneswalker(), controllerId = you)
             .contains(forest) shouldBe true
     }
 })


### PR DESCRIPTION
## What

Battlefield targeting in `TargetFinder` filtered candidates by the **printed**
type line (`cardComponent.typeLine.isCreature` / `cardComponent.isPlaneswalker`),
so a permanent whose type comes from a continuous effect was never offered as a
legal target. Concretely: an Earthbend land (e.g. via Earthbending Lesson) becomes
a 0/0 land *creature* in projection, but Cat-Gator's "deal damage to any target"
ETB could not target it.

## Change

All four type checks in `TargetFinder` now read **projected** state
(`projected.isCreature` / `projected.isPlaneswalker`), matching this engine's
projected-vs-base-state rule (CR 115.4 governs what "any target" may be):

- `findAnyTargets`
- `findCreatureOrPlaneswalkerTargets`
- `findOpponentOrPlaneswalkerTargets`
- `findPlayerOrPlaneswalkerTargets`

No SDK types added — pure correctness plumbing.

## Tests

`CatGatorEarthbendTargetingTest` asserts an earthbended Forest is **not** a legal
"any target" / "creature or planeswalker" before animation and **is** after.
Verified green (`:rules-engine:test`, BUILD SUCCESSFUL).

Out of scope: Cat-Gator still lacks a card-level ETB-damage scenario test; "any
target" does not yet include battles (not modeled in this engine).