### PR TITLE
Show chosen color on enchanted land (Shimmerwilds Growth)

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientDTO.kt
@@ -159,6 +159,14 @@ data class ClientCard(
     /** Card colors */
     val colors: Set<Color>,
 
+    /**
+     * Colors this permanent has been granted by an attached "choose a color" aura
+     * (e.g. Shimmerwilds Growth's "Enchanted land is the chosen color"). The chosen
+     * colour lives on the hidden aura behind the host, so we surface it here so the
+     * client can paint a mana pip on the host showing the colour it has become.
+     */
+    val grantedColors: Set<Color> = emptySet(),
+
     /** Oracle text / rules text (for display in card details) */
     val oracleText: String,
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GrantChosenColor
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.ProtectionScope
 import com.wingedsheep.engine.state.GameState
@@ -911,6 +912,21 @@ class ClientStateTransformer(
             state.getEntity(otherId)?.get<AttachedToComponent>()?.targetId == entityId
         }
 
+        // Surface colours granted to this permanent by an attached "choose a colour" aura
+        // (Shimmerwilds Growth: "Enchanted land is the chosen color"). The chosen colour is
+        // stored on the *aura's* CastChoicesComponent, and the aura sits hidden behind its host,
+        // so without this the host shows no sign of the colour it has become. We only surface a
+        // colour from auras that actually grant the chosen colour to their host (they carry a
+        // GrantChosenColor static ability), so an aura that picks a colour for some other reason
+        // doesn't paint a misleading pip on the host.
+        val grantedColors = attachments.mapNotNull { auraId ->
+            val auraContainer = state.getEntity(auraId) ?: return@mapNotNull null
+            val grantsColor = auraContainer.get<CardComponent>()
+                ?.let { cardRegistry.getCard(it.cardDefinitionId) }
+                ?.script?.staticAbilities?.any { it is GrantChosenColor } == true
+            if (grantsColor) auraContainer.chosenColor() else null
+        }.toSet()
+
         // Get linked exile (cards exiled by this permanent, e.g., Suspension Field)
         val linkedExile = container.get<LinkedExileComponent>()?.exiledIds ?: emptyList()
 
@@ -1146,6 +1162,7 @@ class ClientStateTransformer(
             cardTypes = displayCardTypes.map { it.name }.toSet(),
             subtypes = displaySubtypes.toSet(),
             colors = if (castFace != null) castFace.manaCost.colors else colors,
+            grantedColors = grantedColors,
             oracleText = castFace?.oracleText ?: cardComponent.oracleText,
             // A non-permanent cast face (Omen/Adventure/split half) has no power/toughness.
             power = if (castFace != null) null else power,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShimmerwildsGrowthTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShimmerwildsGrowthTest.kt
@@ -11,6 +11,7 @@ import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.basicLand
@@ -232,5 +233,41 @@ class ShimmerwildsGrowthTest : FunSpec({
 
         val pool = driver.state.getEntity(activePlayer)!!.get<ManaPoolComponent>()!!
         pool.green shouldBe 2
+    }
+
+    test("Client view surfaces the chosen color on the enchanted land") {
+        // The chosen color lives on the (hidden) aura, so the client projection lifts it
+        // onto the enchanted land's grantedColors so the UI can paint a pip showing the
+        // color the land has become.
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putPermanentOnBattlefield(activePlayer, "Forest")
+        val growth = driver.putCardInHand(activePlayer, "Shimmerwilds Growth")
+        driver.giveMana(activePlayer, Color.GREEN, 2)
+        driver.castSpell(activePlayer, growth, listOf(forest))
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as ChooseColorDecision
+        driver.submitDecision(activePlayer, ColorChosenResponse(decision.id, Color.BLUE))
+
+        val view = ClientStateTransformer(cardRegistry = driver.cardRegistry)
+            .transform(driver.state, viewingPlayerId = activePlayer)
+
+        // The land carries the chosen color so the client can render a pip on it.
+        view.cards[forest]?.grantedColors shouldBe setOf(Color.BLUE)
+        // The aura made no choice "of its own" — its chosenColor is its display label, but
+        // it carries no grantedColors (nothing is attached to it).
+        val auraId = driver.state.getBattlefield().first { entityId ->
+            driver.state.getEntity(entityId)
+                ?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Shimmerwilds Growth"
+        }
+        view.cards[auraId]?.grantedColors shouldBe emptySet()
     }
 })

--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -6,7 +6,7 @@ import type { ClientCard, EntityId } from '@/types'
 import { Color, ColorSymbols, Keyword } from '@/types/enums'
 import { getCardImageUrl, getScryfallFallbackUrl, MANIFEST_FACE_DOWN_IMAGE_URL, MORPH_FACE_DOWN_IMAGE_URL } from '@/utils/cardImages.ts'
 import { useInteraction } from '@/hooks/useInteraction.ts'
-import { ManaCost } from '@/components/ui/ManaSymbols.tsx'
+import { ManaCost, ManaSymbol } from '@/components/ui/ManaSymbols.tsx'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview.tsx'
 import {
   useResponsiveContext,
@@ -58,6 +58,15 @@ import { KeywordIcons, ActiveEffectBadges } from './CardOverlays'
 import { counterManaClass, counterSvgIcon } from '@/assets/icons/keywords'
 import { SvgGlyph } from '@/assets/icons/SvgGlyph'
 import { RenderProfiler } from '@/utils/renderProfiler'
+
+/** Soft halo colors for the chosen-color gem, keyed by MTG color (see grantedColors). */
+const COLOR_GLOW: Record<Color, string> = {
+  [Color.WHITE]: 'rgba(245, 240, 210, 0.9)',
+  [Color.BLUE]: 'rgba(74, 144, 217, 0.9)',
+  [Color.BLACK]: 'rgba(150, 120, 165, 0.9)',
+  [Color.RED]: 'rgba(214, 74, 58, 0.9)',
+  [Color.GREEN]: 'rgba(74, 168, 90, 0.9)',
+}
 
 interface GameCardProps {
   card: ClientCard
@@ -1338,6 +1347,42 @@ function GameCardImpl({
               filter: 'drop-shadow(0 0 2px rgba(212, 175, 55, 0.85))',
             }}
           />
+        </div>
+      )}
+
+      {/* Chosen-color gem — when an attached "choose a color" aura (e.g. Shimmerwilds Growth's
+          "Enchanted land is the chosen color") has made this permanent a color, the aura sits
+          hidden behind the host, so paint the chosen color(s) as mana pip(s) on the host itself.
+          A soft colored halo makes the granted color readable at a glance even on an
+          otherwise-colorless land. */}
+      {battlefield && !faceDown && card.grantedColors && card.grantedColors.length > 0 && (
+        <div
+          aria-label={`Chosen color: ${card.grantedColors.map((c) => c.toLowerCase()).join(', ')}`}
+          title={`Chosen color: ${card.grantedColors
+            .map((c) => c.charAt(0) + c.slice(1).toLowerCase())
+            .join(', ')}`}
+          style={{
+            position: 'absolute',
+            top: 3,
+            // Slide clear of the ring-bearer marker on the rare creature that has both.
+            left: card.isRingBearer ? 3 + responsive.badges.ptFontSize * 2 : 3,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            padding: '2px 4px',
+            borderRadius: 999,
+            background: 'radial-gradient(circle at 35% 30%, rgba(34, 34, 42, 0.92) 0%, rgba(10, 10, 14, 0.92) 90%)',
+            border: '1px solid rgba(255, 255, 255, 0.28)',
+            boxShadow: card.grantedColors
+              .map((c) => `0 0 6px 1px ${COLOR_GLOW[c]}`)
+              .join(', '),
+            zIndex: 7,
+            pointerEvents: 'none',
+          }}
+        >
+          {card.grantedColors.map((c) => (
+            <ManaSymbol key={c} symbol={ColorSymbols[c]} size={responsive.badges.ptFontSize * 1.25} />
+          ))}
         </div>
       )}
 

--- a/web-client/src/types/gameState.ts
+++ b/web-client/src/types/gameState.ts
@@ -125,6 +125,14 @@ export interface ClientCard {
   /** Card colors */
   readonly colors: readonly Color[]
 
+  /**
+   * Colors this permanent has been granted by an attached "choose a color" aura
+   * (e.g. Shimmerwilds Growth's "Enchanted land is the chosen color"). The chosen
+   * color lives on the hidden aura behind the host, so it's surfaced here to paint
+   * a mana pip on the host showing the color it has become.
+   */
+  readonly grantedColors?: readonly Color[]
+
   /** Oracle text / rules text (for display in card details) */
   readonly oracleText: string
 


### PR DESCRIPTION
## Problem

[Shimmerwilds Growth](https://scryfall.com/card/eoc/194)'s "Enchanted land is the chosen color" stores the chosen colour on the **Aura**. On the battlefield the Aura sits hidden behind its host, so the enchanted land showed **no sign** of the colour it had become — the player had to remember what they picked.

## Fix

Surface the chosen colour on the **host** permanent instead of leaving it on the hidden aura.

- **`ClientCard.grantedColors`** (new, defaults empty — purely additive to the DTO).
- **`ClientStateTransformer`** derives it from the host's attachments: for each attached aura that actually grants the chosen colour to its host (it carries a `GrantChosenColor` static ability), the aura's chosen colour is lifted onto the host. Auras that pick a colour for some other reason don't paint a misleading pip.
- **`GameCard`** renders one `ManaSymbol` gem per granted colour in a softly glowing pill at the card's top-left, so an otherwise-colourless land visibly reads as the colour it has become. The pill slides clear of the Ring-bearer marker on the rare creature that has both.
- **`ShimmerwildsGrowthTest`** gains a projection test asserting the enchanted land carries `grantedColors = {BLUE}` while the aura itself carries none.

Generic by construction: any current/future "choose a colour" aura that grants its host a colour gets the pip for free.

## Screenshots

Enchanted Mountain (Blue chosen) now shows a blue `{U}` gem, next to a plain Forest and Island for contrast:

![Enchanted land chosen-color pip](https://raw.githubusercontent.com/wingedsheep/argentum-engine/shimmerwilds-chosen-color-screenshots/chosen-color-lands.png)

In-board context:

![Board view](https://raw.githubusercontent.com/wingedsheep/argentum-engine/shimmerwilds-chosen-color-screenshots/chosen-color-board.png)

_(Screenshots live on the throwaway `shimmerwilds-chosen-color-screenshots` branch, not this PR's diff.)_

## Testing

- `just test-class ShimmerwildsGrowthTest` — 6/6 pass (incl. new projection test).
- `just build` — green.
- `web-client` `npm run typecheck` + `npm run build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)