### PR TITLE
Add 10 Avatar: The Last Airbender cards

### DIFF
--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 51 / 286  (17%)
+**Implemented:** 52 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -228,7 +228,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [x] Meteor Sword
 - [x] Misty Palms Oasis
 - [ ] Momo, Friendly Flier
-- [ ] Momo, Playful Pet
+- [x] Momo, Playful Pet
 - [ ] Mongoose Lizard
 - [ ] Mountain
 - [x] North Pole Gates

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 49 / 286  (17%)
+**Implemented:** 50 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -132,7 +132,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] Earth King's Lieutenant
 - [ ] Earth Kingdom General
 - [ ] Earth Kingdom Jailer
-- [ ] Earth Kingdom Protectors
+- [x] Earth Kingdom Protectors
 - [ ] Earth Kingdom Soldier
 - [ ] Earth Rumble
 - [ ] Earth Rumble Wrestlers

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 54 / 286  (17%)
+**Implemented:** 55 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -179,7 +179,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] Gran-Gran
 - [ ] Great Divide Guide
 - [ ] Guru Pathik
-- [ ] Hakoda, Selfless Commander
+- [x] Hakoda, Selfless Commander
 - [ ] Hama, the Bloodbender
 - [x] Haru, Hidden Talent
 - [ ] Heartless Act

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 55 / 286  (17%)
+**Implemented:** 56 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -207,7 +207,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] Katara, Bending Prodigy
 - [ ] Katara, Water Tribe's Hope
 - [ ] Katara, the Fearless
-- [ ] Knowledge Seeker
+- [x] Knowledge Seeker
 - [ ] Koh, the Face Stealer
 - [ ] Kyoshi Battle Fan
 - [ ] Kyoshi Island Plaza

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 52 / 286  (17%)
+**Implemented:** 53 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -303,7 +303,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] The Legend of Kyoshi
 - [ ] The Legend of Roku
 - [ ] The Legend of Yangchen
-- [ ] The Lion-Turtle
+- [x] The Lion-Turtle
 - [ ] The Mechanist, Aerial Artisan
 - [ ] The Rise of Sozin
 - [ ] The Spirit Oasis

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 50 / 286  (17%)
+**Implemented:** 51 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -133,7 +133,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] Earth Kingdom General
 - [ ] Earth Kingdom Jailer
 - [x] Earth Kingdom Protectors
-- [ ] Earth Kingdom Soldier
+- [x] Earth Kingdom Soldier
 - [ ] Earth Rumble
 - [ ] Earth Rumble Wrestlers
 - [x] Earth Village Ruffians

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 53 / 286  (17%)
+**Implemented:** 54 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -277,7 +277,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [x] Shared Roots
 - [ ] Sokka's Haiku
 - [ ] Sokka, Bold Boomeranger
-- [ ] Sokka, Lateral Strategist
+- [x] Sokka, Lateral Strategist
 - [ ] Sokka, Tenacious Tactician
 - [ ] Sold Out
 - [ ] Solstice Revelations

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 56 / 286  (17%)
+**Implemented:** 57 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -310,7 +310,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] The Unagi of Kyoshi Island
 - [x] The Walls of Ba Sing Se
 - [ ] Tiger-Dillo
-- [ ] Tiger-Seal
+- [x] Tiger-Seal
 - [ ] Tolls of War
 - [ ] Toph, Hardheaded Teacher
 - [ ] Toph, the Blind Bandit

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 57 / 286  (17%)
+**Implemented:** 58 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -162,7 +162,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] Firebending Lesson
 - [ ] Firebending Student
 - [ ] First-Time Flyer
-- [ ] Flexible Waterbender
+- [x] Flexible Waterbender
 - [ ] Flopsie, Bumi's Buddy
 - [x] Foggy Bottom Swamp
 - [ ] Foggy Swamp Hunters

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 58 / 286  (17%)
+**Implemented:** 59 / 286  (17%)
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 ## Mechanics needed to complete the set
@@ -344,7 +344,7 @@ The set is built around four **"bending" keyword families** plus a returning **E
 - [ ] White Lotus Tile
 - [ ] Wolfbat
 - [ ] Yip Yip!
