### PR TITLE
Add four no-engine-change Final Fantasy cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LightningSecuritySergeant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LightningSecuritySergeant.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.Exists
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Lightning, Security Sergeant — Final Fantasy #560
+ * {2}{R} · Legendary Creature — Human Soldier · 2/3
+ *
+ * Menace
+ * Whenever Lightning deals combat damage to a player, exile the top card of your library.
+ * You may play that card for as long as you control Lightning.
+ *
+ * The impulse-exile + conditional play permission is the Possibility Technician shape
+ * (Gather top → Move to exile → [Effects.GrantMayPlayFromExile] with [MayPlayExpiry.Permanent]
+ * and a re-evaluated gate). "For as long as you control Lightning" is modeled as an [Exists]
+ * gate for a battlefield creature named "Lightning, Security Sergeant" — Lightning is legendary,
+ * so at most one is ever controlled, making this equivalent to controlling the source. As with
+ * Possibility Technician, the gate is re-evaluated on every legal-action query, so the permission
+ * ends when Lightning leaves; the only divergence from the strict one-way CR 611.2i duration is
+ * that it would resume if a new Lightning re-entered your control (the accepted corpus approximation).
+ */
+val LightningSecuritySergeant = card("Lightning, Security Sergeant") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 2
+    toughness = 3
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Whenever Lightning deals combat damage to a player, exile the top card of your library. " +
+        "You may play that card for as long as you control Lightning."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(1)),
+                    storeAs = "exiledCard"
+                ),
+                MoveCollectionEffect(
+                    from = "exiledCard",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                ),
+                Effects.GrantMayPlayFromExile(
+                    from = "exiledCard",
+                    expiry = MayPlayExpiry.Permanent,
+                    condition = Exists(
+                        player = Player.You,
+                        zone = Zone.BATTLEFIELD,
+                        filter = GameObjectFilter.Creature.named("Lightning, Security Sergeant")
+                    )
+                )
+            )
+        )
+        description = "Whenever Lightning deals combat damage to a player, exile the top card of " +
+            "your library. You may play that card for as long as you control Lightning."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "560"
+        artist = "Ramza Psyru"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4ad4dce3-6e43-4528-b570-85547d03164e.jpg?1782686124"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/NoctisPrinceOfLucis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/NoctisPrinceOfLucis.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MayCastFromGraveyard
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+
+/**
+ * Noctis, Prince of Lucis — Final Fantasy #235
+ * {1}{W}{U}{B} · Legendary Creature — Human Noble · 4/3
+ *
+ * Lifelink
+ * You may cast artifact spells from your graveyard by paying 3 life in addition to paying their
+ * other costs. If you cast a spell this way, that artifact enters with a finality counter on it.
+ *
+ * The artifact analogue of Leonardo, Sewer Samurai: a [MayCastFromGraveyard] permission (filtered
+ * to artifacts, with an additional 3-life cost) plus a non-self [EntersWithCounters] that stamps a
+ * finality counter on artifacts you control that were cast from a graveyard. The default
+ * `appliesTo` for [EntersWithCounters] is creatures-you-control, so it MUST be overridden to
+ * artifacts-you-control here, or the replacement would never fire for non-creature artifacts.
+ *
+ * As with Leonardo, [Conditions.WasCastFromGraveyard] is true for any graveyard cast of a
+ * you-controlled artifact, not strictly via Noctis's permission — the accepted corpus modeling for
+ * "if you cast a spell this way" (it only diverges if another effect also grants artifact-from-
+ * graveyard casting). The finality counter's die→exile replacement is engine-intrinsic.
+ */
+val NoctisPrinceOfLucis = card("Noctis, Prince of Lucis") {
+    manaCost = "{1}{W}{U}{B}"
+    colorIdentity = "WUB"
+    typeLine = "Legendary Creature — Human Noble"
+    power = 4
+    toughness = 3
+    oracleText = "Lifelink\n" +
+        "You may cast artifact spells from your graveyard by paying 3 life in addition to paying " +
+        "their other costs. If you cast a spell this way, that artifact enters with a finality counter on it."
+
+    keywords(Keyword.LIFELINK)
+
+    staticAbility {
+        ability = MayCastFromGraveyard(
+            filter = GameObjectFilter.Artifact,
+            lifeCost = 3
+        )
+    }
+
+    // Artifacts you control cast from the graveyard enter with a finality counter. selfOnly = false
+    // targets the *other* artifact; appliesTo is overridden to artifacts (the default is creatures).
+    replacementEffect(
+        EntersWithCounters(
+            counterType = CounterTypeFilter.Named(Counters.FINALITY),
+            count = 1,
+            selfOnly = false,
+            condition = Conditions.WasCastFromGraveyard,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Artifact.youControl(),
+                to = Zone.BATTLEFIELD
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "235"
+        artist = "Jeremy Chong"
+        flavorText = "Many sacrificed all for the King; so must the King sacrifice himself for all."
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/1881a66b-956d-4bab-b578-5b2d3407c972.jpg?1782686412"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TripleTriad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TripleTriad.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CollectionFilter
+import com.wingedsheep.sdk.scripting.effects.FilterCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GrantMayPlayFromExileEffect
+import com.wingedsheep.sdk.scripting.effects.GrantPlayWithoutPayingCostEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Triple Triad — Final Fantasy #166
+ * {3}{R}{R}{R} · Enchantment
+ *
+ * At the beginning of your upkeep, each player exiles the top card of their library. Until end of
+ * turn, you may play the card you own exiled this way and each other card exiled this way with
+ * lesser mana value than it without paying their mana costs.
+ *
+ * Built from impulse atoms. The two exile groups are gathered separately so the "always playable"
+ * card (yours) and the MV-filtered set (everyone else's) can be handled independently:
+ *  - "mine": your top card → exile.
+ *  - "others": each opponent's top card → exile.
+ *  - "playableOthers": the others strictly below your card's mana value. MVs are non-negative
+ *    integers, so "lesser than it" (< n) is modeled exactly as [CollectionFilter.ManaValueAtMost]
+ *    of [DynamicAmount.Subtract](mineMV, 1) — which correctly excludes cards tied with yours.
+ *  - Play permission until end of turn, free, is granted over "mine" (unconditionally) and
+ *    "playableOthers": [GrantMayPlayFromExileEffect] (also permits lands) + [GrantPlayWithoutPayingCostEffect].
+ *
+ * Defaults are correct as-is: opponents' cards are cast by you (controller-controls) and go to
+ * their owner's graveyard after resolving (exileAfterResolve = false). Same gather→exile idiom as
+ * Alania's Pathmaker; the per-player [Player.Each]/[Player.EachOpponent] reveal mirrors Psychic Battle.
+ */
+val TripleTriad = card("Triple Triad") {
+    manaCost = "{3}{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, each player exiles the top card of their " +
+        "library. Until end of turn, you may play the card you own exiled this way and each other " +
+        "card exiled this way with lesser mana value than it without paying their mana costs."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            listOf(
+                // Your top card → "mine"
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(count = DynamicAmount.Fixed(1), player = Player.You),
+                    storeAs = "mine"
+                ),
+                MoveCollectionEffect(from = "mine", destination = CardDestination.ToZone(Zone.EXILE)),
+                // Each opponent's top card → "others"
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(count = DynamicAmount.Fixed(1), player = Player.EachOpponent),
+                    storeAs = "others"
+                ),
+                MoveCollectionEffect(from = "others", destination = CardDestination.ToZone(Zone.EXILE)),
+                // Others with strictly lesser mana value than your card (< mineMV  ==  <= mineMV - 1)
+                FilterCollectionEffect(
+                    from = "others",
+                    filter = CollectionFilter.ManaValueAtMost(
+                        DynamicAmount.Subtract(DynamicAmount.StoredCardManaValue("mine"), DynamicAmount.Fixed(1))
+                    ),
+                    storeMatching = "playableOthers"
+                ),
+                // Until end of turn, play them without paying mana costs.
+                GrantMayPlayFromExileEffect("mine", MayPlayExpiry.EndOfTurn),
+                GrantPlayWithoutPayingCostEffect("mine"),
+                GrantMayPlayFromExileEffect("playableOthers", MayPlayExpiry.EndOfTurn),
+                GrantPlayWithoutPayingCostEffect("playableOthers")
+            )
+        )
+        description = "At the beginning of your upkeep, each player exiles the top card of their " +
+            "library. Until end of turn, you may play the card you own exiled this way and each " +
+            "other card exiled this way with lesser mana value than it without paying their mana costs."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "166"
+        artist = "Ben Wootten"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d9a1de36-7f47-4b28-bb56-38d7e5bed82f.jpg?1782686477"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/YunaHopeOfSpira.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/YunaHopeOfSpira.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantWard
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Yuna, Hope of Spira — Final Fantasy #250
+ * {3}{G}{W} · Legendary Creature — Human Cleric · 3/5
+ *
+ * During your turn, Yuna and enchantment creatures you control have trample, lifelink, and ward {2}.
+ * At the beginning of your end step, return up to one target enchantment card from your graveyard
+ * to the battlefield with a finality counter on it.
+ *
+ * Clause 1 is a conditional ("during your turn") anthem — the FreyaCrescent shape
+ * (`staticAbility { condition = Conditions.IsYourTurn }`). It needs two scopes because Yuna is not
+ * herself an enchantment creature and there is no battlefield "is source" predicate to union her
+ * into the group: [Filters.Self] for Yuna + a `GroupFilter` of enchantment creatures you control.
+ * Ward-with-cost is granted via [GrantWard] ([WardCost.Mana]); enforcement reads the configured cost.
+ *
+ * Clause 2 is the Rydia "return … with a finality counter" idiom: an end-step trigger with an
+ * optional ("up to one") graveyard target, moved GRAVEYARD → BATTLEFIELD then given a
+ * [Counters.FINALITY] counter (whose die→exile replacement is engine-intrinsic).
+ */
+val YunaHopeOfSpira = card("Yuna, Hope of Spira") {
+    manaCost = "{3}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 3
+    toughness = 5
+    oracleText = "During your turn, Yuna and enchantment creatures you control have trample, " +
+        "lifelink, and ward {2}.\n" +
+        "At the beginning of your end step, return up to one target enchantment card from your " +
+        "graveyard to the battlefield with a finality counter on it. (If a permanent with a " +
+        "finality counter on it would be put into a graveyard from the battlefield, exile it instead.)"
+
+    // "enchantment creatures you control"
+    val enchantmentCreatures = GroupFilter(GameObjectFilter.Creature.youControl() and GameObjectFilter.Enchantment)
+
+    // Clause 1: "During your turn, Yuna and enchantment creatures you control have trample,
+    // lifelink, and ward {2}." Self + group are separate scopes (Yuna is not an enchantment creature).
+    staticAbility { condition = Conditions.IsYourTurn; ability = GrantKeyword(Keyword.TRAMPLE, Filters.Self) }
+    staticAbility { condition = Conditions.IsYourTurn; ability = GrantKeyword(Keyword.TRAMPLE, enchantmentCreatures) }
+    staticAbility { condition = Conditions.IsYourTurn; ability = GrantKeyword(Keyword.LIFELINK, Filters.Self) }
+    staticAbility { condition = Conditions.IsYourTurn; ability = GrantKeyword(Keyword.LIFELINK, enchantmentCreatures) }
+    staticAbility { condition = Conditions.IsYourTurn; ability = GrantWard(WardCost.Mana("{2}"), Filters.Self) }
+    staticAbility { condition = Conditions.IsYourTurn; ability = GrantWard(WardCost.Mana("{2}"), enchantmentCreatures) }
+
+    // Clause 2: end-step return of an enchantment card with a finality counter.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        val enchantment = target(
+            "up to one target enchantment card from your graveyard",
+            TargetObject(
+                filter = TargetFilter(GameObjectFilter.Enchantment.ownedByYou(), zone = Zone.GRAVEYARD),
+                optional = true
+            )
+        )
+        effect = Effects.Move(enchantment, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+            .then(AddCountersEffect(Counters.FINALITY, 1, enchantment))
+        description = "At the beginning of your end step, return up to one target enchantment card " +
+            "from your graveyard to the battlefield with a finality counter on it."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "250"
+        artist = "NINNIN"
+        imageUri = "https://cards.scryfall.io/normal/front/3/5/35b613ad-86f0-431b-af93-147d21041fde.jpg?1748706729"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -8363,6 +8363,78 @@
     ]
 }
 
+// Lightning, Security Sergeant
+{
+    "name": "Lightning, Security Sergeant",
+    "manaCost": "{2}{R}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nWhenever Lightning deals combat damage to a player, exile the top card of your library. You may play that card for as long as you control Lightning.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "exiledCard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "exiledCard",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "exiledCard",
+                            "expiry": "Permanent",
+                            "condition": {
+                                "type": "Exists",
+                                "player": "You",
+                                "zone": "Battlefield",
+                                "filter": "creature name:Lightning, Security Sergeant"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "Whenever Lightning deals combat damage to a player, exile the top card of your library. You may play that card for as long as you control Lightning."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "560",
+        "rarity": "RARE",
+        "artist": "Ramza Psyru",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4ad4dce3-6e43-4528-b570-85547d03164e.jpg?1782686124"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Lindblum, Industrial Regency
 {
     "name": "Lindblum, Industrial Regency",
@@ -10275,6 +10347,61 @@
         "imageUri": "https://cards.scryfall.io/normal/front/a/6/a6b5af82-3646-44f9-ac12-1d7fa698f037.jpg?1748706165"
     },
     "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Noctis, Prince of Lucis
+{
+    "name": "Noctis, Prince of Lucis",
+    "manaCost": "{1}{W}{U}{B}",
+    "typeLine": "Legendary Creature — Human Noble",
+    "oracleText": "Lifelink\nYou may cast artifact spells from your graveyard by paying 3 life in addition to paying their other costs. If you cast a spell this way, that artifact enters with a finality counter on it.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "MayCastFromGraveyard",
+                "filter": "artifact",
+                "lifeCost": 3
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "counterType": {
+                    "type": "Named",
+                    "name": "finality"
+                },
+                "count": 1,
+                "condition": {
+                    "type": "WasCastFromZone",
+                    "zone": "Graveyard"
+                },
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "RARE",
+        "artist": "Jeremy Chong",
+        "flavorText": "Many sacrificed all for the King; so must the King sacrifice himself for all.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/1881a66b-956d-4bab-b578-5b2d3407c972.jpg?1782686412"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE",
         "BLACK"
     ]
 }
@@ -17952,6 +18079,115 @@
     ]
 }
 
