### PR TITLE
Add 4 TLA cards + GrantingSource / removeLegendary / graveyard-filter SDK primitives

### DIFF
--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 248 / 286
+**Implemented:** 250 / 286
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 > **Status (June 2026):** 248/286 implemented. The **Exhaust** keyword is now built (`isExhaust = true`
@@ -37,8 +37,8 @@ up by Airbend, not Firebending).
 | Mechanic | Total | Remaining | Notes |
 |----------|------:|----------:|-------|
 | Earthbend | 28 | 6 | Target land you control becomes a 0/0 haste creature-land; put N +1/+1 counters on it. ✅ built (`Effects.Earthbend`, incl. dynamic X). |
-| Waterbend | 25 | 10 | Convoke+improvise-style alt cost (tap artifacts/creatures to help pay). ✅ **activated-ability** cost (`hasWaterbend = true`), **spell-level additional cost** (incl. **waterbend {X}**), and **Exhaust—Waterbend** (`isExhaust` + `hasWaterbend`, e.g. Invasion Submersible, Avatar Kuruk) all built. ❌ still needed: **Ward—Waterbend** and **waterbend-as-alternative-cast** (Hama). |
-| Firebending | 28 | 14 | Attack-triggered combat-duration red mana. ✅ built — `firebending(n)` keyword + dynamic versions hand-wired via `AddManaEffect(…, ManaExpiry.END_OF_COMBAT)`. ❌ still missing: **granting** firebending to others / **conditional** "has firebending as long as …" / "gains firebending until EOT". |
+| Waterbend | 25 | 9 | Convoke+improvise-style alt cost (tap artifacts/creatures to help pay). ✅ **activated-ability** cost (`hasWaterbend = true`), **spell-level additional cost** (incl. **waterbend {X}**), and **Exhaust—Waterbend** (`isExhaust` + `hasWaterbend`, e.g. Invasion Submersible, Avatar Kuruk) all built. ❌ still needed: **Ward—Waterbend** and **waterbend-as-alternative-cast** (Hama). |
+| Firebending | 28 | 13 | Attack-triggered combat-duration red mana. ✅ built — `firebending(n)` keyword + dynamic versions hand-wired via `AddManaEffect(…, ManaExpiry.END_OF_COMBAT)`. ❌ still missing: **granting** firebending to others / **conditional** "has firebending as long as …" / "gains firebending until EOT". |
 | Airbend | 11 | 3 | Exile target permanent; owner may recast it for {2}. ✅ built — `Effects.Airbend` / `Effects.AirbendAll` (fixed-alternative-cost may-play from exile) + the spell stack branch (`Effects.ExileTargetSpell(fixedAlternativeManaCost)` + `Conditions.TargetIsSpellOnStack` — *exile* from the stack, not a counter, so it bypasses can't-be-countered). ❌ remaining 3 blocked by *other* gaps: cast-zone restriction (Avatar's Wrath), each-player-choose Saga chapter (Yangchen), four-bend events + {WUBRG} reduction (Avatar Aang). |
 | Exhaust | 8 | 0 | Activated ability usable only once (per object, CR 702.177). ✅ built — `isExhaust = true` on `activatedAbility` desugars to `ActivationRestriction.Once` (the existing per-object tracker is rules-correct; **not** once-per-game) and renders the "Exhaust — " prefix. **All 8 implemented**: Hog-Monkey, Rough Rhino Cavalry, Rebellious Captives, Bitter Work, plus Jeong Jeong (copy-next-Lesson rider), Invasion Submersible (Exhaust—Waterbend → becomes-artifact-creature via `AddCardType`), The Legend of Kuruk (Saga DFC + Exhaust—Waterbend {20} extra turn), and Mai (new **double strike** keyword counter). |
 
@@ -53,7 +53,7 @@ up by Airbend, not Firebending).
 | Transform | 8 | 5 |
 | Mill | 8 | 1 |
 | Reach | 8 | 1 |
-| Prowess | 7 | 2 |
+| Prowess | 7 | 1 |
 | Menace | 6 | 2 |
 | Equip | 5 | 2 |
 | Food | 5 | 1 |
@@ -183,7 +183,7 @@ up by Airbend, not Firebending).
 - [x] Fire Sages
 - [ ] Firebender Ascension
 - [x] Firebending Lesson
-- [ ] Firebending Student
+- [x] Firebending Student
 - [x] First-Time Flyer
 - [x] Flexible Waterbender
 - [x] Flopsie, Bumi's Buddy
@@ -255,7 +255,7 @@ up by Airbend, not Firebending).
 - [x] Mongoose Lizard
 - [x] Mountain
 - [x] North Pole Gates
-- [ ] North Pole Patrol
+- [x] North Pole Patrol
 - [x] Northern Air Temple
 - [x] Obsessive Pursuit
 - [x] Octopus Form

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 251 / 286
+**Implemented:** 252 / 286
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 > **Status (June 2026):** 248/286 implemented. The **Exhaust** keyword is now built (`isExhaust = true`
@@ -38,7 +38,7 @@ up by Airbend, not Firebending).
 |----------|------:|----------:|-------|
 | Earthbend | 28 | 6 | Target land you control becomes a 0/0 haste creature-land; put N +1/+1 counters on it. ✅ built (`Effects.Earthbend`, incl. dynamic X). |
 | Waterbend | 25 | 9 | Convoke+improvise-style alt cost (tap artifacts/creatures to help pay). ✅ **activated-ability** cost (`hasWaterbend = true`), **spell-level additional cost** (incl. **waterbend {X}**), and **Exhaust—Waterbend** (`isExhaust` + `hasWaterbend`, e.g. Invasion Submersible, Avatar Kuruk) all built. ❌ still needed: **Ward—Waterbend** and **waterbend-as-alternative-cast** (Hama). |