-- [ ] Yue, the Moon Spirit
+- [x] Yue, the Moon Spirit
 - [x] Yuyan Archers
 - [ ] Zhao, Ruthless Admiral
 - [ ] Zhao, the Moon Slayer

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/EarthKingdomProtectors.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/EarthKingdomProtectors.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Earth Kingdom Protectors
+ * {W}
+ * Creature — Human Soldier Ally
+ * 1/1
+ *
+ * Vigilance
+ * Sacrifice this creature: Another target Ally you control gains indestructible until end of turn.
+ */
+val EarthKingdomProtectors = card("Earth Kingdom Protectors") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier Ally"
+    oracleText = "Vigilance\n" +
+        "Sacrifice this creature: Another target Ally you control gains indestructible until end of turn. " +
+        "(Damage and effects that say \"destroy\" don't destroy it.)"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target(
+            "another target Ally you control",
+            TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.withSubtype(Subtype.ALLY).youControl(),
+                    excludeSelf = true
+                )
+            )
+        )
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "17"
+        artist = "Leonardo Borazio"
+        flavorText = "\"Stand your ground! The Earth King must be protected!\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d263472e-1d75-4cb9-8f7b-986fa22bc841.jpg?1764119985"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/EarthKingdomSoldier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/EarthKingdomSoldier.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Earth Kingdom Soldier
+ * {4}{G/W}
+ * Creature — Human Soldier
+ * 3/4
+ *
+ * Vigilance
+ * When this creature enters, put a +1/+1 counter on each of up to two target creatures you control.
+ *
+ * The ETB mirrors Byrke, Long Ear of the Law's "each of up to two target creatures" shape — an
+ * optional `count = 2` [TargetCreature] (filtered to creatures you control) fanned out with
+ * [ForEachTargetEffect] so each chosen creature gets one +1/+1 counter.
+ */
+val EarthKingdomSoldier = card("Earth Kingdom Soldier") {
+    manaCost = "{4}{G/W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "When this creature enters, put a +1/+1 counter on each of up to two target creatures you control."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to two target creatures you control",
+            TargetCreature(count = 2, optional = true, filter = TargetFilter.CreatureYouControl)
+        )
+        effect = ForEachTargetEffect(
+            listOf(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))
+        )
+        description = "When this creature enters, put a +1/+1 counter on each of up to two target creatures you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "216"
+        artist = "Rafater"
+        flavorText = "Trained to be steady as the earth beneath their feet."
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d543d35-945a-4ffa-beb7-7c5d4f894f79.jpg?1764121553"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/FlexibleWaterbender.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/FlexibleWaterbender.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Flexible Waterbender
+ * {3}{U}
+ * Creature — Human Warrior Ally
+ * 2/5
+ *
+ * Vigilance
+ * Waterbend {3}: This creature has base power and toughness 5/2 until end of turn.
+ *
+ * The waterbend cost is the existing activated-ability carrier (`hasWaterbend = true`, as on
+ * Geyser Leaper); the body sets the creature's own base P/T via [Effects.SetBasePowerAndToughness]
+ * (Layer 7b), defaulting to until end of turn.
+ */
+val FlexibleWaterbender = card("Flexible Waterbender") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Warrior Ally"
+    power = 2
+    toughness = 5
+    oracleText = "Vigilance\n" +
+        "Waterbend {3}: This creature has base power and toughness 5/2 until end of turn. " +
+        "(While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Mana("{3}")
+        hasWaterbend = true
+        effect = Effects.SetBasePowerAndToughness(5, 2, EffectTarget.Self)
+        description = "This creature has base power and toughness 5/2 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "50"
+        artist = "Rafater"
+        flavorText = "\"Water is the element of change.\"\n—Iroh"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/1447ebce-7e48-4b21-a39c-740920538bdd.jpg?1764120230"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/HakodaSelflessCommander.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/HakodaSelflessCommander.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.effects.GrantKeywordEffect
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Hakoda, Selfless Commander
+ * {3}{W}
+ * Legendary Creature — Human Warrior Ally
+ * 3/3
+ *
+ * Vigilance
+ * You may look at the top card of your library any time.
+ * You may cast Ally spells from the top of your library.
+ * Sacrifice Hakoda: Creatures you control get +0/+5 and gain indestructible until end of turn.
+ *
+ * The two top-of-library clauses are the [LookAtTopOfLibrary] + [CastSpellTypesFromTopOfLibrary]
+ * statics. The sacrifice ability mirrors Kamahl, Fist of Krosa's "creatures you control get
+ * +X/+Y and gain <keyword> until end of turn" shape — two [Effects.ForEachInGroup] passes over
+ * `Creature.youControl()`. Hakoda is already gone (sacrificed as a cost) when the effect
+ * resolves, so it correctly excludes itself from the buff.
+ */
+val HakodaSelflessCommander = card("Hakoda, Selfless Commander") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Warrior Ally"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "You may look at the top card of your library any time.\n" +
+        "You may cast Ally spells from the top of your library.\n" +
+        "Sacrifice Hakoda: Creatures you control get +0/+5 and gain indestructible until end of turn."
+
+    keywords(Keyword.VIGILANCE)
+
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+    staticAbility {
+        ability = CastSpellTypesFromTopOfLibrary(
+            filter = GameObjectFilter.Any.withSubtype(Subtype.ALLY)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+                effect = ModifyStatsEffect(0, 5, EffectTarget.Self)
+            ),
+            Effects.ForEachInGroup(
+                filter = GroupFilter(GameObjectFilter.Creature.youControl()),
+                effect = GrantKeywordEffect(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+            )
+        )
+        description = "Sacrifice Hakoda: Creatures you control get +0/+5 and gain indestructible until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "23"
+        artist = "Rafater"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9aef3ddb-9bb7-42c8-975b-b1917955a416.jpg?1764120030"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/KnowledgeSeeker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/KnowledgeSeeker.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Knowledge Seeker
+ * {1}{U}
+ * Creature — Fox Spirit
+ * 2/1
+ *
+ * Vigilance
+ * Whenever you draw your second card each turn, put a +1/+1 counter on this creature.
+ * When this creature dies, create a Clue token.
+ *
+ * The "second card each turn" trigger is the existing [Triggers.NthCardDrawn] (n = 2), backed by
+ * the engine's per-player `CardsDrawnThisTurnComponent`.
+ */
+val KnowledgeSeeker = card("Knowledge Seeker") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Fox Spirit"
+    power = 2
+    toughness = 1
+    oracleText = "Vigilance\n" +
+        "Whenever you draw your second card each turn, put a +1/+1 counter on this creature.\n" +
+        "When this creature dies, create a Clue token. (It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")"
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever you draw your second card each turn, put a +1/+1 counter on this creature."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateClue()
+        description = "When this creature dies, create a Clue token."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "60"
+        artist = "Shiren"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/8554e862-f78a-42f5-b876-076aac6c9504.jpg?1764120328"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/MomoPlayfulPet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/MomoPlayfulPet.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Momo, Playful Pet
+ * {W}
+ * Legendary Creature — Lemur Bat Ally
+ * 1/1
+ *
+ * Flying, vigilance
+ * When Momo leaves the battlefield, choose one —
+ * • Create a Food token.
+ * • Put a +1/+1 counter on target creature you control.
+ * • Scry 2.
+ *
+ * A modal leaves-battlefield trigger (`ModalEffect.chooseOne`). Only the second mode targets, so
+ * it carries its own [Targets.CreatureYouControl] requirement via [Mode.withTarget]; the Food and
+ * Scry modes are [Mode.noTarget].
+ */
+val MomoPlayfulPet = card("Momo, Playful Pet") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Lemur Bat Ally"
+    power = 1
+    toughness = 1
+    oracleText = "Flying, vigilance\n" +
+        "When Momo leaves the battlefield, choose one —\n" +
+        "• Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "• Put a +1/+1 counter on target creature you control.\n" +
+        "• Scry 2."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.LeavesBattlefield
+        effect = ModalEffect.chooseOne(
+            Mode.noTarget(Effects.CreateFood(), "Create a Food token."),
+            Mode.withTarget(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)),
+                Targets.CreatureYouControl,
+                "Put a +1/+1 counter on target creature you control."
+            ),
+            Mode.noTarget(Effects.Scry(2), "Scry 2.")
+        )
+        description = "When Momo leaves the battlefield, choose one — Create a Food token; " +
+            "put a +1/+1 counter on target creature you control; or Scry 2."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "30"
+        artist = "Awanqi (Angela Wang)"
+        imageUri = "https://cards.scryfall.io/normal/front/9/3/9350bf4a-fa12-4867-b31f-1f1394d99571.jpg?1764120089"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/SokkaLateralStrategist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/SokkaLateralStrategist.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+
+/**
+ * Sokka, Lateral Strategist
+ * {1}{W/U}{W/U}
+ * Legendary Creature — Human Warrior Ally
+ * 2/4
+ *
+ * Vigilance
+ * Whenever Sokka and at least one other creature attack, draw a card.
+ *
+ * "Sokka and at least one other creature attack" is the battalion shape — a SELF-bound attack
+ * trigger gated on [AttackPredicate.AttackerCountAtLeast] of 2 (Sokka plus one more), so it fires
+ * only when at least one other creature is also declared as an attacker.
+ */
+val SokkaLateralStrategist = card("Sokka, Lateral Strategist") {
+    manaCost = "{1}{W/U}{W/U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Human Warrior Ally"
+    power = 2
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "Whenever Sokka and at least one other creature attack, draw a card."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.attacks(requires = setOf(AttackPredicate.AttackerCountAtLeast(2)))
+        effect = Effects.DrawCards(1)
+        description = "Whenever Sokka and at least one other creature attack, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "241"
+        artist = "Axel Sauerwald"
+        flavorText = "\"That's called Sokka style. Learn it!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/1326c5db-4615-495f-8e30-376243d91352.jpg?1764121782"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TheLionTurtle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TheLionTurtle.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.CantBlockUnless
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Lion-Turtle
+ * {1}{G}{U}
+ * Legendary Creature — Elder Cat Turtle
+ * 3/6
+ *
+ * Vigilance, reach
+ * When The Lion-Turtle enters, you gain 3 life.
+ * The Lion-Turtle can't attack or block unless there are three or more Lesson cards in your graveyard.
+ * {T}: Add one mana of any color.
+ *
+ * The "can't attack or block unless …" clause is two static restrictions ([CantAttackUnless] +
+ * [CantBlockUnless]) sharing a single graveyard-count condition — composed inline from
+ * [DynamicAmount.Count] over Lesson-subtyped cards in your graveyard rather than a bespoke
+ * condition type.
+ */
+val TheLionTurtle = card("The Lion-Turtle") {
+    manaCost = "{1}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Creature — Elder Cat Turtle"
+    power = 3
+    toughness = 6
+    oracleText = "Vigilance, reach\n" +
+        "When The Lion-Turtle enters, you gain 3 life.\n" +
+        "The Lion-Turtle can't attack or block unless there are three or more Lesson cards in your graveyard.\n" +
+        "{T}: Add one mana of any color."
+
+    keywords(Keyword.VIGILANCE, Keyword.REACH)
+
+    val threeOrMoreLessons = Conditions.CompareAmounts(
+        DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Any.withSubtype(Subtype.LESSON)),
+        ComparisonOperator.GTE,
+        DynamicAmount.Fixed(3)
+    )
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+        description = "When The Lion-Turtle enters, you gain 3 life."
+    }
+
+    staticAbility {
+        ability = CantAttackUnless(threeOrMoreLessons)
+    }
+    staticAbility {
+        ability = CantBlockUnless(threeOrMoreLessons)
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "232"
+        artist = "Yuumei"
+        imageUri = "https://cards.scryfall.io/normal/front/8/4/8491585c-81d0-48be-8ed0-832e42fad9c6.jpg?1764121714"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TigerSeal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TigerSeal.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tiger-Seal
+ * {U}
+ * Creature — Cat Seal
+ * 3/3
+ *
+ * Vigilance
+ * At the beginning of your upkeep, tap this creature.
+ * Whenever you draw your second card each turn, untap this creature.
+ *
+ * The "second card each turn" trigger is the existing [Triggers.NthCardDrawn] (n = 2), backed by
+ * the engine's per-player `CardsDrawnThisTurnComponent`.
+ */
+val TigerSeal = card("Tiger-Seal") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Cat Seal"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance\n" +
+        "At the beginning of your upkeep, tap this creature.\n" +
+        "Whenever you draw your second card each turn, untap this creature."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Tap(EffectTarget.Self)
+        description = "At the beginning of your upkeep, tap this creature."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        effect = Effects.Untap(EffectTarget.Self)
+        description = "Whenever you draw your second card each turn, untap this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Jinho Bae"
+        flavorText = "Every creature in the world felt the Avatar's return and paid respects in whatever way it could."
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7aef2891-1269-4a1a-acea-0aa37ef544c4.jpg?1764120490"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/YueTheMoonSpirit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/YueTheMoonSpirit.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Yue, the Moon Spirit
+ * {3}{U}
+ * Legendary Creature — Spirit Ally
+ * 3/3
+ *
+ * Flash
+ * Flying, vigilance
+ * Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost.
+ *
+ * The waterbend cost is the existing activated-ability carrier (`hasWaterbend = true`). The body is
+ * the standard gather → choose-up-to-one → cast-without-paying pipeline (as on Kellan, the Kid):
+ * [GatherCardsEffect] pulls noncreature, nonland cards from hand, [SelectFromCollectionEffect]
+ * makes the "you may" choice (up to one), and [Effects.CastFromCollectionWithoutPayingCost] casts
+ * the chosen card for free.
+ */
+val YueTheMoonSpirit = card("Yue, the Moon Spirit") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Spirit Ally"
+    power = 3
+    toughness = 3
+    oracleText = "Flash\n" +
+        "Flying, vigilance\n" +
+        "Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost. " +
+        "(While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)"
+
+    keywords(Keyword.FLASH, Keyword.FLYING, Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap)
+        hasWaterbend = true
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                CardSource.FromZone(Zone.HAND, filter = GameObjectFilter.Nonland.notCreature()),
+                storeAs = "yueCandidates",
+            ),
+            SelectFromCollectionEffect(
+                from = "yueCandidates",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "yueChosen",
+                selectedLabel = "Cast without paying its mana cost",
+            ),
+            Effects.CastFromCollectionWithoutPayingCost("yueChosen"),
+        )
+        description = "You may cast a noncreature spell from your hand without paying its mana cost."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "83"
+        artist = "Yuumei"
+        flavorText = "\"You'll save the world again. But you can't give up.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ecdac50f-c639-43fc-a03e-d488fac96ae2.jpg?1764120573"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -2809,6 +2809,56 @@
     ]
 }
 
