### PR TITLE
Use the account profile name for in-game player identity

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -174,6 +174,13 @@ Auth tokens are stateless HMAC-SHA256-signed (a minimal JWT shape) so REST calls
 authenticate. The token also links the in-game identity to the account so finished games count toward
 the account's stats.
 
+When a signed-in connect handshake carries that token, `ConnectionHandler.linkAccount` stamps the
+account id onto the `PlayerIdentity` **and** overwrites its `playerName` with the account's current
+profile display name. The server is therefore authoritative over the in-game name for signed-in
+players — the client-sent name is only a fallback for guests — so the name set on the profile (and
+any later change to it) is what opponents and spectators see. The token itself carries only
+`uid`/`email`/`exp`, so the display name is looked up from the `users` table at connect time.
+
 ## Admin access
 
 The admin dashboard accepts **two** credentials, resolved by `AdminAuthService`:

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -2,6 +2,7 @@ package com.wingedsheep.gameserver.handler
 
 import com.wingedsheep.gameserver.ai.AiGameManager
 import com.wingedsheep.gameserver.auth.AuthSupport
+import com.wingedsheep.gameserver.auth.MagicLinkService
 import com.wingedsheep.gameserver.friends.FriendPresenceBroadcaster
 import org.springframework.beans.factory.ObjectProvider
 import com.wingedsheep.gameserver.lobby.LobbyState
