### PR TITLE
Improve the profile page: mode variants, opponent links, ELO, tournament detail

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AccountStatsController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AccountStatsController.kt
@@ -210,6 +210,17 @@ class AccountStatsController(
     ): List<UserTournamentEntry> =
         statsQuery.tournamentHistory(authSupport.requireUser(auth).userId, limit.coerceIn(1, 100))
 
+    /**
+     * Public detail for one tournament: final standings for every participant and every game played in
+     * it (all players', not just the viewer's), each linkable to its public replay. No auth required —
+     * the same data is already public on each player's profile — but the tournament must exist (404).
+     */
+    @GetMapping("/tournaments/{id}")
+    fun tournamentDetail(@PathVariable id: Long): ResponseEntity<com.wingedsheep.gameserver.stats.TournamentDetail> {
+        val detail = statsQuery.tournamentDetail(id) ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(detail)
+    }
+
     // ---- Public profiles --------------------------------------------------------------------
 
     /** Everything a read-only public profile shows for another player, in one request. */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -697,6 +697,7 @@ class GamePlayHandler(
                         it.setNames.joinToString(" / ") + " " + it.format.name.lowercase()
                             .replaceFirstChar { c -> c.uppercase() }
                     },
+                    lobbyId = lobbyId,
                     gameMode = gameMode,
                     ranked = gameSession.ranked,
                     frameCount = frameCount,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Rows.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Rows.kt
