### PR TITLE
Add 7 Wilds of Eldraine cards + image-rotation for flip-token Roles

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -138,6 +138,11 @@ section; do not let SDK additions land without a corresponding doc update.
 - `artist: String` — illustrator credit.
 - `flavorText: String` — italicized flavor.
 - `imageUri: String?` — art URL; auto-fetched from Scryfall if omitted.
+- `imageRotation: Int` — clockwise degrees to rotate the art when rendered (default `0`). Set `180` for
+  flip-layout tokens whose only Scryfall image shows the other face upright — the WOE Role tokens are printed
+  two-to-a-card (`Wicked // Cursed`, `Monster // Sorcerer`), so the bottom face (`Cursed`, `Sorcerer`) reads
+  upside-down on the single image. Purely cosmetic: flows SDK → `ClientCard.imageRotation` → client CSS transform;
+  the engine never reads it.
 - `scryfallId: String?` — Scryfall UUID.
 - `releaseDate: String?` — `YYYY-MM-DD`.
 - `inBooster: Boolean` — part of the draft/sealed product (default `true`; `false` for Special Guests / starter

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/CardBuilder.kt
@@ -1593,6 +1593,13 @@ class MetadataBuilder {
     var flavorText: String? = null
     var imageUri: String? = null
     var inBooster: Boolean = true
+
+    /**
+     * Clockwise rotation in degrees for the card art (default 0). Set `180` for flip-layout tokens
+     * whose only available image shows the other face upright — e.g. the Wilds of Eldraine "Cursed"
+     * and "Sorcerer" Roles, which are the bottom face of a two-roles-per-card flip token.
+     */
+    var imageRotation: Int = 0
     private val _rulings = mutableListOf<Ruling>()
 
     /**
@@ -1611,7 +1618,8 @@ class MetadataBuilder {
         flavorText = flavorText,
         imageUri = imageUri,
         rulings = _rulings.toList(),
-        inBooster = inBooster
+        inBooster = inBooster,
+        imageRotation = imageRotation
     )
 }
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/CardDefinition.kt
@@ -31,6 +31,14 @@ data class ScryfallMetadata(
     val releaseDate: String? = null,
     val rulings: List<Ruling> = emptyList(),
     /**
+     * Clockwise rotation in degrees to apply to the card art when rendered (default 0 = none).
+     * Used for flip-layout tokens whose only Scryfall image shows the *other* face upright: the
+     * Wilds of Eldraine Role tokens are printed two-to-a-card (e.g. "Wicked // Cursed"), so the
+     * bottom face ("Cursed") reads upside-down on the single available image and needs 180. Purely
+     * cosmetic — the engine never reads this; it flows through to the client renderer only.
+     */
+    val imageRotation: Int = 0,
+    /**
      * Whether this printing is part of the set's draft/sealed product. Mirrors Scryfall's
      * `booster` field — false for Special Guests, The List, promos, and other non-draft slots.
      * Drives [com.wingedsheep.engine.limited.BoosterGenerator]: gates both the booster pool and

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BelunasGatekeeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BelunasGatekeeper.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Beluna's Gatekeeper // Entry Denied
+ * {5}{U}
+ * Creature — Giant Soldier
+ * 6/5
+ *
+ * Adventure: Entry Denied — {1}{U}, Sorcery — Adventure
+ * Return target creature you don't control with mana value 3 or less to its owner's hand.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val BelunasGatekeeper = card("Beluna's Gatekeeper") {
+    manaCost = "{5}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Giant Soldier"
+    oracleText = ""
+    power = 6
+    toughness = 5
+
+    adventure("Entry Denied") {
+        manaCost = "{1}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Return target creature you don't control with mana value 3 or less to its owner's hand. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target(
+                "target",
+                TargetCreature(filter = TargetFilter.Creature.opponentControls().manaValueAtMost(3))
+            )
+            effect = Effects.ReturnToHand(t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "43"
+        artist = "Kai Carpenter"
+        flavorText = "\"And what makes you think Lady Grandsquall wants to see you, little one?\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BesottedKnight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/BesottedKnight.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Besotted Knight // Betroth the Beast
+ * {3}{W}
+ * Creature — Human Knight
+ * 3/3
+ *
+ * Adventure: Betroth the Beast — {W}, Sorcery — Adventure
+ * Create a Royal Role token attached to target creature you control.
+ * (Enchanted creature gets +1/+1 and has ward {1}.)
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val BesottedKnight = card("Besotted Knight") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    oracleText = ""
+    power = 3
+    toughness = 3
+
+    adventure("Betroth the Beast") {
+        manaCost = "{W}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Create a Royal Role token attached to target creature you control. " +
+            "(If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.) " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.CreatureYouControl)
+            effect = Effects.CreateRoleToken("Royal Role", t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "4"
+        artist = "Andreia Ugrai"
+        flavorText = "\"You are no monster to me, my love.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CheekyHouseMouse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/CheekyHouseMouse.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Cheeky House-Mouse // Squeak By
+ * {W}
+ * Creature — Mouse
+ * 2/1
+ *
+ * Adventure: Squeak By — {W}, Sorcery — Adventure
+ * Target creature you control gets +1/+1 until end of turn. It can't be blocked by creatures
+ * with power 3 or greater this turn.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val CheekyHouseMouse = card("Cheeky House-Mouse") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Mouse"
+    oracleText = ""
+    power = 2
+    toughness = 1
+
+    adventure("Squeak By") {
+        manaCost = "{W}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Target creature you control gets +1/+1 until end of turn. It can't be blocked by " +
+            "creatures with power 3 or greater this turn. (Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.CreatureYouControl)
+            effect = Effects.Composite(
+                Effects.ModifyStats(1, 1, t),
+                Effects.GrantStaticAbility(
+                    CantBeBlockedBy(GameObjectFilter.Creature.powerAtLeast(3)),
+                    t
+                )
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "7"
+        artist = "Uriah Voth"
+        flavorText = "\"Get back here, vile rodent! I was almost done cursing that ring!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FoodFight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/FoodFight.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.AnyTarget
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Food Fight
+ * {1}{R}
+ * Enchantment
+ *
+ * Artifacts you control have "{2}, Sacrifice this artifact: It deals damage to any target equal
+ * to 1 plus the number of permanents named Food Fight you control."
+ */
+val FoodFight = card("Food Fight") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Artifacts you control have \"{2}, Sacrifice this artifact: It deals damage to any target " +
+        "equal to 1 plus the number of permanents named Food Fight you control.\""
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{2}"), Costs.SacrificeSelf),
+                effect = Effects.DealDamage(
+                    DynamicAmount.Add(
+                        DynamicAmount.Fixed(1),
+                        DynamicAmount.Count(
+                            Player.You,
+                            Zone.BATTLEFIELD,
+                            GameObjectFilter.Any.named("Food Fight")
+                        )
+                    ),
+                    EffectTarget.ContextTarget(0),
+                    damageSource = EffectTarget.Self
+                ),
+                targetRequirement = AnyTarget()
+            ),
+            filter = GroupFilter(GameObjectFilter.Artifact.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "129"
+        artist = "Filipe Pagliuso"
+        flavorText = "With no time to gather weapons, the dwarves fought the redcaps with anything within reach."
+        imageUri = "https://cards.scryfall.io/normal/front/1/a/1a7cc43c-6e8c-41d2-a885-24604dfc7e7f.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MinecartDaredevil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MinecartDaredevil.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Minecart Daredevil // Ride the Rails
+ * {2}{R}
+ * Creature — Dwarf Knight
+ * 4/2
+ *
+ * Adventure: Ride the Rails — {1}{R}, Instant — Adventure
+ * Target creature gets +2/+1 until end of turn.
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val MinecartDaredevil = card("Minecart Daredevil") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dwarf Knight"
+    oracleText = ""
+    power = 4
+    toughness = 2
+
+    adventure("Ride the Rails") {
+        manaCost = "{1}{R}"
+        typeLine = "Instant — Adventure"
+        oracleText = "Target creature gets +2/+1 until end of turn. " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.Creature)
+            effect = Effects.ModifyStats(2, 1, t)
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "141"
+        artist = "Edgar Sánchez Hidalgo"
+        flavorText = "Mines that once rang with the strikes of pickaxes now echo with shouts of reckless glee."
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ThreeBowlsOfPorridge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/ThreeBowlsOfPorridge.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Three Bowls of Porridge
+ * {2}
+ * Artifact — Food
+ *
+ * {2}, {T}: Choose one that hasn't been chosen —
+ * • This artifact deals 2 damage to target creature.
+ * • Tap target creature.
+ * • Sacrifice this artifact. You gain 3 life.
+ *
+ * "Choose one that hasn't been chosen" is [ModalEffect.chooseOneNotYetChosen]: the engine
+ * remembers which modes this artifact has already chosen and never offers them again.
+ */
+val ThreeBowlsOfPorridge = card("Three Bowls of Porridge") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact — Food"
+    oracleText = "{2}, {T}: Choose one that hasn't been chosen —\n" +
+        "• This artifact deals 2 damage to target creature.\n" +
+        "• Tap target creature.\n" +
+        "• Sacrifice this artifact. You gain 3 life."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        effect = ModalEffect.chooseOneNotYetChosen(
+            // • This artifact deals 2 damage to target creature.
+            Mode.withTarget(
+                Effects.DealDamage(2, EffectTarget.ContextTarget(0), damageSource = EffectTarget.Self),
+                Targets.Creature,
+                "This artifact deals 2 damage to target creature"
+            ),
+            // • Tap target creature.
+            Mode.withTarget(
+                Effects.Tap(EffectTarget.ContextTarget(0)),
+                Targets.Creature,
+                "Tap target creature"
+            ),
+            // • Sacrifice this artifact. You gain 3 life.
+            Mode.noTarget(
+                Effects.Composite(
+                    SacrificeSelfEffect,
+                    Effects.GainLife(3)
+                ),
+                "Sacrifice this artifact. You gain 3 life"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "253"
+        artist = "Edgar Sánchez Hidalgo"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a508e040-d1e5-46aa-8404-1adc18f0f8bd.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VantressTransmuter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/VantressTransmuter.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vantress Transmuter // Croaking Curse
+ * {3}{U}
+ * Creature — Human Wizard
+ * 3/4
+ *
+ * Adventure: Croaking Curse — {1}{U}, Sorcery — Adventure
+ * Tap target creature. Create a Cursed Role token attached to it. (Enchanted creature is 1/1.)
+ *
+ * (CR 715: Adventure cards. Casting the Adventure exiles the card on resolution and lets the
+ * caster cast it as the creature spell while it remains in exile.)
+ */
+val VantressTransmuter = card("Vantress Transmuter") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = ""
+    power = 3
+    toughness = 4
+
+    adventure("Croaking Curse") {
+        manaCost = "{1}{U}"
+        typeLine = "Sorcery — Adventure"
+        oracleText = "Tap target creature. Create a Cursed Role token attached to it. " +
+            "(If you control another Role on it, put that one into the graveyard. Enchanted creature has base power and toughness 1/1.) " +
+            "(Then exile this card. You may cast the creature later from exile.)"
+        spell {
+            val t = target("target", Targets.Creature)
+            effect = Effects.Composite(
+                Effects.Tap(t),
+                Effects.CreateRoleToken("Cursed Role", t)
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "75"
+        artist = "Andrey Kuzinskiy"
+        flavorText = "\"My orders were to capture you alive. They didn't specify in what form.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/tokens/PredefinedTokens.kt
@@ -19,7 +19,10 @@ import com.wingedsheep.sdk.scripting.effects.SearchDestination
 import com.wingedsheep.sdk.scripting.effects.TransformEffect
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.GrantWard
 import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.effects.WardCost
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
@@ -325,7 +328,57 @@ object PredefinedTokens {
         }
 
         metadata {
+            // "Monster // Sorcerer" flip token: the single image shows Monster upright; Sorcerer is
+            // the bottom face and reads upside-down, so rotate 180° to display it correctly.
             imageUri = "https://cards.scryfall.io/normal/front/6/b/6b8a810b-8538-41c3-a792-dbd1a1845faa.jpg?1694737457"
+            imageRotation = 180
+            artist = "Rovina Cai"
+        }
+    }
+
+    /**
+     * Royal Role — Enchantment — Aura Role token (Wilds of Eldraine).
+     * "Enchanted creature gets +1/+1 and has ward {1}."
+     */
+    val RoyalRole = card("Royal Role") {
+        typeLine = "Enchantment — Aura Role"
+        oracleText = "Enchant creature\nEnchanted creature gets +1/+1 and has ward {1}."
+
+        auraTarget = Targets.Creature
+
+        staticAbility {
+            ability = ModifyStats(+1, +1, Filters.EnchantedCreature)
+        }
+
+        staticAbility {
+            ability = GrantWard(WardCost.Mana("{1}"))
+        }
+
+        metadata {
+            imageUri = "https://cards.scryfall.io/normal/front/c/f/cff8ef48-2988-4d21-837e-01f1459e07c5.jpg?1782732082"
+            artist = "Rovina Cai"
+        }
+    }
+
+    /**
+     * Cursed Role — Enchantment — Aura Role token (Wilds of Eldraine).
+     * "Enchanted creature has base power and toughness 1/1."
+     */
+    val CursedRole = card("Cursed Role") {
+        typeLine = "Enchantment — Aura Role"
+        oracleText = "Enchant creature\nEnchanted creature has base power and toughness 1/1."
+
+        auraTarget = Targets.Creature
+
+        staticAbility {
+            ability = SetBasePowerToughnessStatic(1, 1)
+        }
+
+        metadata {
+            // "Wicked // Cursed" flip token: the single image shows Wicked upright; Cursed is the
+            // bottom face and reads upside-down, so rotate 180° to display it correctly.
+            imageUri = "https://cards.scryfall.io/normal/front/a/9/a9b7040e-cd24-42cc-b043-9af8c557da6a.jpg?1782732081"
+            imageRotation = 180
             artist = "Rovina Cai"
         }
     }
@@ -529,6 +582,8 @@ object PredefinedTokens {
         Cragflame,
         Mutavault,
         SorcererRole,
+        RoyalRole,
+        CursedRole,
         Incubator,
         Drone,
         Everywhere,

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -152,6 +152,102 @@
     ]
 }
 
+// Beluna's Gatekeeper
+{
+    "name": "Beluna's Gatekeeper",
+    "manaCost": "{5}{U}",
+    "typeLine": "Creature — Giant Soldier",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "artist": "Kai Carpenter",
+        "flavorText": "\"And what makes you think Lady Grandsquall wants to see you, little one?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/c/5c1d410e-4237-4963-b015-54d26730e63d.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Entry Denied",
+            "manaCost": "{1}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Return target creature you don't control with mana value 3 or less to its owner's hand. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature mv<=3 ctrl:opponent"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
+// Besotted Knight
+{
+    "name": "Besotted Knight",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "artist": "Andreia Ugrai",
+        "flavorText": "\"You are no monster to me, my love.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/5980a930-c7f8-45e1-a18a-87734d9ed09e.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Betroth the Beast",
+            "manaCost": "{W}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Create a Royal Role token attached to target creature you control. (If you control another Role on it, put that one into the graveyard. Enchanted creature gets +1/+1 and has ward {1}.) (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "CreateRoleToken",
+                    "roleName": "Royal Role",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
+}
+
 // Bestial Bloodline
 {
     "name": "Bestial Bloodline",
@@ -360,6 +456,86 @@
         "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a860925-d912-49e5-9ddc-41ab26916bb3.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Cheeky House-Mouse
+{
+    "name": "Cheeky House-Mouse",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Mouse",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "metadata": {
+        "collectorNumber": "7",
+        "rarity": "UNCOMMON",
+        "artist": "Uriah Voth",
+        "flavorText": "\"Get back here, vile rodent! I was almost done cursing that ring!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f3013bf-9647-4bdb-a638-d299ae00f88e.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Squeak By",
+            "manaCost": "{W}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Target creature you control gets +1/+1 until end of turn. It can't be blocked by creatures with power 3 or greater this turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantStaticAbility",
+                            "ability": {
+                                "type": "CantBeBlockedBy",
+                                "blockerFilter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "PowerAtLeast",
+                                            "min": 3
+                                        }
+                                    ]
+                                }
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
+    ]
 }
 
 // Collector's Vault
@@ -863,6 +1039,74 @@
     ]
 }
 
+// Food Fight
+{
+    "name": "Food Fight",
+    "manaCost": "{1}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Artifacts you control have \"{2}, Sacrifice this artifact: It deals damage to any target equal to 1 plus the number of permanents named Food Fight you control.\"",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_1",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}"
+                                }
+                            },
+                            "CostSacrificeSelf"
+                        ]
+                    },
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Add",
+                            "left": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "right": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Battlefield",
+                                "filter": "name:Food Fight"
+                            }
+                        },
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "damageSource": "Self"
+                    },
+                    "targetRequirements": [
+                        "AnyTarget"
+                    ]
+                },
+                "filter": {
+                    "baseFilter": "artifact ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "rarity": "RARE",
+        "artist": "Filipe Pagliuso",
+        "flavorText": "With no time to gather weapons, the dwarves fought the redcaps with anything within reach.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/a/1a7cc43c-6e8c-41d2-a885-24604dfc7e7f.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Freeze in Place
 {
     "name": "Freeze in Place",
@@ -1221,6 +1465,61 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Minecart Daredevil
+{
+    "name": "Minecart Daredevil",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Dwarf Knight",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "metadata": {
+        "collectorNumber": "141",
+        "artist": "Edgar Sánchez Hidalgo",
+        "flavorText": "Mines that once rang with the strikes of pickaxes now echo with shouts of reckless glee.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5b2a02f3-3921-4f40-9ffa-70bc08b052e1.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Ride the Rails",
+            "manaCost": "{1}{R}",
+            "typeLine": "Instant — Adventure",
+            "oracleText": "Target creature gets +2/+1 until end of turn. (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
     ]
 }
 
@@ -2196,6 +2495,105 @@
     ]
 }
 
