### PR TITLE
Admin portal: global recent games + tournaments (click-through)

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminStatsController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminStatsController.kt
@@ -90,6 +90,24 @@ class AdminStatsController(
         ResponseEntity.ok(statsQuery.recentTournaments(limit.coerceIn(1, 200)))
     }
 
+    /**
+     * A page of the most-recent games across every player, newest first, with the total in
+     * `X-Total-Count` so the admin UI can page through every recorded game. Neutral (lists every
+     * seat, winner flagged) — unlike the per-user history which is a single viewer's perspective.
+     */
+    @GetMapping("/recent-games")
+    fun recentGames(
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+        @RequestParam(defaultValue = "25") limit: Int,
+        @RequestParam(defaultValue = "0") offset: Int,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        val entries = statsQuery.recentGamesGlobal(limit.coerceIn(1, 100), offset.coerceAtLeast(0))
+        ResponseEntity.ok()
+            .header("X-Total-Count", statsQuery.recentGamesGlobalCount().toString())
+            .body(entries)
+    }
+
     @GetMapping("/geo")
     fun geo(
         @RequestHeader("X-Admin-Password", required = false) password: String?,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -190,14 +190,35 @@ data class AdminUserStat(
     val lastPlayed: String?,
 )
 
-/** A recorded tournament for the admin list. */
+/** A recorded tournament for the admin list. The [id] opens the shared tournament detail view. */
 data class TournamentSummary(
+    val id: Long,
     val endedAt: String,
     val name: String?,
     val format: String?,
     val gameMode: String?,
     val playerCount: Int,
     val winnerName: String?,
+)
+
+/** One seat in a recorded game, for the admin global game list. */
+data class AdminGamePlayer(
+    val name: String,
+    val userId: UUID?,
+    val isAi: Boolean,
+    val won: Boolean,
+)
+
+/** A recorded game for the admin global game list, newest first, with every seat. */
+data class AdminRecentGame(
+    val gameId: String,
+    val endedAt: String,
+    val gameMode: String?,
+    val format: String?,
+    val players: List<AdminGamePlayer>,
+    val winnerName: String?,
+    val hasReplay: Boolean,
+    val tournamentName: String?,
 )
 
 /**
@@ -915,13 +936,14 @@ class StatsQueryService(
     /** Recorded tournaments, newest first. */
     fun recentTournaments(limit: Int): List<TournamentSummary> = jdbc.query(
         """
-        SELECT ended_at, name, format, game_mode, player_count, winner_name
+        SELECT id, ended_at, name, format, game_mode, player_count, winner_name
         FROM tournaments
         ORDER BY ended_at DESC
         LIMIT ?
         """.trimIndent(),
         { rs, _ ->
             TournamentSummary(
+                id = rs.getLong("id"),
                 endedAt = rs.getTimestamp("ended_at").toInstant().toString(),
                 name = rs.getString("name"),
                 format = rs.getString("format"),
@@ -932,4 +954,112 @@ class StatsQueryService(
         },
         limit,
     )
+
+    /** Total number of recorded games across every player — drives the admin global game pager. */
+    fun recentGamesGlobalCount(): Long = jdbc.queryForObject(
+        "SELECT count(*) FROM match_results",
+        Long::class.java,
+    ) ?: 0
+
+    /**
+     * The most-recent games across every player, newest first, one page at a time. Unlike the
+     * per-user [recentGames] this is neutral — it lists every seat (winner flagged) rather than a
+     * single viewer's perspective — and tags each game with its tournament name when it came from one.
+     */
+    fun recentGamesGlobal(limit: Int, offset: Int): List<AdminRecentGame> {
+        data class Row(
+            val mid: Long,
+            val gameId: String,
+            val endedAt: String,
+            val gameMode: String?,
+            val format: String?,
+            val lobbyId: String?,
+            val hasReplay: Boolean,
+        )
+        val rows = jdbc.query(
+            """
+            SELECT r.id AS mid, r.game_id AS game_id, r.ended_at AS ended_at, r.game_mode AS game_mode,
+                   r.format AS format, r.lobby_id AS lobby_id, (gr.id IS NOT NULL) AS has_replay
+            FROM match_results r
+            LEFT JOIN game_replays gr ON gr.game_id = r.game_id
+            ORDER BY r.ended_at DESC
+            LIMIT ? OFFSET ?
+            """.trimIndent(),
+            { rs, _ ->
+                Row(
+                    mid = rs.getLong("mid"),
+                    gameId = rs.getString("game_id"),
+                    endedAt = rs.getTimestamp("ended_at").toInstant().toString(),
+                    gameMode = rs.getString("game_mode"),
+                    format = rs.getString("format"),
+                    lobbyId = rs.getString("lobby_id"),
+                    hasReplay = rs.getBoolean("has_replay"),
+                )
+            },
+            limit, offset,
+        )
+        if (rows.isEmpty()) return emptyList()
+        val playersByMid = playersForMatches(rows.map { it.mid })
+        val tournamentNames = tournamentNamesByLobby(rows.mapNotNull { it.lobbyId })
+        return rows.map { row ->
+            val players = playersByMid[row.mid].orEmpty()
+            AdminRecentGame(
+                gameId = row.gameId,
+                endedAt = row.endedAt,
+                gameMode = row.gameMode,
+                format = row.format,
+                players = players,
+                winnerName = players.firstOrNull { it.won }?.name,
+                hasReplay = row.hasReplay,
+                tournamentName = row.lobbyId?.let { tournamentNames[it] },
+            )
+        }
+    }
+
+    /** Every seat for a set of match ids, keyed by match id (seat order preserved). */
+    private fun playersForMatches(matchIds: List<Long>): Map<Long, List<AdminGamePlayer>> {
+        if (matchIds.isEmpty()) return emptyMap()
+        val placeholders = matchIds.joinToString(",") { "?" }
+        val out = LinkedHashMap<Long, MutableList<AdminGamePlayer>>()
+        jdbc.query(
+            """
+            SELECT p.match_id AS mid, COALESCE(u.display_name, p.player_name) AS name,
+                   p.user_id AS uid, p.is_ai AS is_ai, p.won AS won
+            FROM match_participants p
+            LEFT JOIN users u ON u.id = p.user_id
+            WHERE p.match_id IN ($placeholders)
+            ORDER BY p.id
+            """.trimIndent(),
+            { rs ->
+                out.getOrPut(rs.getLong("mid")) { mutableListOf() }.add(
+                    AdminGamePlayer(
+                        name = rs.getString("name"),
+                        userId = rs.getObject("uid", UUID::class.java),
+                        isAi = rs.getBoolean("is_ai"),
+                        won = rs.getBoolean("won"),
+                    ),
+                )
+            },
+            *matchIds.toTypedArray(),
+        )
+        return out
+    }
+
+    /** Tournament name for each lobby id that has one, keyed by lobby id. */
+    private fun tournamentNamesByLobby(lobbyIds: List<String>): Map<String, String> {
+        val distinct = lobbyIds.distinct()
+        if (distinct.isEmpty()) return emptyMap()
+        val placeholders = distinct.joinToString(",") { "?" }
+        val out = HashMap<String, String>()
+        jdbc.query(
+            "SELECT lobby_id, name FROM tournaments WHERE lobby_id IN ($placeholders)",
+            { rs ->
+                val lobby = rs.getString("lobby_id")
+                val name = rs.getString("name")
+                if (lobby != null && name != null) out[lobby] = name
+            },
+            *distinct.toTypedArray(),
+        )
+        return out
+    }
 }

--- a/web-client/src/api/adminStats.ts
+++ b/web-client/src/api/adminStats.ts
@@ -42,12 +42,40 @@ export interface CardWinRate {
 }
 
 export interface TournamentSummary {
+  /** Opens the full tournament detail (standings + games). */
+  readonly id: number
   readonly endedAt: string
   readonly name: string | null
   readonly format: string | null
   readonly gameMode: string | null
   readonly playerCount: number
   readonly winnerName: string | null
+}
+
+/** One seat in a recorded game, for the admin global game list. */
+export interface AdminGamePlayer {
+  readonly name: string
+  readonly userId: string | null
+  readonly isAi: boolean
+  readonly won: boolean
+}
+
+/** A recorded game in the admin global game list, with every seat. */
+export interface AdminRecentGame {
+  readonly gameId: string
+  readonly endedAt: string
+  readonly gameMode: string | null
+  readonly format: string | null
+  readonly players: AdminGamePlayer[]
+  readonly winnerName: string | null
+  readonly hasReplay: boolean
+  readonly tournamentName: string | null
+}
+
+/** A page of global games plus the total count (for the pager). */
+export interface AdminRecentGamesPage {
+  readonly entries: AdminRecentGame[]
+  readonly total: number
 }
 
 async function getAdminStats<T>(auth: AdminAuth, path: string): Promise<T> {
@@ -68,3 +96,18 @@ export const fetchCardWinRates = (auth: AdminAuth, minDecks = 10, limit = 50) =>
   getAdminStats<CardWinRate[]>(auth, `/cards/win-rates?minDecks=${minDecks}&limit=${limit}`)
 export const fetchTournaments = (auth: AdminAuth, limit = 50) =>
   getAdminStats<TournamentSummary[]>(auth, `/tournaments?limit=${limit}`)
+
+/** A page of global games, newest first; `total` comes from the `X-Total-Count` header. */
+export async function fetchRecentGames(
+  auth: AdminAuth,
+  limit: number,
+  offset: number,
+): Promise<AdminRecentGamesPage> {
+  const res = await fetch(`/api/stats/admin/recent-games?limit=${limit}&offset=${offset}`, {
+    headers: adminAuthHeaders(auth),
+  })
+  if (!res.ok) throw new Error(`Failed to load games (${res.status})`)
+  const total = Number(res.headers.get('X-Total-Count') ?? '0')
+  const entries = (await res.json()) as AdminRecentGame[]
+  return { entries, total: Number.isFinite(total) ? total : entries.length }
+}

--- a/web-client/src/components/admin/AdminActivity.tsx
+++ b/web-client/src/components/admin/AdminActivity.tsx
@@ -1,0 +1,218 @@
+/**
+ * Admin Activity: global, cross-player lists of recent games and recent tournaments — the same
+ * "recent games + tournaments you can click through" experience a player gets on their own profile,
+ * but spanning every player. Games page through every recorded game (newest first) and link to their
+ * replay; tournaments open the shared {@link TournamentDetailModal} (standings + every game played).
+ *
+ * Read-only and gated behind the dashboard's shared {@link AdminAuth}. The screen scrolls itself
+ * (see AdminScreen).
+ */
+import { useCallback, useEffect, useState } from 'react'
+import type React from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  type AdminGamePlayer,
+  type AdminRecentGame,
+  type TournamentSummary,
+  fetchRecentGames,
+  fetchTournaments,
+} from '@/api/adminStats'
+import type { AdminAuth } from '@/api/adminAuth'
+import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
+import { gameModeLabel } from './statFormat'
+import { AdminScreen, Panel, Table, adminTheme, cellStyle } from './adminUi'
+
+/** Games per page in the recent-games pager. */
+const GAMES_PAGE_SIZE = 20
+/** How many tournaments to list. */
+const TOURNAMENTS_LIMIT = 50
+
+export function AdminActivity({ auth, onBack }: { auth: AdminAuth; onBack: () => void }) {
+  const navigate = useNavigate()
+
+  const [games, setGames] = useState<AdminRecentGame[]>([])
+  const [gamesTotal, setGamesTotal] = useState(0)
+  const [page, setPage] = useState(0)
+  const [gamesError, setGamesError] = useState<string | null>(null)
+
+  const [tournaments, setTournaments] = useState<TournamentSummary[]>([])
+  const [tournamentsError, setTournamentsError] = useState<string | null>(null)
+  const [openTournament, setOpenTournament] = useState<number | null>(null)
+
+  const loadGames = useCallback(
+    async (p: number) => {
+      try {
+        const { entries, total } = await fetchRecentGames(auth, GAMES_PAGE_SIZE, p * GAMES_PAGE_SIZE)
+        setGames(entries)
+        setGamesTotal(total)
+        setGamesError(null)
+      } catch (e) {
+        setGamesError(e instanceof Error ? e.message : 'Failed to load games')
+      }
+    },
+    [auth],
+  )
+
+  useEffect(() => {
+    void loadGames(page)
+  }, [loadGames, page])
+
+  useEffect(() => {
+    let cancelled = false
+    fetchTournaments(auth, TOURNAMENTS_LIMIT)
+      .then((t) => !cancelled && setTournaments(t))
+      .catch((e) => !cancelled && setTournamentsError(e instanceof Error ? e.message : 'Failed to load tournaments'))
+    return () => {
+      cancelled = true
+    }
+  }, [auth])
+
+  const lastPage = Math.max(0, Math.ceil(gamesTotal / GAMES_PAGE_SIZE) - 1)
+  const rangeStart = gamesTotal === 0 ? 0 : page * GAMES_PAGE_SIZE + 1
+  const rangeEnd = Math.min(gamesTotal, (page + 1) * GAMES_PAGE_SIZE)
+
+  return (
+    <AdminScreen
+      title="Activity"
+      subtitle="Recent games and tournaments across every player"
+      onBack={onBack}
+      backLabel="← Dashboard"
+    >
+      <Panel
+        title="Recent games"
+        action={
+          gamesTotal > 0 ? (
+            <span style={styles.pager}>
+              <button type="button" style={pageBtn(page <= 0)} disabled={page <= 0} onClick={() => setPage((p) => Math.max(0, p - 1))}>
+                ← Newer
+              </button>
+              <span style={styles.pageInfo}>
+                {rangeStart}–{rangeEnd} of {gamesTotal}
+              </span>
+              <button type="button" style={pageBtn(page >= lastPage)} disabled={page >= lastPage} onClick={() => setPage((p) => Math.min(lastPage, p + 1))}>
+                Older →
+              </button>
+            </span>
+          ) : null
+        }
+      >
+        {gamesError ? (
+          <p style={styles.error}>{gamesError}</p>
+        ) : games.length === 0 ? (
+          <p style={cellStyle.muted}>No games recorded yet.</p>
+        ) : (
+          <Table head={['Date', 'Mode', 'Players', 'Winner', 'Replay']}>
+            {games.map((g) => {
+              const mode = gameModeLabel(g.gameMode, g.format)
+              return (
+                <tr key={g.gameId}>
+                  <td style={cellStyle.td}>{g.endedAt.slice(0, 10)}</td>
+                  <td style={cellStyle.td}>
+                    {mode.primary}
+                    {mode.variant ? <span style={styles.variant}> › {mode.variant}</span> : null}
+                    {g.tournamentName ? <span style={styles.tournamentTag}> · {g.tournamentName}</span> : null}
+                  </td>
+                  <td style={cellStyle.td}>
+                    <Players players={g.players} onProfile={(uid) => navigate(`/u/${uid}`)} />
+                  </td>
+                  <td style={cellStyle.td}>{g.winnerName ?? '—'}</td>
+                  <td style={cellStyle.tdNum}>
+                    {g.hasReplay ? (
+                      <button type="button" style={styles.link} onClick={() => navigate(`/replay/${g.gameId}`)}>
+                        Watch
+                      </button>
+                    ) : (
+                      <span style={styles.noReplay}>—</span>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
+          </Table>
+        )}
+      </Panel>
+
+      <Panel title="Recent tournaments">
+        {tournamentsError ? (
+          <p style={styles.error}>{tournamentsError}</p>
+        ) : tournaments.length === 0 ? (
+          <p style={cellStyle.muted}>No tournaments recorded yet.</p>
+        ) : (
+          <Table head={['Date', 'Name', 'Mode', 'Players', 'Winner']}>
+            {tournaments.map((t) => {
+              const mode = gameModeLabel(t.gameMode, t.format)
+              return (
+                <tr key={t.id} style={styles.clickableRow} onClick={() => setOpenTournament(t.id)}>
+                  <td style={cellStyle.td}>{t.endedAt.slice(0, 10)}</td>
+                  <td style={cellStyle.td}>{t.name ?? '—'}</td>
+                  <td style={cellStyle.td}>
+                    {mode.primary}
+                    {mode.variant ? <span style={styles.variant}> › {mode.variant}</span> : null}
+                  </td>
+                  <td style={cellStyle.tdNum}>{t.playerCount}</td>
+                  <td style={cellStyle.td}>{t.winnerName ?? '—'}</td>
+                </tr>
+              )
+            })}
+          </Table>
+        )}
+      </Panel>
+
+      {openTournament != null && (
+        <TournamentDetailModal tournamentId={openTournament} onClose={() => setOpenTournament(null)} />
+      )}
+    </AdminScreen>
+  )
+}
+
+/** A game's seats, joined by "vs", with the winner bolded; named accounts link to their profile. */
+function Players({ players, onProfile }: { players: AdminGamePlayer[]; onProfile: (userId: string) => void }) {
+  if (players.length === 0) return <span style={cellStyle.muted}>—</span>
+  return (
+    <span>
+      {players.map((p, i) => (
+        <span key={`${p.name}-${i}`}>
+          {i > 0 && <span style={styles.vs}> vs </span>}
+          {p.userId ? (
+            <button type="button" style={p.won ? styles.playerLinkWon : styles.playerLink} onClick={() => onProfile(p.userId as string)}>
+              {p.name}
+            </button>
+          ) : (
+            <span style={p.won ? styles.winner : undefined}>
+              {p.name}
+              {p.isAi ? <span style={styles.aiTag}> AI</span> : null}
+            </span>
+          )}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function pageBtn(disabled: boolean): React.CSSProperties {
+  return { ...styles.pageBtn, opacity: disabled ? 0.4 : 1, cursor: disabled ? 'default' : 'pointer' }
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  error: { color: adminTheme.bad, fontSize: 13, margin: 0 },
+  variant: { color: adminTheme.textMuted },
+  tournamentTag: { color: adminTheme.accent },
+  link: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 13, padding: 0 },
+  noReplay: { color: adminTheme.textMuted, fontSize: 13 },
+  vs: { color: adminTheme.textMuted },
+  winner: { color: adminTheme.text, fontWeight: 600 },
+  playerLink: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 'inherit', padding: 0 },
+  playerLinkWon: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 'inherit', padding: 0, fontWeight: 600 },
+  aiTag: { color: adminTheme.textMuted, fontSize: 11 },
+  clickableRow: { cursor: 'pointer' },
+  pager: { display: 'inline-flex', alignItems: 'center', gap: 10 },
+  pageInfo: { color: adminTheme.textMuted, fontSize: 12, fontVariantNumeric: 'tabular-nums' },
+  pageBtn: {
+    background: 'none',
+    border: `1px solid ${adminTheme.border}`,
+    color: adminTheme.accent,
+    borderRadius: 8,
+    padding: '5px 10px',
+    fontSize: 12,
+  },
+}

--- a/web-client/src/components/admin/AdminDashboard.tsx
+++ b/web-client/src/components/admin/AdminDashboard.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/api/adminStats'
 import type { AdminAuth } from '@/api/adminAuth'
 import type { StatBucket } from '@/api/account'
+import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
 import { colorLabel } from './statFormat'
 import { GeoMap } from './GeoMap'
 import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle, chartTooltipStyle } from './adminUi'
@@ -55,6 +56,7 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
   const [geo, setGeo] = useState<GeoBucket[]>([])
   const [showAllCards, setShowAllCards] = useState(false)
   const [showAllWinRates, setShowAllWinRates] = useState(false)
+  const [openTournament, setOpenTournament] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -160,8 +162,8 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
           <p style={cellStyle.muted}>No tournaments recorded yet.</p>
         ) : (
           <Table head={['Date', 'Name', 'Mode', 'Players', 'Winner']}>
-            {tournaments.map((t, i) => (
-              <tr key={`${t.endedAt}-${i}`}>
+            {tournaments.map((t) => (
+              <tr key={t.id} style={styles.clickableRow} onClick={() => setOpenTournament(t.id)}>
                 <td style={cellStyle.td}>{t.endedAt.slice(0, 10)}</td>
                 <td style={cellStyle.td}>{t.name ?? '—'}</td>
                 <td style={cellStyle.td}>{t.gameMode ?? '—'}</td>
@@ -180,6 +182,10 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
           <GeoMap buckets={geo} />
         )}
       </Panel>
+
+      {openTournament != null && (
+        <TournamentDetailModal tournamentId={openTournament} onClose={() => setOpenTournament(null)} />
+      )}
     </AdminScreen>
   )
 }
@@ -213,4 +219,5 @@ const styles: Record<string, React.CSSProperties> = {
   cardRow: { display: 'flex', gap: 12, flexWrap: 'wrap' },
   twoCol: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 18 },
   toggle: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 12, padding: 0 },
+  clickableRow: { cursor: 'pointer' },
 }

--- a/web-client/src/components/admin/AdminHub.tsx
+++ b/web-client/src/components/admin/AdminHub.tsx
@@ -1,12 +1,12 @@
 /**
- * The admin dashboard landing page: a hub that routes to the three admin areas (Stats, Replays,
+ * The admin dashboard landing page: a hub that routes to the admin areas (Stats, Activity, Replays,
  * Players). It's the starting point a signed-in admin lands on; the bootstrap-password login also
  * arrives here after authenticating.
  */
 import type React from 'react'
 import { AdminScreen, adminTheme } from './adminUi'
 
-export type AdminArea = 'stats' | 'replays' | 'players'
+export type AdminArea = 'stats' | 'activity' | 'replays' | 'players'
 
 interface HubItem {
   area: AdminArea
@@ -17,6 +17,7 @@ interface HubItem {
 
 const ITEMS: HubItem[] = [
   { area: 'stats', icon: '📊', title: 'Stats', description: 'Global activity, decks, cards, win rates and geography.' },
+  { area: 'activity', icon: '🏆', title: 'Activity', description: 'Recent games and tournaments across every player — click through to replays and standings.' },
   { area: 'replays', icon: '🎞️', title: 'Replays', description: 'Browse and play back every completed game.' },
   { area: 'players', icon: '👥', title: 'Players', description: 'Registered accounts, their games, and admin access.' },
 ]

--- a/web-client/src/components/admin/AdminPage.tsx
+++ b/web-client/src/components/admin/AdminPage.tsx
@@ -13,6 +13,7 @@ import type React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ReplayViewer, type GameSummary } from './ReplayViewer'
 import { AdminDashboard } from './AdminDashboard'
+import { AdminActivity } from './AdminActivity'
 import { AdminPlayers } from './AdminPlayers'
 import { AdminHub, type AdminArea } from './AdminHub'
 import { adminTheme } from './adminUi'
@@ -142,6 +143,9 @@ export function AdminPage() {
 
   if (view === 'stats') {
     return <AdminDashboard auth={auth} onBack={() => setView('hub')} />
+  }
+  if (view === 'activity') {
+    return <AdminActivity auth={auth} onBack={() => setView('hub')} />
   }
   if (view === 'players') {
     return <AdminPlayers auth={auth} onBack={() => setView('hub')} />

--- a/web-client/src/components/admin/AdminPlayers.tsx
+++ b/web-client/src/components/admin/AdminPlayers.tsx
@@ -17,6 +17,7 @@ import {
   setUserAdmin,
 } from '@/api/adminUsers'
 import type { AdminAuth } from '@/api/adminAuth'
+import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
 import { colorForIdentity, colorLabel, mergeModeBuckets } from './statFormat'
 import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle } from './adminUi'
 import { AdminDeckModal, AdminSavedDecks } from './AdminPlayerDecks'
@@ -116,6 +117,7 @@ function PlayerDetail({
   const [games, setGames] = useState<AdminGamesPage>({ entries: [], total: 0 })
   const [gamesPage, setGamesPage] = useState(0)
   const [deckModal, setDeckModal] = useState<{ gameId: string; opponent: string } | null>(null)
+  const [openTournament, setOpenTournament] = useState<number | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -238,8 +240,8 @@ function PlayerDetail({
           {detail.tournaments.length > 0 && (
             <Panel title="Tournaments">
               <Table head={['Date', 'Tournament', 'Place']}>
-                {detail.tournaments.map((t, i) => (
-                  <tr key={`${t.endedAt}-${i}`}>
+                {detail.tournaments.map((t) => (
+                  <tr key={t.id} style={styles.row} onClick={() => setOpenTournament(t.id)}>
                     <td style={cellStyle.td}>{t.endedAt.slice(0, 10)}</td>
                     <td style={cellStyle.td}>{t.name ?? '—'}</td>
                     <td style={cellStyle.tdNum}>
@@ -334,6 +336,10 @@ function PlayerDetail({
           opponentLabel={deckModal.opponent}
           onClose={() => setDeckModal(null)}
         />
+      )}
+
+      {openTournament != null && (
+        <TournamentDetailModal tournamentId={openTournament} onClose={() => setOpenTournament(null)} />
       )}
     </AdminScreen>
   )


### PR DESCRIPTION
## What

Adds a **list of recent games and tournaments to the admin portal** — the same "recent games + tournaments you can click through" experience players get on their own profile, but spanning **every player**.

### New "Activity" hub area
A new card on the admin dashboard hub (🏆 **Activity**) opens two lists:

- **Recent games** — a paginated, global, newest-first list of every recorded game. Each row shows the date, mode (e.g. `Tournament › Draft`, with the tournament name tagged), both players (winner bolded; named accounts link to their public profile), the winner, and a **Watch** link that opens the replay. Pages through all games (`Newer`/`Older`).
- **Recent tournaments** — the recorded tournaments, newest first. Clicking a row opens the shared `TournamentDetailModal` (final standings + every game played, each linkable to its replay) — the exact modal used on player profiles.

### Click-through everywhere tournaments are listed
`TournamentSummary` now carries the tournament `id`, which also makes two previously-static tables click-through to the same detail modal:
- the **Stats** dashboard's Tournaments table, and
- the **per-player** admin detail's Tournaments table.

## How

**Backend** (`game-server`)
- `StatsQueryService`: new `recentGamesGlobal(limit, offset)` + `recentGamesGlobalCount()` — a neutral, every-seat game summary (winner flagged, tagged with its tournament name via `lobby_id`), batching seat/tournament lookups like the existing `tournamentGames`. Added `id` to `recentTournaments`' query/DTO.
- `AdminStatsController`: new `GET /api/stats/admin/recent-games?limit&offset`, guarded by the same `AdminAuthService` as the other admin-stats endpoints, returning the page with the total in `X-Total-Count` (mirrors the per-player games endpoint).
- Tournament detail itself reuses the existing **public** `GET /api/stats/tournaments/{id}` — no new endpoint needed, and it works under both admin auth modes (bootstrap password or admin account).

**Frontend** (`web-client`)
- `adminStats.ts`: `id` on `TournamentSummary`; new `AdminRecentGame`/`AdminGamePlayer` types + `fetchRecentGames` (reads `X-Total-Count`).
- New `AdminActivity.tsx` component; wired into `AdminHub` (`AdminArea` + hub card) and `AdminPage` routing.
- `AdminDashboard.tsx` and `AdminPlayers.tsx`: tournament rows now open `TournamentDetailModal`.

## Verification

- `npm run typecheck` ✅ and `npm run build` ✅ (web-client)
- `just test-server` ✅ (BUILD SUCCESSFUL — game-server compiles + tests pass)

## Screenshots

Not included: the Activity screen needs an **accounts-enabled** server with a **populated** match/tournament history (Postgres) to render meaningful data, which isn't available in this environment. Happy to capture screenshots against a seeded environment if you point me at one. The UI reuses the existing admin `AdminScreen`/`Panel`/`Table` primitives, so it matches the rest of the dashboard's styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)