@@ -59,6 +59,12 @@ data class MatchResultRow(
     val gameId: String,
     val format: String? = null,
     val tournamentName: String? = null,
+    /**
+     * The lobby that produced this game, when it came from one (tournament bracket / multiplayer pod).
+     * Joins to [TournamentRow.lobbyId] so a tournament's full game list can be found. Null for
+     * non-lobby games (quick game / casual) and games recorded before this column existed.
+     */
+    val lobbyId: String? = null,
     /** Matchmaking context: a [LobbyGameMode] name, or QUICK_GAME / CASUAL / HOTSEAT for non-lobby games. */
     val gameMode: String? = null,
     /** True for a ranked (ELO-adjusting) game. */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/MatchResultSink.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/MatchResultSink.kt
@@ -15,6 +15,8 @@ data class RecordedMatch(
     val gameId: String,
     val format: String?,
     val tournamentName: String?,
+    /** The lobby that produced this game, or null for non-lobby games. Links games to a tournament. */
+    val lobbyId: String? = null,
     /** Matchmaking context: a LobbyGameMode name, or QUICK_GAME / CASUAL for non-lobby games. */
     val gameMode: String?,
     /** True for a ranked (ELO-adjusting) game. */
@@ -79,6 +81,7 @@ class JdbcMatchResultSink(private val matchResults: MatchResultRepository) : Mat
                 gameId = match.gameId,
                 format = match.format,
                 tournamentName = match.tournamentName,
+                lobbyId = match.lobbyId,
                 gameMode = match.gameMode,
                 ranked = match.ranked,
                 frameCount = match.frameCount,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -21,14 +21,29 @@ data class HeadToHead(
     val losses: Long,
 )
 
+/** One opponent seat in a recorded game (so the client can link to a human opponent's profile). */
+data class GameOpponent(
+    val name: String,
+    /** Null for guests and AI seats — only signed-in opponents link to a public profile. */
+    val userId: UUID?,
+    val isAi: Boolean,
+)
+
 /** One row in a user's game history. */
 data class GameHistoryEntry(
     val endedAt: String,
     val gameMode: String?,
     val format: String?,
     val colors: String?,
+    /** Comma-joined opponent names — kept for callers that just want a label (e.g. the deck modal). */
     val opponents: String?,
+    /** Per-seat opponents, so signed-in opponents can be linked to their public profile. */
+    val opponentList: List<GameOpponent>,
     val won: Boolean,
+    /** This player's ELO *before* this game, when it was a ranked game; null otherwise. */
+    val selfRating: Int?,
+    /** The opponent's ELO at the time of a ranked game; null otherwise (or for multi-seat games). */
+    val opponentRating: Int?,
     /** Stable game id, used to open/share the replay. */
     val gameId: String,
     /** True when a compact replay was stored for this game and can be watched/shared. */
@@ -98,20 +113,67 @@ data class DailyCount(val day: String, val count: Long)
 /** One IP and how many games connected from it (admin-only; resolved to a location elsewhere). */
 data class IpCount(val ip: String, val count: Long)
 
-/** A card and how often it has appeared in decks. */
-data class CardStat(val cardName: String, val copies: Long, val decks: Long)
+/** A card and how often it has appeared in decks. [imageUri] is set only for per-user top cards. */
+data class CardStat(val cardName: String, val copies: Long, val decks: Long, val imageUri: String? = null)
 
 /** A card's win rate: games (decks containing it) and how many of those decks won. */
 data class CardWinRate(val cardName: String, val decks: Long, val wins: Long, val winRate: Double)
 
-/** One tournament in a user's tournament history. */
+/** One tournament in a user's tournament history. [id] opens the full tournament detail. */
 data class UserTournamentEntry(
+    val id: Long,
     val endedAt: String,
     val name: String?,
     val format: String?,
     val gameMode: String?,
     val placement: Int,
     val playerCount: Int,
+)
+
+/** One player's final standing in a tournament. */
+data class TournamentStanding(
+    val placement: Int,
+    val playerName: String,
+    /** Null for guests and AI seats. */
+    val userId: UUID?,
+    val isAi: Boolean,
+    val wins: Int,
+    val losses: Int,
+    val draws: Int,
+)
+
+/** One seat in a single tournament game. */
+data class TournamentGamePlayer(
+    val name: String,
+    val userId: UUID?,
+    val isAi: Boolean,
+    val won: Boolean,
+)
+
+/** One game played within a tournament, with its replay availability. */
+data class TournamentGame(
+    val gameId: String,
+    val endedAt: String,
+    val hasReplay: Boolean,
+    val players: List<TournamentGamePlayer>,
+)
+
+/**
+ * Full, public detail for one finished tournament: every participant's final standing and every game
+ * that was played (not just the requesting player's), each linkable to its replay. [games] is empty
+ * for tournaments recorded before games carried a lobby id (those show standings only).
+ */
+data class TournamentDetail(
+    val id: Long,
+    val name: String?,
+    val format: String?,
+    val gameMode: String?,
+    val setCodes: String?,
+    val playerCount: Int,
+    val winnerName: String?,
+    val endedAt: String,
+    val standings: List<TournamentStanding>,
+    val games: List<TournamentGame>,
 )
 
 /** A registered account plus its lifetime game counts, for the admin Players list. */
@@ -186,14 +248,19 @@ class StatsQueryService(
         userId,
     )
 
-    /** How often the user has played each game mode, most-played first. */
+    /**
+     * How often the user has played each game mode, most-played first. The label is a composite
+     * `"<gameMode>~<format>"` (format may be empty) so the client can render the mode as a hierarchy
+     * (e.g. "Tournament › Draft"); the client merges buckets whose display label collapses to the same
+     * thing. `~` never occurs in the enum names being concatenated.
+     */
     fun modeBreakdown(userId: UUID): List<StatBucket> = jdbc.query(
         """
-        SELECT COALESCE(r.game_mode, 'UNKNOWN') AS label, count(*) AS n
+        SELECT COALESCE(r.game_mode, 'UNKNOWN') || '~' || COALESCE(r.format, '') AS label, count(*) AS n
         FROM match_participants p
         JOIN match_results r ON r.id = p.match_id
         WHERE p.user_id = ?
-        GROUP BY COALESCE(r.game_mode, 'UNKNOWN')
+        GROUP BY COALESCE(r.game_mode, 'UNKNOWN') || '~' || COALESCE(r.format, '')
         ORDER BY n DESC
         """.trimIndent(),
         { rs, _ -> StatBucket(rs.getString("label"), rs.getLong("n")) },
@@ -247,17 +314,15 @@ class StatsQueryService(
     fun recentGames(userId: UUID, limit: Int, offset: Int): List<GameHistoryEntry> {
         data class Row(
             val pid: Long,
+            val mid: Long,
+            val gameId: String,
             val entry: GameHistoryEntry,
         )
         val rows = jdbc.query(
             """
-            SELECT me.id AS pid, r.ended_at AS ended_at, r.game_mode AS game_mode, r.format AS format,
-                   me.won AS won, me.colors AS colors, r.game_id AS game_id,
-                   (gr.id IS NOT NULL) AS has_replay,
-                   (SELECT string_agg(COALESCE(u2.display_name, o.player_name), ', ')
-                      FROM match_participants o
-                      LEFT JOIN users u2 ON u2.id = o.user_id
-                      WHERE o.match_id = r.id AND o.id <> me.id) AS opponents
+            SELECT me.id AS pid, me.match_id AS mid, r.ended_at AS ended_at, r.game_mode AS game_mode,
+                   r.format AS format, me.won AS won, me.colors AS colors, r.game_id AS game_id,
+                   (gr.id IS NOT NULL) AS has_replay
             FROM match_participants me
             JOIN match_results r ON r.id = me.match_id
             LEFT JOIN game_replays gr ON gr.game_id = r.game_id
@@ -268,13 +333,18 @@ class StatsQueryService(
             { rs, _ ->
                 Row(
                     pid = rs.getLong("pid"),
+                    mid = rs.getLong("mid"),
+                    gameId = rs.getString("game_id"),
                     entry = GameHistoryEntry(
                         endedAt = rs.getTimestamp("ended_at").toInstant().toString(),
                         gameMode = rs.getString("game_mode"),
                         format = rs.getString("format"),
                         colors = rs.getString("colors"),
-                        opponents = rs.getString("opponents"),
+                        opponents = null,
+                        opponentList = emptyList(),
                         won = rs.getBoolean("won"),
+                        selfRating = null,
+                        opponentRating = null,
                         gameId = rs.getString("game_id"),
                         hasReplay = rs.getBoolean("has_replay"),
                     ),
@@ -283,13 +353,79 @@ class StatsQueryService(
             userId, limit, offset,
         )
         val cardsByPid = cardsForParticipants(rows.map { it.pid })
+        val opponentsByMid = opponentsForMatches(rows.map { it.mid }, userId)
+        val ratingByGame = ratingsForGames(rows.map { it.gameId }, userId)
         return rows.map { row ->
             val cards = cardsByPid[row.pid]
             // Recompute from the recorded deck when we have one; otherwise keep whatever was stored.
             val colors = if (cards.isNullOrEmpty()) row.entry.colors
             else deckProfiler.profile(cards.map { it.cardName }).colors
-            row.entry.copy(colors = colors)
+            val opps = opponentsByMid[row.mid].orEmpty()
+            val rating = ratingByGame[row.gameId]
+            row.entry.copy(
+                colors = colors,
+                opponents = opps.takeIf { it.isNotEmpty() }?.joinToString(", ") { it.name },
+                opponentList = opps,
+                selfRating = rating?.first,
+                opponentRating = rating?.second,
+            )
         }
+    }
+
+    /** Opponent seats (everyone but [userId]'s own seat) for a set of match ids, keyed by match id. */
+    private fun opponentsForMatches(matchIds: List<Long>, userId: UUID): Map<Long, List<GameOpponent>> {
+        if (matchIds.isEmpty()) return emptyMap()
+        val placeholders = matchIds.joinToString(",") { "?" }
+        val out = LinkedHashMap<Long, MutableList<GameOpponent>>()
+        jdbc.query(
+            """
+            SELECT o.match_id AS mid, COALESCE(u.display_name, o.player_name) AS name,
+                   o.user_id AS uid, o.is_ai AS is_ai
+            FROM match_participants o
+            LEFT JOIN users u ON u.id = o.user_id
+            WHERE o.match_id IN ($placeholders) AND (o.user_id IS NULL OR o.user_id <> ?)
+            ORDER BY o.id
+            """.trimIndent(),
+            { rs ->
+                out.getOrPut(rs.getLong("mid")) { mutableListOf() }.add(
+                    GameOpponent(
+                        name = rs.getString("name"),
+                        userId = rs.getObject("uid", UUID::class.java),
+                        isAi = rs.getBoolean("is_ai"),
+                    ),
+                )
+            },
+            *buildList<Any> { addAll(matchIds); add(userId) }.toTypedArray(),
+        )
+        return out
+    }
+
+    /**
+     * Each player's pre-game ELO and the opponent's ELO for the given ranked games, keyed by game id.
+     * `rating_before` is the rating the player carried into the game and `opponent_rating` is the
+     * opponent's rating at that time — i.e. both players' ELO "at the time the game was played".
+     * Non-ranked games have no row and are simply absent from the map.
+     */
+    private fun ratingsForGames(gameIds: List<String>, userId: UUID): Map<String, Pair<Int, Int?>> {
+        if (gameIds.isEmpty()) return emptyMap()
+        val placeholders = gameIds.joinToString(",") { "?" }
+        val out = HashMap<String, Pair<Int, Int?>>()
+        jdbc.query(
+            """
+            SELECT game_id, rating_before, opponent_rating
+            FROM rating_history
+            WHERE user_id = ? AND game_id IN ($placeholders)
+            """.trimIndent(),
+            { rs ->
+                val gameId = rs.getString("game_id") ?: return@query
+                val self = Math.round(rs.getDouble("rating_before")).toInt()
+                val oppRaw = rs.getObject("opponent_rating")
+                val opp = if (oppRaw == null) null else Math.round((oppRaw as Number).toDouble()).toInt()
+                out[gameId] = self to opp
+            },
+            *buildList<Any> { add(userId); addAll(gameIds) }.toTypedArray(),
+        )
+        return out
     }
 
     /**
@@ -500,13 +636,21 @@ class StatsQueryService(
         """.trimIndent(),
         { rs, _ -> CardStat(rs.getString("card_name"), rs.getLong("copies"), rs.getLong("decks")) },
         userId,
-    ).filterNot { lookupCard(it.cardName)?.typeLine?.isBasicLand == true }.take(limit)
+    ).filterNot { lookupCard(it.cardName)?.typeLine?.isBasicLand == true }
+        .take(limit)
+        // Resolve each card's art the same way as the deck viewer (default printing → canonical
+        // metadata) so the most-played-cards section can show a hover preview without a Scryfall hit.
+        .map { it.copy(imageUri = imageUriFor(it.cardName)) }
+
+    /** Default-printing art URL for a card name, or null when it can't be resolved (mirrors [enrichDeckCards]). */
+    private fun imageUriFor(name: String): String? =
+        lookupCard(name)?.let { printingRegistry.defaultPrinting(it.name)?.imageUri ?: it.metadata.imageUri }
 
     /** The user's tournament finishes, newest first. */
     fun tournamentHistory(userId: UUID, limit: Int): List<UserTournamentEntry> = jdbc.query(
         """
-        SELECT t.ended_at AS ended_at, t.name AS name, t.format AS format, t.game_mode AS game_mode,
-               tp.placement AS placement, t.player_count AS player_count
+        SELECT t.id AS id, t.ended_at AS ended_at, t.name AS name, t.format AS format,
+               t.game_mode AS game_mode, tp.placement AS placement, t.player_count AS player_count
         FROM tournament_participants tp
         JOIN tournaments t ON t.id = tp.tournament_id
         WHERE tp.user_id = ?
@@ -515,6 +659,7 @@ class StatsQueryService(
         """.trimIndent(),
         { rs, _ ->
             UserTournamentEntry(
+                id = rs.getLong("id"),
                 endedAt = rs.getTimestamp("ended_at").toInstant().toString(),
                 name = rs.getString("name"),
                 format = rs.getString("format"),
@@ -525,6 +670,106 @@ class StatsQueryService(
         },
         userId, limit,
     )
+
+    /**
+     * Full public detail for one tournament: every participant's standing plus every game played in it
+     * (found by the lobby id the games were recorded under), each with replay availability. Returns
+     * null when no tournament has that id. Games are empty for tournaments recorded before games
+     * carried a lobby id.
+     */
+    fun tournamentDetail(id: Long): TournamentDetail? {
+        val header = jdbc.query(
+            """
+            SELECT id, lobby_id, name, format, game_mode, set_codes, player_count, winner_name, ended_at
+            FROM tournaments WHERE id = ?
+            """.trimIndent(),
+            { rs, _ ->
+                TournamentDetail(
+                    id = rs.getLong("id"),
+                    name = rs.getString("name"),
+                    format = rs.getString("format"),
+                    gameMode = rs.getString("game_mode"),
+                    setCodes = rs.getString("set_codes"),
+                    playerCount = rs.getInt("player_count"),
+                    winnerName = rs.getString("winner_name"),
+                    endedAt = rs.getTimestamp("ended_at").toInstant().toString(),
+                    standings = emptyList(),
+                    games = emptyList(),
+                ) to rs.getString("lobby_id")
+            },
+            id,
+        ).firstOrNull() ?: return null
+        val (detail, lobbyId) = header
+
+        val standings = jdbc.query(
+            """
+            SELECT tp.placement AS placement, COALESCE(u.display_name, tp.player_name) AS name,
+                   tp.user_id AS uid, tp.is_ai AS is_ai, tp.wins AS wins, tp.losses AS losses, tp.draws AS draws
+            FROM tournament_participants tp
+            LEFT JOIN users u ON u.id = tp.user_id
+            WHERE tp.tournament_id = ?
+            ORDER BY tp.placement ASC, name ASC
+            """.trimIndent(),
+            { rs, _ ->
+                TournamentStanding(
+                    placement = rs.getInt("placement"),
+                    playerName = rs.getString("name"),
+                    userId = rs.getObject("uid", UUID::class.java),
+                    isAi = rs.getBoolean("is_ai"),
+                    wins = rs.getInt("wins"),
+                    losses = rs.getInt("losses"),
+                    draws = rs.getInt("draws"),
+                )
+            },
+            id,
+        )
+
+        val games = if (lobbyId.isNullOrEmpty()) emptyList() else tournamentGames(lobbyId)
+        return detail.copy(standings = standings, games = games)
+    }
+
+    /** Every recorded game for a lobby (the tournament's bracket games), oldest first, with seats. */
+    private fun tournamentGames(lobbyId: String): List<TournamentGame> {
+        data class GameRow(val mid: Long, val gameId: String, val endedAt: String, val hasReplay: Boolean)
+        val games = jdbc.query(
+            """
+            SELECT r.id AS mid, r.game_id AS game_id, r.ended_at AS ended_at, (gr.id IS NOT NULL) AS has_replay
+            FROM match_results r
+            LEFT JOIN game_replays gr ON gr.game_id = r.game_id
+            WHERE r.lobby_id = ?
+            ORDER BY r.ended_at ASC
+            """.trimIndent(),
+            { rs, _ ->
+                GameRow(rs.getLong("mid"), rs.getString("game_id"), rs.getTimestamp("ended_at").toInstant().toString(), rs.getBoolean("has_replay"))
+            },
+            lobbyId,
+        )
+        if (games.isEmpty()) return emptyList()
+        val placeholders = games.joinToString(",") { "?" }
+        val playersByMid = LinkedHashMap<Long, MutableList<TournamentGamePlayer>>()
+        jdbc.query(
+            """
+            SELECT p.match_id AS mid, COALESCE(u.display_name, p.player_name) AS name,
+                   p.user_id AS uid, p.is_ai AS is_ai, p.won AS won
+            FROM match_participants p
+            LEFT JOIN users u ON u.id = p.user_id
+            WHERE p.match_id IN ($placeholders)
+            ORDER BY p.id
+            """.trimIndent(),
+            { rs ->
+                playersByMid.getOrPut(rs.getLong("mid")) { mutableListOf() }.add(
+                    TournamentGamePlayer(
+                        name = rs.getString("name"),
+                        userId = rs.getObject("uid", UUID::class.java),
+                        isAi = rs.getBoolean("is_ai"),
+                        won = rs.getBoolean("won"),
+                    ),
+                )
+            },
+            *games.map { it.mid }.toTypedArray(),
+        )
+        return games.map { TournamentGame(it.gameId, it.endedAt, it.hasReplay, playersByMid[it.mid].orEmpty()) }
+    }
 
     // ---- Global (admin) ----------------------------------------------------------------------
 

--- a/game-server/src/main/resources/db/migration/V8__match_lobby_id.sql
+++ b/game-server/src/main/resources/db/migration/V8__match_lobby_id.sql
@@ -1,0 +1,13 @@
+-- Link recorded games back to the lobby/tournament that produced them.
+--
+-- A finished tournament is stored as one `tournaments` row keyed by its `lobby_id`, and its bracket
+-- games are stored as ordinary `match_results` rows — but until now nothing tied the two together in
+-- the database (the live game→lobby link lives only in the in-memory game cache). This adds the lobby
+-- id to `match_results` so a tournament's full game list (every player's games, not just yours) and
+-- their replays can be found with a single join: `match_results.lobby_id = tournaments.lobby_id`.
+--
+-- Nullable: non-lobby games (quick game / casual) never have a lobby id, and games recorded before
+-- this migration keep a null (their tournament detail simply shows standings without a game list).
+-- Like the rest of the accounts subsystem this only runs when accounts are enabled.
+ALTER TABLE match_results ADD COLUMN lobby_id TEXT;
+CREATE INDEX idx_match_results_lobby ON match_results (lobby_id);

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -216,13 +216,27 @@ export interface HeadToHead {
   readonly losses: number
 }
 
+/** One opponent seat in a recorded game; `userId` is set only for signed-in opponents. */
+export interface GameOpponent {
+  readonly name: string
+  readonly userId: string | null
+  readonly isAi: boolean
+}
+
 export interface GameHistoryEntry {
   readonly endedAt: string
   readonly gameMode: string | null
   readonly format: string | null
   readonly colors: string | null
+  /** Comma-joined opponent names — a plain label fallback. */
   readonly opponents: string | null
+  /** Per-seat opponents, so signed-in opponents can link to their public profile. */
+  readonly opponentList: GameOpponent[]
   readonly won: boolean
+  /** This player's ELO before a ranked game; null for non-ranked games. */
+  readonly selfRating: number | null
+  /** The opponent's ELO at the time of a ranked game; null otherwise. */
+  readonly opponentRating: number | null
   readonly gameId: string
   /** True when a compact replay was stored for this game and can be watched/shared. */
   readonly hasReplay: boolean
@@ -232,15 +246,60 @@ export interface CardStat {
   readonly cardName: string
   readonly copies: number
   readonly decks: number
+  /** Default-printing art URL (per-user top cards only); null when unresolved. */
+  readonly imageUri: string | null
 }
 
 export interface UserTournamentEntry {
+  /** Opens the full tournament detail (standings + games). */
+  readonly id: number
   readonly endedAt: string
   readonly name: string | null
   readonly format: string | null
   readonly gameMode: string | null
   readonly placement: number
   readonly playerCount: number
+}
+
+/** One player's final standing in a tournament. */
+export interface TournamentStanding {
+  readonly placement: number
+  readonly playerName: string
+  readonly userId: string | null
+  readonly isAi: boolean
+  readonly wins: number
+  readonly losses: number
+  readonly draws: number
+}
+
+/** One seat within a single tournament game. */
+export interface TournamentGamePlayer {
+  readonly name: string
+  readonly userId: string | null
+  readonly isAi: boolean
+  readonly won: boolean
+}
+
+/** One game played within a tournament. */
+export interface TournamentGame {
+  readonly gameId: string
+  readonly endedAt: string
+  readonly hasReplay: boolean
+  readonly players: TournamentGamePlayer[]
+}
+
+/** Full public detail for one tournament: standings + every game played (all players'). */
+export interface TournamentDetail {
+  readonly id: number
+  readonly name: string | null
+  readonly format: string | null
+  readonly gameMode: string | null
+  readonly setCodes: string | null
+  readonly playerCount: number
+  readonly winnerName: string | null
+  readonly endedAt: string
+  readonly standings: TournamentStanding[]
+  readonly games: TournamentGame[]
 }
 
 /** One card line within a stored deck. */
@@ -383,6 +442,14 @@ export async function fetchHistoryPage(limit: number, offset: number): Promise<H
   const entries = (await res.json()) as GameHistoryEntry[]
   const total = Number(res.headers.get('X-Total-Count') ?? entries.length)
   return { entries, total: Number.isFinite(total) ? total : entries.length }
+}
+
+/** Full public detail for one tournament (standings + all games). */
+export async function fetchTournamentDetail(id: number): Promise<TournamentDetail> {
+  const res = await fetch(`/api/stats/tournaments/${id}`, { headers: authHeaders() })
+  if (res.status === 404) throw new ProfileNotFoundError()
+  if (!res.ok) throw new Error(`Failed to load tournament (${res.status})`)
+  return (await res.json()) as TournamentDetail
 }
 
 /** Both seats' decklists for one of the user's finished games (for the recent-games deck viewer). */

--- a/web-client/src/components/admin/AdminPlayers.tsx
+++ b/web-client/src/components/admin/AdminPlayers.tsx
@@ -17,7 +17,7 @@ import {
   setUserAdmin,
 } from '@/api/adminUsers'
 import type { AdminAuth } from '@/api/adminAuth'
-import { colorForIdentity, colorLabel } from './statFormat'
+import { colorForIdentity, colorLabel, mergeModeBuckets } from './statFormat'
 import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle } from './adminUi'
 import { AdminDeckModal, AdminSavedDecks } from './AdminPlayerDecks'
 
@@ -208,7 +208,7 @@ function PlayerDetail({
 
           {detail.modes.length > 0 && (
             <Panel title="Game modes">
-              <ChipList items={detail.modes.map((m) => `${prettyMode(m.label)} · ${m.count}`)} />
+              <ChipList items={mergeModeBuckets(detail.modes).map((m) => `${m.label} · ${m.count}`)} />
             </Panel>
           )}
 

--- a/web-client/src/components/admin/statFormat.ts
+++ b/web-client/src/components/admin/statFormat.ts
@@ -32,3 +32,80 @@ export function colorForIdentity(colors: string): string {
   if (pips.length === 1) return COLOR_SWATCH[pips[0] as string] as string
   return '#cba14a'
 }
+
+/** Title-case an UPPER_SNAKE enum token: WINSTON_DRAFT → "Winston Draft". */
+function titleCaseToken(token: string): string {
+  return token
+    .toLowerCase()
+    .split('_')
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+    .join(' ')
+}
+
+/** A TournamentFormat enum name as a short label (PREMADE_DECKS reads better as just "Premade"). */
+function prettyFormat(format: string): string {
+  if (format === 'PREMADE_DECKS') return 'Premade'
+  return titleCaseToken(format)
+}
+
+/**
+ * A game's mode as a two-level hierarchy — a top-level category plus an optional variant — so the
+ * profile can show "Tournament › Draft" or "Multiplayer › Two-Headed Giant" instead of a flat
+ * "Tournament" / "Free For All". `gameMode` is a LobbyGameMode name (or QUICK_GAME / CASUAL for
+ * non-lobby games); `format` is the TournamentFormat used to acquire decks, shown as the variant for
+ * tournaments. Falls back to a title-cased token for anything unrecognised.
+ */
+export function gameModeLabel(
+  gameMode: string | null,
+  format: string | null,
+): { primary: string; variant: string | null } {
+  switch (gameMode) {
+    case 'TOURNAMENT':
+      return { primary: 'Tournament', variant: format ? prettyFormat(format) : null }
+    case 'FREE_FOR_ALL':
+      return { primary: 'Multiplayer', variant: 'Free-for-All' }
+    case 'TWO_HEADED_GIANT':
+      return { primary: 'Multiplayer', variant: 'Two-Headed Giant' }
+    case 'TEAM_VS_TEAM':
+      return { primary: 'Multiplayer', variant: 'Team vs Team' }
+    case 'QUICK_GAME':
+      return { primary: 'Quick Game', variant: null }
+    case 'CASUAL':
+      return { primary: 'Casual', variant: null }
+    case 'HOTSEAT':
+      return { primary: 'Hotseat', variant: null }
+    case null:
+    case '':
+    case 'UNKNOWN':
+      return { primary: '—', variant: null }
+    default:
+      return { primary: titleCaseToken(gameMode), variant: null }
+  }
+}
+
+/**
+ * Split a mode-breakdown bucket label — a `"<gameMode>~<format>"` composite emitted by the server's
+ * `modeBreakdown` — into the display hierarchy. Tolerates a bare label (no `~`) defensively.
+ */
+export function splitModeBucket(label: string): { primary: string; variant: string | null } {
+  const sep = label.indexOf('~')
+  const gameMode = sep < 0 ? label || null : label.slice(0, sep) || null
+  const format = sep < 0 ? null : label.slice(sep + 1) || null
+  return gameModeLabel(gameMode, format)
+}
+
+/**
+ * Merge raw mode buckets into display rows, summing any whose hierarchy label collapses to the same
+ * thing (e.g. several quick-game engine formats all read as "Quick Game"). Most-played first.
+ */
+export function mergeModeBuckets(
+  buckets: readonly { label: string; count: number }[],
+): { label: string; count: number }[] {
+  const acc = new Map<string, number>()
+  for (const b of buckets) {
+    const { primary, variant } = splitModeBucket(b.label)
+    const label = variant ? `${primary} › ${variant}` : primary
+    acc.set(label, (acc.get(label) ?? 0) + b.count)
+  }
+  return [...acc.entries()].map(([label, count]) => ({ label, count })).sort((a, b) => b.count - a.count)
+}

--- a/web-client/src/components/profile/StatsDashboard.tsx
+++ b/web-client/src/components/profile/StatsDashboard.tsx
@@ -6,6 +6,7 @@
  * opponents with an account link to their own public profile. An optional read-only recent-games list
  * is shown when provided (public profiles); the signed-in page keeps its own paginated table.
  */
+import { useState } from 'react'
 import type React from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
@@ -33,7 +34,10 @@ import type {
   StatBucket,
   UserTournamentEntry,
 } from '@/api/account'
-import { colorForIdentity, colorLabel } from '@/components/admin/statFormat'
+import { colorForIdentity, colorLabel, splitModeBucket } from '@/components/admin/statFormat'
+import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
+import { EloCell, GameModeCell, OpponentCell } from '@/components/profile/gameHistoryCells'
+import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
 
 export interface StatsDashboardData {
   stats: AccountStats | null
@@ -78,6 +82,7 @@ export function StatsDashboard(props: StatsDashboardData) {
   const { stats, ratings, ratingHistory, colors, cardTypes, curve, creatureTypes, modes, sets, topCards, opponents, tournaments, recentGames } = props
   const navigate = useNavigate()
   const hasData = (stats?.games ?? 0) > 0
+  const [openTournament, setOpenTournament] = useState<number | null>(null)
 
   return (
     <>
@@ -191,7 +196,15 @@ export function StatsDashboard(props: StatsDashboardData) {
 
         {modes.length > 0 && (
           <Panel title="Game modes">
-            <ChipList items={modes.map((m) => `${prettyMode(m.label)} · ${m.count}`)} />
+            <div style={styles.chipRow}>
+              {mergeModes(modes).map((m) => (
+                <span key={`${m.primary}-${m.variant ?? ''}`} style={styles.chip}>
+                  {m.primary}
+                  {m.variant ? <span style={styles.chipVariant}> › {m.variant}</span> : null}
+                  <span style={styles.chipCount}> · {m.count}</span>
+                </span>
+              ))}
+            </div>
           </Panel>
         )}
 
@@ -204,7 +217,7 @@ export function StatsDashboard(props: StatsDashboardData) {
         {opponents.length > 0 && (
           <Panel title="Head to head">
             <p style={styles.subtle}>Most-played human opponents (AI excluded).</p>
-            <SimpleTable head={['Opponent', 'W', 'L']}>
+            <SimpleTable head={['Opponent', { label: 'W', numeric: true }, { label: 'L', numeric: true }]}>
               {opponents.map((o, i) => (
                 <tr key={`${o.opponent}-${i}`}>
                   <td style={styles.td}>
@@ -226,24 +239,25 @@ export function StatsDashboard(props: StatsDashboardData) {
 
         {topCards.length > 0 && (
           <Panel title="Most-played cards">
-            <div style={styles.cardChips}>
-              {topCards.map((c) => (
-                <span key={c.cardName} style={styles.cardChip}>
-                  <span style={styles.cardChipCount}>{c.copies}×</span>
-                  {c.cardName}
-                </span>
-              ))}
-            </div>
+            <TopCards cards={topCards} />
           </Panel>
         )}
 
         {tournaments.length > 0 && (
           <Panel title="Tournaments">
-            <SimpleTable head={['Date', 'Tournament', 'Place']}>
+            <p style={styles.subtle}>Open a tournament to see its final standings and every game’s replay.</p>
+            <SimpleTable head={['Date', 'Tournament', { label: 'Mode' }, { label: 'Place', numeric: true }]}>
               {tournaments.map((t, i) => (
-                <tr key={`${t.endedAt}-${i}`}>
+                <tr
+                  key={`${t.id}-${i}`}
+                  style={styles.clickableRow}
+                  onClick={() => setOpenTournament(t.id)}
+                >
                   <td style={styles.td}>{t.endedAt.slice(0, 10)}</td>
-                  <td style={styles.td}>{t.name ?? '—'}</td>
+                  <td style={styles.tdLink}>{t.name?.trim() || 'Tournament'}</td>
+                  <td style={styles.td}>
+                    <GameModeCell gameMode={t.gameMode} format={t.format} />
+                  </td>
                   <td style={styles.tdNum}>
                     {t.placement}/{t.playerCount}
                   </td>
@@ -256,11 +270,13 @@ export function StatsDashboard(props: StatsDashboardData) {
 
       {recentGames && recentGames.length > 0 && (
         <Panel title="Recent games" wide>
-          <SimpleTable head={['Date', 'Mode', 'Colors', 'Opponent', 'Result']}>
+          <SimpleTable head={['Date', 'Mode', 'Colors', 'Opponent', { label: 'Elo' }, { label: 'Result', numeric: true }]}>
             {recentGames.map((g, i) => (
               <tr key={`${g.gameId}-${i}`}>
                 <td style={styles.td}>{g.endedAt.slice(0, 10)}</td>
-                <td style={styles.td}>{prettyMode(g.gameMode)}</td>
+                <td style={styles.td}>
+                  <GameModeCell gameMode={g.gameMode} format={g.format} />
+                </td>
                 <td style={styles.td}>
                   {g.colors ? (
                     <span style={styles.colorsCell}>
@@ -271,15 +287,62 @@ export function StatsDashboard(props: StatsDashboardData) {
                     '—'
                   )}
                 </td>
-                <td style={styles.td}>{g.opponents ?? '—'}</td>
+                <td style={styles.td}>
+                  <OpponentCell entry={g} />
+                </td>
+                <td style={styles.td}>
+                  <EloCell entry={g} />
+                </td>
                 <td style={{ ...styles.tdNum, color: g.won ? '#5bd16e' : '#e15b6e' }}>{g.won ? 'Win' : 'Loss'}</td>
               </tr>
             ))}
           </SimpleTable>
         </Panel>
       )}
+
+      {openTournament != null && (
+        <TournamentDetailModal tournamentId={openTournament} onClose={() => setOpenTournament(null)} />
+      )}
     </>
   )
+}
+
+/** Most-played cards as count chips, each showing the card art on hover (like the deck viewer). */
+function TopCards({ cards }: { cards: CardStat[] }) {
+  const [hover, setHover] = useState<{ name: string; imageUri: string | null; pos: { x: number; y: number } } | null>(null)
+  return (
+    <div style={styles.cardChips}>
+      {cards.map((c) => (
+        <span
+          key={c.cardName}
+          style={styles.cardChip}
+          onMouseEnter={(e) => setHover({ name: c.cardName, imageUri: c.imageUri, pos: { x: e.clientX, y: e.clientY } })}
+          onMouseMove={(e) => setHover({ name: c.cardName, imageUri: c.imageUri, pos: { x: e.clientX, y: e.clientY } })}
+          onMouseLeave={() => setHover(null)}
+        >
+          <span style={styles.cardChipCount}>{c.copies}×</span>
+          {c.cardName}
+        </span>
+      ))}
+      {hover && <HoverCardPreview name={hover.name} imageUri={hover.imageUri} pos={hover.pos} />}
+    </div>
+  )
+}
+
+/**
+ * Merge raw mode buckets (keyed by a `"<gameMode>~<format>"` composite) into display rows, summing
+ * any whose hierarchy label collapses to the same thing (e.g. several Quick Game engine formats).
+ */
+function mergeModes(modes: StatBucket[]): { primary: string; variant: string | null; count: number }[] {
+  const acc = new Map<string, { primary: string; variant: string | null; count: number }>()
+  for (const m of modes) {
+    const { primary, variant } = splitModeBucket(m.label)
+    const key = `${primary}|${variant ?? ''}`
+    const cur = acc.get(key)
+    if (cur) cur.count += m.count
+    else acc.set(key, { primary, variant, count: m.count })
+  }
+  return [...acc.values()].sort((a, b) => b.count - a.count)
 }
 
 /** Colors-you-play as mana-pip rows with proportional bars. Reads nicer than an axis-labelled chart. */
@@ -289,14 +352,16 @@ function ColorsList({ colors }: { colors: StatBucket[] }) {
     <div style={styles.colorList}>
       {colors.map((c) => (
         <div key={c.label || 'colorless'} style={styles.colorRow}>
-          <span style={styles.colorPips}>{manaPips(c.label)}</span>
-          <span style={styles.colorName}>{colorLabel(c.label)}</span>
+          <div style={styles.colorHead}>
+            <span style={styles.colorPips}>{manaPips(c.label)}</span>
+            <span style={styles.colorName}>{colorLabel(c.label)}</span>
+            <span style={styles.colorCount}>{c.count}</span>
+          </div>
           <span style={styles.colorBarTrack}>
             <span
               style={{ ...styles.colorBarFill, width: `${(c.count / max) * 100}%`, backgroundColor: colorForIdentity(c.label) }}
             />
           </span>
-          <span style={styles.colorCount}>{c.count}</span>
         </div>
       ))}
     </div>
@@ -430,32 +495,35 @@ function ChipList({ items }: { items: string[] }) {
   )
 }
 
-function SimpleTable({ head, children }: { head: string[]; children: React.ReactNode }) {
+/** A table-head cell: a plain string (left-aligned) or `{ label, numeric }` for a right-aligned column. */
+type HeadCell = string | { label: string; numeric?: boolean }
+
+/**
+ * A minimal table whose header alignment matches its body columns. Pass a plain string for a normal
+ * left-aligned column and `{ label, numeric: true }` for a right-aligned numeric column — so headers
+ * always sit over the data they describe (previously every non-first header was forced right).
+ */
+function SimpleTable({ head, children }: { head: HeadCell[]; children: React.ReactNode }) {
   return (
     <div style={styles.tableWrap}>
       <table style={styles.table}>
         <thead>
           <tr>
-            {head.map((h, i) => (
-              <th key={h} style={i === 0 ? styles.th : styles.thNum}>
-                {h}
-              </th>
-            ))}
+            {head.map((h) => {
+              const label = typeof h === 'string' ? h : h.label
+              const numeric = typeof h === 'string' ? false : (h.numeric ?? false)
+              return (
+                <th key={label} style={numeric ? styles.thNum : styles.th}>
+                  {label}
+                </th>
+              )
+            })}
           </tr>
         </thead>
         <tbody>{children}</tbody>
       </table>
     </div>
   )
-}
-
-function prettyMode(mode: string | null): string {
-  if (!mode) return '—'
-  return mode
-    .toLowerCase()
-    .split('_')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ')
 }
 
 const tooltipStyle: React.CSSProperties = {
@@ -521,13 +589,16 @@ const styles: Record<string, React.CSSProperties> = {
   ratingValue: { color: '#fff', fontSize: 30, fontWeight: 800, lineHeight: 1.1, marginTop: 4 },
   ratingTier: { fontSize: 14, fontWeight: 700, marginTop: 2 },
   ratingRecord: { color: '#888', fontSize: 12, marginTop: 4 },
-  colorList: { display: 'flex', flexDirection: 'column', gap: 10 },
-  colorRow: { display: 'flex', alignItems: 'center', gap: 10 },
-  colorPips: { display: 'inline-flex', minWidth: 70, fontSize: 15 },
-  colorName: { color: '#cdd', fontSize: 13, width: 92, flexShrink: 0 },
-  colorBarTrack: { flex: 1, height: 10, backgroundColor: '#1d1d2e', borderRadius: 999, overflow: 'hidden' },
+  // Two rows per colour: pips + name + count on top (wraps for many colours), full-width bar below —
+  // so a five-colour identity never overflows the panel the way a single fixed-width row did.
+  colorList: { display: 'flex', flexDirection: 'column', gap: 12 },
+  colorRow: { display: 'flex', flexDirection: 'column', gap: 5 },
+  colorHead: { display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' },
+  colorPips: { display: 'inline-flex', flexWrap: 'wrap', fontSize: 15, flexShrink: 0 },
+  colorName: { color: '#cdd', fontSize: 13, flex: '1 1 auto', minWidth: 0 },
+  colorBarTrack: { width: '100%', height: 8, backgroundColor: '#1d1d2e', borderRadius: 999, overflow: 'hidden' },
   colorBarFill: { display: 'block', height: '100%', borderRadius: 999 },
-  colorCount: { color: '#aab', fontSize: 12, width: 28, textAlign: 'right', fontVariantNumeric: 'tabular-nums' },
+  colorCount: { color: '#aab', fontSize: 12, marginLeft: 'auto', flexShrink: 0, fontVariantNumeric: 'tabular-nums' },
   legend: { display: 'flex', flexWrap: 'wrap', gap: '6px 14px', marginTop: 8, justifyContent: 'center' },
   legendItem: { display: 'inline-flex', alignItems: 'center', gap: 6, color: '#bbc', fontSize: 12 },
   legendSwatch: { width: 10, height: 10, borderRadius: 3, display: 'inline-block' },
@@ -542,6 +613,8 @@ const styles: Record<string, React.CSSProperties> = {
     color: '#cdd',
     fontSize: 13,
   },
+  chipVariant: { color: '#9aa0b5' },
+  chipCount: { color: '#7f8694' },
   cardChips: { display: 'flex', flexWrap: 'wrap', gap: 8 },
   cardChip: {
     display: 'inline-flex',
@@ -561,6 +634,8 @@ const styles: Record<string, React.CSSProperties> = {
   thNum: { textAlign: 'right', color: '#888', fontWeight: 600, padding: '6px 8px', borderBottom: '1px solid #2a2a3e' },
   td: { textAlign: 'left', color: '#ccc', padding: '6px 8px', borderBottom: '1px solid #1f1f2e' },
   tdNum: { textAlign: 'right', color: '#ccc', padding: '6px 8px', borderBottom: '1px solid #1f1f2e' },
+  tdLink: { textAlign: 'left', color: '#8b9bff', padding: '6px 8px', borderBottom: '1px solid #1f1f2e' },
+  clickableRow: { cursor: 'pointer' },
   opponentLink: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 13, padding: 0 },
   colorsCell: { display: 'inline-flex', alignItems: 'center', gap: 6 },
   colorDot: { width: 9, height: 9, borderRadius: 999, display: 'inline-block' },

--- a/web-client/src/components/profile/TournamentDetailModal.tsx
+++ b/web-client/src/components/profile/TournamentDetailModal.tsx
@@ -1,0 +1,230 @@
+/**
+ * Modal showing one tournament's full public detail: the final standings for every participant and
+ * every game that was played in it (all players', not just the viewer's), each linkable to its
+ * replay. Opened from the Tournaments table on a profile. Player names link to their public profile.
+ */
+import { useEffect, useState } from 'react'
+import type React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { type TournamentDetail, fetchTournamentDetail } from '@/api/account'
+import { gameModeLabel } from '@/components/admin/statFormat'
+
+export function TournamentDetailModal({
+  tournamentId,
+  onClose,
+}: {
+  tournamentId: number
+  onClose: () => void
+}) {
+  const navigate = useNavigate()
+  const [detail, setDetail] = useState<TournamentDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let live = true
+    setDetail(null)
+    setError(null)
+    fetchTournamentDetail(tournamentId)
+      .then((d) => live && setDetail(d))
+      .catch(() => live && setError('Could not load this tournament.'))
+    return () => {
+      live = false
+    }
+  }, [tournamentId])
+
+  const goProfile = (userId: string | null) => {
+    if (userId) {
+      onClose()
+      navigate(`/u/${userId}`)
+    }
+  }
+
+  const mode = detail ? gameModeLabel(detail.gameMode, detail.format) : null
+  const title = detail?.name?.trim() || [detail?.setCodes, mode?.variant ?? mode?.primary].filter(Boolean).join(' ') || 'Tournament'
+
+  return (
+    <div style={styles.backdrop} onClick={onClose} role="presentation">
+      <div style={styles.modal} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
+        <div style={styles.header}>
+          <h2 style={styles.title}>{title}</h2>
+          <button type="button" style={styles.close} onClick={onClose} aria-label="Close">
+            ✕
+          </button>
+        </div>
+        {detail && mode && (
+          <p style={styles.muted}>
+            {mode.primary}
+            {mode.variant ? <span style={styles.variant}> › {mode.variant}</span> : null}
+            {' · '}
+            {detail.playerCount} players · {detail.endedAt.slice(0, 10)}
+          </p>
+        )}
+
+        {error ? (
+          <p style={styles.error}>{error}</p>
+        ) : !detail ? (
+          <p style={styles.muted}>Loading…</p>
+        ) : (
+          <>
+            <h3 style={styles.section}>Final standings</h3>
+            <div style={styles.tableWrap}>
+              <table style={styles.table}>
+                <thead>
+                  <tr>
+                    <th style={styles.thNumLeft}>#</th>
+                    <th style={styles.th}>Player</th>
+                    <th style={styles.thNum}>W</th>
+                    <th style={styles.thNum}>L</th>
+                    <th style={styles.thNum}>D</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detail.standings.map((s, i) => (
+                    <tr key={`${s.playerName}-${i}`}>
+                      <td style={styles.tdRank}>
+                        {s.placement}
+                        {s.placement === 1 ? ' 🏆' : ''}
+                      </td>
+                      <td style={styles.td}>
+                        <PlayerName name={s.playerName} userId={s.userId} isAi={s.isAi} onClick={goProfile} />
+                      </td>
+                      <td style={styles.tdNum}>{s.wins}</td>
+                      <td style={styles.tdNum}>{s.losses}</td>
+                      <td style={styles.tdNum}>{s.draws}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <h3 style={styles.section}>Games</h3>
+            {detail.games.length === 0 ? (
+              <p style={styles.muted}>No game records were stored for this tournament.</p>
+            ) : (
+              <ul style={styles.gameList}>
+                {detail.games.map((g, i) => (
+                  <li key={`${g.gameId}-${i}`} style={styles.gameRow}>
+                    <span style={styles.gamePlayers}>
+                      {g.players.map((p, j) => (
+                        <span key={`${p.name}-${j}`}>
+                          {j > 0 && <span style={styles.vs}> vs </span>}
+                          <span style={p.won ? styles.winner : undefined}>
+                            <PlayerName name={p.name} userId={p.userId} isAi={p.isAi} onClick={goProfile} />
+                            {p.won ? ' ✓' : ''}
+                          </span>
+                        </span>
+                      ))}
+                    </span>
+                    <span style={styles.gameActions}>
+                      <span style={styles.gameDate}>{g.endedAt.slice(0, 10)}</span>
+                      {g.hasReplay ? (
+                        <button
+                          type="button"
+                          style={styles.link}
+                          onClick={() => {
+                            onClose()
+                            navigate(`/replay/${g.gameId}`)
+                          }}
+                        >
+                          Watch
+                        </button>
+                      ) : (
+                        <span style={styles.noReplay}>—</span>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** A player name that links to their public profile when signed in, with an AI tag otherwise. */
+function PlayerName({
+  name,
+  userId,
+  isAi,
+  onClick,
+}: {
+  name: string
+  userId: string | null
+  isAi: boolean
+  onClick: (userId: string | null) => void
+}) {
+  if (userId) {
+    return (
+      <button type="button" style={styles.playerLink} onClick={() => onClick(userId)}>
+        {name}
+      </button>
+    )
+  }
+  return (
+    <span style={styles.playerPlain}>
+      {name}
+      {isAi ? <span style={styles.aiTag}> AI</span> : null}
+    </span>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  backdrop: {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+    zIndex: 1000,
+  },
+  modal: {
+    width: 'min(720px, 100%)',
+    maxHeight: '85vh',
+    overflowY: 'auto',
+    backgroundColor: '#12121e',
+    border: '1px solid #2a2a3e',
+    borderRadius: 14,
+    padding: '20px 22px',
+  },
+  header: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 },
+  title: { margin: 0, color: '#fff', fontSize: 20 },
+  close: { background: 'none', border: 'none', color: '#999', cursor: 'pointer', fontSize: 18 },
+  muted: { margin: '4px 0 0', color: '#888', fontSize: 13 },
+  variant: { color: '#aab' },
+  error: { margin: '8px 0 0', color: '#ff6b6b', fontSize: 13 },
+  section: { margin: '18px 0 8px', color: '#fff', fontSize: 15 },
+  tableWrap: { overflowX: 'auto' },
+  table: { width: '100%', borderCollapse: 'collapse', fontSize: 13 },
+  th: { textAlign: 'left', color: '#888', fontWeight: 600, padding: '6px 8px', borderBottom: '1px solid #2a2a3e' },
+  thNum: { textAlign: 'right', color: '#888', fontWeight: 600, padding: '6px 8px', borderBottom: '1px solid #2a2a3e' },
+  thNumLeft: { textAlign: 'left', color: '#888', fontWeight: 600, padding: '6px 8px', borderBottom: '1px solid #2a2a3e', width: 48 },
+  td: { textAlign: 'left', color: '#ccc', padding: '6px 8px', borderBottom: '1px solid #1f1f2e' },
+  tdNum: { textAlign: 'right', color: '#ccc', padding: '6px 8px', borderBottom: '1px solid #1f1f2e', fontVariantNumeric: 'tabular-nums' },
+  tdRank: { textAlign: 'left', color: '#cdd', padding: '6px 8px', borderBottom: '1px solid #1f1f2e', fontVariantNumeric: 'tabular-nums', fontWeight: 600 },
+  gameList: { listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 6 },
+  gameRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+    flexWrap: 'wrap',
+    backgroundColor: '#171723',
+    border: '1px solid #23233a',
+    borderRadius: 8,
+    padding: '8px 12px',
+  },
+  gamePlayers: { color: '#cdd', fontSize: 13 },
+  vs: { color: '#666' },
+  winner: { color: '#fff', fontWeight: 600 },
+  gameActions: { display: 'inline-flex', alignItems: 'center', gap: 12, flexShrink: 0 },
+  gameDate: { color: '#777', fontSize: 12, fontVariantNumeric: 'tabular-nums' },
+  link: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 13, padding: 0 },
+  noReplay: { color: '#555', fontSize: 13 },
+  playerLink: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 'inherit', padding: 0 },
+  playerPlain: { color: 'inherit' },
+  aiTag: { color: '#888', fontSize: 11 },
+}

--- a/web-client/src/components/profile/gameHistoryCells.tsx
+++ b/web-client/src/components/profile/gameHistoryCells.tsx
@@ -1,0 +1,70 @@
+/**
+ * Shared cell renderers for the recent-games tables used by both the signed-in profile and a public
+ * profile, so the two tables read identically: the game mode as a "Tournament › Draft" hierarchy, the
+ * opponents linked to their public profiles, and each player's ELO at the time of a ranked game.
+ */
+import type React from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { GameHistoryEntry } from '@/api/account'
+import { gameModeLabel } from '@/components/admin/statFormat'
+
+/** The game mode as a top-level category with an optional dimmer variant ("Tournament › Draft"). */
+export function GameModeCell({ gameMode, format }: { gameMode: string | null; format: string | null }) {
+  const { primary, variant } = gameModeLabel(gameMode, format)
+  return (
+    <span>
+      {primary}
+      {variant ? <span style={styles.variant}> › {variant}</span> : null}
+    </span>
+  )
+}
+
+/** Opponent names, each linking to their public profile when the opponent is a signed-in account. */
+export function OpponentCell({ entry }: { entry: GameHistoryEntry }) {
+  const navigate = useNavigate()
+  if (entry.opponentList.length === 0) return <>{entry.opponents ?? '—'}</>
+  return (
+    <span style={styles.opponents}>
+      {entry.opponentList.map((o, i) => (
+        <span key={`${o.name}-${i}`}>
+          {i > 0 && <span style={styles.sep}>, </span>}
+          {o.userId ? (
+            <button type="button" style={styles.link} onClick={() => navigate(`/u/${o.userId}`)}>
+              {o.name}
+            </button>
+          ) : (
+            <span>{o.name}</span>
+          )}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+/** Both players' ELO at the time of a ranked game (you → opponent); a dash for non-ranked games. */
+export function EloCell({ entry }: { entry: GameHistoryEntry }) {
+  if (entry.selfRating == null) return <span style={styles.dim}>—</span>
+  return (
+    <span style={styles.elo}>
+      <span style={styles.eloSelf}>{entry.selfRating}</span>
+      {entry.opponentRating != null && (
+        <>
+          <span style={styles.eloVs}> vs </span>
+          <span style={styles.eloOpp}>{entry.opponentRating}</span>
+        </>
+      )}
+    </span>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  variant: { color: '#9aa0b5' },
+  opponents: { color: 'inherit' },
+  sep: { color: '#666' },
+  link: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 'inherit', padding: 0 },
+  dim: { color: '#666' },
+  elo: { fontVariantNumeric: 'tabular-nums' },
+  eloSelf: { color: '#cdd' },
+  eloVs: { color: '#666' },
+  eloOpp: { color: '#9aa0b5' },
+}

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/api/account'
 import { LoginModal } from '@/components/auth/LoginModal'
 import { DeckViewModal } from '@/components/profile/DeckViewModal'
+import { EloCell, GameModeCell, OpponentCell } from '@/components/profile/gameHistoryCells'
 import { colorForIdentity, colorLabel } from '@/components/admin/statFormat'
 import { useAuthStore } from '@/store/authStore'
 
@@ -203,11 +204,24 @@ export function ProfilePage() {
                   </span>
                 )}
               </div>
-              <SimpleTable head={['Date', 'Mode', 'Colors', 'Opponent', 'Result', 'Deck', 'Replay']}>
+              <SimpleTable
+                head={[
+                  'Date',
+                  'Mode',
+                  'Colors',
+                  'Opponent',
+                  { label: 'Elo' },
+                  { label: 'Result', numeric: true },
+                  { label: 'Deck', numeric: true },
+                  { label: 'Replay', numeric: true },
+                ]}
+              >
                 {history.map((g, i) => (
                   <tr key={`${g.gameId}-${i}`}>
                     <td style={styles.td}>{g.endedAt.slice(0, 10)}</td>
-                    <td style={styles.td}>{prettyMode(g.gameMode)}</td>
+                    <td style={styles.td}>
+                      <GameModeCell gameMode={g.gameMode} format={g.format} />
+                    </td>
                     <td style={styles.td}>
                       {g.colors ? (
                         <span style={styles.colorsCell}>
@@ -218,7 +232,12 @@ export function ProfilePage() {
                         '—'
                       )}
                     </td>
-                    <td style={styles.td}>{g.opponents ?? '—'}</td>
+                    <td style={styles.td}>
+                      <OpponentCell entry={g} />
+                    </td>
+                    <td style={styles.td}>
+                      <EloCell entry={g} />
+                    </td>
                     <td style={{ ...styles.tdNum, color: g.won ? '#5bd16e' : '#e15b6e' }}>
                       {g.won ? 'Win' : 'Loss'}
                     </td>
@@ -324,33 +343,30 @@ function Stat({ label, value }: { label: string; value: number | string }) {
   )
 }
 
-function SimpleTable({ head, children }: { head: string[]; children: React.ReactNode }) {
+/** A table-head cell: a plain string (left-aligned) or `{ label, numeric }` for a right-aligned column. */
+type HeadCell = string | { label: string; numeric?: boolean }
+
+function SimpleTable({ head, children }: { head: HeadCell[]; children: React.ReactNode }) {
   return (
     <div style={styles.tableWrap}>
       <table style={styles.table}>
         <thead>
           <tr>
-            {head.map((h, i) => (
-              <th key={h} style={i === 0 ? styles.th : styles.thNum}>
-                {h}
-              </th>
-            ))}
+            {head.map((h) => {
+              const label = typeof h === 'string' ? h : h.label
+              const numeric = typeof h === 'string' ? false : (h.numeric ?? false)
+              return (
+                <th key={label} style={numeric ? styles.thNum : styles.th}>
+                  {label}
+                </th>
+              )
+            })}
           </tr>
         </thead>
         <tbody>{children}</tbody>
       </table>
     </div>
   )
-}
-
-/** Turn a raw game-mode token (TOURNAMENT / QUICK_GAME / ...) into a readable label. */
-function prettyMode(mode: string | null): string {
-  if (!mode) return '—'
-  return mode
-    .toLowerCase()
-    .split('_')
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ')
 }
 
 const styles: Record<string, React.CSSProperties> = {


### PR DESCRIPTION
Implements the requested profile-page improvements (plus two layout fixes spotted along the way).

## What changed

1. **Game modes show the variant as a hierarchy.** "Tournament › Draft", "Tournament › Premade", "Multiplayer › Two-Headed Giant", etc. — both in the *Game modes* breakdown and the *Recent games* table. `modeBreakdown` now carries the format alongside the mode; a shared `gameModeLabel` / `splitModeBucket` / `mergeModeBuckets` in `statFormat` renders it, and the admin player view reuses the same helpers.
2. **Recent games link to the opponent's profile.** Each human opponent is a link to `/u/:userId` (new `opponentList` with per-seat user ids on `GameHistoryEntry`); AI/guest seats render as plain text.
3. **Recent games show both players' ELO at the time of the game.** New *Elo* column ("you vs opponent"), joined from `rating_history` by game id — your pre-game rating + the opponent's rating at that time. Non-ranked games show a dash.
4. **Most-played cards have a hover preview.** Reuses the existing `HoverCardPreview`; `topCardsForUser` now resolves each card's default-printing art (new `imageUri` on `CardStat`).
5. **"Colors you play" no longer overflows** for 4–5 colour identities — each row is now pips + name + count over a full-width bar instead of a single fixed-width line.
6. **Tournaments are clickable → full detail.** A new **public** `GET /api/stats/tournaments/{id}` returns final standings for *every* participant plus *every* game played in the tournament (not just yours), each with a replay link, shown in a new `TournamentDetailModal`. Games are tied to a tournament via a new `match_results.lobby_id` column (migration **V8**) joined to `tournaments.lobby_id`. Tournaments recorded before this column show standings only (noted in the modal).

**Bonus fix (from the second screenshot):** the *Recent games* header/column misalignment on other players' profiles — `SimpleTable` now aligns each header to its column instead of forcing every non-first header right.

## Notes
- New games carry `lobby_id`; historical games don't, so their tournament's game list is empty (standings still show). No backfill attempted (the live game→lobby link only existed in memory).
- The tournament detail and opponent links are public, consistent with the existing public profile / head-to-head data; decklists remain owner-only.

## Verification
- `just test-server` — BUILD SUCCESSFUL, all tests pass (incl. `MatchResultSinkTest`).
- `npm run typecheck` and `npm run build` — clean.
- Screenshots below captured from the running app via a throwaway preview harness with mock data (the screens need a populated accounts DB to show real data). The screenshots branch is throwaway.

### Profile dashboard (mode variants, colours fix, ELO, opponent links, most-played)
![dashboard](https://raw.githubusercontent.com/wingedsheep/argentum-engine/profile-page-improvements-screenshots/profile-dashboard.png)

### Most-played card hover preview
![hover](https://raw.githubusercontent.com/wingedsheep/argentum-engine/profile-page-improvements-screenshots/profile-hover.png)

### Tournament detail (standings + every game's replay)
![tournament](https://raw.githubusercontent.com/wingedsheep/argentum-engine/profile-page-improvements-screenshots/tournament-modal.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)