### PR TITLE
Fix Lorwyn Eclipsed archetype backgrounds + load art crops from the CDN

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
@@ -306,6 +306,30 @@ object SetArchetypes {
                     "Ramp into expensive instants and sorceries that cascade for free value, snowballing card advantage with Increment counters. A go-big spells-matter ramp deck."),
             )
         ),
+        "ECL" to SetSynergies(
+            setCode = "ECL",
+            setName = "Lorwyn Eclipsed",
+            archetypes = listOf(
+                Archetype("Kithkin", listOf(Color.GREEN, Color.WHITE),
+                    "Flood the board with 1/1 Kithkin tokens, then use Convoke to cast expensive spells for free. Mass pump effects turn the token horde lethal.",
+                    creatureTypes = listOf("Kithkin")),
+                Archetype("Merfolk", listOf(Color.WHITE, Color.BLUE),
+                    "Merfolk untap each other after combat and chain together card draw. Control the pace of the game with bounce and tempo plays while building an unstoppable Merrow tide.",
+                    creatureTypes = listOf("Merfolk")),
+                Archetype("Faeries", listOf(Color.BLUE, Color.BLACK),
+                    "Operate entirely at flash speed — drop Faeries at end of turn, steal blockers, and lock out opponents with aerial superiority. A control deck that wins with evasion.",
+                    creatureTypes = listOf("Faerie")),
+                Archetype("Boggarts", listOf(Color.BLACK, Color.RED),
+                    "Relentless Boggart aggro backed by Wither. Your attackers deal damage as -1/-1 counters, permanently shrinking blockers. Blight provides flexible sacrifice payoffs.",
+                    creatureTypes = listOf("Goblin")),
+                Archetype("Elementals", listOf(Color.BLUE, Color.RED),
+                    "Flamekin Elementals reward casting instants and sorceries. Evoke provides flexible tempo plays — pay the cheap cost for a burst of value, or go full price for a permanent threat.",
+                    creatureTypes = listOf("Elemental")),
+                Archetype("Changelings", listOf(Color.BLUE, Color.GREEN),
+                    "Changelings count as every creature type simultaneously, triggering Kithkin, Merfolk, Elf, and Faerie payoffs all at once. A tribal swiss-army-knife deck with enormous flexibility.",
+                    creatureTypes = listOf("Shapeshifter")),
+            )
+        ),
     )
 
     /** Get archetypes for a specific set code, or null if not found. */

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -25,7 +25,7 @@ import { ManaCost, ManaSymbol } from '@/components/ui/ManaSymbols'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
 import { useDfcHoverFlip } from '@/components/ui/useDfcHoverFlip'
 import { SetIcon } from '@/components/ui/SetIcon'