@@ -33,6 +34,7 @@ class ConnectionHandler(
     private val boosterGenerator: BoosterGenerator,
     // Present only when accounts are enabled; resolved lazily so this handler stays usable without it.
     private val authSupport: ObjectProvider<AuthSupport>,
+    private val magicLinkService: ObjectProvider<MagicLinkService>,
     private val friendPresenceBroadcaster: ObjectProvider<FriendPresenceBroadcaster>,
 ) {
     private val logger = LoggerFactory.getLogger(ConnectionHandler::class.java)
@@ -40,6 +42,22 @@ class ConnectionHandler(
     /** Resolve the durable account id from a connect message's auth token, or null if absent/invalid. */
     private fun resolveAccountUserId(authToken: String?): UUID? =
         authToken?.let { authSupport.ifAvailable?.userOrNull(it)?.userId }
+
+    /**
+     * Link the signed-in account (if any) behind [authToken] to [identity]: stamp its [userId] and
+     * adopt the account's current profile display name as the identity's player name. The server is
+     * authoritative over the display name for signed-in players — the client-sent name is only a
+     * fallback for guests — so games use the name the player set on their profile, not a stale name
+     * carried over from a guest session. No-op when accounts are disabled or the token is
+     * absent/invalid (guest play keeps its connect name).
+     */
+    private fun linkAccount(identity: PlayerIdentity, authToken: String?) {
+        val userId = resolveAccountUserId(authToken) ?: return
+        identity.userId = userId
+        magicLinkService.ifAvailable?.findUser(userId)?.displayName
+            ?.takeIf { it.isNotBlank() }
+            ?.let { identity.playerName = it }
+    }
 
     /** Tell a signed-in identity's friends that its visible-online state changed (no-op for guests). */
     private fun broadcastFriendPresence(identity: PlayerIdentity) {
@@ -73,8 +91,9 @@ class ConnectionHandler(
             val existingIdentity = sessionRegistry.getIdentityByToken(token)
             logger.info("Token lookup result: ${if (existingIdentity != null) "found identity for ${existingIdentity.playerName}" else "no identity found"}")
             if (existingIdentity != null) {
-                // Re-link the account in case the player signed in since their last connect.
-                resolveAccountUserId(message.authToken)?.let { existingIdentity.userId = it }
+                // Re-link the account in case the player signed in (or changed their display name)
+                // since their last connect — this also refreshes the identity's name from the profile.
+                linkAccount(existingIdentity, message.authToken)
                 // Refresh the IP — the player may be reconnecting from a different network.
                 clientIpOf(session)?.let { existingIdentity.clientIp = it }
                 handleReconnect(session, existingIdentity)
@@ -87,19 +106,21 @@ class ConnectionHandler(
             playerId = playerId,
             playerName = message.playerName
         ).apply {
-            userId = resolveAccountUserId(message.authToken)
+            // Adopt the signed-in account's profile name (if any) before the identity is used for a
+            // game; falls back to the client-sent name for guests.
+            linkAccount(this, message.authToken)
             clientIp = clientIpOf(session)
         }
 
         val playerSession = PlayerSession(
             webSocketSession = session,
             playerId = playerId,
-            playerName = message.playerName
+            playerName = identity.playerName
         )
 
         sessionRegistry.register(identity, session, playerSession)
 
-        logger.info("Player connected: ${message.playerName} (${playerId.value}), token: ${identity.token}")
+        logger.info("Player connected: ${identity.playerName} (${playerId.value}), token: ${identity.token}")
         sender.send(session, ServerMessage.Connected(
             playerId.value,
             identity.token,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/PlayerIdentity.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/PlayerIdentity.kt
@@ -14,11 +14,20 @@ import java.util.concurrent.ScheduledFuture
 class PlayerIdentity(
     val token: String = UUID.randomUUID().toString(),
     val playerId: EntityId,
-    val playerName: String,
+    playerName: String,
     val isAi: Boolean = false,
     /** LLM model override for AI players, null otherwise. Persisted alongside the lobby. */
     val aiModelOverride: String? = null
 ) {
+    /**
+     * Display name shown to opponents and spectators. For a signed-in player this is the account's
+     * profile display name — the server overwrites it whenever the account is (re)linked (see
+     * `ConnectionHandler.linkAccount`), so the name set on the profile is authoritative for games.
+     * Guests keep the name they connected with.
+     */
+    @Volatile
+    var playerName: String = playerName
+
     /** Account id this identity is signed in as (from magic-link auth), or null for guest play. */
     @Volatile
     var userId: UUID? = null

--- a/web-client/src/store/slices/connectionSlice.ts
+++ b/web-client/src/store/slices/connectionSlice.ts
@@ -15,6 +15,7 @@ import {
   clearDeckState,
 } from './shared'
 import { createMessageHandlers } from './handlers'
+import { useAuthStore } from '@/store/authStore'
 
 export interface ConnectionSliceState {
   connectionStatus: ConnectionStatus
@@ -98,7 +99,13 @@ export const createConnectionSlice: SliceCreator<ConnectionSlice> = (set, get) =
       // Spectator sessions connect tokenless (fresh identity every time) so a new spectate tab
       // never reconnects as an existing identity and gets its old spectating game restored.
       const token = spectator ? undefined : (urlToken ?? localStorage.getItem('argentum-token') ?? undefined)
-      const connectName = spectator ? playerName : (localStorage.getItem('argentum-player-name') ?? playerName)
+      // When signed in, the account's profile display name is the source of truth for the player's
+      // name — prefer it over a (possibly stale) locally-stored name so games show the profile name.
+      // The server is authoritative and re-applies this too, but sending it keeps the local UI aligned.
+      const accountName = useAuthStore.getState().user?.displayName?.trim() || undefined
+      const connectName = spectator
+        ? playerName
+        : (accountName ?? localStorage.getItem('argentum-player-name') ?? playerName)
       // Durable account token (magic-link login) links this session to the account for stats.
       const authToken = spectator ? undefined : (localStorage.getItem('argentum-auth') ?? undefined)
       getWebSocket()?.send(createConnectMessage(connectName, token, authToken))


### PR DESCRIPTION
## Problem

After signing in and setting a display **name** on the profile page, that name was **not** used for the games the user played — games kept showing an old guest/typed name.

Two cooperating bugs:

- **Server trusted the client-sent connect name.** `ConnectionHandler` resolved the authenticated account id from the token but never looked up the account's `displayName`, so it used whatever name the client sent.
- **Client sent a stale name.** `connectionSlice` sent the name from `localStorage['argentum-player-name']` (set at the name-entry screen, often a guest name) instead of the signed-in account's `displayName`.

Because a returning signed-in player reconnects against an *existing* `PlayerIdentity` (matched by the session token), even a corrected first-connect name wouldn't have been enough — the stale name persisted on the identity across reconnects.

## Fix

**Server is authoritative (the real fix).** New `ConnectionHandler.linkAccount(identity, authToken)` resolves the account behind the auth token, stamps `userId`, and overwrites the identity's `playerName` with the account's **current** profile display name. It's called on both paths:
- new connect (before the identity is used for a game), and
- reconnect / re-link (so a name changed mid-session, or after the guest identity already existed, is picked up).

Guests and accounts-disabled servers are unaffected — `linkAccount` is a no-op when the token is absent/invalid or the accounts subsystem isn't present, so guest play keeps its connect name. `PlayerIdentity.playerName` is now a `@Volatile var` so a (re)linked account can refresh it; downstream `PlayerSession` / `seatInfos` already read from the identity, so the fresh name flows through automatically.

**Client keeps the local UI aligned.** `connectionSlice` now prefers the signed-in account's `displayName` over the locally-stored name when building the connect message (falls back to the stored/typed name for guests and spectators).

**Docs.** `accounts-and-persistence.md` documents that the profile name is authoritative for the in-game identity (the auth token carries only `uid`/`email`/`exp`, so the name is looked up from `users` at connect time).

## Verification

- `web-client` `npm run typecheck` ✅
- `:game-server:compileTestKotlin` ✅ (only pre-existing deprecation warnings)

Behavior is otherwise exercised via the stack; suggested manual check: sign in, change the profile name, start a game, and confirm both seats/opponent view show the new name (including after a reconnect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)