+// Triple Triad
+{
+    "name": "Triple Triad",
+    "manaCost": "{3}{R}{R}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, each player exiles the top card of their library. Until end of turn, you may play the card you own exiled this way and each other card exiled this way with lesser mana value than it without paying their mana costs.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "mine"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "mine",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "player": "EachOpponent"
+                            },
+                            "storeAs": "others"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "others",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "others",
+                            "filter": {
+                                "type": "ManaValueAtMost",
+                                "max": {
+                                    "type": "Subtract",
+                                    "left": {
+                                        "type": "StoredCardManaValue",
+                                        "collectionName": "mine"
+                                    },
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            },
+                            "storeMatching": "playableOthers"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "mine"
+                        },
+                        {
+                            "type": "GrantPlayWithoutPayingCost",
+                            "from": "mine"
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "playableOthers"
+                        },
+                        {
+                            "type": "GrantPlayWithoutPayingCost",
+                            "from": "playableOthers"
+                        }
+                    ]
+                },
+                "descriptionOverride": "At the beginning of your upkeep, each player exiles the top card of their library. Until end of turn, you may play the card you own exiled this way and each other card exiled this way with lesser mana value than it without paying their mana costs."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "166",
+        "rarity": "RARE",
+        "artist": "Ben Wootten",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d9a1de36-7f47-4b28-bb56-38d7e5bed82f.jpg?1782686477"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ultima Weapon
 {
     "name": "Ultima Weapon",
@@ -19646,6 +19882,150 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/8/1867b5cb-2bb0-4f49-b302-036fdffa2344.jpg?1748705918"
     },
     "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Yuna, Hope of Spira