+// Three Bowls of Porridge
+{
+    "name": "Three Bowls of Porridge",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Food",
+    "oracleText": "{2}, {T}: Choose one that hasn't been chosen —\n• This artifact deals 2 damage to target creature.\n• Tap target creature.\n• Sacrifice this artifact. You gain 3 life.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "damageSource": "Self"
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature"
+                                    }
+                                }
+                            ],
+                            "description": "This artifact deals 2 damage to target creature"
+                        },
+                        {
+                            "effect": {
+                                "type": "TapUntap",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature"
+                                    }
+                                }
+                            ],
+                            "description": "Tap target creature"
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    "SacrificeSelf",
+                                    {
+                                        "type": "GainLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        }
+                                    }
+                                ]
+                            },
+                            "description": "Sacrifice this artifact. You gain 3 life"
+                        }
+                    ],
+                    "excludePreviouslyChosenModes": true,
+                    "countsAsModalSpell": false
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "253",
+        "rarity": "UNCOMMON",
+        "artist": "Edgar Sánchez Hidalgo",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a508e040-d1e5-46aa-8404-1adc18f0f8bd.jpg"
+    },
+    "colorIdentityOverride": []
+}
+
 // Toadstool Admirer
 {
     "name": "Toadstool Admirer",
@@ -2314,5 +2712,65 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Vantress Transmuter
+{
+    "name": "Vantress Transmuter",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "artist": "Andrey Kuzinskiy",
+        "flavorText": "\"My orders were to capture you alive. They didn't specify in what form.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/11507fa1-ef9e-41c9-b987-be57a03bd0df.jpg"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ],
+    "layout": "ADVENTURE",
+    "cardFaces": [
+        {
+            "name": "Croaking Curse",
+            "manaCost": "{1}{U}",
+            "typeLine": "Sorcery — Adventure",
+            "oracleText": "Tap target creature. Create a Cursed Role token attached to it. (If you control another Role on it, put that one into the graveyard. Enchanted creature has base power and toughness 1/1.) (Then exile this card. You may cast the creature later from exile.)",
+            "script": {
+                "spellEffect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "CreateRoleToken",
+                            "roleName": "Cursed Role",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        }
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -288,6 +288,13 @@ data class ClientCard(
     /** Image URI from card metadata (for rendering card images) */
     val imageUri: String? = null,
 
+    /**
+     * Clockwise rotation in degrees to apply to the card art when rendering (default 0). Non-zero
+     * only for flip-layout tokens whose single Scryfall image shows the other face upright — e.g.
+     * the Wilds of Eldraine "Cursed" / "Sorcerer" Roles need 180. Purely cosmetic.
+     */
+    val imageRotation: Int = 0,
+
     /** Active effects on this card (e.g., "can't be blocked except by black creatures") */
     val activeEffects: List<ClientCardEffect> = emptyList(),
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -1187,6 +1187,7 @@ class ClientStateTransformer(
             morphCost = if (isFaceDown && morphData != null) morphData.morphCost.description else null,
             targets = targets,
             imageUri = state.imageOverrideFor(entityId) ?: cardComponent.imageUri ?: cardDef?.metadata?.imageUri,
+            imageRotation = cardDef?.metadata?.imageRotation ?: 0,
             activeEffects = activeEffects,
             rulings = cardDef?.metadata?.rulings?.map {
                 ClientRuling(date = it.date, text = it.text)

--- a/web-client/src/components/game/card/CardPreview.tsx
+++ b/web-client/src/components/game/card/CardPreview.tsx
@@ -128,6 +128,11 @@ export function CardPreview() {
   const isRoom = card.isRoom === true
   const isSplit = card.cardFaces != null && card.cardFaces.length === 2
   const splitImageRotateDeg: 0 | 90 = isSplit ? 90 : 0
+  // Flip-layout tokens (WOE "Cursed" / "Sorcerer" Roles) carry imageRotation = 180 so the bottom
+  // face reads upright. Split-card landscape rotation takes precedence when both somehow apply.
+  const previewImageRotateDeg: 0 | 90 | 180 | 270 = splitImageRotateDeg !== 0
+    ? splitImageRotateDeg
+    : ((card.imageRotation ?? 0) as 0 | 90 | 180 | 270)
 
   // Mana cost overlay badge for the card image (only for hand cards)
   const previewOverlay = (
@@ -234,7 +239,7 @@ export function CardPreview() {
       pos={hoverPosition}
       rulings={card.rulings}
       extraHeight={extraHeight}
-      imageRotateDeg={splitImageRotateDeg}
+      imageRotateDeg={previewImageRotateDeg}
       overlay={previewOverlay}
     >
       {/* Stats box (for creatures with modifications) */}

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -412,6 +412,12 @@ function GameCardImpl({
     ? (card.isManifested ? MANIFEST_FACE_DOWN_IMAGE_URL : MORPH_FACE_DOWN_IMAGE_URL)
     : getCardImageUrl(card.name, card.imageUri, 'normal')
 
+  // Flip-layout tokens (e.g. the WOE "Cursed" / "Sorcerer" Roles) carry only one Scryfall image,
+  // which shows the other face upright; imageRotation (degrees) flips the art to read correctly.
+  const imageRotationStyle = !faceDown && card.imageRotation
+    ? { transform: `rotate(${card.imageRotation}deg)` }
+    : undefined
+
   // Use responsive sizes, but allow override for fitting cards in hand
   const baseWidth = small
     ? responsive.smallCardWidth
@@ -1226,7 +1232,7 @@ function GameCardImpl({
             <img
               src={cardImageUrl}
               alt={card.name}
-              style={styles.tokenArtImage}
+              style={imageRotationStyle ? { ...styles.tokenArtImage, ...imageRotationStyle } : styles.tokenArtImage}
             />
           </div>
           <div style={{
@@ -1242,7 +1248,7 @@ function GameCardImpl({
           <img
             src={cardImageUrl}
             alt={faceDown ? 'Card back' : card.name}
-            style={styles.cardImage}
+            style={imageRotationStyle ? { ...styles.cardImage, ...imageRotationStyle } : styles.cardImage}
             onError={(e) => {
               const img = e.currentTarget
               const fallbackUrl = getScryfallFallbackUrl(card.name, 'normal')

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -261,6 +261,13 @@ export interface ClientCard {
   /** Image URI from card metadata (for rendering card images) */
   readonly imageUri?: string | null
 
+  /**
+   * Clockwise rotation in degrees for the card art (default 0 / absent). Non-zero only for
+   * flip-layout tokens whose single image shows the other face upright (e.g. the WOE "Cursed" /
+   * "Sorcerer" Roles need 180). Purely cosmetic.
+   */
+  readonly imageRotation?: number
+
   /** Active effects on this card (e.g., "can't be blocked except by black creatures") */
   readonly activeEffects?: readonly ClientCardEffect[]
 


### PR DESCRIPTION
## Summary

Implements **7 Wilds of Eldraine cards** plus a small cross-layer **image-rotation** capability for flip-layout Role tokens.

These were surfaced via `mtgish-tooling` as "AUTOGEN / complete render," but on inspection the emitter **mis-rendered all of them** (dropped Adventure faces, lossy-filtered effects), so each card was hand-modeled from authoritative Scryfall data. Of the original 10 AUTOGEN candidates, 3 genuinely need new engine predicates (`IsEnchanted`, "has an Adventure") and are deferred to a follow-up `add-feature`.

### Cards
- **Beluna's Gatekeeper // Entry Denied** — Adventure: return target creature you don't control with MV ≤ 3
- **Cheeky House-Mouse // Squeak By** — Adventure: +1/+1 + can't be blocked by power 3+ this turn
- **Minecart Daredevil // Ride the Rails** — Adventure: +2/+1 until EOT
- **Besotted Knight // Betroth the Beast** — Adventure: create a Royal Role on a creature you control
- **Vantress Transmuter // Croaking Curse** — Adventure: tap target creature + create a Cursed Role
- **Three Bowls of Porridge** — "choose one that hasn't been chosen" modal (damage / tap / sac + gain life)
- **Food Fight** — grants artifacts a sac ability dealing `1 + #permanents named Food Fight you control` to any target

### Tokens
- **Royal Role** (+1/+1, ward {1}) and **Cursed Role** (base P/T 1/1) added to `PredefinedTokens`.

### Feature: `imageRotation`
The WOE Role tokens are printed two-to-a-card flip tokens (`Wicked // Cursed`, `Monster // Sorcerer`), so the bottom face reads upside-down on the single available Scryfall image. Added a cosmetic `ScryfallMetadata.imageRotation` (degrees) flowing **SDK → `ClientCard` DTO → client `GameCard` render + hover `CardPreview`**. Cursed Role and Sorcerer Role set `imageRotation = 180` to display right-side-up on both the board and the hover preview. The engine never reads it. Documented in `card-sdk-language-reference.md`.

## Testing
- ✅ Full `just test` — BUILD SUCCESSFUL
- ✅ Card snapshot re-blessed (`WOE.json`); diff is exactly the 7 new cards, nothing unrelated moved
- ✅ Web-client typecheck clean for changed files (pre-existing `admin/GeoMap.tsx` missing-module errors are unrelated and untouched)
- ⚠️ No behavioral scenario tests added — all 7 cards compose pre-existing mechanics, so coverage rests on the snapshot net + full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)