+// Sokka, Lateral Strategist
+{
+    "name": "Sokka, Lateral Strategist",
+    "manaCost": "{1}{W/U}{W/U}",
+    "typeLine": "Legendary Creature — Human Warrior Ally",
+    "oracleText": "Vigilance\nWhenever Sokka and at least one other creature attack, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        {
+                            "type": "AttackerCountAtLeast",
+                            "n": 2
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever Sokka and at least one other creature attack, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "241",
+        "rarity": "UNCOMMON",
+        "artist": "Axel Sauerwald",
+        "flavorText": "\"That's called Sokka style. Learn it!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/1326c5db-4615-495f-8e30-376243d91352.jpg?1764121782"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Sun-Blessed Peak
 {
     "name": "Sun-Blessed Peak",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -1206,6 +1206,59 @@
     ]
 }
 
+// Flexible Waterbender
+{
+    "name": "Flexible Waterbender",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Warrior Ally",
+    "oracleText": "Vigilance\nWaterbend {3}: This creature has base power and toughness 5/2 until end of turn. (While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "SetBaseStats",
+                    "target": "Self",
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "duration": "EndOfTurn"
+                },
+                "descriptionOverride": "This creature has base power and toughness 5/2 until end of turn.",
+                "hasWaterbend": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "artist": "Rafater",
+        "flavorText": "\"Water is the element of change.\"\n—Iroh",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/1447ebce-7e48-4b21-a39c-740920538bdd.jpg?1764120230"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Foggy Bottom Swamp
 {
     "name": "Foggy Bottom Swamp",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -2878,6 +2878,95 @@
     ]
 }
 
