### PR TITLE
Fix unfair tournament standings: canonical MTG tiebreakers

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -663,8 +663,14 @@ sealed interface ServerMessage {
         val gamesWon: Int = 0,
         val gamesLost: Int = 0,
         val lifeDifferential: Int = 0,
+        /** Opponents' match-win % (0..1), the first Magic Tournament Rules tiebreaker after points. */
+        val omwPercent: Double = 0.0,
+        /** This player's own game-win % (0..1), the second tiebreaker. */
+        val gwPercent: Double = 0.0,
+        /** Opponents' game-win % (0..1), the third tiebreaker. */
+        val ogwPercent: Double = 0.0,
         val rank: Int = 0,
-        /** Tiebreaker reason: "HEAD_TO_HEAD", "H2H_GAMES", "LIFE_DIFF", "TIED", or null if no tie */
+        /** Tiebreaker reason: "OMW", "GW", "OGW", "TIED", or null if separated on match points. */
         val tiebreakerReason: String? = null
     )
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/TournamentManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/tournament/TournamentManager.kt
@@ -23,15 +23,36 @@ data class PlayerStanding(
 }
 
 /**
- * Reason why a player's position was determined by a tiebreaker.
+ * Reason why a player's position was determined by a tiebreaker. The order mirrors the official
+ * Magic Tournament Rules standings tiebreakers (match points, then OMW%, then GW%, then OGW%).
+ * Head-to-head is deliberately *not* used: it is non-transitive (A>B>C>A) and so cannot define a
+ * consistent total order.
  */
 enum class TiebreakerReason {
-    NONE,           // No tie - won on points
-    HEAD_TO_HEAD,   // Won head-to-head matchup
-    H2H_GAMES,      // Won on head-to-head game differential
-    LIFE_DIFF,      // Won on life differential
+    NONE,           // No tie - separated on match points
+    OMW,            // Won on opponents' match-win percentage
+    GW,             // Won on game-win percentage
+    OGW,            // Won on opponents' game-win percentage
     TIED            // True tie - shared position
 }
+
+/**
+ * Pre-computed standings tiebreaker metrics for one player, per the Magic Tournament Rules. Computing
+ * these once up front (rather than via pairwise lookups inside a comparator) keeps the final sort a
+ * pure, transitive comparison over plain numbers — the head-to-head comparator this replaces violated
+ * the total-ordering contract and could sort arbitrarily (or throw) on a head-to-head cycle.
+ *
+ *   omw - mean of each opponent's match-win % (each floored at [TournamentManager.MINIMUM_PERCENTAGE]).
+ *   gw  - this player's own game-win % (not floored; the floor only protects opponents' averages).
+ *   ogw - mean of each opponent's game-win % (each floored at [TournamentManager.MINIMUM_PERCENTAGE]).
+ * Byes are excluded from the opponent list, so they never feed OMW%/OGW%.
+ */
+data class StandingMetrics(
+    val points: Int,
+    val omw: Double,
+    val gw: Double,
+    val ogw: Double
+)
 
 /**
  * A player standing with calculated rank and tiebreaker information.
@@ -86,6 +107,15 @@ class TournamentManager(
     players: List<Pair<EntityId, String>>, // (playerId, playerName)
     private val gamesPerMatch: Int = 1
 ) {
+    companion object {
+        /**
+         * Floor applied to each opponent's percentage when averaging OMW%/OGW% (Magic Tournament Rules:
+         * a contributing match-win/game-win percentage is never treated as below 1/3). Keeps a player
+         * from being dragged down by an opponent who later collapsed.
+         */
+        const val MINIMUM_PERCENTAGE: Double = 1.0 / 3.0
+    }
+
     private val standings = players.associate { (id, name) ->
         id to PlayerStanding(id, name)
     }.toMutableMap()