-import { getCardImageUrl, getScryfallArtCropUrl, splitImageRotateDeg } from '@/utils/cardImages'
+import { getCardImageUrl, getCdnArtCropUrl, getScryfallArtCropUrl, splitImageRotateDeg } from '@/utils/cardImages'
 import { rarityColor } from '@/components/draft/RarityBadge'
 import {
   parseQuery,
@@ -2564,9 +2564,14 @@ function DeckCard({
   onRename: (d: UnifiedDeck) => void
   onDelete: (d: UnifiedDeck) => void
 }) {
-  // Hero art = the deck's rarest card as a wide Scryfall art crop. Falls back to a
-  // colour-identity gradient when the deck has no catalogued non-land card yet.
-  const artUrl = useMemo(() => (hero ? getScryfallArtCropUrl(hero.name) : null), [hero])
+  // Hero art = the deck's rarest card as a wide Scryfall art crop. Derive it straight
+  // from the card's CDN image URL (no rate-limited api.scryfall.com lookup) when we have
+  // one, falling back to the by-name API lookup otherwise. Falls back to a colour-identity
+  // gradient when the deck has no catalogued non-land card yet.
+  const artUrl = useMemo(
+    () => (hero ? (getCdnArtCropUrl(hero.imageUri) ?? getScryfallArtCropUrl(hero.name)) : null),
+    [hero]
+  )
   const gradient = useMemo(() => deckBannerGradient(colors), [colors])
   const nameColor = deckNameColor(hero?.rarity)
   // One chip only: the format the deck was saved as, else the first format it's legal in.

--- a/web-client/src/components/draft/SetSynergiesOverlay.tsx
+++ b/web-client/src/components/draft/SetSynergiesOverlay.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import type { SealedCardInfo } from '@/types'
 import { ManaSymbol } from '../ui/ManaSymbols'
-import { getScryfallArtCropUrl } from '@/utils/cardImages'
+import { getCdnArtCropUrl, getScryfallArtCropUrl } from '@/utils/cardImages'
 
 /**
  * Archetype definition for a set's draft strategy.
@@ -371,36 +371,42 @@ const SET_SYNERGIES: Record<string, SetSynergies> = {
         name: 'Kithkin',
         colors: ['G', 'W'],
         creatureTypes: ['Kithkin'],
+        keyCard: "Brigid, Clachan's Heart",
         description: 'Flood the board with 1/1 Kithkin tokens, then use Convoke to cast expensive spells for free. Mass pump effects turn the token horde lethal.',
       },
       {
         name: 'Merfolk',
         colors: ['W', 'U'],
         creatureTypes: ['Merfolk'],
+        keyCard: 'Sygg, Wanderwine Wisdom',
         description: 'Merfolk untap each other after combat and chain together card draw. Control the pace of the game with bounce and tempo plays while building an unstoppable Merrow tide.',
       },
       {
         name: 'Faeries',
         colors: ['U', 'B'],
         creatureTypes: ['Faerie'],
+        keyCard: 'Maralen, Fae Ascendant',
         description: 'Operate entirely at flash speed — drop Faeries at end of turn, steal blockers, and lock out opponents with aerial superiority. A control deck that wins with evasion.',
       },
       {
         name: 'Boggarts',
         colors: ['B', 'R'],
         creatureTypes: ['Goblin'],
+        keyCard: 'Grub, Storied Matriarch',
         description: 'Relentless Boggart aggro backed by Wither. Your attackers deal damage as -1/-1 counters, permanently shrinking blockers. Blight provides flexible sacrifice payoffs.',
       },
       {
         name: 'Elementals',
         colors: ['U', 'R'],
         creatureTypes: ['Elemental'],
+        keyCard: 'Ashling, Rekindled',
         description: 'Flamekin Elementals reward casting instants and sorceries. Evoke provides flexible tempo plays — pay the cheap cost for a burst of value, or go full price for a permanent threat.',
       },
       {
         name: 'Changelings',
         colors: ['U', 'G'],
         creatureTypes: ['Shapeshifter'],
+        keyCard: 'Omni-Changeling',
         description: 'Changelings count as every creature type simultaneously, triggering Kithkin, Merfolk, Elf, and Faerie payoffs all at once. A tribal swiss-army-knife deck with enormous flexibility.',
       },
     ],
@@ -1168,7 +1174,14 @@ function ArchetypeCard({
   const [artFailed, setArtFailed] = useState(false)
   const [hovered, setHovered] = useState(false)
 
-  const artUrl = archetype.keyCard ? getScryfallArtCropUrl(archetype.keyCard) : null
+  // Prefer a direct CDN art crop derived from the key card's own image URL when that card
+  // is in the supplied pool — it skips the rate-limited api.scryfall.com lookup + redirect.
+  // Otherwise fall back to the by-name API lookup (the key card often isn't in the pool).
+  const artUrl = useMemo(() => {
+    if (!archetype.keyCard) return null
+    const poolMatch = cardPool?.find((c) => c.name === archetype.keyCard)
+    return getCdnArtCropUrl(poolMatch?.imageUri) ?? getScryfallArtCropUrl(archetype.keyCard)
+  }, [archetype.keyCard, cardPool])
   const showArt = artUrl != null && !artFailed
 
   const rarities = useMemo(() => {

--- a/web-client/src/utils/cardImages.test.ts
+++ b/web-client/src/utils/cardImages.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { getCdnArtCropUrl } from './cardImages'
+
+describe('getCdnArtCropUrl', () => {
+  it('rewrites the dominant `normal` CDN size to art_crop on the same host', () => {
+    expect(
+      getCdnArtCropUrl('https://cards.scryfall.io/normal/front/a/b/abc-123.jpg')
+    ).toBe('https://cards.scryfall.io/art_crop/front/a/b/abc-123.jpg')
+  })
+
+  it('preserves the cache-busting query string', () => {
+    expect(
+      getCdnArtCropUrl('https://cards.scryfall.io/normal/front/a/b/abc-123.jpg?1677416389')
+    ).toBe('https://cards.scryfall.io/art_crop/front/a/b/abc-123.jpg?1677416389')
+  })
+
+  it('rewrites the other croppable sizes', () => {
+    for (const size of ['small', 'large', 'border_crop']) {
+      expect(getCdnArtCropUrl(`https://cards.scryfall.io/${size}/front/a/b/id.jpg`)).toBe(
+        'https://cards.scryfall.io/art_crop/front/a/b/id.jpg'
+      )
+    }
+  })
+
+  it('normalises a png source to the jpg art_crop Scryfall serves', () => {
+    expect(getCdnArtCropUrl('https://cards.scryfall.io/png/front/a/b/id.png')).toBe(
+      'https://cards.scryfall.io/art_crop/front/a/b/id.jpg'
+    )
+  })
+
+  it('returns null for null/undefined so callers can fall back to the by-name lookup', () => {
+    expect(getCdnArtCropUrl(null)).toBeNull()
+    expect(getCdnArtCropUrl(undefined)).toBeNull()
+    expect(getCdnArtCropUrl('')).toBeNull()
+  })
+
+  it('returns null for non-Scryfall-CDN URLs (e.g. the api host or a test fixture)', () => {
+    expect(
+      getCdnArtCropUrl('https://api.scryfall.com/cards/named?exact=Foo&format=image&version=normal')
+    ).toBeNull()
+    expect(getCdnArtCropUrl('not-a-url')).toBeNull()
+  })
+})

--- a/web-client/src/utils/cardImages.ts
+++ b/web-client/src/utils/cardImages.ts
@@ -78,3 +78,30 @@ export function getScryfallArtCropUrl(cardName: string): string {
   const scryfallName = cardName.endsWith(' Token') ? cardName.slice(0, -6) : cardName
   return `https://api.scryfall.com/cards/named?exact=${encodeURIComponent(scryfallName)}&format=image&version=art_crop`
 }
+
+/**
+ * Derive the landscape *art crop* directly from a card's stored image URL.
+ *
+ * Our card metadata already carries a direct `cards.scryfall.io` CDN URL in `imageUri`
+ * (almost always the `normal` size). Scryfall keys every size of an image under the same
+ * path with only the size segment differing (`small` | `normal` | `large` | `png` |
+ * `border_crop` | `art_crop`), so swapping that segment yields the crop on the same CDN
+ * host — no `api.scryfall.com` round-trip, no redirect, and no API rate limiting (which
+ * only applies to the API host, not the image CDN).
+ *
+ * Prefer this over {@link getScryfallArtCropUrl} whenever a card's `imageUri` is on hand;
+ * fall back to the by-name API lookup only when it isn't (returns null here).
+ *
+ * @param imageUri A card's `imageUri` (e.g. `https://cards.scryfall.io/normal/front/a/b/<id>.jpg`)
+ * @returns The CDN `art_crop` URL, or null when `imageUri` isn't a recognised Scryfall CDN image URL
+ */
+export function getCdnArtCropUrl(imageUri: string | null | undefined): string | null {
+  if (!imageUri) return null
+  const match = imageUri.match(
+    /^(https:\/\/cards\.scryfall\.io\/)(small|normal|large|png|border_crop)(\/.*?)(\.\w+)(\?.*)?$/
+  )
+  if (!match) return null
+  const [, host, , path, , query = ''] = match
+  // art_crop is always served as .jpg, even when the source size (e.g. png) isn't.
+  return `${host}art_crop${path}.jpg${query}`
+}


### PR DESCRIPTION
## Problem

Two issues, both in the draft/sealed **set synergies overlay** (and the deck-gallery hero art):

1. **Lorwyn Eclipsed (ECL) archetype background images don't show.** All six ECL archetype tiles rendered as plain colour-identity gradients. Every other set's archetype entry carries a `keyCard` (the card whose Scryfall art crop becomes the tile backdrop); the ECL entries were added **without one**, so no art was ever fetched.

2. **Art crops load slowly.** Crops were requested via `https://api.scryfall.com/cards/named?exact=…&format=image&version=art_crop`. That endpoint does a DB lookup and a **302 redirect** to the `cards.scryfall.io` CDN, and — unlike the CDN — the **API host is rate-limited**. Rendering six tiles fires six API requests at once, which can trip `429`s (and intermittently fail to a gradient).

## Fix

**Backgrounds** — give each ECL archetype a key card. Every name below was verified to resolve on Scryfall in set `ECL` with an `art_crop` available:

| Archetype | Colors | Key card |
|---|---|---|
| Kithkin | GW | Brigid, Clachan's Heart |
| Merfolk | WU | Sygg, Wanderwine Wisdom |
| Faeries | UB | Maralen, Fae Ascendant |
| Boggarts | BR | Grub, Storied Matriarch |
| Elementals | UR | Ashling, Rekindled |
| Changelings | UG | Omni-Changeling |

**CDN** — our card metadata already carries a direct `cards.scryfall.io` URL in `imageUri` (almost always the `normal` size). Scryfall keys every size under the same path, so swapping the size segment to `art_crop` yields the crop on the **same CDN host** — no redirect, no API rate limit. New helper `getCdnArtCropUrl(imageUri)` does that rewrite (returns `null` for non-CDN URLs so callers fall back). 
- The synergies overlay now derives the crop from the key card's pooled `imageUri` when that card is in the player's pool, falling back to the by-name API lookup otherwise.
- The deckbuilder deck-gallery hero now derives its crop from `hero.imageUri` (a guaranteed CDN hit), same fallback.

**Lockstep** — `SetArchetypes.kt` (the AI/server-side archetype source) had **no ECL entry at all**; added one matching the frontend (names, colors, descriptions, creature types).

## Verification

- `npm run typecheck` — clean.
- `npx vitest run src/utils/cardImages.test.ts` — new test for `getCdnArtCropUrl` (6 cases) passes.
- `:ai:compileKotlin` — BUILD SUCCESSFUL.
- All six key-card art crops return `200` from Scryfall; the `normal`→`art_crop` CDN rewrite verified end-to-end against a real ECL card (`200 image/jpeg`).

> Note: no screenshot attached — reaching the overlay needs a full ECL draft/sealed session through the running stack. The visual result is the Scryfall art crop painted as each tile's backdrop; each crop URL was confirmed to return a real image. Happy to capture a live screenshot if wanted.