+// The Lion-Turtle
+{
+    "name": "The Lion-Turtle",
+    "manaCost": "{1}{G}{U}",
+    "typeLine": "Legendary Creature — Elder Cat Turtle",
+    "oracleText": "Vigilance, reach\nWhen The Lion-Turtle enters, you gain 3 life.\nThe Lion-Turtle can't attack or block unless there are three or more Lesson cards in your graveyard.\n{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE",
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "descriptionOverride": "When The Lion-Turtle enters, you gain 3 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "isManaAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "Lesson"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            },
+            {
+                "type": "CantBlockUnless",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "Lesson"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "RARE",
+        "artist": "Yuumei",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/4/8491585c-81d0-48be-8ed0-832e42fad9c6.jpg?1764121714"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // The Walls of Ba Sing Se
 {
     "name": "The Walls of Ba Sing Se",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -3188,6 +3188,62 @@
     "colorIdentityOverride": []
 }
 
+// Tiger-Seal
+{
+    "name": "Tiger-Seal",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Cat Seal",
+    "oracleText": "Vigilance\nAt the beginning of your upkeep, tap this creature.\nWhenever you draw your second card each turn, untap this creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self"
+                },
+                "descriptionOverride": "At the beginning of your upkeep, tap this creature."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "descriptionOverride": "Whenever you draw your second card each turn, untap this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Jinho Bae",
+        "flavorText": "Every creature in the world felt the Avatar's return and paid respects in whatever way it could.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7aef2891-1269-4a1a-acea-0aa37ef544c4.jpg?1764120490"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Treetop Freedom Fighters
 {
     "name": "Treetop Freedom Fighters",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -827,6 +827,57 @@
     ]
 }
 