@@ -335,101 +365,94 @@ class TournamentManager(
     // =========================================================================
 
     /**
-     * Get the head-to-head result between two players.
-     *
-     * @return positive if player1 won more head-to-head matches,
-     *         negative if player2 won more,
-     *         0 if tied
+     * Each player's opponents across all completed, non-bye matches, with repeats preserved (a player
+     * met twice in a `gamesPerMatch > 1` schedule counts twice, so OMW%/OGW% average per match as the
+     * Magic Tournament Rules intend). Byes are excluded entirely.
      */
-    private fun getHeadToHeadResult(player1: EntityId, player2: EntityId): Int {
-        val matches = rounds.flatMap { it.matches }
-            .filter { it.hasPlayers(player1, player2) && it.isComplete && !it.isBye }
+    private fun opponentsByPlayer(): Map<EntityId, List<EntityId>> {
+        val opponents = playerIds.associateWith { mutableListOf<EntityId>() }
+        for (match in rounds.flatMap { it.matches }) {
+            if (!match.isComplete || match.isBye) continue
+            val p2 = match.player2Id ?: continue
+            opponents[match.player1Id]?.add(p2)
+            opponents[p2]?.add(match.player1Id)
+        }
+        return opponents
+    }
 
-        val p1Wins = matches.count { it.winnerId == player1 }
-        val p2Wins = matches.count { it.winnerId == player2 }
+    /** A player's own match-win % = match points / (3 × matches played); 0 with no matches played. */
+    private fun PlayerStanding.matchWinPercentage(): Double {
+        val matchesPlayed = wins + losses + draws
+        return if (matchesPlayed == 0) 0.0 else points.toDouble() / (3.0 * matchesPlayed)
+    }
 
-        return p1Wins.compareTo(p2Wins)
+    /** A player's own game-win % = games won / games played; 0 with no games played. */
+    private fun PlayerStanding.gameWinPercentage(): Double {
+        val gamesPlayed = gamesWon + gamesLost
+        return if (gamesPlayed == 0) 0.0 else gamesWon.toDouble() / gamesPlayed
     }
 
     /**
-     * Get the head-to-head game differential between two players.
-     * This counts individual game wins across all head-to-head matches.
-     *
-     * @return positive if player1 won more games in H2H matches,
-     *         negative if player2 won more,
-     *         0 if tied
+     * Compute the Magic Tournament Rules standings tiebreakers for every player. The opponents' averages
+     * floor each contributing percentage at [MINIMUM_PERCENTAGE] so a player isn't punished for having
+     * faced someone who later collapsed; a player with no completed non-bye matches gets `0.0` for the
+     * opponents' metrics.
      */
-    private fun getHeadToHeadGameDiff(player1: EntityId, player2: EntityId): Int {
-        val matches = rounds.flatMap { it.matches }
-            .filter { it.hasPlayers(player1, player2) && it.isComplete && !it.isBye }
-
-        var p1GameWins = 0
-        var p2GameWins = 0
-
-        for (match in matches) {
-            if (match.player1Id == player1) {
-                p1GameWins += match.player1GameWins
-                p2GameWins += match.player2GameWins
-            } else {
-                // player1 is in the player2Id slot
-                p1GameWins += match.player2GameWins
-                p2GameWins += match.player1GameWins
-            }
+    private fun computeMetrics(): Map<EntityId, StandingMetrics> {
+        val opponents = opponentsByPlayer()
+        return standings.mapValues { (id, standing) ->
+            val opps = opponents[id].orEmpty()
+            val omw = opps.map { maxOf(standings.getValue(it).matchWinPercentage(), MINIMUM_PERCENTAGE) }
+                .averageOrZero()
+            val ogw = opps.map { maxOf(standings.getValue(it).gameWinPercentage(), MINIMUM_PERCENTAGE) }
+                .averageOrZero()
+            StandingMetrics(standing.points, omw = omw, gw = standing.gameWinPercentage(), ogw = ogw)
         }
+    }
 
-        return p1GameWins.compareTo(p2GameWins)
+    private fun List<Double>.averageOrZero(): Double = if (isEmpty()) 0.0 else average()
+
+    /**
+     * Determine which Magic Tournament Rules tiebreaker first separated two adjacent players, given the
+     * already-computed [metrics]. Returns the first metric in MTR order (OMW% → GW% → OGW%) on which the
+     * higher player exceeds the lower; [TiebreakerReason.NONE] if they differ on match points (no tie),
+     * or [TiebreakerReason.TIED] if every metric is equal.
+     */
+    private fun determineTiebreakerUsed(
+        higher: PlayerStanding,
+        lower: PlayerStanding,
+        metrics: Map<EntityId, StandingMetrics>
+    ): TiebreakerReason {
+        val h = metrics.getValue(higher.playerId)
+        val l = metrics.getValue(lower.playerId)
+        return when {
+            h.points != l.points -> TiebreakerReason.NONE
+            h.omw > l.omw -> TiebreakerReason.OMW
+            h.gw > l.gw -> TiebreakerReason.GW
+            h.ogw > l.ogw -> TiebreakerReason.OGW
+            else -> TiebreakerReason.TIED
+        }
     }
 
     /**
-     * Determine which tiebreaker separated two players.
+     * Current standings sorted by the Magic Tournament Rules tiebreaker order:
+     * 1. Match points (wins × 3 + draws)
+     * 2. Opponents' match-win % (OMW%)
+     * 3. Game-win % (GW%)
+     * 4. Opponents' game-win % (OGW%)
      *
-     * @param higher The player ranked higher
-     * @param lower The player ranked lower
-     * @return The tiebreaker reason for the lower player
+     * The comparison is a pure, transitive order over pre-computed numbers, so — unlike the old
+     * head-to-head comparator — it can never violate the sort contract on a head-to-head cycle.
      */
-    private fun determineTiebreakerUsed(higher: PlayerStanding, lower: PlayerStanding): TiebreakerReason {
-        // If points differ, no tiebreaker needed
-        if (higher.points != lower.points) {
-            return TiebreakerReason.NONE
-        }
+    fun getStandings(): List<PlayerStanding> = getStandings(computeMetrics())
 
-        // Check head-to-head
-        val h2hResult = getHeadToHeadResult(higher.playerId, lower.playerId)
-        if (h2hResult > 0) {
-            return TiebreakerReason.HEAD_TO_HEAD
-        }
-
-        // Check head-to-head game differential
-        val h2hGameDiff = getHeadToHeadGameDiff(higher.playerId, lower.playerId)
-        if (h2hGameDiff > 0) {
-            return TiebreakerReason.H2H_GAMES
-        }
-
-        // Check life differential
-        if (higher.lifeDifferential > lower.lifeDifferential) {
-            return TiebreakerReason.LIFE_DIFF
-        }
-
-        // True tie
-        return TiebreakerReason.TIED
-    }
-
-    /**
-     * Get current standings sorted by points with tiebreakers applied.
-     *
-     * Tiebreaker order:
-     * 1. Points (wins × 3 + draws)
-     * 2. Head-to-head result
-     * 3. Head-to-head game differential
-     * 4. Life differential
-     * 5. Tied (shared position)
-     */
-    fun getStandings(): List<PlayerStanding> {
+    private fun getStandings(metrics: Map<EntityId, StandingMetrics>): List<PlayerStanding> {
+        fun key(s: PlayerStanding) = metrics.getValue(s.playerId)
         return standings.values.sortedWith(
-            compareByDescending<PlayerStanding> { it.points }
-                .thenComparator { a, b -> -getHeadToHeadResult(a.playerId, b.playerId) }
-                .thenComparator { a, b -> -getHeadToHeadGameDiff(a.playerId, b.playerId) }
-                .thenByDescending { it.lifeDifferential }
+            compareByDescending<PlayerStanding> { key(it).points }
+                .thenByDescending { key(it).omw }
+                .thenByDescending { key(it).gw }
+                .thenByDescending { key(it).ogw }
         )
     }
 
@@ -438,7 +461,8 @@ class TournamentManager(
      * Players who are truly tied share the same rank.
      */
     fun getRankedStandings(): List<RankedStanding> {
-        val sorted = getStandings()
+        val metrics = computeMetrics()
+        val sorted = getStandings(metrics)
         if (sorted.isEmpty()) return emptyList()
 
         val result = mutableListOf<RankedStanding>()
@@ -453,7 +477,7 @@ class TournamentManager(
                 tiebreakerReason = TiebreakerReason.NONE
             } else {
                 val previous = sorted[i - 1]
-                tiebreakerReason = determineTiebreakerUsed(previous, standing)
+                tiebreakerReason = determineTiebreakerUsed(previous, standing, metrics)
 
                 // Update rank only if truly different (not TIED)
                 if (tiebreakerReason != TiebreakerReason.TIED) {
@@ -471,8 +495,10 @@ class TournamentManager(
      * Get standings as server message format with tiebreaker information.
      */
     fun getStandingsInfo(connectedPlayerIds: Set<EntityId> = emptySet()): List<ServerMessage.PlayerStandingInfo> {
+        val metrics = computeMetrics()
         return getRankedStandings().map { ranked ->
             val s = ranked.standing
+            val m = metrics.getValue(s.playerId)
             ServerMessage.PlayerStandingInfo(
                 playerId = s.playerId.value,
                 playerName = s.playerName,
@@ -484,6 +510,9 @@ class TournamentManager(
                 gamesWon = s.gamesWon,
                 gamesLost = s.gamesLost,
                 lifeDifferential = s.lifeDifferential,
+                omwPercent = m.omw,
+                gwPercent = m.gw,
+                ogwPercent = m.ogw,
                 rank = ranked.rank,
                 tiebreakerReason = if (ranked.tiebreakerReason == TiebreakerReason.NONE) null else ranked.tiebreakerReason.name
             )

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentStandingsTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/tournament/TournamentStandingsTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.gameserver.tournament
+
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Standings tiebreaker behaviour, per the Magic Tournament Rules order
+ * (match points → OMW% → GW% → OGW%). The headline case is the head-to-head *cycle*, which the
+ * previous head-to-head comparator could not order consistently (it violated the sort contract).
+ */
+class TournamentStandingsTest : FunSpec({
+
+    // Drives the full round-robin to completion, deciding each non-bye match with [winnerOf]
+    // (null = draw). Byes auto-complete in startNextRound and award no points.
+    fun TournamentManager.playOut(winnerOf: (EntityId, EntityId) -> EntityId?) {
+        var game = 0
+        while (true) {
+            val round = startNextRound() ?: break
+            for (match in round.matches) {
+                if (match.isBye) continue
+                val p2 = match.player2Id ?: continue
+                val sessionId = "g${game++}"
+                match.gameSessionId = sessionId
+                reportMatchResult(sessionId, winnerOf(match.player1Id, p2))
+            }
+        }
+    }
+
+    fun pair(p1: EntityId, p2: EntityId, a: EntityId, b: EntityId) =
+        (p1 == a && p2 == b) || (p1 == b && p2 == a)
+
+    test("a head-to-head cycle sorts deterministically and never throws") {
+        // A beat B, B beat C, C beat A: each 1-1 (3 pts), identical on every metric. The old
+        // head-to-head comparator could throw "Comparison method violates its general contract" here.
+        val a = EntityId("A"); val b = EntityId("B"); val c = EntityId("C")
+        val manager = TournamentManager("lobby", listOf(a to "Alice", b to "Bob", c to "Cara"))
+
+        manager.playOut { p1, p2 ->
+            when {
+                pair(p1, p2, a, b) -> a
+                pair(p1, p2, b, c) -> b
+                pair(p1, p2, c, a) -> c
+                else -> null
+            }
+        }
+
+        val standings = manager.getStandings() // must not throw
+        standings.map { it.points }.toSet() shouldBe setOf(3)
+
+        val ranked = manager.getRankedStandings()
+        ranked shouldNotBe emptyList<RankedStanding>()
+        // Truly tied → everyone shares rank 1; followers are reported as TIED.
+        ranked.all { it.rank == 1 } shouldBe true
+        ranked.drop(1).all { it.tiebreakerReason == TiebreakerReason.TIED } shouldBe true
+    }
+
+    test("game-win % breaks a tie that match points and OMW% cannot") {
+        // A and B both finish 6 points over 4 matches (equal OMW%), but B drew three and never lost,
+        // so B's game-win % (1/1) tops A's (2/4). B must rank above A with reason GW.
+        val a = EntityId("A"); val b = EntityId("B")
+        val c = EntityId("C"); val d = EntityId("D"); val e = EntityId("E")
+        val manager = TournamentManager(
+            "lobby",
+            listOf(a to "A", b to "B", c to "C", d to "D", e to "E")
+        )
+
+        manager.playOut { p1, p2 ->
+            when {
+                pair(p1, p2, b, a) -> b   // B beats A (B's only win)
+                pair(p1, p2, b, c) -> null // B draws C
+                pair(p1, p2, b, d) -> null // B draws D
+                pair(p1, p2, b, e) -> null // B draws E
+                pair(p1, p2, a, c) -> a   // A beats C
+                pair(p1, p2, a, d) -> a   // A beats D
+                pair(p1, p2, a, e) -> e   // A loses to E
+                pair(p1, p2, c, d) -> c
+                pair(p1, p2, c, e) -> c
+                pair(p1, p2, d, e) -> d
+                else -> null
+            }
+        }
+
+        val info = manager.getStandingsInfo()
+        val byName = info.associateBy { it.playerName }
+
+        byName.getValue("A").points shouldBe 6
+        byName.getValue("B").points shouldBe 6
+        // Equal match points and equal OMW% (same 4-match record, shared opponent pool)…
+        byName.getValue("A").omwPercent shouldBe (byName.getValue("B").omwPercent plusOrMinus 1e-9)
+        // …but B's game-win % is higher, so B is ranked ahead of A and the break is reported as GW.
+        byName.getValue("B").gwPercent shouldBe (1.0 plusOrMinus 1e-9)
+        byName.getValue("A").gwPercent shouldBe (0.5 plusOrMinus 1e-9)
+        byName.getValue("B").rank shouldBe (byName.getValue("A").rank - 1)
+        byName.getValue("A").tiebreakerReason shouldBe TiebreakerReason.GW.name
+    }
+
+    test("OMW% floors each opponent's match-win % at 1/3 and excludes byes") {
+        // Three players (each round one byes): A 2-0, B 1-1, C 0-2.
+        // OMW(A) averages B's MW% (.5) with C's MW% (0 → floored to 1/3).
+        val a = EntityId("A"); val b = EntityId("B"); val c = EntityId("C")
+        val manager = TournamentManager("lobby", listOf(a to "A", b to "B", c to "C"))
+
+        manager.playOut { p1, p2 ->
+            when {
+                pair(p1, p2, a, b) -> a
+                pair(p1, p2, a, c) -> a
+                pair(p1, p2, b, c) -> b
+                else -> null
+            }
+        }
+
+        val info = manager.getStandingsInfo().associateBy { it.playerName }
+        // (0.5 + 1/3) / 2 — the floor lifts C's 0% up to 1/3.
+        info.getValue("A").omwPercent shouldBe (((0.5 + 1.0 / 3.0) / 2.0) plusOrMinus 1e-9)
+    }
+})

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -1805,6 +1805,8 @@ interface HoveredStanding {
   gamesWon: number
   gamesLost: number
   lifeDifferential: number | undefined
+  omwPercent: number | undefined
+  ogwPercent: number | undefined
   tiebreakerReason: string | null | undefined
   rect: DOMRect
 }
@@ -2305,6 +2307,8 @@ function TournamentOverlay({
                   gamesWon: gamesWon,
                   gamesLost: gamesLost,
                   lifeDifferential: standing.lifeDifferential,
+                  omwPercent: standing.omwPercent,
+                  ogwPercent: standing.ogwPercent,
                   tiebreakerReason: standing.tiebreakerReason,
                   rect,
                 })
@@ -2380,11 +2384,23 @@ function TournamentOverlay({
             </div>
             {(hoveredStanding.gamesWon + hoveredStanding.gamesLost) > 0 && (
               <div className={styles.tooltipStat}>
-                <span className={styles.tooltipStatLabel}>Game Record</span>
+                <span className={styles.tooltipStatLabel}>Game Win % (GW%)</span>
                 <span className={styles.tooltipStatValue}>
                   {hoveredStanding.gamesWon}-{hoveredStanding.gamesLost} (
                   {((hoveredStanding.gamesWon / (hoveredStanding.gamesWon + hoveredStanding.gamesLost)) * 100).toFixed(0)}%)
                 </span>
+              </div>
+            )}
+            {hoveredStanding.omwPercent !== undefined && (
+              <div className={styles.tooltipStat}>
+                <span className={styles.tooltipStatLabel}>Opp. Match Win % (OMW%)</span>
+                <span className={styles.tooltipStatValue}>{(hoveredStanding.omwPercent * 100).toFixed(1)}%</span>
+              </div>
+            )}
+            {hoveredStanding.ogwPercent !== undefined && (
+              <div className={styles.tooltipStat}>
+                <span className={styles.tooltipStatLabel}>Opp. Game Win % (OGW%)</span>
+                <span className={styles.tooltipStatValue}>{(hoveredStanding.ogwPercent * 100).toFixed(1)}%</span>
               </div>
             )}
             {hoveredStanding.lifeDifferential !== undefined && (
@@ -2397,12 +2413,12 @@ function TournamentOverlay({
             )}
             {hoveredStanding.tiebreakerReason && hoveredStanding.tiebreakerReason !== 'TIED' && (
               <div className={styles.tooltipTiebreaker}>
-                {hoveredStanding.tiebreakerReason === 'HEAD_TO_HEAD'
-                  ? 'Ranked by head-to-head'
-                  : hoveredStanding.tiebreakerReason === 'H2H_GAMES'
-                    ? 'Ranked by H2H games'
-                    : hoveredStanding.tiebreakerReason === 'LIFE_DIFF'
-                      ? 'Ranked by life diff'
+                {hoveredStanding.tiebreakerReason === 'OMW'
+                  ? "Ranked by opponents' match-win %"
+                  : hoveredStanding.tiebreakerReason === 'GW'
+                    ? 'Ranked by game-win %'
+                    : hoveredStanding.tiebreakerReason === 'OGW'
+                      ? "Ranked by opponents' game-win %"
                       : null}
               </div>
             )}

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1423,8 +1423,14 @@ export interface PlayerStandingInfo {
   readonly gamesWon?: number
   readonly gamesLost?: number
   readonly lifeDifferential?: number
+  /** Opponents' match-win % (0..1), first tiebreaker after match points. */
+  readonly omwPercent?: number
+  /** This player's own game-win % (0..1), second tiebreaker. */
+  readonly gwPercent?: number
+  /** Opponents' game-win % (0..1), third tiebreaker. */
+  readonly ogwPercent?: number
   readonly rank?: number
-  /** Tiebreaker reason: "HEAD_TO_HEAD", "H2H_GAMES", "LIFE_DIFF", "TIED", or null if no tie */
+  /** Tiebreaker reason: "OMW", "GW", "OGW", "TIED", or null if separated on match points. */
   readonly tiebreakerReason?: string | null
 }
 


### PR DESCRIPTION
## Problem

Tournament outcomes sometimes felt unfair. Two real defects in the round-robin standings logic (`TournamentManager.kt`):

1. **Non-transitive sort (a correctness bug).** `getStandings()` sorted with head-to-head *inside* the comparator. Head-to-head is non-transitive — with a cycle (A beat B, B beat C, C beat A) it violates the total-ordering contract Kotlin's `sortedWith`/TimSort requires, yielding arbitrary standings and risking an `IllegalArgumentException: Comparison method violates its general contract`.
2. **Non-standard tiebreaker.** `lifeDifferential` (life remaining after a win) rewards blowouts/variance, not skill — it isn't how MTG ranks players.

## Fix

Replace both with the official **Magic Tournament Rules** tiebreaker stack, computed once per player as pre-computed numeric metrics so the final sort is a pure, transitive comparison over plain numbers:

> match points → **OMW%** → **GW%** → **OGW%**

- OMW%/OGW% floor each opponent's percentage at **1/3** and **exclude byes**, per MTR.
- **Head-to-head is intentionally dropped** — MTR omits it for exactly this non-transitivity.
- `lifeDifferential` is still computed and displayed, just no longer affects ordering.

## Transparency

`PlayerStandingInfo` now carries `omwPercent` / `gwPercent` / `ogwPercent`, and the standings tooltip shows them plus the correct "Ranked by opponents' match-win %" reason text, so players can see *why* they placed where.

## Tests

New `TournamentStandingsTest` (all passing):
- A head-to-head **cycle** now sorts deterministically and never throws (the exact failure the old comparator could produce).
- **GW%** breaks a tie that match points and OMW% cannot.
- **OMW%** applies the 1/3 floor and excludes byes.

`scripts/gradle-locked :game-server:test --tests "...TournamentStandingsTest"` → BUILD SUCCESSFUL. Client files typecheck clean (pre-existing unrelated `admin/GeoMap.tsx` dep errors are not touched here).

## Note

Scope is tournament standings only (no rating/ELO/matchmaking changes). In a *complete* round-robin OMW% is near-uniform between equal-point players and GW% does most of the differentiating — the headline win is eliminating the non-transitive sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)