### PR TITLE
Keep revealed/returned cards visible in hand until a same-named card is played

### DIFF
--- a/docs/architecture-principles.md
+++ b/docs/architecture-principles.md
@@ -1126,6 +1126,11 @@ per-player view of the state that hides private information:
 - **Face-down cards:** Show as generic "Card back" to all players (even the controller cannot see
   the identity in the masked view — only when they choose to interact)
 - **Revealed cards:** `RevealedToComponent` overrides hiding for cards that have been explicitly revealed
+- **Revealed / returned hand cards:** A card revealed *into* a hand, or returned to a hand from a public
+  zone (battlefield, graveyard, the stack), stays visible to opponents until its owner *plays* a card with
+  the same name (the known copy then becomes indistinguishable from the one just played) or it leaves the
+  hand. `RevealedInHandTracker` (run over each action's events in `ActionProcessor`) manages this
+  `RevealedToComponent` lifecycle; the transformer just reads the component as above.
 
 **Why server-side masking instead of client-side filtering?**
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ActionProcessor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ActionProcessor.kt
@@ -84,8 +84,11 @@ class ActionProcessor(
             return ProcessedAction(ExecutionResult.error(state, validationError))
         }
 
-        // Execute the action and compute undo policy
-        val result = registry.execute(state, action)
+        // Execute the action, then update which revealed/returned cards opponents may see
+        // (cards revealed into hand or bounced back to hand stay visible until a same-named
+        // card is played — see [RevealedInHandTracker]).
+        val result = com.wingedsheep.engine.mechanics.RevealedInHandTracker
+            .applyAfterAction(registry.execute(state, action))
         val undoPolicy = if (computeUndo) {
             UndoPolicyComputer.compute(action, state, result, services.cardRegistry)
         } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/RevealedInHandTracker.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.mechanics
+
+import com.wingedsheep.engine.core.CardsRevealedEvent
+import com.wingedsheep.engine.core.ExecutionResult
+import com.wingedsheep.engine.core.SpellCastEvent
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.handlers.effects.library.LibraryRevealUtils
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Keeps opponents informed of cards whose identity became public *as they entered their
+ * owner's hand*, and lets that knowledge expire the way it does on MTGO/Arena: a card a
+ * player reveals into their hand, or returns to their hand from a public zone, stays
+ * face-up to opponents until that player **plays a card with the same name** — at which
+ * point the opponent can no longer tell the known copy from the one just played, so the
+ * knowledge is forgotten.
+ *
+ * Visibility itself is the existing [RevealedToComponent] mechanism consulted by
+ * [com.wingedsheep.engine.view.ClientStateTransformer]; this tracker only manages the
+ * *lifecycle* of that component for cards sitting in the [Zone.HAND]:
+ *
+ *  - **Reveal into hand** — a [CardsRevealedEvent] for a card now in its owner's hand
+ *    (CR 701.16: revealing shows the card to every player), and **return to hand from a
+ *    public zone** — a [ZoneChangeEvent] into [Zone.HAND] from the battlefield, a
+ *    graveyard, or the stack — mark the card known to the whole table.
+ *  - **Playing a same-named card from hand** — a [SpellCastEvent] whose spell was cast
+ *    from hand, or a land played from hand — forgets every still-known copy of that name
+ *    in the player's hand.
+ *  - **Leaving the hand** — any [ZoneChangeEvent] out of [Zone.HAND] drops that card's
+ *    hand-knowledge, so it can't leak once the card is hidden again (e.g. cast face-down,
+ *    or put back on top of the library).
+ *
+ * It deliberately does **not** touch library/face-down reveals: a private tutor to hand
+ * (a [Zone.LIBRARY] → [Zone.HAND] move with no reveal) stays hidden, returns from
+ * [Zone.EXILE]/[Zone.SIDEBOARD] are left alone (a face-down-exiled card must not leak),
+ * and only cards currently in a hand are ever marked or cleared.
+ *
+ * Pure and event-driven: it runs once over each action's emitted events from
+ * [com.wingedsheep.engine.core.ActionProcessor], so it replays deterministically.
+ */
+object RevealedInHandTracker {
+
+    /**
+     * Zones whose contents are public knowledge, so a card returning from them to a hand
+     * keeps being known to opponents. [Zone.EXILE]/[Zone.COMMAND] are excluded: cards can
+     * sit face-down in exile, and marking those known on return would leak their identity.
+     */
+    private val PUBLIC_RETURN_SOURCES = setOf(Zone.BATTLEFIELD, Zone.GRAVEYARD, Zone.STACK)
+
+    /**
+     * Apply the hand-reveal lifecycle for the events an action produced, returning the
+     * (possibly updated) result. A no-op for results without events (errors, plain passes).
+     */
+    fun applyAfterAction(result: ExecutionResult): ExecutionResult {
+        if (result.events.isEmpty()) return result
+        var state = result.state
+        for (event in result.events) {
+            state = when (event) {
+                is CardsRevealedEvent -> onCardsRevealed(state, event)
+                is ZoneChangeEvent -> onZoneChange(state, event)
+                is SpellCastEvent -> onSpellCast(state, event)
+                else -> state
+            }
+        }
+        return if (state === result.state) result else result.copy(state = state)
+    }
+
+    private fun onCardsRevealed(state: GameState, event: CardsRevealedEvent): GameState {
+        val inHand = event.cardIds.filter { isInOwnersHand(state, it) }
+        if (inHand.isEmpty()) return state
+        return LibraryRevealUtils.markRevealed(state, inHand, state.turnOrder)
+    }
+
+    private fun onZoneChange(state: GameState, event: ZoneChangeEvent): GameState {
+        // Returned to hand from a public zone → known to the whole table.
+        if (event.toZone == Zone.HAND && event.fromZone in PUBLIC_RETURN_SOURCES) {
+            return if (isInOwnersHand(state, event.entityId)) {
+                LibraryRevealUtils.markRevealed(state, listOf(event.entityId), state.turnOrder)
+            } else {
+                state
+            }
+        }
+        // Left the hand → forget this card's hand-knowledge so it can't leak once hidden.
+        if (event.fromZone == Zone.HAND) {
+            var newState = LibraryRevealUtils.clearReveals(state, listOf(event.entityId))
+            // A land enters the battlefield straight from hand (it is never cast), so the
+            // land play itself is the "play a same-named card" trigger.
+            if (event.toZone == Zone.BATTLEFIELD) {
+                newState = forgetSameNamedInHand(newState, event.ownerId, event.entityName)
+            }
+            return newState
+        }
+        return state
+    }
+
+    private fun onSpellCast(state: GameState, event: SpellCastEvent): GameState {
+        // The cast card is public on the stack regardless; dropping its hand-knowledge also
+        // stops a bounced-then-cast-face-down card from leaking its real identity.
+        var newState = LibraryRevealUtils.clearReveals(state, listOf(event.spellEntityId))
+        val castFromZone = state.getEntity(event.spellEntityId)
+            ?.get<SpellOnStackComponent>()?.castFromZone
+        // Only a card played *from hand* makes the known copies of its name ambiguous;
+        // casting the same name from the graveyard/exile leaves the hand copy identifiable.
+        if (castFromZone == Zone.HAND) {
+            newState = forgetSameNamedInHand(newState, event.casterId, event.cardName)
+        }
+        return newState
+    }
+
+    /** Forget every still-known card named [name] in [playerId]'s hand. */
+    private fun forgetSameNamedInHand(state: GameState, playerId: EntityId, name: String): GameState {
+        val sameNamed = state.getHand(playerId).filter { cardId ->
+            val container = state.getEntity(cardId) ?: return@filter false
+            container.get<RevealedToComponent>() != null &&
+                container.get<CardComponent>()?.name == name
+        }
+        if (sameNamed.isEmpty()) return state
+        return LibraryRevealUtils.clearReveals(state, sameNamed)
+    }
+
+    private fun isInOwnersHand(state: GameState, cardId: EntityId): Boolean {
+        val ownerId = state.getEntity(cardId)?.get<CardComponent>()?.ownerId ?: return false
+        return cardId in state.getHand(ownerId)
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RevealedHandVisibilityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RevealedHandVisibilityScenarioTest.kt
@@ -1,0 +1,185 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RevealedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cards revealed into a hand, or returned to a hand from a public zone, stay visible to
+ * opponents until the hand's owner *plays* a card with the same name — the way MTGO/Arena
+ * keeps showing a known card until it can no longer be told apart from a freshly played one.
+ *
+ * Exercises [com.wingedsheep.engine.mechanics.RevealedInHandTracker], which manages the
+ * [RevealedToComponent] lifecycle for the [Zone.HAND] over each action's emitted events.
+ */
+class RevealedHandVisibilityScenarioTest : ScenarioTestBase() {
+
+    /** Players whom [cardId] is currently revealed to. */
+    private fun GameState.revealedTo(cardId: EntityId): Set<EntityId> =
+        getEntity(cardId)?.get<RevealedToComponent>()?.playerIds ?: emptySet()
+
+    /** The id of the (first) card named [name] in [playerId]'s hand. */
+    private fun GameState.handCard(playerId: EntityId, name: String): EntityId =
+        getHand(playerId).first { getEntity(it)?.get<CardComponent>()?.name == name }
+
+    init {
+        context("revealed / returned cards stay visible to opponents") {
+
+            test("a creature bounced back to its owner's hand becomes visible to the opponent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Unsummon")
+                    .withCardInHand(1, "Forest") // an unrelated hand card to prove scoping
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val secretCard = game.state.handCard(game.player1Id, "Forest")
+                val unsummonId = game.state.handCard(game.player1Id, "Unsummon")
+
+                // Player1 casts Unsummon on their own Grizzly Bears, returning it to hand.
+                val cast = game.execute(
+                    CastSpell(game.player1Id, unsummonId, listOf(ChosenTarget.Permanent(bears)))
+                )
+                withClue("Unsummon should cast: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Grizzly Bears is back in Player1's hand") {
+                    game.state.getHand(game.player1Id) shouldContain bears
+                }
+                withClue("the bounced creature is now known to the opponent (Player2)") {
+                    game.state.revealedTo(bears) shouldContain game.player2Id
+                }
+                withClue("an unrelated card in the same hand stays hidden — only the bounced card is shown") {
+                    (game.player2Id in game.state.revealedTo(secretCard)).shouldBeFalse()
+                }
+
+                // End to end: Player2's view of Player1's hand actually exposes the card face-up.
+                val opponentView = game.getClientState(2)
+                val p1Hand = opponentView.zones.first {
+                    it.zoneId.ownerId == game.player1Id && it.zoneId.zoneType == Zone.HAND
+                }
+                withClue("opponent's masked view exposes the bounced card id and full card data") {
+                    p1Hand.cardIds shouldContain bears
+                    opponentView.cards.containsKey(bears).shouldBeTrue()
+                    opponentView.cards[bears]!!.name shouldBe "Grizzly Bears"
+                }
+                withClue("opponent's view does NOT expose the unrelated hidden hand card") {
+                    (secretCard in p1Hand.cardIds).shouldBeFalse()
+                }
+            }
+
+            test("a creature returned from the graveyard to hand becomes visible to the opponent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Raise Dead")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.state.getGraveyard(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val raiseDeadId = game.state.handCard(game.player1Id, "Raise Dead")
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        raiseDeadId,
+                        listOf(ChosenTarget.Card(bears, game.player1Id, Zone.GRAVEYARD)),
+                    )
+                )
+                withClue("Raise Dead should cast: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Grizzly Bears returned to Player1's hand") {
+                    game.state.getHand(game.player1Id) shouldContain bears
+                }
+                withClue("a card returned from the public graveyard stays known to the opponent") {
+                    game.state.revealedTo(bears) shouldContain game.player2Id
+                }
+            }
+
+            test("playing a same-named card from hand forgets the revealed copy") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Unsummon")
+                    .withCardInHand(1, "Grizzly Bears")     // the card we will cast (never revealed)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // the card we will bounce (revealed)
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castCopy = game.state.handCard(game.player1Id, "Grizzly Bears")
+                val bouncedCopy = game.findPermanent("Grizzly Bears")!!
+                val unsummonId = game.state.handCard(game.player1Id, "Unsummon")
+
+                // Bounce one copy so it becomes a known card in hand.
+                game.execute(CastSpell(game.player1Id, unsummonId, listOf(ChosenTarget.Permanent(bouncedCopy))))
+                game.resolveStack()
+                withClue("the bounced copy is known to the opponent before any same-named card is played") {
+                    game.state.revealedTo(bouncedCopy) shouldContain game.player2Id
+                }
+
+                // Now play a DIFFERENT Grizzly Bears from hand. The known copy can no longer be told
+                // apart from the one just cast, so the opponent forgets it.
+                val cast = game.execute(CastSpell(game.player1Id, castCopy, emptyList()))
+                withClue("casting Grizzly Bears should succeed: ${cast.error}") { cast.error shouldBe null }
+
+                withClue("the still-in-hand revealed copy is forgotten once a same-named card is played") {
+                    game.state.getHand(game.player1Id) shouldContain bouncedCopy
+                    (game.player2Id in game.state.revealedTo(bouncedCopy)).shouldBeFalse()
+                }
+            }
+
+            test("a card searched from the library and revealed into hand is visible to the opponent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lay of the Land")
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fetched = game.state.getLibrary(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                }
+
+                val layId = game.state.handCard(game.player1Id, "Lay of the Land")
+                game.execute(CastSpell(game.player1Id, layId, emptyList()))
+                game.resolveStack()
+                // Resolve the search selection (pick the Forest) if one is pending.
+                if (game.getPendingDecision() != null) {
+                    game.selectCards(listOf(fetched))
+                    game.resolveStack()
+                }
+
+                withClue("the revealed land is now in Player1's hand") {
+                    game.state.getHand(game.player1Id) shouldContain fetched
+                }
+                withClue("a card revealed as it entered the hand is known to the opponent") {
+                    game.state.revealedTo(fetched) shouldContain game.player2Id
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

When a player **reveals a card into their hand**, or **returns a card to their hand from a public zone** (battlefield, graveyard, the stack), opponents now keep seeing that card — the way MTGO/Arena do — **until the owner plays a card with the same name** (at which point the known copy can no longer be told apart from the one just played), or the card leaves the hand.

This matches the two cases in the request:
1. *reveal a card to put it into your hand* (e.g. Lay of the Land), and
2. *return a card from another zone to your hand* (e.g. Unsummon bounce, Raise Dead from the graveyard).

## How

Pure engine bookkeeping over **existing** vocabulary — no new SDK type, no transformer change, no client change.

- New `RevealedInHandTracker` runs over each action's emitted events inside `ActionProcessor.process` and manages the lifecycle of the existing `RevealedToComponent` (already consulted by `ClientStateTransformer`) for cards in the `HAND` zone:
  - **mark known**: a `CardsRevealedEvent` for a card now in hand (CR 701.16 — revealing shows the card to all players), or a `ZoneChangeEvent` into `HAND` from the battlefield / graveyard / stack;
  - **forget on play**: a `SpellCastEvent` whose spell was cast *from hand*, or a land played from hand, clears the still-known copies of that name in the player's hand;
  - **forget on leave-hand**: any `ZoneChangeEvent` out of `HAND` drops that card's hand-knowledge, so it can't leak once the card is hidden again (e.g. cast face-down, or put back on the library).
- Deliberately **does not** touch library/face-down reveals: a private tutor to hand stays hidden; returns from exile/sideboard are left alone (a face-down-exiled card must not leak).
- The web client already renders individually-revealed opponent hand cards face-up (`HandZone` mixed revealed/placeholder logic), so no UI work was required.

## Scope boundary

Only manages `RevealedToComponent` visibility for hand cards; it is not a rules/gameplay change (no triggers, priority, or legal actions are affected). Casting a same-named card *from the graveyard/exile* does **not** forget the hand copy (it stays identifiable), which is why "forget on play" is scoped to plays from hand.

## Tests

New `RevealedHandVisibilityScenarioTest` (rules-engine), all green, covering:
- a creature **bounced** back to hand becomes visible to the opponent (asserted both on `RevealedToComponent` and end-to-end through the masked `ClientStateTransformer` view), while an unrelated hand card stays hidden;
- a creature **returned from the graveyard** to hand becomes visible;
- **playing a same-named card from hand forgets** the revealed copy;
- a card **searched + revealed into hand** (Lay of the Land) is visible to the opponent.

Full `just test-rules` and `just test-server` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)