+// Earth Kingdom Protectors
+{
+    "name": "Earth Kingdom Protectors",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Soldier Ally",
+    "oracleText": "Vigilance\nSacrifice this creature: Another target Ally you control gains indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy it.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "INDESTRUCTIBLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target Ally you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Ally ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "another target Ally you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "UNCOMMON",
+        "artist": "Leonardo Borazio",
+        "flavorText": "\"Stand your ground! The Earth King must be protected!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d263472e-1d75-4cb9-8f7b-986fa22bc841.jpg?1764119985"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Earth Village Ruffians
 {
     "name": "Earth Village Ruffians",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -1739,6 +1739,62 @@
     ]
 }
 
+// Knowledge Seeker
+{
+    "name": "Knowledge Seeker",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Fox Spirit",
+    "oracleText": "Vigilance\nWhenever you draw your second card each turn, put a +1/+1 counter on this creature.\nWhen this creature dies, create a Clue token. (It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you draw your second card each turn, put a +1/+1 counter on this creature."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Clue"
+                },
+                "descriptionOverride": "When this creature dies, create a Clue token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "UNCOMMON",
+        "artist": "Shiren",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/8554e862-f78a-42f5-b876-076aac6c9504.jpg?1764120328"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Kyoshi Village
 {
     "name": "Kyoshi Village",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -3670,6 +3670,94 @@
     ]
 }
 
