### PR TITLE
Add Yue, the Moon Spirit to Avatar: The Last Airbender

### DIFF
--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,11 +2,11 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 231 / 286
+**Implemented:** 232 / 286
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
-> **Status (June 2026):** 231/286 implemented. Every card buildable on the *current* engine has been
-> added — the 55 remaining all need new engine/SDK work first (see the gap analysis). Since the
+> **Status (June 2026):** 232/286 implemented. Every card buildable on the *current* engine has been
+> added — the 54 remaining all need new engine/SDK work first (see the gap analysis). Since the
 > original gap doc was written, **Firebending**, the **Vigilance keyword counter**, the
 > **Nth-card-drawn** and **Surveil** triggers, **`PERMANENTS_SACRIFICED`**, **dynamic Earthbend**,
 > and the **spell-level Waterbend additional cost** (including **waterbend {X}**) all landed, which
@@ -357,7 +357,7 @@ up by Airbend, not Firebending).
 - [ ] White Lotus Tile
 - [x] Wolfbat
 - [x] Yip Yip!
-- [ ] Yue, the Moon Spirit
+- [x] Yue, the Moon Spirit
 - [x] Yuyan Archers
 - [ ] Zhao, Ruthless Admiral
 - [ ] Zhao, the Moon Slayer

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/YueTheMoonSpirit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/YueTheMoonSpirit.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Yue, the Moon Spirit
+ * {3}{U}
+ * Legendary Creature — Spirit Ally
+ * 3/3
+ *
+ * Flash
+ * Flying, vigilance
+ * Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost.
+ *
+ * The waterbend cost is the existing activated-ability carrier (`hasWaterbend = true`). The body is
+ * the standard gather → choose-up-to-one → cast-without-paying pipeline (as on Kellan, the Kid):
+ * [GatherCardsEffect] pulls noncreature, nonland cards from hand, [SelectFromCollectionEffect]
+ * makes the "you may" choice (up to one), and [Effects.CastFromCollectionWithoutPayingCost] casts
+ * the chosen card for free.
+ */
+val YueTheMoonSpirit = card("Yue, the Moon Spirit") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Spirit Ally"
+    power = 3
+    toughness = 3
+    oracleText = "Flash\n" +
+        "Flying, vigilance\n" +
+        "Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost. " +
+        "(While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)"
+
+    keywords(Keyword.FLASH, Keyword.FLYING, Keyword.VIGILANCE)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap)
+        hasWaterbend = true
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                CardSource.FromZone(Zone.HAND, filter = GameObjectFilter.Nonland.notCreature()),
+                storeAs = "yueCandidates",
+            ),
+            SelectFromCollectionEffect(
+                from = "yueCandidates",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "yueChosen",
+                selectedLabel = "Cast without paying its mana cost",
+            ),
+            Effects.CastFromCollectionWithoutPayingCost("yueChosen"),
+        )
+        description = "You may cast a noncreature spell from your hand without paying its mana cost."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "83"
+        artist = "Yuumei"
+        flavorText = "\"You'll save the world again. But you can't give up.\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/c/ecdac50f-c639-43fc-a03e-d488fac96ae2.jpg?1764120573"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/YueTheMoonSpirit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/YueTheMoonSpirit.kt
@@ -19,7 +19,6 @@ import com.wingedsheep.sdk.scripting.values.DynamicAmount
  * Legendary Creature — Spirit Ally
  * 3/3
  *
- * Flash
  * Flying, vigilance
  * Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost.
  *
@@ -35,12 +34,11 @@ val YueTheMoonSpirit = card("Yue, the Moon Spirit") {
     typeLine = "Legendary Creature — Spirit Ally"
     power = 3
     toughness = 3
-    oracleText = "Flash\n" +
-        "Flying, vigilance\n" +
+    oracleText = "Flying, vigilance\n" +
         "Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost. " +
         "(While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)"
 
-    keywords(Keyword.FLASH, Keyword.FLYING, Keyword.VIGILANCE)
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
 
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{5}"), Costs.Tap)

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -17045,13 +17045,12 @@
     "name": "Yue, the Moon Spirit",
     "manaCost": "{3}{U}",
     "typeLine": "Legendary Creature — Spirit Ally",
-    "oracleText": "Flash\nFlying, vigilance\nWaterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost. (While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)",
+    "oracleText": "Flying, vigilance\nWaterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost. (While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)",
     "creatureStats": {
         "power": 3,
         "toughness": 3
     },
     "keywords": [
-        "FLASH",
         "FLYING",
         "VIGILANCE"
     ],

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -17040,6 +17040,94 @@
     ]
 }
 
