### PR TITLE
Show logged-in state immediately after magic-link login

### DIFF
--- a/web-client/src/store/authStore.ts
+++ b/web-client/src/store/authStore.ts
@@ -59,7 +59,10 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   setSession: (login) => {
     setAuthToken(login.authToken)
-    set({ user: login.user, status: 'authenticated' })
+    // A successful login means the server runs the accounts subsystem, so flip accountsEnabled on
+    // here too. Otherwise the account UI (AuthWidget, profile) stays hidden until a manual refresh
+    // re-runs init() — the magic-link flow lands on '/' without ever calling init().
+    set({ user: login.user, status: 'authenticated', accountsEnabled: true })
   },
 
   updateDisplayName: async (displayName) => {


### PR DESCRIPTION
## Problem

After clicking a magic-link to sign in, the UI showed the user as logged out (no account widget, no profile access) until they manually refreshed the page.

## Root cause

The magic-link verify flow (`LoginVerifyPage`) calls `setSession()` and navigates to `/` — it never runs `init()`. But `setSession()` only set `user` and `status`, leaving `accountsEnabled` at its default `false`:

```ts
setSession: (login) => {
  setAuthToken(login.authToken)
  set({ user: login.user, status: 'authenticated' })
},
```

The `AuthWidget` (and the side panel that wraps it in `GameUI`) is gated on `accountsEnabled`, so it stayed hidden. A manual refresh re-ran `init()`, which fetches the server config and sets `accountsEnabled: true` — which is why the refresh "fixed" it.

## Fix

A successful login implies the server runs the accounts subsystem, so `setSession()` now also sets `accountsEnabled: true`. The account UI and profile appear reactively, no refresh needed.

## Testing

- `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)