+{
+    "name": "Yuna, Hope of Spira",
+    "manaCost": "{3}{G}{W}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "During your turn, Yuna and enchantment creatures you control have trample, lifelink, and ward {2}.\nAt the beginning of your end step, return up to one target enchantment card from your graveyard to the battlefield with a finality counter on it. (If a permanent with a finality counter on it would be put into a graveyard from the battlefield, exile it instead.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target enchantment card from your graveyard"
+                            },
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "finality",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target enchantment card from your graveyard"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "enchantment own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to one target enchantment card from your graveyard"
+                },
+                "descriptionOverride": "At the beginning of your end step, return up to one target enchantment card from your graveyard to the battlefield with a finality counter on it."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "creature enchantment ctrl:you"
+                    }
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "LIFELINK",
+                    "filter": {
+                        "baseFilter": "creature enchantment ctrl:you"
+                    }
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantWard",
+                    "cost": {
+                        "type": "WardCost.Mana",
+                        "manaCost": "{2}"
+                    },
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantWard",
+                    "cost": {
+                        "type": "WardCost.Mana",
+                        "manaCost": "{2}"
+                    },
+                    "filter": {
+                        "baseFilter": "creature enchantment ctrl:you"
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "250",
+        "rarity": "MYTHIC",
+        "artist": "NINNIN",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/5/35b613ad-86f0-431b-af93-147d21041fde.jpg?1748706729"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
         "WHITE"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightningSecuritySergeantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightningSecuritySergeantScenarioTest.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Lightning, Security Sergeant (FIN).
+ *
+ * Whenever Lightning deals combat damage to a player, the top card of the controller's library is
+ * exiled and may be played for as long as they control Lightning. Exercises the impulse-exile +
+ * conditional play permission (Possibility Technician shape): combat damage → exile → a CastSpell
+ * play action for the exiled card is enumerated while Lightning is on the battlefield.
+ */
+class LightningSecuritySergeantScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lightning, Security Sergeant") {
+
+            test("combat damage exiles the top card and lets you play it while you control Lightning") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Lightning, Security Sergeant", summoningSickness = false)
+                    .withCardInLibrary(1, "Mons's Goblin Raiders") // {R} 1/1 — a known top card
+                    .withLandsOnBattlefield(1, "Mountain", 1)       // so the exiled card is affordable
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Lightning, Security Sergeant" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.state.pendingDecision != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("Combat damage to a player should exile the top card of your library") {
+                    game.isInExile(1, "Mons's Goblin Raiders") shouldBe true
+                }
+
+                // Advance to your postcombat main phase (sorcery-speed window) and confirm the
+                // exiled creature is now playable — the granted may-play permission is honored
+                // because you still control Lightning.
+                game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                game.resolveStack()
+
+                val canPlayExiledCard = game.getLegalActions(1).any { info ->
+                    val action = info.action
+                    action is CastSpell &&
+                        game.state.getEntity(action.cardId)?.get<CardComponent>()?.name == "Mons's Goblin Raiders"
+                }
+                withClue("While controlling Lightning, the exiled card must be playable from exile") {
+                    canPlayExiledCard shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NoctisPrinceOfLucisScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NoctisPrinceOfLucisScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Noctis, Prince of Lucis (FIN) — the artifact analogue of Leonardo, Sewer Samurai.
+ *
+ * Casting an artifact from your graveyard via Noctis's permission costs 3 life in addition to its
+ * other costs, and the artifact enters with a finality counter. Exercises [MayCastFromGraveyard]
+ * (filtered to artifacts, lifeCost = 3) plus the non-self `EntersWithCounters(FINALITY,
+ * condition = WasCastFromGraveyard)` whose `appliesTo` is overridden to artifacts-you-control.
+ */
+class NoctisPrinceOfLucisScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Noctis, Prince of Lucis") {
+
+            test("an artifact cast from the graveyard via Noctis costs 3 life and enters with a finality counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Noctis, Prince of Lucis")
+                    .withCardInGraveyard(1, "Ornithopter") // {0} Artifact Creature — no mana needed
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Cast Ornithopter ({0}) from the graveyard via Noctis, paying the 3-life additional cost.
+                val ornithopterInGrave = game.findCardsInGraveyard(1, "Ornithopter").first()
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.state.activePlayerId!!,
+                        cardId = ornithopterInGrave,
+                        graveyardLifeCost = 3
+                    )
+                )
+                withClue("Casting an artifact from the graveyard via Noctis should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("The 3-life additional cost should have been paid (20 -> 17)") {
+                    game.getLifeTotal(1) shouldBe 17
+                }
+
+                val ornithopter = game.findPermanent("Ornithopter")!!
+                val counters = game.state.getEntity(ornithopter)?.get<CountersComponent>()
+                withClue("Cast from graveyard via Noctis → enters with one finality counter") {
+                    (counters?.getCount(CounterType.FINALITY) ?: 0) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TripleTriadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TripleTriadScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Triple Triad (FIN).
+ *
+ * At the beginning of your upkeep, each player exiles the top card of their library. Until end of
+ * turn, you may play (free) the card you own exiled this way and each other card exiled this way
+ * with lesser mana value than it. Exercises the relative-mana-value impulse: your card is always
+ * playable; an opponent's exiled card is playable only when its mana value is strictly less than
+ * the mana value of the card you exiled.
+ *
+ * "Playable" is asserted by enumerating a free CastSpell action for player 1 at their precombat
+ * main phase (sorcery-speed window). Mons's Goblin Raiders = {R} (MV 1); Wind Drake = {2}{U} (MV 3).
+ */
+class TripleTriadScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Triple Triad") {
+
+            test("an opponent's card with lesser mana value than yours becomes playable") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Triple Triad")
+                    .withCardInLibrary(1, "Wind Drake")             // yours: MV 3
+                    .withCardInLibrary(2, "Mons's Goblin Raiders")  // opponent: MV 1 (< 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("Each player exiles the top card of their library on your upkeep") {
+                    game.isInExile(1, "Wind Drake") shouldBe true
+                    game.isInExile(2, "Mons's Goblin Raiders") shouldBe true
+                }
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.resolveStack()
+
+                val playable = game.getLegalActions(1)
+                    .mapNotNull { it.action as? CastSpell }
+                    .mapNotNull { game.state.getEntity(it.cardId)?.get<CardComponent>()?.name }
+                    .toSet()
+
+                withClue("Your own exiled card is always playable") {
+                    playable.contains("Wind Drake") shouldBe true
+                }
+                withClue("The opponent's exiled card has lesser mana value, so it is playable") {
+                    playable.contains("Mons's Goblin Raiders") shouldBe true
+                }
+            }
+
+            test("an opponent's card with greater-or-equal mana value than yours is NOT playable") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Triple Triad")
+                    .withCardInLibrary(1, "Mons's Goblin Raiders") // yours: MV 1
+                    .withCardInLibrary(2, "Wind Drake")            // opponent: MV 3 (NOT < 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("Both top cards are still exiled this way") {
+                    game.isInExile(1, "Mons's Goblin Raiders") shouldBe true
+                    game.isInExile(2, "Wind Drake") shouldBe true
+                }
+
+                game.passUntilPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                game.resolveStack()
+
+                val playable = game.getLegalActions(1)
+                    .mapNotNull { it.action as? CastSpell }
+                    .mapNotNull { game.state.getEntity(it.cardId)?.get<CardComponent>()?.name }
+                    .toSet()
+
+                withClue("Your own exiled card is always playable") {
+                    playable.contains("Mons's Goblin Raiders") shouldBe true
+                }
+                withClue("The opponent's card is not of lesser mana value, so it stays unplayable") {
+                    playable.contains("Wind Drake") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YunaHopeOfSpiraScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/YunaHopeOfSpiraScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Yuna, Hope of Spira (FIN).
+ *
+ * Clause 1: a conditional ("during your turn") anthem granting trample, lifelink, and ward {2} to
+ * Yuna and enchantment creatures you control — asserted via projected keywords on your turn vs. the
+ * opponent's turn. Clause 2: an end-step trigger returning an enchantment card from your graveyard
+ * with a finality counter.
+ */
+class YunaHopeOfSpiraScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Yuna, Hope of Spira") {
+
+            test("during your turn, Yuna and your enchantment creatures gain trample, lifelink, and ward") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Yuna, Hope of Spira", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Enduring Curiosity", summoningSickness = false) // Enchantment Creature
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val yuna = game.findPermanent("Yuna, Hope of Spira")!!
+                val enchantmentCreature = game.findPermanent("Enduring Curiosity")!!
+                val projected = projector.project(game.state)
+
+                withClue("On your turn, Yuna has trample, lifelink, and ward") {
+                    projected.hasKeyword(yuna, Keyword.TRAMPLE) shouldBe true
+                    projected.hasKeyword(yuna, Keyword.LIFELINK) shouldBe true
+                    projected.hasKeyword(yuna, Keyword.WARD) shouldBe true
+                }
+                withClue("On your turn, an enchantment creature you control also gains the keywords") {
+                    projected.hasKeyword(enchantmentCreature, Keyword.TRAMPLE) shouldBe true
+                    projected.hasKeyword(enchantmentCreature, Keyword.LIFELINK) shouldBe true
+                }
+            }
+
+            test("the anthem is inactive during an opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Yuna, Hope of Spira", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val yuna = game.findPermanent("Yuna, Hope of Spira")!!
+                val projected = projector.project(game.state)
+
+                withClue("It's not your turn, so the anthem grants nothing") {
+                    projected.hasKeyword(yuna, Keyword.TRAMPLE) shouldBe false
+                    projected.hasKeyword(yuna, Keyword.LIFELINK) shouldBe false
+                }
+            }
+
+            test("at your end step, return an enchantment from your graveyard with a finality counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Yuna, Hope of Spira", summoningSickness = false)
+                    .withCardInGraveyard(1, "Angelic Shield") // {2}{W} Enchantment, no ETB decision
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                // "Up to one target" — choose the enchantment in the graveyard.
+                if (game.state.pendingDecision != null) {
+                    val target = game.findCardsInGraveyard(1, "Angelic Shield").first()
+                    game.selectTargets(listOf(target))
+                    game.resolveStack()
+                }
+
+                withClue("The enchantment should have returned to the battlefield") {
+                    game.isOnBattlefield("Angelic Shield") shouldBe true
+                }
+                val returned = game.findPermanent("Angelic Shield")!!
+                val counters = game.state.getEntity(returned)?.get<CountersComponent>()
+                withClue("It returns with a finality counter on it") {
+                    (counters?.getCount(CounterType.FINALITY) ?: 0) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Implements four unimplemented **Final Fantasy (FIN)** cards that a feasibility review confirmed are authorable using **only existing SDK primitives** — no engine, SDK, or server changes:

| Card | Mechanic | Precedent reused |
|------|----------|------------------|
| **Lightning, Security Sergeant** | Combat-damage impulse-exile; play permission "for as long as you control Lightning" | Possibility Technician (`GrantMayPlayFromExile` + `Permanent` expiry + `Exists` gate) |
| **Noctis, Prince of Lucis** | Cast artifacts from graveyard for 3 life; they enter with a finality counter | Leonardo, Sewer Samurai (`MayCastFromGraveyard` + non-self `EntersWithCounters`, `appliesTo` overridden to artifacts) |
| **Triple Triad** | Each player exiles top card; play yours + others of *lesser* mana value, free | Psychic Battle / Alania's Pathmaker (`StoredCardManaValue` + `Subtract` + `CollectionFilter.ManaValueAtMost`) |
| **Yuna, Hope of Spira** | Conditional "during your turn" anthem (trample/lifelink/ward {2}); end-step return of an enchantment with a finality counter | Freya Crescent (conditional anthem) / Rydia, Summoner of Mist (return + finality) |

## Background

This started from `just coverage-gaps --set FIN`, which flagged 9 unimplemented cards as **SCAFFOLD** (predicted coverable by existing capabilities). Per-card feasibility verification found only **4 of the 9** are truly authorable without engine work. The other 5 were set aside as genuine `add-feature` gaps:

- **Edgar, King of Figaro** — "win all coin flips / come up heads" has no replacement/static seam on the coin-flip executors.
- **Lightning, Army of One** — a granted `DoubleDamage` replacement is inert (the damage read-path ignores `grantedReplacementEffects`), and there is no player-scoped recipient binding.
- **Cloud, Planet's Champion** — needs a *target-scoped* equip-cost reduction; existing `ReduceEquipCost` is controller-scoped and would over-apply.
- **Balthier and Fran** — needs an inverse-crew filter (`crewedBySourceThisTurn`); existing crew filters run the opposite direction.
- **The Lunar Whale** — the only all-types play-from-top static publicly reveals the top card to opponents; faithful play needs a private (no-reveal) variant.

## Tests

- A scenario test per card (7 tests total) — all pass.
- Re-blessed `CardDefinitionSnapshotTest` for FIN; diff adds only these 4 cards, no other set/card changed.
- Full `:mtg-sets:test` green (snapshot, **CardLintTest**, FacadeBoundaryTest, printing, discovery, legality).

No SDK additions, so no `card-sdk-language-reference.md` change. No FIN backlog file exists to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)