### PR TITLE
Add "Save deck" to the recent-games deck viewer

### DIFF
--- a/web-client/src/components/deck/GameDeckView.tsx
+++ b/web-client/src/components/deck/GameDeckView.tsx
@@ -139,9 +139,21 @@ export function DeckCardBody({ cards }: { cards: GameDeckCard[] }) {
   )
 }
 
-/** One seat in a game's deck view: a header (name / result / colours) above its {@link DeckCardBody}. */
-export function SeatDeckColumn({ p }: { p: GameDeckParticipant }) {
+/**
+ * One seat in a game's deck view: a header (name / result / colours) above its {@link DeckCardBody}.
+ * `renderActions` is an optional slot for per-seat controls (e.g. a "Save deck" button) — the
+ * recent-games modal supplies one; the admin viewer leaves it unset. Keeping it a render prop lets
+ * this component stay a pure renderer with no save-store dependency.
+ */
+export function SeatDeckColumn({
+  p,
+  renderActions,
+}: {
+  p: GameDeckParticipant
+  renderActions?: (p: GameDeckParticipant) => React.ReactNode
+}) {
   const total = p.cards.reduce((sum, c) => sum + c.copies, 0)
+  const actions = renderActions?.(p)
   return (
     <div style={styles.col}>
       <div style={styles.colHead}>
@@ -155,17 +167,24 @@ export function SeatDeckColumn({ p }: { p: GameDeckParticipant }) {
         <span>{p.colors ? colorLabel(p.colors) : 'Colourless'}</span>
         <span style={styles.dim}>· {total} cards</span>
       </div>
+      {actions ? <div style={styles.actions}>{actions}</div> : null}
       <DeckCardBody cards={p.cards} />
     </div>
   )
 }
 
 /** Both seats' decks side by side — the body of the recent-games / admin deck modal. */
-export function GameDeckColumns({ participants }: { participants: GameDeckParticipant[] }) {
+export function GameDeckColumns({
+  participants,
+  renderActions,
+}: {
+  participants: GameDeckParticipant[]
+  renderActions?: (p: GameDeckParticipant) => React.ReactNode
+}) {
   return (
     <div style={styles.columns}>
       {participants.map((p, i) => (
-        <SeatDeckColumn key={`${p.playerName}-${i}`} p={p} />
+        <SeatDeckColumn key={`${p.playerName}-${i}`} p={p} {...(renderActions ? { renderActions } : {})} />
       ))}
     </div>
   )
@@ -187,6 +206,7 @@ const styles: Record<string, React.CSSProperties> = {
   resultTag: { fontSize: 12, fontWeight: 700 },
   aiTag: { color: '#888', fontSize: 11 },
   colMeta: { display: 'flex', alignItems: 'center', gap: 6, color: '#bbb', fontSize: 12, margin: '6px 0 4px' },
+  actions: { margin: '2px 0 4px' },
   dim: { color: '#777' },
   body: { display: 'flex', flexDirection: 'column', gap: 12, marginTop: 8 },
   pips: { display: 'flex', flexWrap: 'wrap', gap: 10 },

--- a/web-client/src/components/profile/DeckViewModal.tsx
+++ b/web-client/src/components/profile/DeckViewModal.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import type React from 'react'
 import { type GameDecks, fetchGameDecks } from '@/api/account'
 import { GameDeckColumns } from '@/components/deck/GameDeckView'
+import { SaveGameDeckButton } from '@/components/profile/SaveGameDeckButton'
 
 export function DeckViewModal({
   gameId,
@@ -51,7 +52,10 @@ export function DeckViewModal({
           <p style={styles.muted}>No decklist was recorded for this game.</p>
         ) : (
           <div style={styles.columnsWrap}>
-            <GameDeckColumns participants={decks.participants} />
+            <GameDeckColumns
+              participants={decks.participants}
+              renderActions={(p) => <SaveGameDeckButton participant={p} endedAt={decks.endedAt} />}
+            />
           </div>
         )}
       </div>

--- a/web-client/src/components/profile/SaveGameDeckButton.tsx
+++ b/web-client/src/components/profile/SaveGameDeckButton.tsx
@@ -1,0 +1,156 @@
+/**
+ * "Save deck" control for one seat in the recent-games deck viewer ({@link DeckViewModal}).
+ *
+ * A recorded game deck is just a name→copies list (the registry-enriched {@link GameDeckCard} lines
+ * carry no printing pins), so saving it produces a name-only deck — exactly what the deckbuilder
+ * accepts. The save routes through {@link useSaveDeck}, so it lands in the user's account when signed
+ * in and in the browser library otherwise, matching every other "save a deck" button in the app.
+ *
+ * Clicking expands an inline name field (prefilled with a sensible default) so the player can title
+ * the deck before it is saved — important because account saves upsert by name and would otherwise
+ * silently overwrite a same-named deck.
+ */
+import { useState } from 'react'
+import type React from 'react'
+import type { GameDeckParticipant } from '@/api/account'
+import { useSaveDeck } from '@/store/useSaveDeck'
+
+/** Build the default deck name from the seat and the game's date (YYYY-MM-DD prefix of the ISO ts). */
+function defaultName(p: GameDeckParticipant, endedAt: string): string {
+  const date = endedAt.slice(0, 10)
+  const who = p.isSelf ? 'My deck' : `${p.playerName}’s deck`
+  return date ? `${who} · ${date}` : who
+}
+
+type Phase =
+  | { kind: 'idle' }
+  | { kind: 'editing'; name: string }
+  | { kind: 'saving' }
+  | { kind: 'done'; online: boolean }
+  | { kind: 'error' }
+
+export function SaveGameDeckButton({
+  participant,
+  endedAt,
+}: {
+  participant: GameDeckParticipant
+  endedAt: string
+}) {
+  const { save, isLoggedIn } = useSaveDeck()
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' })
+
+  // No decklist recorded for this seat — nothing to save.
+  if (participant.cards.length === 0) return null
+
+  const doSave = async (name: string) => {
+    const trimmed = name.trim() || defaultName(participant, endedAt)
+    const cards: Record<string, number> = {}
+    for (const c of participant.cards) cards[c.cardName] = c.copies
+    setPhase({ kind: 'saving' })
+    try {
+      const result = await save({ name: trimmed, cards })
+      setPhase({ kind: 'done', online: result.online })
+    } catch {
+      setPhase({ kind: 'error' })
+    }
+  }
+
+  if (phase.kind === 'done') {
+    return (
+      <span style={styles.feedback} title={phase.online ? 'Saved to your account' : 'Saved to this browser'}>
+        Saved {phase.online ? 'online' : 'locally'} ✓
+      </span>
+    )
+  }
+
+  if (phase.kind === 'error') {
+    return (
+      <button type="button" style={styles.button} onClick={() => setPhase({ kind: 'idle' })}>
+        Save failed — retry
+      </button>
+    )
+  }
+
+  if (phase.kind === 'editing') {
+    return (
+      <form
+        style={styles.editRow}
+        onSubmit={(e) => {
+          e.preventDefault()
+          void doSave(phase.name)
+        }}
+      >
+        <input
+          autoFocus
+          style={styles.input}
+          value={phase.name}
+          onChange={(e) => setPhase({ kind: 'editing', name: e.target.value })}
+          aria-label="Deck name"
+        />
+        <button type="submit" style={styles.saveBtn}>
+          Save
+        </button>
+        <button type="button" style={styles.cancelBtn} onClick={() => setPhase({ kind: 'idle' })}>
+          Cancel
+        </button>
+      </form>
+    )
+  }
+
+  if (phase.kind === 'saving') {
+    return <span style={styles.feedback}>Saving…</span>
+  }
+
+  return (
+    <button
+      type="button"
+      style={styles.button}
+      onClick={() => setPhase({ kind: 'editing', name: defaultName(participant, endedAt) })}
+      title={isLoggedIn ? 'Save this deck to your account' : 'Save this deck to your browser'}
+    >
+      Save deck
+    </button>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  button: {
+    background: '#23233a',
+    border: '1px solid #3a3a55',
+    color: '#cdd0e6',
+    borderRadius: 8,
+    padding: '4px 10px',
+    fontSize: 12,
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+  feedback: { color: '#5bd16e', fontSize: 12, fontWeight: 600 },
+  editRow: { display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' },
+  input: {
+    background: '#0f0f1a',
+    border: '1px solid #3a3a55',
+    color: '#e6e8f2',
+    borderRadius: 8,
+    padding: '4px 8px',
+    fontSize: 12,
+    minWidth: 0,
+    flex: '1 1 120px',
+  },
+  saveBtn: {
+    background: '#4456d6',
+    border: '1px solid #5566e6',
+    color: '#fff',
+    borderRadius: 8,
+    padding: '4px 10px',
+    fontSize: 12,
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+  cancelBtn: {
+    background: 'none',
+    border: 'none',
+    color: '#999',
+    fontSize: 12,
+    cursor: 'pointer',
+  },
+}


### PR DESCRIPTION
## Summary

When reviewing a past game from your profile, the deck-view modal now lets you **save a deck**. Each seat's deck column gets a **Save deck** button; clicking it opens an inline name field (prefilled with a sensible default like *"My deck · 2026-06-29"*) and saves the recorded decklist through the shared `useSaveDeck` hook — **to your account when signed in, to the browser library otherwise** — with inline feedback ("Saved online ✓" / "Saved locally ✓").

The button shows on every seat, so you can also netdeck an interesting opponent list. This modal is only used on your own logged-in profile (not public profiles or the admin viewer).

## Changes

- **`SaveGameDeckButton.tsx`** (new) — converts a recorded `GameDeckParticipant`'s cards into a name-only `SaveDeckInput` and routes it through `useSaveDeck`. Hidden when no decklist was recorded for that seat.
- **`GameDeckView.tsx`** — added an optional `renderActions` render-prop slot to `SeatDeckColumn`/`GameDeckColumns`, keeping the renderer a pure component with no save-store dependency, so the admin deck viewer that reuses it is unaffected.
- **`DeckViewModal.tsx`** — injects the save button per seat.

## Notes

- Recorded game decks carry no per-card printing pins (only image URLs), so the save is **name-only** — exactly what the deckbuilder accepts; the saved deck resolves default printings. Commander/format designation is not recovered from a recorded game.
- Account saves upsert by name, hence the editable name field to avoid silently overwriting a same-named deck.

## Testing

- `npm run typecheck` — clean
- `npm run build` — clean (pre-existing chunk-size warning only)
- No screenshot: capturing needs the full stack plus a logged-in account with recorded game history, which isn't reproducible in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)