+// Yue, the Moon Spirit
+{
+    "name": "Yue, the Moon Spirit",
+    "manaCost": "{3}{U}",
+    "typeLine": "Legendary Creature — Spirit Ally",
+    "oracleText": "Flash\nFlying, vigilance\nWaterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost. (While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsNonland",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsCreature"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "yueCandidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "yueCandidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "yueChosen",
+                            "selectedLabel": "Cast without paying its mana cost"
+                        },
+                        {
+                            "type": "CastFromCollectionWithoutPayingCost",
+                            "from": "yueChosen"
+                        }
+                    ]
+                },
+                "descriptionOverride": "You may cast a noncreature spell from your hand without paying its mana cost.",
+                "hasWaterbend": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "RARE",
+        "artist": "Yuumei",
+        "flavorText": "\"You'll save the world again. But you can't give up.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ecdac50f-c639-43fc-a03e-d488fac96ae2.jpg?1764120573"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Yuyan Archers
 {
     "name": "Yuyan Archers",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -878,6 +878,65 @@
     ]
 }
 
+// Earth Kingdom Soldier
+{
+    "name": "Earth Kingdom Soldier",
+    "manaCost": "{4}{G/W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Vigilance\nWhen this creature enters, put a +1/+1 counter on each of up to two target creatures you control.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "up to two target creatures you control"
+                },
+                "descriptionOverride": "When this creature enters, put a +1/+1 counter on each of up to two target creatures you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "216",
+        "artist": "Rafater",
+        "flavorText": "Trained to be steady as the earth beneath their feet.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d543d35-945a-4ffa-beb7-7c5d4f894f79.jpg?1764121553"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Earth Village Ruffians
 {
     "name": "Earth Village Ruffians",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -2043,6 +2043,82 @@
     ]
 }
 