+// Yue, the Moon Spirit
+{
+    "name": "Yue, the Moon Spirit",
+    "manaCost": "{3}{U}",
+    "typeLine": "Legendary Creature — Spirit Ally",
+    "oracleText": "Flash\nFlying, vigilance\nWaterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost. (While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsNonland",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsCreature"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "yueCandidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "yueCandidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "yueChosen",
+                            "selectedLabel": "Cast without paying its mana cost"
+                        },
+                        {
+                            "type": "CastFromCollectionWithoutPayingCost",
+                            "from": "yueChosen"
+                        }
+                    ]
+                },
+                "descriptionOverride": "You may cast a noncreature spell from your hand without paying its mana cost.",
+                "hasWaterbend": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "RARE",
+        "artist": "Yuumei",
+        "flavorText": "\"You'll save the world again. But you can't give up.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/c/ecdac50f-c639-43fc-a03e-d488fac96ae2.jpg?1764120573"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Yuyan Archers
 {
     "name": "Yuyan Archers",

--- a/review.md
+++ b/review.md
@@ -1,0 +1,58 @@
+# Review: Add Yue, the Moon Spirit (TLA)
+
+## Verdict
+The SDK shape is **right** — the card composes existing pipeline primitives with zero new
+types, exactly the SDK-elegance goal. The one **blocking correctness bug** was that the
+implementation gave Yue **Flash**, which the real card does not have. Verified against both
+the local `bolav/tla_full.json` and the live Scryfall API (`set=tla`): keywords are only
+`Flying, Vigilance, Waterbend`. *(Fixed — see Resolution below.)*
+
+## What's good (kept)
+- **Pure primitive composition, no new SDK types.** `GatherCardsEffect →
+  SelectFromCollectionEffect(ChooseUpTo 1) → Effects.CastFromCollectionWithoutPayingCost`
+  mirrors `KellanTheKid` exactly. Nothing card-specific leaked into the engine.
+- **Reuses the existing waterbend carrier** (`hasWaterbend = true`) rather than inventing a
+  cost type.
+- **Filter models the oracle precisely.** `GameObjectFilter.Nonland.notCreature()` →
+  `IsNonland ∧ ¬IsCreature` correctly captures "noncreature spell" (lands aren't spells;
+  artifact-creatures are still creature spells and excluded).
+- **Tests are well-designed.** The exact-`{5}`-blue-mana trick makes the free cast observable
+  (the `{2}{U}` enchantment can only resolve onto the battlefield if it was genuinely cast for
+  free), and the second test covers the decline path (`emptyList()` selection → stays in hand).
+- Mana cost, subtype (`Spirit Ally`), color identity, P/T, rarity, collector number, artist,
+  flavor, and image all match Scryfall.
+- Registration is correct — TLA uses `CardDiscovery.findIn(CARDS_PACKAGE)` reflection, so
+  dropping the file in `cards/` is sufficient; no manual set-file edit needed.
+
+## Issues
+
+### Blocking
+- **`YueTheMoonSpirit.kt:43` — `Keyword.FLASH`.** The real card has no Flash; this materially
+  changes it (lets you cast Yue at instant speed). Remove from `keywords(...)`.
+- **`YueTheMoonSpirit.kt:38` — `"Flash\n"` oracle prefix.** Scryfall oracle starts at
+  `"Flying, vigilance\n…"`. Also remove the doc-comment line at `:22`.
+- **Re-bless the snapshot** (`mtg-sets/.../snapshots/cards/TLA.json`) after the fix — it pinned
+  the wrong `"FLASH"` keyword and oracle text.
+
+### Minor
+- **Backlog not updated.** `backlog/sets/avatar-the-last-airbender/cards.md` showed
+  `- [ ] Yue, the Moon Spirit` and the header count still read `231 / 286`.
+- The two tests exercise the pipeline but not the keyword set, so they would *not* have caught
+  the Flash bug — the snapshot is the only net there.
+
+## Test result
+Both scenario tests pass (`BUILD SUCCESSFUL`):
+- `Waterbend ability casts a noncreature spell from hand for free` — PASSED
+- `declining the optional cast leaves the spell in hand` — PASSED
+
+As predicted, the green tests don't catch the Flash bug (they don't assert on keywords).
+
+## Resolution (applied)
+1. Removed `Keyword.FLASH` (`:43`), the `"Flash\n"` oracle prefix (`:38`), and the comment
+   line (`:22`).
+2. Re-blessed `TLA.json` (FLASH keyword + oracle text corrected).
+3. Checked Yue off in the backlog and bumped the count to `232 / 286` (and `55 → 54` remaining).
+
+No engine/SDK changes needed — the composition is correct and reusable as-is. The branch
+already had `origin/main` merged (was up to date — no merge commit). Review ran in place; no
+worktree created.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YueTheMoonSpiritScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YueTheMoonSpiritScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.tla.cards.YueTheMoonSpirit
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Yue, the Moon Spirit.
+ *
+ * Yue, the Moon Spirit ({3}{U}): Legendary Creature — Spirit Ally, 3/3, Flash, Flying, vigilance.
+ * "Waterbend {5}, {T}: You may cast a noncreature spell from your hand without paying its mana cost."
+ *
+ * Exercises the activated-ability waterbend carrier (`hasWaterbend = true`) plus the
+ * gather → choose-up-to-one → cast-without-paying pipeline filtered to noncreature, nonland cards.
+ */
+class YueTheMoonSpiritScenarioTest : FunSpec({
+
+    // A {2}{U} noncreature permanent with no targeting — a clean, observable free-cast payoff
+    // (it simply enters the battlefield on resolution).
+    val freeSpell = card("Yue Test Free Spell") {
+        manaCost = "{2}{U}"
+        typeLine = "Enchantment"
+        oracleText = "Test enchantment."
+    }
+
+    val abilityId = YueTheMoonSpirit.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(YueTheMoonSpirit))
+        driver.registerCard(freeSpell)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("Waterbend ability casts a noncreature spell from hand for free") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val yue = driver.putCreatureOnBattlefield(player, "Yue, the Moon Spirit")
+        driver.removeSummoningSickness(yue)
+        val spell = driver.putCardInHand(player, "Yue Test Free Spell")
+        // Exactly enough mana to pay the {5} activation — and nothing left over, so the {2}{U}
+        // enchantment can only enter if it was genuinely cast without paying.
+        driver.giveMana(player, Color.BLUE, 5)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = yue, abilityId = abilityId),
+        ).isSuccess shouldBe true
+
+        // The ability is on the stack — both players pass so it resolves, then it pauses to
+        // choose the noncreature spell to free-cast.
+        driver.passPriority(player)
+        driver.passPriority(driver.getOpponent(player))
+        driver.submitCardSelection(player, listOf(spell))
+        driver.bothPass()
+
+        // The enchantment was cast for free and is now on the battlefield, out of hand.
+        (spell in driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD))) shouldBe true
+        (spell in driver.state.getZone(ZoneKey(player, Zone.HAND))) shouldBe false
+        // The {T} cost tapped Yue.
+        driver.isTapped(yue) shouldBe true
+    }
+
+    test("declining the optional cast leaves the spell in hand") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val yue = driver.putCreatureOnBattlefield(player, "Yue, the Moon Spirit")
+        driver.removeSummoningSickness(yue)
+        val spell = driver.putCardInHand(player, "Yue Test Free Spell")
+        driver.giveMana(player, Color.BLUE, 5)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = yue, abilityId = abilityId),
+        ).isSuccess shouldBe true
+
+        // Resolve the ability off the stack, then decline the optional cast (choose nothing).
+        driver.passPriority(player)
+        driver.passPriority(driver.getOpponent(player))
+        driver.submitCardSelection(player, emptyList())
+        driver.bothPass()
+
+        // The spell never left the player's hand.
+        (spell in driver.state.getZone(ZoneKey(player, Zone.HAND))) shouldBe true
+        (spell in driver.state.getZone(ZoneKey(player, Zone.BATTLEFIELD))) shouldBe false
+    }
+})


### PR DESCRIPTION
Brought over from the tla-vigelance-counter branch (the only net-new card there; the rest were already on this branch in newer form). Waterbend {5}, {T}: cast a noncreature spell from hand for free, via the existing hasWaterbend activated-ability carrier. Reblessed the TLA card snapshot.