### PR TITLE
Always surface both normal and warp cast options for warp cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5898,7 +5898,12 @@ Card authors rarely reference these directly; they are created/updated by the ma
   `SourceProjectionCondition.ControllerHasCitysBlessing` + `PlayerCitysBlessingComponent`.
 - **Siege (named-mode entry)** — `EntersWithChoice(ChoiceType.MODE, modeOptions = ...)` + `SourceChosenModeIs("id")`.
 - **Morph** — `morph = "{2}{U}"` (top-level) + `morphFaceUpEffect` for "as it turns face up".
-- **Warp** — `warp = "{1}{R}"`; alt-cost that exiles end of turn.
+- **Warp** — `warp = "{1}{R}"`; alt-cost that exiles end of turn. Like morph and cycle, a warp card
+  always surfaces *both* cast options — its normal cost and its warp cost — in the action window, even
+  when only one (or neither) is payable; the unpayable side appears grayed out (CR 118.9a, the caster
+  chooses which cost to use). The warp action is enumerated by `CastFromZoneEnumerator`, which also
+  emits the grayed-out normal-cast placeholder when the normal cost is unaffordable (mirroring
+  `MorphCastEnumerator`).
 - **Evoke** — `evoke = "{U}"`; pay alt cost, sacrifice on ETB.
 - **Sneak** — `sneak("{1}{U}")`; declare-blockers-step alt cost (pay mana + return an unblocked attacker you control to hand); a resolving permanent enters tapped and attacking the same defender. `Conditions.SneakCostWasPaid` reads the rider flag.
 - **Ninjutsu** — `ninjutsu("{1}{U}{B}")`; the canonical CR 702.49 keyword that **Sneak** reflavors. Same declare-blockers alt cost and tapped-and-attacking entry, shared via `KeywordAbility.ninjutsuStyleCost`. *Kaito, Bane of Nightmares* (DSK).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -1448,6 +1448,32 @@ class CastFromZoneEnumerator : ActionEnumerator {
             val castRestrictions = cardDef.script.castRestrictions
             if (!context.castPermissionUtils.checkCastRestrictions(state, playerId, castRestrictions)) continue
 
+            // A warp card can always be cast two ways — its normal cost or its warp cost — and
+            // which to use is the caster's choice (CR 118.9a). Surface both in the action window
+            // even when only one is payable, mirroring how morph (MorphCastEnumerator) shows the
+            // normal cast alongside the face-down cast. The normal cast is otherwise legal here
+            // (timing, cast restrictions, and the no-cast lock have all been checked above); when
+            // it's affordable, CastSpellEnumerator emits the full-featured action, so we only add a
+            // greyed-out placeholder when the player can't pay the normal cost. Hand-only: there is
+            // no normal cast from the graveyard.
+            if (zone == Zone.HAND) {
+                val normalCost = context.costCalculator.calculateEffectiveCost(state, cardDef, playerId)
+                val canAffordNormal = context.manaSolver.canPay(
+                    state, playerId, normalCost, precomputedSources = context.availableManaSources
+                )
+                if (!canAffordNormal) {
+                    result.add(
+                        LegalAction(
+                            actionType = "CastSpell",
+                            description = "Cast ${cardComponent.name}",
+                            action = CastSpell(playerId, cardId),
+                            affordable = false,
+                            manaCostString = normalCost.toString()
+                        )
+                    )
+                }
+            }
+
             val effectiveCost = context.costCalculator.calculateEffectiveCostWithAlternativeBase(
                 state, cardDef, warpAbility.cost, playerId
             )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WarpMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WarpMechanicTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.AlternativeCostType
 import com.wingedsheep.engine.core.CastSpell
 import com.wingedsheep.engine.core.PaymentStrategy
 import com.wingedsheep.engine.state.components.battlefield.WarpedComponent
@@ -17,6 +18,7 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 import io.kotest.core.spec.style.FunSpec
@@ -269,6 +271,81 @@ class WarpMechanicTest : FunSpec({
             cast?.cardId == exiledCardId && cast.useAlternativeCost == true
         }
         warpCostCastFromExile shouldBe null
+    }
+
+    // A warp card in hand can be cast two ways — its normal cost or its warp cost — and which to
+    // use is the caster's choice (CR 118.9a). The action window must always surface both, even when
+    // only one is payable, mirroring how morph shows the normal cast alongside the face-down cast.
+
+    fun GameTestDriver.castOptionsFor(
+        cardId: EntityId,
+    ): Pair<com.wingedsheep.engine.legalactions.LegalAction?, com.wingedsheep.engine.legalactions.LegalAction?> {
+        val enumerator = LegalActionEnumerator.create(cardRegistry)
+        val legalActions = enumerator.enumerate(state, activePlayer!!)
+        val normalCast = legalActions.firstOrNull { action ->
+            val cast = action.action as? CastSpell
+            cast?.cardId == cardId && !cast.useAlternativeCost && !cast.castFaceDown
+        }
+        val warpCast = legalActions.firstOrNull { action ->
+            val cast = action.action as? CastSpell
+            cast?.cardId == cardId && cast.useAlternativeCost &&
+                cast.alternativeCostType == AlternativeCostType.WARP
+        }
+        return normalCast to warpCast
+    }
+
+    test("warp card shows both normal and warp cast when only the warp cost is affordable") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.gotoMainPhase()
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Warp Test Creature")
+        // Warp {1}{R} (2 mana, affordable) vs normal {3}{R}{R} (5 mana, not affordable).
+        repeat(2) { driver.putLandOnBattlefield(player, "Mountain") }
+
+        val (normalCast, warpCast) = driver.castOptionsFor(cardId)
+
+        warpCast shouldNotBe null
+        warpCast!!.affordable shouldBe true
+        normalCast shouldNotBe null
+        normalCast!!.affordable shouldBe false
+    }
+
+    test("warp card shows both normal and warp cast when neither cost is affordable") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.gotoMainPhase()
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Warp Test Creature")
+        // No mana sources — both the normal cost and the warp cost are unaffordable, but both
+        // ways to cast must still appear (greyed out) so the player sees the full action window.
+
+        val (normalCast, warpCast) = driver.castOptionsFor(cardId)
+
+        warpCast shouldNotBe null
+        warpCast!!.affordable shouldBe false
+        normalCast shouldNotBe null
+        normalCast!!.affordable shouldBe false
+    }
+
+    test("warp card shows both normal and warp cast when both costs are affordable") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.gotoMainPhase()
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Warp Test Creature")
+        // Five mana covers both the normal {3}{R}{R} and the warp {1}{R} cost.
+        repeat(5) { driver.putLandOnBattlefield(player, "Mountain") }
+
+        val (normalCast, warpCast) = driver.castOptionsFor(cardId)
+
+        warpCast shouldNotBe null
+        warpCast!!.affordable shouldBe true
+        normalCast shouldNotBe null
+        normalCast!!.affordable shouldBe true
     }
 
     test("spellWarpedThisTurn is set when a spell is warped") {


### PR DESCRIPTION
## Summary

A warp card can be cast two ways — its **normal cost** or its **warp cost** — and which to use is the caster's choice (CR 118.9a). The action window should always show **both**, even when only one (or neither) is currently payable, the same way morph and cycle cards already do.

Previously a warp card you could only afford to warp-cast arrived with a single legal action, so the client fired it directly instead of opening the cast menu with both options.

## Root cause

The warp action was already enumerated (and shown grayed-out when unaffordable). But the **normal cast** was hidden whenever its cost was unaffordable — `CastSpellEnumerator` `continue`s past spells it can't pay for. With only one legal action present, the client's `shouldShowCastModal` returned false and auto-fired the warp cast.

Morph already solved this: `MorphCastEnumerator` emits a grayed-out normal `CastSpell` placeholder when the normal cost is unaffordable, so both the face-down and normal options appear.

## Change

In `CastFromZoneEnumerator`'s warp path, when the normal cast is *legal-but-unaffordable* (timing, cast restrictions, and the no-cast lock are all checked first), emit a grayed-out normal `CastSpell` placeholder — mirroring `MorphCastEnumerator`. The client's existing multi-cast-option logic then renders both buttons, so **no client change is needed**.

- Gated to the **hand** pass only — there is no normal cast from the graveyard.
- When the normal cast *is* affordable, `CastSpellEnumerator` emits the full-featured action, so the placeholder is skipped to avoid a duplicate.

## Tests

Added three scenario cases to `WarpMechanicTest` asserting the action window surfaces **both** the normal and warp cast actions: only-warp-affordable (warp enabled, normal grayed), neither-affordable (both grayed), both-affordable (both enabled). Full `rules-engine` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)