-| Firebending | 28 | 13 | Attack-triggered combat-duration red mana. ✅ built — `firebending(n)` keyword + dynamic versions hand-wired via `AddManaEffect(…, ManaExpiry.END_OF_COMBAT)`. ❌ still missing: **granting** firebending to others / **conditional** "has firebending as long as …" / "gains firebending until EOT". |
+| Firebending | 28 | 12 | Attack-triggered combat-duration red mana. ✅ built — `firebending(n)` keyword + dynamic versions hand-wired via `AddManaEffect(…, ManaExpiry.END_OF_COMBAT)`. ❌ still missing: **granting** firebending to others / **conditional** "has firebending as long as …" / "gains firebending until EOT". |
 | Airbend | 11 | 3 | Exile target permanent; owner may recast it for {2}. ✅ built — `Effects.Airbend` / `Effects.AirbendAll` (fixed-alternative-cost may-play from exile) + the spell stack branch (`Effects.ExileTargetSpell(fixedAlternativeManaCost)` + `Conditions.TargetIsSpellOnStack` — *exile* from the stack, not a counter, so it bypasses can't-be-countered). ❌ remaining 3 blocked by *other* gaps: cast-zone restriction (Avatar's Wrath), each-player-choose Saga chapter (Yangchen), four-bend events + {WUBRG} reduction (Avatar Aang). |
 | Exhaust | 8 | 0 | Activated ability usable only once (per object, CR 702.177). ✅ built — `isExhaust = true` on `activatedAbility` desugars to `ActivationRestriction.Once` (the existing per-object tracker is rules-correct; **not** once-per-game) and renders the "Exhaust — " prefix. **All 8 implemented**: Hog-Monkey, Rough Rhino Cavalry, Rebellious Captives, Bitter Work, plus Jeong Jeong (copy-next-Lesson rider), Invasion Submersible (Exhaust—Waterbend → becomes-artifact-creature via `AddCardType`), The Legend of Kuruk (Saga DFC + Exhaust—Waterbend {20} extra turn), and Mai (new **double strike** keyword counter). |
 
@@ -46,7 +46,7 @@ up by Airbend, not Firebending).
 
 | Keyword | Total | Remaining |
 |---------|------:|----------:|
-| Flying | 26 | 10 |
+| Flying | 26 | 9 |
 | Vigilance | 15 | 2 |
 | Scry | 10 | 2 |
 | Flash | 9 | 5 |
@@ -276,7 +276,7 @@ up by Airbend, not Firebending).
 - [x] Price of Freedom
 - [x] Professor Zei, Anthropologist
 - [x] Rabaroo Troop
-- [ ] Ran and Shaw
+- [x] Ran and Shaw
 - [x] Raucous Audience
 - [x] Raven Eagle
 - [x] Razor Rings

--- a/backlog/sets/avatar-the-last-airbender/cards.md
+++ b/backlog/sets/avatar-the-last-airbender/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 draft/booster cards (excluding basic lands beyond the set's own, tokens, and special variants)
 **Release Date:** November 21, 2025
-**Implemented:** 250 / 286
+**Implemented:** 251 / 286
 **Engine gap analysis:** [`tla-engine-gaps.md`](tla-engine-gaps.md)
 
 > **Status (June 2026):** 248/286 implemented. The **Exhaust** keyword is now built (`isExhaust = true`
@@ -55,7 +55,7 @@ up by Airbend, not Firebending).
 | Reach | 8 | 1 |
 | Prowess | 7 | 1 |
 | Menace | 6 | 2 |
-| Equip | 5 | 2 |
+| Equip | 5 | 1 |
 | Food | 5 | 1 |
 | Enchant | 5 | 1 |
 | Landcycling | 5 | 0 |
@@ -340,7 +340,7 @@ up by Airbend, not Firebending).
 - [x] Toph, the First Metalbender
 - [x] Treetop Freedom Fighters
 - [x] True Ancestry
-- [ ] Trusty Boomerang
+- [x] Trusty Boomerang
 - [x] Tundra Tank
 - [x] Turtle-Duck
 - [x] Twin Blades

--- a/backlog/sets/avatar-the-last-airbender/tla-engine-gaps.md
+++ b/backlog/sets/avatar-the-last-airbender/tla-engine-gaps.md
@@ -3,11 +3,14 @@
 Cross-reference of the remaining (unimplemented) TLA cards against the engine's actual capabilities.
 Generated to scope what must be built before the set can be completed.
 
-> ## ⚠️ Status update — June 2026: now 231 / 286 (81%)
+> ## ⚠️ Status update — June 2026: now 248 / 286 (87%)
 >
-> **Most of this document's Tier-1/Tier-2 gaps have since been closed.** Every TLA card buildable on
-> the current engine has been implemented; the **55 cards still missing all need new engine/SDK work**.
-> What changed since the original write-up (✅ = now built, so the cards it gated are done):
+> **Most of this document's Tier-1/Tier-2 gaps have since been closed.** Of the **38 cards still
+> missing**, the large majority need new engine/SDK work — but a handful were *unblocked* by the
+> keywords built since the original write-up (activated/spell Waterbend, dynamic Firebending, Equip)
+> and are now plain `add-card` authoring with no new engine work (e.g. North Pole Patrol,
+> Firebending Student, Trusty Boomerang, Ran and Shaw). What changed since the original write-up
+> (✅ = now built, so the cards it gated are done):
 >
 > - ✅ **Firebending** — `firebending(n)` keyword + attack-triggered combat-duration mana
 >   (`AddManaEffect(…, ManaExpiry.END_OF_COMBAT)`); dynamic "Firebending X" hand-wired with a
@@ -24,8 +27,12 @@ Generated to scope what must be built before the set can be completed.
 > - ✅ **Dynamic Earthbend** (`Effects.Earthbend` accepts a `DynamicAmount` for X) + **Sagas /
 >   Transform DFCs** proven across the set (incl. saga→creature transform).
 >