+// Momo, Playful Pet
+{
+    "name": "Momo, Playful Pet",
+    "manaCost": "{W}",
+    "typeLine": "Legendary Creature — Lemur Bat Ally",
+    "oracleText": "Flying, vigilance\nWhen Momo leaves the battlefield, choose one —\n• Create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n• Put a +1/+1 counter on target creature you control.\n• Scry 2.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Food"
+                            },
+                            "description": "Create a Food token."
+                        },
+                        {
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                }
+                            ],
+                            "description": "Put a +1/+1 counter on target creature you control."
+                        },
+                        {
+                            "effect": {
+                                "type": "Scry",
+                                "count": 2
+                            },
+                            "description": "Scry 2."
+                        }
+                    ]
+                },
+                "descriptionOverride": "When Momo leaves the battlefield, choose one — Create a Food token; put a +1/+1 counter on target creature you control; or Scry 2."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "rarity": "UNCOMMON",
+        "artist": "Awanqi (Angela Wang)",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/3/9350bf4a-fa12-4867-b31f-1f1394d99571.jpg?1764120089"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // North Pole Gates
 {
     "name": "North Pole Gates",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -1400,6 +1400,86 @@
     ]
 }
 
+// Hakoda, Selfless Commander
+{
+    "name": "Hakoda, Selfless Commander",
+    "manaCost": "{3}{W}",
+    "typeLine": "Legendary Creature — Human Warrior Ally",
+    "oracleText": "Vigilance\nYou may look at the top card of your library any time.\nYou may cast Ally spells from the top of your library.\nSacrifice Hakoda: Creatures you control get +0/+5 and gain indestructible until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 5
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "body": {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Sacrifice Hakoda: Creatures you control get +0/+5 and gain indestructible until end of turn."
+            }
+        ],
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            {
+                "type": "CastSpellTypesFromTopOfLibrary",
+                "filter": "Ally"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "23",
+        "rarity": "RARE",
+        "artist": "Rafater",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9aef3ddb-9bb7-42c8-975b-b1917955a416.jpg?1764120030"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Haru, Hidden Talent
 {
     "name": "Haru, Hidden Talent",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YueTheMoonSpiritScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YueTheMoonSpiritScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tla.cards.YueTheMoonSpirit
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Yue, the Moon Spirit.
+ *
+ * Yue, the Moon Spirit ({3}{U}): Legendary Creature — Spirit Ally, 3/3, Flash, Flying, vigilance.
+ * "Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost."
+ *
+ * Exercises the activated-ability waterbend carrier (`hasWaterbend = true`) plus the
+ * gather → choose-up-to-one → cast-without-paying pipeline filtered to noncreature, nonland cards.
+ */
+class YueTheMoonSpiritScenarioTest : FunSpec({
+
+    // A {2}{U} noncreature permanent with no targeting — a clean, observable free-cast payoff
+    // (it simply enters the battlefield on resolution).
+    val freeSpell = card("Yue Test Free Spell") {
+        manaCost = "{2}{U}"
+        typeLine = "Enchantment"
+        oracleText = "Test enchantment."
+    }
+
+    val abilityId = YueTheMoonSpirit.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(YueTheMoonSpirit))
+        driver.registerCard(freeSpell)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Waterbend ability casts a noncreature spell from hand for free") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val yue = driver.putCreatureOnBattlefield(player, "Yue, the Moon Spirit")
+        driver.removeSummoningSickness(yue)
+        val spell = driver.putCardInHand(player, "Yue Test Free Spell")
+        // Exactly enough mana to pay the {5} activation — and nothing left over, so the {2}{U}
+        // enchantment can only enter if it was genuinely cast without paying.
+        driver.giveMana(player, Color.BLUE, 5)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = yue, abilityId = abilityId),
+        ).isSuccess shouldBe true
+
+        // The ability is on the stack — both players pass so it resolves, then it pauses to
+        // choose the noncreature spell to free-cast.
+        driver.passPriority(player)
+        driver.passPriority(driver.getOpponent(player))
+        driver.submitCardSelection(player, listOf(spell))
+        driver.bothPass()
+
+        // The enchantment was cast for free and is now on the battlefield, out of hand.
+        (spell in driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD))) shouldBe true
+        (spell in driver.state.getZone(ZoneKey(player, Zone.HAND))) shouldBe false
+        // The {T} cost tapped Yue.
+        driver.isTapped(yue) shouldBe true
+    }
+
+    test("declining the optional cast leaves the spell in hand") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val yue = driver.putCreatureOnBattlefield(player, "Yue, the Moon Spirit")
+        driver.removeSummoningSickness(yue)
+        val spell = driver.putCardInHand(player, "Yue Test Free Spell")
+        driver.giveMana(player, Color.BLUE, 5)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = yue, abilityId = abilityId),
+        ).isSuccess shouldBe true
+
+        // Resolve the ability off the stack, then decline the optional cast (choose nothing).
+        driver.passPriority(player)
+        driver.passPriority(driver.getOpponent(player))
+        driver.submitCardSelection(player, emptyList())
+        driver.bothPass()
+
+        // The spell never left the player's hand.
+        (spell in driver.state.getZone(ZoneKey(player, Zone.HAND))) shouldBe true
+        (spell in driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD))) shouldBe false
+    }
+})