-> **The genuine remaining gaps** (what's still blocking the last 55 cards):
-> - ❌ **Airbend** keyword (~11 cards) — exile + recast-for-{2} fixed-alternative-cost may-play.
+> **The genuine remaining gaps** (what's still blocking most of the last 38 cards):
+> - ✅ **Airbend** keyword (~8 of 11 cards) — exile + recast-for-{2} fixed-alternative-cost may-play
+>   (`Effects.Airbend` / `Effects.AirbendAll`) plus the stack-spell branch
+>   (`Effects.ExileTargetSpell(fixedAlternativeManaCost)`). The 3 remaining Airbend cards are each
+>   blocked by a *different* gap (cast-zone restriction, each-player-choose Saga chapter, four-bend
+>   events + {WUBRG} reduction), not by airbend itself.
 > - ✅ **Exhaust** keyword (8 cards) — `isExhaust = true` → `ActivationRestriction.Once` (per-object,
 >   CR 702.177 "Activate only once"; *not* once-per-game). Plus a strip-on-leave fix so the once-ever
 >   record resets on a new object (CR 400.7). All 8 exhaust cards implemented.
@@ -62,8 +69,9 @@ TLA is built around **four "bending" keyword families** (Earthbend, Waterbend, F
 plus a returning **Exhaust** keyword and a pervasive **"second card drawn each turn"** sub-theme.
 *(Update: Earthbend, Firebending, Exhaust, the draw-count theme, and activated-ability, spell-level,
 and Exhaust—Waterbend cost shapes (incl. waterbend {X}) are now all built — see the status banner
-above. Airbend and the remaining Waterbend cost shapes (Ward—Waterbend, waterbend-as-alternative-cast)
-remain the headline work.)* Once those primitives land, the large majority of the remaining cards (standard creatures,
+above. Airbend and Exhaust are now also done; the remaining Waterbend cost shapes (Ward—Waterbend,
+in-resolution may-pay, waterbend-as-alternative-cast) plus granting/conditional Firebending and the
+Tier-3 one-offs remain the headline work.)* Once those primitives land, the large majority of the remaining cards (standard creatures,
 dual lands, sieges, sagas, lords, modal removal, cycling cards, Food/token makers) are buildable —
 and indeed most now are.
 
@@ -363,10 +371,18 @@ RemoveAllAbilities + SetStats + SetCreatureSubtypes + grant-mana-ability composi
 **Done since this analysis** (✅ no longer on the list): Earthbend (incl. dynamic X), Firebending (§2),
 Vigilance counter (§5), Nth-card-drawn (§6), Surveil (§7), sacrificed-this-turn count (§8),
 activated-ability Waterbend (§1), and spell-level Waterbend additional cost incl. waterbend {X} (the §1
-spell half). The set is now at **231/286**; the order below covers only what's left.
+spell half), plus **Airbend** (§3, keyword + stack branch) and **Exhaust** (§4). The set is now at
+**248/286**; the order below covers only what's left.
 
-1. **Airbend** (§3) — fixed-alternative-cost may-play + stack-spell exile branch. **~11 cards** — the
-   single highest-leverage remaining keyword.
+0. **Now-unblocked plain authoring** (no new engine work) — a handful of cards gated only by keywords
+   already built: **North Pole Patrol** (activated Waterbend), **Firebending Student** (Firebending
+   X = power + prowess), **Trusty Boomerang** (Equipment granting a tap/bounce ability), **Ran and
+   Shaw** (copy-self ETB + graveyard type count + firebending 2). Knock these out via `add-card` first.
+
+1. ~~**Airbend** (§3)~~ — ✅ **done**: fixed-alternative-cost may-play (`Effects.Airbend` /
+   `Effects.AirbendAll`) + stack-spell exile branch (`Effects.ExileTargetSpell`). 8 of 11 cards built;
+   the 3 leftovers are blocked by *other* gaps (cast-zone restriction, each-player-choose Saga chapter,
+   four-bend events + {WUBRG} reduction), not by airbend.
 2. **Remaining Waterbend cost shapes** (the §1 leftovers) — Ward — Waterbend, in-resolution "may pay
    a waterbend cost", and waterbend-as-alternative-cast (Hama). **~7 cards.** (Exhaust — Waterbend done.)
 3. ~~**Exhaust** (§4)~~ — ✅ **done**: `isExhaust` → per-object `ActivationRestriction.Once` (CR
@@ -379,5 +395,5 @@ spell half). The set is now at **231/286**; the order below covers only what's l
    self-scoped untap, shared-creature-type cross-target, flash-rider on play-from-exile) — as the
    relevant legendaries / rares come up.
 
-Airbend, the remaining Waterbend cost shapes, and Exhaust together gate the large majority of the
-remaining 55 cards.
+With Airbend and Exhaust now done, the **remaining Waterbend cost shapes** plus the granting/conditional
+Firebending and Tier-3 one-offs gate the bulk of the remaining 38 cards.

--- a/backlog/sets/avatar-the-last-airbender/tla-engine-gaps.md
+++ b/backlog/sets/avatar-the-last-airbender/tla-engine-gaps.md
@@ -3,14 +3,16 @@
 Cross-reference of the remaining (unimplemented) TLA cards against the engine's actual capabilities.
 Generated to scope what must be built before the set can be completed.
 
-> ## ⚠️ Status update — June 2026: now 248 / 286 (87%)
+> ## ⚠️ Status update — June 2026: now 252 / 286 (88%)
 >
-> **Most of this document's Tier-1/Tier-2 gaps have since been closed.** Of the **38 cards still
-> missing**, the large majority need new engine/SDK work — but a handful were *unblocked* by the
-> keywords built since the original write-up (activated/spell Waterbend, dynamic Firebending, Equip)
-> and are now plain `add-card` authoring with no new engine work (e.g. North Pole Patrol,
-> Firebending Student, Trusty Boomerang, Ran and Shaw). What changed since the original write-up
-> (✅ = now built, so the cards it gated are done):
+> **Most of this document's Tier-1/Tier-2 gaps have since been closed.** Of the **34 cards still
+> missing**, the large majority need new engine/SDK work. The keyword work since the original
+> write-up (activated/spell Waterbend, dynamic Firebending, Equip) unblocked a recent batch, now
+> all implemented: **North Pole Patrol** and **Firebending Student** (plain `add-card`, no engine
+> work); **Trusty Boomerang** (needed `EffectTarget.GrantingSource` — name the Equipment that
+> granted a bearer's ability); **Ran and Shaw** (needed `removeLegendary` on the self-copy token +
+> `CardsInGraveyardMatchingAtLeast`). What changed since the original write-up (✅ = now built, so
+> the cards it gated are done):
 >
 > - ✅ **Firebending** — `firebending(n)` keyword + attack-triggered combat-duration mana
 >   (`AddManaEffect(…, ManaExpiry.END_OF_COMBAT)`); dynamic "Firebending X" hand-wired with a
@@ -374,10 +376,10 @@ activated-ability Waterbend (§1), and spell-level Waterbend additional cost inc
 spell half), plus **Airbend** (§3, keyword + stack branch) and **Exhaust** (§4). The set is now at
 **248/286**; the order below covers only what's left.
 
-0. **Now-unblocked plain authoring** (no new engine work) — a handful of cards gated only by keywords
-   already built: **North Pole Patrol** (activated Waterbend), **Firebending Student** (Firebending
-   X = power + prowess), **Trusty Boomerang** (Equipment granting a tap/bounce ability), **Ran and
-   Shaw** (copy-self ETB + graveyard type count + firebending 2). Knock these out via `add-card` first.
+0. ~~**Now-unblocked recent batch**~~ — ✅ **done**: **North Pole Patrol** (activated Waterbend) and
+   **Firebending Student** (Firebending X = power + prowess) were plain `add-card`; **Trusty Boomerang**
+   added `EffectTarget.GrantingSource` (name the granting Equipment from a granted ability); **Ran and
+   Shaw** added `removeLegendary` on the self-copy token + `CardsInGraveyardMatchingAtLeast`.
 
 1. ~~**Airbend** (§3)~~ — ✅ **done**: fixed-alternative-cost may-play (`Effects.Airbend` /
    `Effects.AirbendAll`) + stack-spell exile branch (`Effects.ExileTargetSpell`). 8 of 11 cards built;

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -763,7 +763,9 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   Replicator: "create an X/X creature token of the chosen color and type." (Replaces the old one-off
   `CreateChosenTokenEffect`; under the hood it sets `CreateTokenEffect.colorsFromChoice` /
   `creatureTypesFromChoice`.)
-- `CreateTokenCopyOfSelf(count?, tapped?)` — token copies of source.
+- `CreateTokenCopyOfSelf(count?, overridePower?, overrideToughness?, removeLegendary?)` — token copies
+  of the source. `removeLegendary = true` applies the "except it's not legendary" copy clause (Ran and
+  Shaw), mirroring `CreateTokenCopyOfEquippedCreature`.
 - `CreateTokenCopyOfTarget(target, count?, overridePower?, overrideToughness?, tapped?, attacking?, triggeredAbilities?, addedKeywords?, addedSupertypes?, removedSupertypes?, overrideColors?, addedColors?, overrideSubtypes?, addedSubtypes?, overrideCardTypes?, activatedAbilities?, sacrificeAtStep?, sacrificeOnlyOnControllersTurn?, addCardTypes?, exileAtStep?, exileUnlessSourceIsRingBearer?, controller?)` —
   token copy of another permanent (or a card in any zone — the executor copies the target's `CardComponent`,
   so a graveyard/exile card works; pass `EffectTarget.PipelineTarget("name")` to copy a card a prior pipeline
@@ -4626,6 +4628,12 @@ default to "you" so card authors don't need to pass it explicitly.
   checks, e.g. `All(GraveyardContains(Filters.Instant), GraveyardContains(Filters.Sorcery))` =
   "an instant card and a sorcery card in your graveyard" (Flow State). `GraveyardContainsSubtype(subtype)`
   is the subtype-filtered sibling.
+- `CardsInGraveyardMatchingAtLeast(count, filter)` — "there are `count` or more cards matching `filter`
+  in your graveyard" (`Compare(Count(Player.You, Zone.GRAVEYARD, filter), GTE, count)`). The general
+  form behind `CreatureCardsInGraveyardAtLeast(count)`; use for "N or more <kind> cards", e.g. Ran and
+  Shaw's "three or more Dragon and/or Lesson cards" with
+  `GameObjectFilter.Any.withAnySubtype("Dragon", "Lesson")` (a card matching multiple ways is counted
+  once). `CardsInGraveyardAtLeast(count)` is the unfiltered total.
 - `Delirium(count = 4)` — the Delirium ability word: "there are `count` or more card types among
   cards in your graveyard." Composes through `Compare(DynamicAmount.AggregateZone(Player.You,
   Zone.GRAVEYARD, GameObjectFilter.Any, Aggregation.DISTINCT_TYPES), GTE, Fixed(count))` — the

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1688,7 +1688,19 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 
 - `EffectTarget.ContextTarget(i)` — i-th cast-time target.
 - `EffectTarget.Controller` — controller of the source ability.
-- `EffectTarget.Self` — the source permanent.
+- `EffectTarget.Self` — the source permanent. In a *granted* ability (Equipment/Aura "equipped
+  creature has …"), `Self` is the **host** that received the ability — its `{T}` taps the host —
+  not the granting object (CR 113.7).
+- `EffectTarget.GrantingSource` — the permanent whose static ability granted the currently-resolving
+  ability: the Equipment/Aura/permanent bearing the `GrantActivatedAbility` static, as the counterpart
+  to `Self` (the host). Use when a granted ability names the *granting object* — e.g. Trusty
+  Boomerang's "equipped creature has '{1}, {T}: Tap target creature. **Return Trusty Boomerang** to
+  its owner's hand'" (`Effects.ReturnToHand(EffectTarget.GrantingSource)`), or Cranial Plating's
+  "Attach Cranial Plating to target creature". The granter is captured when the ability is put on the
+  stack (threaded `ActivatedAbilityOnStackComponent.granterId` → `EffectContext.granterId`), so it
+  survives the granter leaving play — the referencing effect no-ops if it's gone (CR 113.7a). For an
+  ability whose source already *is* the granter (Territory Forge / Sharkey-style gains), it resolves
+  to the same entity as `Self`.
 - `EffectTarget.TriggeringEntity` — the entity that caused the trigger to fire.
 - `EffectTarget.DiscardedAsCost(index = 0)` — a card discarded to pay this spell's additional discard
   cost (`Costs.additional.DiscardCards(...)`). The discarded card is in its owner's graveyard by

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -594,14 +594,24 @@ object Conditions {
     // =========================================================================
 
     /**
-     * If there are N or more creature cards in your graveyard.
+     * If there are N or more cards matching [filter] in your graveyard. The general form behind
+     * [CreatureCardsInGraveyardAtLeast]; use for any "N or more <kind> cards in your graveyard"
+     * gate — e.g. Ran and Shaw's "three or more Dragon and/or Lesson cards"
+     * (`GameObjectFilter.Any.withAnySubtype("Dragon", "Lesson")`). A card matching the filter in
+     * more than one way is still counted once.
      */
-    fun CreatureCardsInGraveyardAtLeast(count: Int): ConditionInterface =
+    fun CardsInGraveyardMatchingAtLeast(count: Int, filter: GameObjectFilter): ConditionInterface =
         Compare(
-            DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Creature),
+            DynamicAmount.Count(Player.You, Zone.GRAVEYARD, filter),
             ComparisonOperator.GTE,
             DynamicAmount.Fixed(count)
         )
+
+    /**
+     * If there are N or more creature cards in your graveyard.
+     */
+    fun CreatureCardsInGraveyardAtLeast(count: Int): ConditionInterface =
+        CardsInGraveyardMatchingAtLeast(count, GameObjectFilter.Creature)
 
     /**
      * If there are N or more cards in your graveyard.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1840,9 +1840,10 @@ object Effects {
     fun CreateTokenCopyOfSelf(
         count: Int = 1,
         overridePower: Int? = null,
-        overrideToughness: Int? = null
+        overrideToughness: Int? = null,
+        removeLegendary: Boolean = false
     ): Effect =
-        CreateTokenCopyOfSourceEffect(count, overridePower, overrideToughness)
+        CreateTokenCopyOfSourceEffect(count, overridePower, overrideToughness, removeLegendary = removeLegendary)
 
     /**
      * Create a token that's a copy of a randomly chosen creature card with mana value [manaValue]

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TokenEffects.kt
@@ -262,7 +262,13 @@ data class CreateTokenCopyOfSourceEffect(
      * it's an artifact in addition to its other types"); any future copy-token effect
      * with the same shape can reuse the same field.
      */
-    val addCardTypes: Set<String> = emptySet()
+    val addCardTypes: Set<String> = emptySet(),
+    /**
+     * If true, the token copy is not legendary — the "except it's not legendary" copy clause
+     * (e.g. Ran and Shaw's "create a token that's a copy of Ran and Shaw, except it's not
+     * legendary"). Mirrors [CreateTokenCopyOfEquippedCreatureEffect.removeLegendary].
+     */
+    val removeLegendary: Boolean = false
 ) : Effect {
     override val description: String = buildString {
         append("Create ")
@@ -271,6 +277,9 @@ data class CreateTokenCopyOfSourceEffect(
         val excepts = mutableListOf<String>()
         if (overridePower != null && overrideToughness != null) {
             excepts.add("it's $overridePower/$overrideToughness")
+        }
+        if (removeLegendary) {
+            excepts.add("it's not legendary")
         }
         if (addCardTypes.isNotEmpty()) {
             val typeWords = addCardTypes.map { it.lowercase() }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/targets/EffectTarget.kt
@@ -54,6 +54,25 @@ sealed interface EffectTarget {
         override val description: String = "enchanted permanent"
     }
 
+    /**
+     * The permanent whose static ability granted the currently-resolving ability — the
+     * Equipment/Aura/permanent bearing the `GrantActivatedAbility` (or gained-abilities) static,
+     * as opposed to [Self], which in a granted ability is the *host* that received it.
+     *
+     * Use for granted abilities that reference the granting object by name, e.g. an Equipment that
+     * gives its bearer "...Return [this Equipment] to its owner's hand" (Trusty Boomerang), or
+     * "Attach [this Equipment] to target creature" (Cranial Plating). Resolves to the granter
+     * captured when the ability was put on the stack, so it survives the granter leaving play
+     * (CR 113.7a last-known information — the effect no-ops if the granter is gone). For an ability
+     * whose source already *is* the granter (Territory Forge / Sharkey-style gains), this resolves
+     * to the same entity as [Self].
+     */
+    @SerialName("GrantingSource")
+    @Serializable
+    data object GrantingSource : EffectTarget {
+        override val description: String = "the source that granted this ability"
+    }
+
     /** The controller of the target (used for effects like "its controller gains 4 life") */
     @SerialName("TargetController")
     @Serializable

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/FirebendingStudent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/FirebendingStudent.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.ManaExpiry
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Firebending Student
+ * {1}{R}
+ * Creature — Human Monk
+ * 1/2
+ *
+ * Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)
+ * Firebending X, where X is this creature's power. (Whenever this creature attacks, add X {R}.
+ * This mana lasts until end of combat.)
+ *
+ * Dynamic firebending follows the [com.wingedsheep.mtg.sets.definitions.tla.cards.FireLordZuko]
+ * pattern: the fixed `firebending(n)` DSL only models a constant N, so the attack trigger is
+ * hand-wired as an [AddManaEffect] producing red mana equal to this creature's (projected) power
+ * with [ManaExpiry.END_OF_COMBAT]. Reading projected power means prowess's +1/+1 buffs are
+ * already reflected in X when the trigger resolves. The display keyword ability is omitted because
+ * the keyword is fixed-N only; the reminder text lives in `oracleText`.
+ */
+val FirebendingStudent = card("Firebending Student") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Monk"
+    power = 1
+    toughness = 2
+    oracleText = "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n" +
+        "Firebending X, where X is this creature's power. (Whenever this creature attacks, add X {R}. " +
+        "This mana lasts until end of combat.)"
+
+    prowess()
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = AddManaEffect(
+            Color.RED,
+            DynamicAmount.EntityProperty(EntityReference.Source, EntityNumericProperty.Power),
+            expiry = ManaExpiry.END_OF_COMBAT,
+        )
+        description = "Firebending X, where X is this creature's power. Whenever this creature " +
+            "attacks, add X {R}. This mana lasts until end of combat."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "139"
+        artist = "Kozato"
+        flavorText = "\"Fire is the element of power.\"\n—Iroh"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b366f59-16fe-43cb-888d-1f93ef8fd332.jpg?1764120954"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/NorthPolePatrol.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/NorthPolePatrol.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * North Pole Patrol
+ * {2}{U}
+ * Creature — Human Soldier Ally
+ * 2/3
+ * {T}: Untap another target permanent you control.
+ * Waterbend {3}, {T}: Tap target creature an opponent controls. (While paying a waterbend cost,
+ *   you can tap your artifacts and creatures to help. Each one pays for {1}.)
+ *
+ * Both abilities reuse existing primitives: the untap is a plain targeted [Effects.Untap]; the
+ * waterbend ability is a `Costs.Composite(Mana, Tap)` carrying `hasWaterbend = true`, so the engine
+ * extracts the {3} generic and lets the player tap their artifacts/creatures to help pay it while the
+ * Patrol's own tap is consumed by the activation cost.
+ */
+val NorthPolePatrol = card("North Pole Patrol") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Soldier Ally"
+    power = 2
+    toughness = 3
+    oracleText = "{T}: Untap another target permanent you control.\n" +
+        "Waterbend {3}, {T}: Tap target creature an opponent controls. (While paying a waterbend " +
+        "cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)"
+
+    activatedAbility {
+        cost = Costs.Tap
+        val permanent = target(
+            "another target permanent you control",
+            TargetPermanent(filter = TargetFilter.Permanent.youControl().other()),
+        )
+        effect = Effects.Untap(permanent)
+        description = "{T}: Untap another target permanent you control."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}"), Costs.Tap)
+        hasWaterbend = true
+        val theirCreature = target(
+            "target creature an opponent controls",
+            Targets.CreatureOpponentControls,
+        )
+        effect = Effects.Tap(theirCreature)
+        description = "Waterbend {3}, {T}: Tap target creature an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Rose Benjamin"
+        flavorText = "Waterbenders patrol the coast each day for good fishing spots and bad weather omens."
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2c0c138-5b61-4949-8431-4a6d458ead6a.jpg?1764120386"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/RanAndShaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/RanAndShaw.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.firebending
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ran and Shaw
+ * {3}{R}{R}
+ * Legendary Creature — Dragon
+ * 4/4
+ *
+ * Flying, firebending 2
+ * When Ran and Shaw enter, if you cast them and there are three or more Dragon and/or Lesson cards
+ *   in your graveyard, create a token that's a copy of Ran and Shaw, except it's not legendary.
+ * {3}{R}: Dragons you control get +2/+0 until end of turn.
+ *
+ * The ETB is an intervening-if (CR 603.4): `triggerCondition` gates on both "if you cast them"
+ * ([Conditions.WasCast]) and the graveyard count, checked when the ability would trigger and again
+ * on resolution. The copy uses the new `removeLegendary` clause on [Effects.CreateTokenCopyOfSelf]
+ * ("except it's not legendary"). "Dragon and/or Lesson cards" is a single subtype-OR filter, so a
+ * card that is both is still counted once.
+ */
+val RanAndShaw = card("Ran and Shaw") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying, firebending 2\n" +
+        "When Ran and Shaw enter, if you cast them and there are three or more Dragon and/or Lesson " +
+        "cards in your graveyard, create a token that's a copy of Ran and Shaw, except it's not legendary.\n" +
+        "{3}{R}: Dragons you control get +2/+0 until end of turn."
+
+    keywords(Keyword.FLYING)
+    firebending(2)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.All(
+            Conditions.WasCast,
+            Conditions.CardsInGraveyardMatchingAtLeast(3, GameObjectFilter.Any.withAnySubtype("Dragon", "Lesson")),
+        )
+        effect = Effects.CreateTokenCopyOfSelf(removeLegendary = true)
+        description = "When Ran and Shaw enter, if you cast them and there are three or more Dragon " +
+            "and/or Lesson cards in your graveyard, create a token that's a copy of Ran and Shaw, " +
+            "except it's not legendary."
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{R}")
+        effect = Effects.ForEachInGroup(
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Dragon").youControl()),
+            effect = ModifyStatsEffect(2, 0, EffectTarget.Self),
+        )
+        description = "{3}{R}: Dragons you control get +2/+0 until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "150"
+        artist = "Miho Midorikawa"
+        imageUri = "https://cards.scryfall.io/normal/front/6/4/6436e2d0-989f-47e3-90bc-9cde82a2ddb4.jpg?1764121032"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TrustyBoomerang.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TrustyBoomerang.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.tla.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Trusty Boomerang
+ * {1}
+ * Artifact — Equipment
+ *
+ * Equipped creature has "{1}, {T}: Tap target creature. Return Trusty Boomerang to its owner's hand."
+ * Equip {1}
+ *
+ * The granted ability lives on the *equipped creature* (CR 113.7: its source is the host, so the
+ * `{T}` taps that creature and `EffectTarget.ContextTarget(0)` is "target creature"). "Return Trusty
+ * Boomerang" names the Equipment, a different object — resolved via
+ * [EffectTarget.GrantingSource], which points at the permanent whose static granted the ability.
+ * If the Equipment has already left the battlefield by resolution, the move no-ops (CR 113.7a).
+ */
+val TrustyBoomerang = card("Trusty Boomerang") {
+    manaCost = "{1}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has \"{1}, {T}: Tap target creature. Return Trusty Boomerang to " +
+        "its owner's hand.\"\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap),
+                effect = Effects.Composite(
+                    Effects.Tap(EffectTarget.ContextTarget(0)),
+                    Effects.ReturnToHand(EffectTarget.GrantingSource),
+                ),
+                targetRequirements = listOf(TargetCreature()),
+            )
+            // filter defaults to GroupFilter.attachedCreature() — "equipped creature has ..."
+        )
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "260"
+        artist = "Toni Infante"
+        flavorText = "\"Boomerang! You do always come back!\"\n—Sokka"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/df99a166-6d58-4d92-9037-2fdfbaf65629.jpg?1764121919"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -6993,6 +6993,74 @@
     ]
 }
 
+// Firebending Student
+{
+    "name": "Firebending Student",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Monk",
+    "oracleText": "Prowess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nFirebending X, where X is this creature's power. (Whenever this creature attacks, add X {R}. This mana lasts until end of combat.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "PROWESS"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "expiry": "END_OF_COMBAT"
+                },
+                "descriptionOverride": "Firebending X, where X is this creature's power. Whenever this creature attacks, add X {R}. This mana lasts until end of combat."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "RARE",
+        "artist": "Kozato",
+        "flavorText": "\"Fire is the element of power.\"\n—Iroh",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b366f59-16fe-43cb-888d-1f93ef8fd332.jpg?1764120954"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // First-Time Flyer
 {
     "name": "First-Time Flyer",
@@ -11168,6 +11236,89 @@
     },
     "colorIdentityOverride": [
         "WHITE",
+        "BLUE"
+    ]
+}
+
+// North Pole Patrol
+{
+    "name": "North Pole Patrol",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Soldier Ally",
+    "oracleText": "{T}: Untap another target permanent you control.\nWaterbend {3}, {T}: Tap target creature an opponent controls. (While paying a waterbend cost, you can tap your artifacts and creatures to help. Each one pays for {1}.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "another target permanent you control"
+                    },
+                    "tap": false
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "another target permanent you control"
+                    }
+                ],
+                "descriptionOverride": "{T}: Untap another target permanent you control."
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature an opponent controls"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        },
+                        "id": "target creature an opponent controls"
+                    }
+                ],
+                "descriptionOverride": "Waterbend {3}, {T}: Tap target creature an opponent controls.",
+                "hasWaterbend": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Rose Benjamin",
+        "flavorText": "Waterbenders patrol the coast each day for good fishing spots and bad weather omens.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2c0c138-5b61-4949-8431-4a6d458ead6a.jpg?1764120386"
+    },
+    "colorIdentityOverride": [
         "BLUE"
     ]
 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -12694,6 +12694,122 @@
     ]
 }
 
+// Ran and Shaw
+{
+    "name": "Ran and Shaw",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Legendary Creature — Dragon",
+    "oracleText": "Flying, firebending 2\nWhen Ran and Shaw enter, if you cast them and there are three or more Dragon and/or Lesson cards in your graveyard, create a token that's a copy of Ran and Shaw, except it's not legendary.\n{3}{R}: Dragons you control get +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING",
+        "FIREBENDING"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "FIREBENDING",
+            "n": 2
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "expiry": "END_OF_COMBAT"
+                },
+                "descriptionOverride": "Whenever this creature attacks, add {R}{R}. Until end of combat, you don't lose this mana as steps and phases end."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateTokenCopyOfSource",
+                    "removeLegendary": true
+                },
+                "triggerCondition": {
+                    "type": "All",
+                    "conditions": [
+                        "WasCast",
+                        {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Graveyard",
+                                "filter": "Dragon|Lesson"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When Ran and Shaw enter, if you cast them and there are three or more Dragon and/or Lesson cards in your graveyard, create a token that's a copy of Ran and Shaw, except it's not legendary."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature Dragon ctrl:you"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 0
+                        },
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "{3}{R}: Dragons you control get +2/+0 until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "RARE",
+        "artist": "Miho Midorikawa",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/4/6436e2d0-989f-47e3-90bc-9cde82a2ddb4.jpg?1764121032"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Raucous Audience
 {
     "name": "Raucous Audience",

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -17434,6 +17434,100 @@
     ]
 }
 
+// Trusty Boomerang
+{
+    "name": "Trusty Boomerang",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has \"{1}, {T}: Tap target creature. Return Trusty Boomerang to its owner's hand.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{1}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "TapUntap",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            {
+                                "type": "MoveToZone",
+                                "target": "GrantingSource",
+                                "destination": "Hand"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "260",
+        "rarity": "UNCOMMON",
+        "artist": "Toni Infante",
+        "flavorText": "\"Boomerang! You do always come back!\"\n—Sokka",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/df99a166-6d58-4d92-9037-2fdfbaf65629.jpg?1764121919"
+    }
+}
+
 // Tundra Tank
 {
     "name": "Tundra Tank",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -34,6 +34,16 @@ data class EffectContext(
      */
     val effectControllerId: EntityId? = null,
     /**
+     * The permanent whose static ability granted the currently-resolving ability (the
+     * Equipment/Aura/permanent bearing the `GrantActivatedAbility` static), captured when the
+     * ability was put on the stack. Resolves [com.wingedsheep.sdk.scripting.targets.EffectTarget.GrantingSource]
+     * so a granted ability can name its granter — e.g. an Equipment that gives its bearer
+     * "...Return [this Equipment] to its owner's hand" (Trusty Boomerang). Null for non-granted
+     * abilities and for spell resolution; the granter may have left play by resolution, so the
+     * referencing effect must tolerate a now-absent entity (CR 113.7a).
+     */
+    val granterId: EntityId? = null,
+    /**
      * Definition-scoped identity of the triggered/activated ability currently resolving, copied
      * from its stack component (see [com.wingedsheep.sdk.scripting.AbilityIdentity]). Lets a
      * resolution-time may-question consult the controller's persistent auto-answer yields without

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1045,6 +1045,7 @@ class ActivateAbilityHandler(
             val context = EffectContext(
                 sourceId = action.sourceId,
                 controllerId = action.playerId,
+                granterId = staticGranterId,
                 targets = action.targets,
                 // Thread the chosen X so X-based mana abilities produce the right amount
                 // ("{X}, {T}, Sacrifice this: Add X mana..." — Wizard's Rockets). Without
@@ -1324,7 +1325,8 @@ class ActivateAbilityHandler(
             descriptionOverride = ability.descriptionOverride,
             abilityIdentity = com.wingedsheep.sdk.scripting.AbilityIdentity(
                 cardComponent.cardDefinitionId, ability.id
-            )
+            ),
+            granterId = staticGranterId
         )
 
         // Apply text-changing effects to the target requirements for resolution-time re-validation
@@ -1409,7 +1411,8 @@ class ActivateAbilityHandler(
                     descriptionOverride = ability.descriptionOverride,
                     abilityIdentity = com.wingedsheep.sdk.scripting.AbilityIdentity(
                         cardComponent.cardDefinitionId, ability.id
-                    )
+                    ),
+                    granterId = staticGranterId
                 )
                 val repeatStackResult = stackResolver.putActivatedAbility(
                     currentState, repeatAbilityOnStack, action.targets,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -30,6 +30,7 @@ object TargetResolutionUtils {
     fun resolveTarget(effectTarget: EffectTarget, context: EffectContext): EntityId? {
         return when (effectTarget) {
             is EffectTarget.Self -> context.pipeline.iterationTarget ?: context.sourceId
+            is EffectTarget.GrantingSource -> context.granterId
             is EffectTarget.Controller -> context.controllerId
             is EffectTarget.ContextTarget -> context.positionalTarget(effectTarget.index)?.toEntityId()
             is EffectTarget.BoundVariable -> context.pipeline.namedTargets[effectTarget.name]?.toEntityId()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -77,12 +77,18 @@ class CreateTokenCopyOfSourceExecutor(
                     runCatching { CardType.valueOf(name.uppercase()) }.getOrNull()
                 }
                 .toSet()
-            val unionedTypeLine = if (extraCardTypes.isEmpty()) {
+            val typeLineWithExtras = if (extraCardTypes.isEmpty()) {
                 sourceCard.typeLine
             } else {
                 sourceCard.typeLine.copy(
                     cardTypes = sourceCard.typeLine.cardTypes + extraCardTypes
                 )
+            }
+            // "except it's not legendary" copy clause (CR 707.2) — strip the legendary supertype.
+            val unionedTypeLine = if (effect.removeLegendary) {
+                typeLineWithExtras.withoutLegendary()
+            } else {
+                typeLineWithExtras
             }
             val tokenCard = sourceCard.copy(
                 ownerId = controllerId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -2131,6 +2131,7 @@ class StackResolver(
         val context = EffectContext(
             sourceId = abilityComponent.sourceId,
             controllerId = abilityComponent.controllerId,
+            granterId = abilityComponent.granterId,
             abilityIdentity = abilityComponent.abilityIdentity,
             targets = activatedTargets,
             alignedTargets = alignedActivatedTargets,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/stack/StackComponents.kt
@@ -226,7 +226,15 @@ data class ActivatedAbilityOnStackComponent(
      * [com.wingedsheep.sdk.scripting.AbilityIdentity]). Null for synthesized abilities with no
      * stable [com.wingedsheep.sdk.scripting.AbilityId] behind them (e.g. crew/saddle).
      */
-    val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null
+    val abilityIdentity: com.wingedsheep.sdk.scripting.AbilityIdentity? = null,
+    /**
+     * The permanent whose static ability granted this activated ability (the Equipment/Aura/permanent
+     * bearing the `GrantActivatedAbility` static), captured at activation. Read at resolution into
+     * [com.wingedsheep.engine.handlers.EffectContext.granterId] so the granted ability can name its
+     * granter via [com.wingedsheep.sdk.scripting.targets.EffectTarget.GrantingSource] — e.g. Trusty
+     * Boomerang's "Return [this Equipment] to its owner's hand". Null for non-granted abilities.
+     */
+    val granterId: EntityId? = null
 ) : Component {
     val hasTargets: Boolean = false  // Will be updated based on effect
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RanAndShawScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RanAndShawScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ran and Shaw exercises the `removeLegendary` clause on `CreateTokenCopyOfSourceEffect`
+ * ("create a token that's a copy of Ran and Shaw, except it's not legendary") gated by an
+ * intervening-if: "if you cast them and there are three or more Dragon and/or Lesson cards in your
+ * graveyard" (`Conditions.WasCast` + `CardsInGraveyardMatchingAtLeast`).
+ */
+class RanAndShawScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("cast with 3+ Dragon/Lesson cards in graveyard makes a non-legendary copy") {
+            val game = scenario()
+                .withPlayers("Alice", "Bob")
+                .withCardInHand(1, "Ran and Shaw")
+                .withLandsOnBattlefield(1, "Mountain", 5)
+                .withCardInGraveyard(1, "Firebending Lesson")
+                .withCardInGraveyard(1, "Earthbending Lesson")
+                .withCardInGraveyard(1, "Airbending Lesson")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cast = game.castSpell(1, "Ran and Shaw")
+            withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            val copies = game.findPermanents("Ran and Shaw")
+                .mapNotNull { game.state.getEntity(it)?.get<CardComponent>() }
+            withClue("The original plus a non-legendary token coexist (legend rule spares the token)") {
+                copies.size shouldBe 2
+                copies.count { it.typeLine.isLegendary } shouldBe 1
+            }
+            val token = copies.first { !it.typeLine.isLegendary }
+            withClue("Token is a faithful copy: a Dragon creature, just not legendary") {
+                token.typeLine.isCreature shouldBe true
+                token.typeLine.hasSubtype(Subtype("Dragon")) shouldBe true
+            }
+        }
+
+        test("cast with fewer than 3 Dragon/Lesson cards makes no copy") {
+            val game = scenario()
+                .withPlayers("Alice", "Bob")
+                .withCardInHand(1, "Ran and Shaw")
+                .withLandsOnBattlefield(1, "Mountain", 5)
+                .withCardInGraveyard(1, "Firebending Lesson")
+                .withCardInGraveyard(1, "Earthbending Lesson")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val cast = game.castSpell(1, "Ran and Shaw")
+            withClue("Casting should succeed: ${cast.error}") { cast.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            withClue("Intervening-if fails (only 2 Lesson cards) — no token, just Ran and Shaw itself") {
+                game.findPermanents("Ran and Shaw").size shouldBe 1
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrustyBoomerangScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrustyBoomerangScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Trusty Boomerang exercises [com.wingedsheep.sdk.scripting.targets.EffectTarget.GrantingSource]:
+ * an Equipment grants its bearer "{1}, {T}: Tap target creature. Return Trusty Boomerang to its
+ * owner's hand." The granted ability's source is the *host creature* (so `{T}` taps the creature),
+ * but "Return Trusty Boomerang" names the *Equipment* — resolved via `GrantingSource`, the permanent
+ * whose static granted the ability.
+ */
+class TrustyBoomerangScenarioTest : ScenarioTestBase() {
+
+    /** Find the granted "{1}, {T}: ..." ability surfaced on [host], returning its abilityId. */
+    private fun TestGame.grantedAbilityIdOn(host: EntityId): AbilityId =
+        getLegalActions(1)
+            .mapNotNull { it.action as? ActivateAbility }
+            .first { it.sourceId == host }
+            .abilityId
+
+    init {
+        test("granted ability taps a creature and returns the Equipment (not the host) to hand") {
+            val game = scenario()
+                .withPlayers("Alice", "Bob")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardAttachedTo(1, "Trusty Boomerang", "Grizzly Bears")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withCardOnBattlefield(2, "Hill Giant")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val boomerang = game.findPermanent("Trusty Boomerang")!!
+            val giant = game.findPermanent("Hill Giant")!!
+
+            val abilityId = game.grantedAbilityIdOn(bears)
+            val result = game.execute(
+                ActivateAbility(game.player1Id, bears, abilityId, targets = listOf(ChosenTarget.Permanent(giant)))
+            )
+            withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            withClue("Target creature an opponent controls is tapped") {
+                game.state.getEntity(giant)?.get<TappedComponent>().shouldNotBeNull()
+            }
+            withClue("GrantingSource returns the Equipment to its owner's hand") {
+                game.isInHand(1, "Trusty Boomerang") shouldBe true
+                game.findPermanent("Trusty Boomerang") shouldBe null
+            }
+            withClue("The host creature stays on the battlefield (Self != GrantingSource) and is tapped for {T}") {
+                game.findPermanent("Grizzly Bears").shouldNotBeNull()
+                game.state.getEntity(bears)?.get<TappedComponent>().shouldNotBeNull()
+            }
+        }
+
+        test("GrantingSource returns the attached granter specifically, not any same-named Equipment") {
+            // A second, unattached Trusty Boomerang sits on the battlefield granting nothing. Activating
+            // the bearer's ability must bounce the *attached* Equipment (the granter), leaving the
+            // unattached one — proving GrantingSource resolves the specific granter, not "a Boomerang".
+            val game = scenario()
+                .withPlayers("Alice", "Bob")
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardAttachedTo(1, "Trusty Boomerang", "Grizzly Bears")
+                .withCardOnBattlefield(1, "Trusty Boomerang")
+                .withLandsOnBattlefield(1, "Island", 1)
+                .withCardOnBattlefield(2, "Eager Cadet")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val cadet = game.findPermanent("Eager Cadet")!!
+            val unattachedBoomerang = game.findPermanents("Trusty Boomerang")
+                .first { game.state.getEntity(it)?.get<AttachedToComponent>() == null }
+
+            val abilityId = game.grantedAbilityIdOn(bears)
+            val result = game.execute(
+                ActivateAbility(game.player1Id, bears, abilityId, targets = listOf(ChosenTarget.Permanent(cadet)))
+            )
+            withClue("Activation should succeed: ${result.error}") { result.error shouldBe null }
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+            game.resolveStack()
+
+            withClue("The attached granter returned to hand; the unattached Boomerang stayed in play") {
+                game.isInHand(1, "Trusty Boomerang") shouldBe true
+                game.findPermanents("Trusty Boomerang") shouldBe listOf(unattachedBoomerang)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements four Avatar: The Last Airbender cards, each composing existing primitives,
plus three small reusable SDK extensions designed for the next card rather than just these.

### Cards
- **Trusty Boomerang** — Equipment granting "{1}, {T}: Tap target creature. Return Trusty
  Boomerang to its owner's hand."
- **Ran and Shaw** — Legendary Dragon; ETB intervening-if makes a non-legendary copy, plus a
  Dragon lord activated ability.
- **North Pole Patrol** — untap + waterbend tap (reuses existing `hasWaterbend` cost).
- **Firebending Student** — prowess + dynamic firebending X = power (FireLordZuko pattern).

### SDK additions
- **`EffectTarget.GrantingSource`** — resolves the permanent whose static *granted* the
  currently-resolving ability (vs `Self` = host). Threaded granter → stack component →
  `EffectContext`, captured at activation so it survives the granter leaving play (CR 113.7a).
  Unlocks Cranial Plating, Territory Forge, etc.
- **`CreateTokenCopyOfSelf(removeLegendary = …)`** — "except it's not legendary" copy clause,
  mirroring the existing equipped-creature copy effect.
- **`CardsInGraveyardMatchingAtLeast(count, filter)`** — generalizes
  `CreatureCardsInGraveyardAtLeast` to any filter (Dragon and/or Lesson cards).

### Tests
Ran and Shaw (both intervening-if branches) and Trusty Boomerang (incl. a discriminating
case with a second same-named unattached Equipment) — all green. SDK reference and TLA
snapshot updated. Cited CR numbers (113.7, 113.7a, 707.2, 603.4) verified.