### PR DESCRIPTION
Implements 10 cards from Avatar: The Last Airbender (TLA), bringing the set to 59/286 (21%).
All cards compose existing SDK primitives — no engine or SDK changes.

### Cards
| Card | Cost | Notable shape |
|------|------|---------------|
| Yue, the Moon Spirit | {3}{U} | Waterbend free-cast pipeline (mirrors Kellan) |
| The Lion-Turtle | {1}{G}{U} | Two can't-attack/block statics sharing one Lesson-count condition |
| Hakoda, Selfless Commander | {3}{W} | Top-of-library statics + sacrifice mass buff |
| Earth Kingdom Soldier | {4}{G/W} | Up-to-two-target +1/+1 counters (mirrors Byrke) |
| Earth Kingdom Protectors | {W} | Sacrifice: grant another Ally indestructible |
| Flexible Waterbender | {3}{U} | Waterbend set-base-P/T |
| Knowledge Seeker | {1}{U} | NthCardDrawn(2) counter + dies-Clue |
| Tiger-Seal | {U} | Upkeep tap / NthCardDrawn(2) untap |
| Momo, Playful Pet | {W} | Modal leaves-battlefield trigger |
| Sokka, Lateral Strategist | {1}{W/U}{W/U} | Battalion attack trigger (self + 1) |

### Tests
- `CardDefinitionSnapshotTest` — green (256 cards), TLA golden re-blessed
- `CardLintTest` — green
- `YueTheMoonSpiritScenarioTest` — covers free-cast and decline-the-optional branches

All fields verified against Scryfall (cost, type, P/T, collector number, rarity, artist, oracle text).

cards.md not updated, to not have conflicts.