### PR TITLE
Add "unreleased sets" filter to deckbuilder + set completion

### DIFF
--- a/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.module.css
@@ -1102,6 +1102,12 @@
   font-variant-numeric: tabular-nums;
 }
 
+.setComboHeaderControls {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .setComboList {
   list-style: none;
   margin: 0;

--- a/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
+++ b/web-client/src/components/deckbuilder/DeckbuilderPage.tsx
@@ -26,6 +26,7 @@ import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
 import { useDfcHoverFlip } from '@/components/ui/useDfcHoverFlip'
 import { SetIcon } from '@/components/ui/SetIcon'
 import { getCardImageUrl, getCdnArtCropUrl, getScryfallArtCropUrl, splitImageRotateDeg } from '@/utils/cardImages'
+import { isUnreleasedSet, todayIso } from '@/utils/setRelease'
 import { rarityColor } from '@/components/draft/RarityBadge'
 import {
   parseQuery,
@@ -3135,6 +3136,22 @@ function SetCombobox({
     if (typeof window !== 'undefined') window.localStorage.setItem('deckbuilder.setSort', sortMode)
   }, [sortMode])
 
+  // Not-yet-released (future release date) sets are hidden by default; opt in with this toggle.
+  const [showUnreleased, setShowUnreleased] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem('deckbuilder.showUnreleasedSets') === '1'
+  })
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('deckbuilder.showUnreleasedSets', showUnreleased ? '1' : '0')
+    }
+  }, [showUnreleased])
+  const today = useMemo(() => todayIso(), [])
+  const unreleasedCount = useMemo(
+    () => sets.filter((s) => isUnreleasedSet(s.releaseDate, today)).length,
+    [sets, today],
+  )
+
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [activeIdx, setActiveIdx] = useState(0)
@@ -3168,11 +3185,13 @@ function SetCombobox({
 
   const filtered = useMemo(() => {
     const needle = search.trim().toLowerCase()
-    if (!needle) return sorted
-    return sorted.filter(
-      (s) => s.name.toLowerCase().includes(needle) || s.code.toLowerCase().includes(needle),
-    )
-  }, [sorted, search])
+    return sorted.filter((s) => {
+      // The currently-selected set always stays visible so it can be changed or cleared.
+      if (!showUnreleased && s.code !== value && isUnreleasedSet(s.releaseDate, today)) return false
+      if (!needle) return true
+      return s.name.toLowerCase().includes(needle) || s.code.toLowerCase().includes(needle)
+    })
+  }, [sorted, search, showUnreleased, today, value])
 
   // Close on outside click. mousedown (not click) so a selection inside fires before close.
   // The panel is portaled out of rootRef, so check it separately.
@@ -3311,27 +3330,44 @@ function SetCombobox({
             <span className={styles.setComboCount}>
               {filtered.length} {filtered.length === 1 ? 'set' : 'sets'}
             </span>
-            <div className={styles.modeSegmented} role="tablist" aria-label="Sort sets">
-              <button
-                type="button"
-                role="tab"
-                aria-selected={sortMode === 'name'}
-                className={`${styles.modeButton} ${sortMode === 'name' ? styles.modeButtonActive : ''}`}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => setSortMode('name')}
-              >
-                Name
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={sortMode === 'date'}
-                className={`${styles.modeButton} ${sortMode === 'date' ? styles.modeButtonActive : ''}`}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => setSortMode('date')}
-              >
-                Release
-              </button>
+            <div className={styles.setComboHeaderControls}>
+              {unreleasedCount > 0 && (
+                <div className={styles.modeSegmented}>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={showUnreleased}
+                    className={`${styles.modeButton} ${showUnreleased ? styles.modeButtonActive : ''}`}
+                    title="Show sets that haven't been released yet"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => setShowUnreleased((v) => !v)}
+                  >
+                    {showUnreleased ? '✓ ' : ''}Unreleased
+                  </button>
+                </div>
+              )}
+              <div className={styles.modeSegmented} role="tablist" aria-label="Sort sets">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={sortMode === 'name'}
+                  className={`${styles.modeButton} ${sortMode === 'name' ? styles.modeButtonActive : ''}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => setSortMode('name')}
+                >
+                  Name
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={sortMode === 'date'}
+                  className={`${styles.modeButton} ${sortMode === 'date' ? styles.modeButtonActive : ''}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => setSortMode('date')}
+                >
+                  Release
+                </button>
+              </div>
             </div>
           </div>
           <ul

--- a/web-client/src/components/setCompletion/SetCompletionPage.module.css
+++ b/web-client/src/components/setCompletion/SetCompletionPage.module.css
@@ -312,6 +312,17 @@
   padding: 1px 6px;
   border-radius: var(--radius-sm);
 }
+.unreleasedBadge {
+  font-size: var(--font-xs);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #c4b5fd;
+  background: rgba(139, 92, 246, 0.16);
+  border: 1px solid rgba(139, 92, 246, 0.42);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+}
 .percent {
   font-size: var(--font-lg);
   font-weight: var(--font-weight-bold);

--- a/web-client/src/components/setCompletion/SetCompletionPage.tsx
+++ b/web-client/src/components/setCompletion/SetCompletionPage.tsx
@@ -4,6 +4,7 @@ import { SetIcon } from '../ui/SetIcon'
 import { HoverCardPreview } from '../ui/HoverCardPreview'
 import { ProgressChartOverlay } from './ProgressChartOverlay'
 import { getScryfallFallbackUrl } from '@/utils/cardImages'
+import { isUnreleasedSet, todayIso } from '@/utils/setRelease'
 import {
   fetchSetCoverage,
   fetchCoverageSummary,
@@ -69,6 +70,8 @@ export function SetCompletionPage() {
   const [query, setQuery] = useState('')
   const [sort, setSort] = useState<SortKey>('newest')
   const [filter, setFilter] = useState<Filter>('all')
+  // Not-yet-released (future release date) sets are hidden by default; opt in with this toggle.
+  const [showUnreleased, setShowUnreleased] = useState(false)
   const [openCode, setOpenCode] = useState<string | null>(null)
   const [showProgress, setShowProgress] = useState(false)
 
@@ -99,10 +102,17 @@ export function SetCompletionPage() {
     }
   }, [sets])
 
+  const today = todayIso()
+  const unreleasedCount = useMemo(
+    () => (sets ?? []).filter((s) => isUnreleasedSet(s.releaseDate, today)).length,
+    [sets, today],
+  )
+
   const visible = useMemo(() => {
     if (!sets) return []
     const q = query.trim().toLowerCase()
     const filtered = sets.filter((s) => {
+      if (!showUnreleased && isUnreleasedSet(s.releaseDate, today)) return false
       if (filter === 'standard' && !s.inStandard) return false
       if (filter === 'complete' && s.percent < 100) return false
       if (filter === 'inProgress' && (s.percent >= 100 || s.implemented === 0)) return false
@@ -127,7 +137,7 @@ export function SetCompletionPage() {
         break
     }
     return sorted
-  }, [sets, query, sort, filter])
+  }, [sets, query, sort, filter, showUnreleased, today])
 
   return (
     <div className={styles.page}>
@@ -231,6 +241,18 @@ export function SetCompletionPage() {
             </button>
           ))}
         </div>
+        {unreleasedCount > 0 && (
+          <div className={styles.segmented} role="group" aria-label="Unreleased sets">
+            <button
+              className={showUnreleased ? styles.segmentActive : styles.segment}
+              onClick={() => setShowUnreleased((v) => !v)}
+              aria-pressed={showUnreleased}
+              title="Show sets that haven't been released yet"
+            >
+              {showUnreleased ? '✓ ' : ''}Unreleased ({unreleasedCount})
+            </button>
+          </div>
+        )}
       </div>
 
       {error && <div className={styles.error}>Couldn’t load coverage: {error}</div>}
@@ -275,6 +297,11 @@ function SetCard({ set, onOpen }: { set: SetCoverage; onOpen: () => void }) {
             {set.inStandard && (
               <span className={styles.standardBadge} title="Currently legal in Standard">
                 Standard
+              </span>
+            )}
+            {isUnreleasedSet(set.releaseDate) && (
+              <span className={styles.unreleasedBadge} title="Not yet released">
+                Unreleased
               </span>
             )}
           </span>

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1790,6 +1790,19 @@
   border-radius: 999px;
 }
 
+.setUnreleasedBadge {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  font-size: 9px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #c4b5fd;
+  background: rgba(139, 92, 246, 0.16);
+  border: 1px solid rgba(139, 92, 246, 0.42);
+  border-radius: 999px;
+}
+
 .setPickerEmpty {
   font-size: var(--font-sm);
   color: var(--text-disabled);

--- a/web-client/src/components/ui/SetPickerModal.tsx
+++ b/web-client/src/components/ui/SetPickerModal.tsx
@@ -14,6 +14,7 @@
  */
 import { useState } from 'react'
 import type { AvailableSet } from '@/types/messages'
+import { isUnreleasedSet, todayIso } from '@/utils/setRelease'
 import { SetIcon } from './SetIcon'
 import styles from './GameUI.module.css'
 
@@ -75,6 +76,8 @@ export function SetPickerModal({
   const [search, setSearch] = useState('')
   // Partially-implemented sets are hidden by default; the user opts into them with this toggle.
   const [showPartialSets, setShowPartialSets] = useState(false)
+  // Not-yet-released (future spoiler) sets are hidden by default; opt in with this toggle.
+  const [showUnreleasedSets, setShowUnreleasedSets] = useState(false)
   // Hide thin sets (lots of partial sets have only a handful of cards). Defaults to 30.
   const [minCards, setMinCards] = useState(30)
 
@@ -82,13 +85,17 @@ export function SetPickerModal({
   const isSelected = (code: string) => selectedCodes.includes(code)
 
   // Picker visibility rules (an already-selected set always stays visible so it can be changed):
-  //  - partial sets are hidden unless the toggle is flipped, and
+  //  - partial sets are hidden unless the toggle is flipped,
+  //  - unreleased (future release date) sets are hidden unless the toggle is flipped, and
   //  - sets with fewer than `minCards` implemented cards are pruned (kills the long tail of
   //    near-empty sets you'd otherwise see once partial sets are shown).
+  const today = todayIso()
   const partialSetCount = sets.filter((s) => s.partial).length
+  const unreleasedSetCount = sets.filter((s) => isUnreleasedSet(s.releaseDate, today)).length
   const pickerSets = sets.filter((s) => {
     if (isSelected(s.code)) return true
     if (s.partial && !showPartialSets) return false
+    if (isUnreleasedSet(s.releaseDate, today) && !showUnreleasedSets) return false
     if ((s.implementedCount ?? 0) < minCards) return false
     return true
   })
@@ -118,6 +125,7 @@ export function SetPickerModal({
   const renderSetPickerRow = (set: AvailableSet) => {
     const selected = isSelected(set.code)
     const released = formatReleaseDate(set.releaseDate)
+    const unreleased = isUnreleasedSet(set.releaseDate, today)
     return (
       <button
         key={set.code}
@@ -129,6 +137,7 @@ export function SetPickerModal({
         <SetIcon code={set.code} className={styles.setPickerIcon} />
         <span className={styles.setPickerName}>{set.name}</span>
         {set.partial && <span className={styles.setPartialBadge}>partial</span>}
+        {unreleased && <span className={styles.setUnreleasedBadge}>unreleased</span>}
         {released && <span className={styles.setReleaseDate}>{released}</span>}
         {set.implementedCount != null && (
           <span className={styles.setButtonCardCount}>{set.implementedCount} cards</span>
@@ -235,6 +244,23 @@ export function SetPickerModal({
                 )}
               </span>
             </button>
+            {unreleasedSetCount > 0 && (
+              <button
+                type="button"
+                role="switch"
+                aria-checked={showUnreleasedSets}
+                className={`${styles.setPickerSwitch} ${showUnreleasedSets ? styles.setPickerSwitchOn : ''}`}
+                onClick={() => setShowUnreleasedSets((v) => !v)}
+              >
+                <span className={styles.setPickerSwitchTrack} aria-hidden>
+                  <span className={styles.setPickerSwitchThumb} />
+                </span>
+                <span className={styles.setPickerSwitchLabel}>
+                  Show unreleased sets
+                  <span className={styles.setPickerSwitchCount}>{unreleasedSetCount}</span>
+                </span>
+              </button>
+            )}
             <label className={styles.setPickerMinCards}>
               <span className={styles.setPickerMinCardsLabel}>Min cards</span>
               <input
@@ -272,9 +298,11 @@ export function SetPickerModal({
                   No sets match.{' '}
                   {!showPartialSets && partialSetCount > 0
                     ? 'Try enabling partial sets'
-                    : minCards > 0
-                      ? 'Try lowering the minimum card count'
-                      : 'Try a different search'}
+                    : !showUnreleasedSets && unreleasedSetCount > 0
+                      ? 'Try enabling unreleased sets'
+                      : minCards > 0
+                        ? 'Try lowering the minimum card count'
+                        : 'Try a different search'}
                   .
                 </div>
               )

--- a/web-client/src/utils/setRelease.test.ts
+++ b/web-client/src/utils/setRelease.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { isUnreleasedSet, todayIso } from './setRelease'
+
+describe('todayIso', () => {
+  it('formats a date as a zero-padded ISO calendar day', () => {
+    expect(todayIso(new Date(2025, 0, 5))).toBe('2025-01-05')
+    expect(todayIso(new Date(2026, 11, 31))).toBe('2026-12-31')
+  })
+})
+
+describe('isUnreleasedSet', () => {
+  const today = '2026-06-30'
+
+  it('treats a future release date as unreleased', () => {
+    expect(isUnreleasedSet('2026-07-01', today)).toBe(true)
+    expect(isUnreleasedSet('2030-01-01', today)).toBe(true)
+  })
+
+  it('treats today and past dates as released', () => {
+    expect(isUnreleasedSet('2026-06-30', today)).toBe(false)
+    expect(isUnreleasedSet('2025-09-26', today)).toBe(false)
+    expect(isUnreleasedSet('1993-08-05', today)).toBe(false)
+  })
+
+  it('treats missing or malformed dates as released (old / undated sets, never future spoilers)', () => {
+    expect(isUnreleasedSet(null, today)).toBe(false)
+    expect(isUnreleasedSet(undefined, today)).toBe(false)
+    expect(isUnreleasedSet('', today)).toBe(false)
+    expect(isUnreleasedSet('2026', today)).toBe(false)
+    expect(isUnreleasedSet('not-a-date', today)).toBe(false)
+  })
+})

--- a/web-client/src/utils/setRelease.ts
+++ b/web-client/src/utils/setRelease.ts
@@ -1,0 +1,29 @@
+/**
+ * Set release-state helpers, shared by every surface that lists sets (the deckbuilder set
+ * combobox, the Set Completion grid, the lobby/tournament SetPickerModal).
+ *
+ * A set is "unreleased" when its ISO `YYYY-MM-DD` release date is strictly after today.
+ * Sets with no (or malformed) release date are treated as released — those are old / undated
+ * sets, never future spoilers. Dates are compared as ISO strings against the local calendar
+ * day, so there's no timezone drift: lexicographic order on `YYYY-MM-DD` is chronological.
+ */
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n)
+}
+
+/** Today's local calendar day as an ISO `YYYY-MM-DD` string. */
+export function todayIso(now: Date = new Date()): string {
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`
+}
+
+/**
+ * Whether a set's release date is in the future (a not-yet-released spoiler set).
+ * `today` is injectable so callers can compute it once for a whole list.
+ */
+export function isUnreleasedSet(releaseDate?: string | null, today: string = todayIso()): boolean {
+  if (!releaseDate || !ISO_DATE.test(releaseDate)) return false
+  return releaseDate > today
+}


### PR DESCRIPTION
## What & why

Sets with a **future release date** (spoiler-season sets) were silently mixed in with released sets. This adds a default-off **"unreleased sets" toggle** to the three surfaces that list sets, so they're hidden by default and revealable on demand — mirroring the existing "Show partial sets" pattern.

A set is **unreleased** when its ISO release date is strictly after today's local calendar day. Undated / malformed dates count as released (old sets, never future spoilers). Dates are compared as ISO strings, so there's no timezone drift.

## Surfaces (all opted into per request)

- **Deckbuilder set combobox** — default-off "Unreleased" toggle in the panel header (persisted to `localStorage`); the currently-selected set always stays visible so it can still be changed/cleared.
- **Set Completion page** — default-off "Unreleased (N)" toggle + a per-card "Unreleased" badge.
- **Lobby / tournament `SetPickerModal`** — default-off "Show unreleased sets" toggle + per-row "unreleased" badge, alongside the partial-sets toggle.

Each toggle only renders when at least one listed set is actually unreleased, so it stays out of the way when nothing is future-dated.

## Implementation notes

- New shared helper `web-client/src/utils/setRelease.ts` (`isUnreleasedSet` / `todayIso`), unit-tested.
- Purely client-side — all three surfaces already receive `releaseDate` in their DTOs (`/api/sets`, `/api/sets/coverage`, lobby `AvailableSet`). No backend changes.
- Note: as of today no catalogued set is future-dated (SPM "Marvel's Spider-Man" released 2025-09-26), so the toggle currently won't show with live data — it activates automatically as soon as a catalogued set has a future release date. Screenshots below were captured with the browser clock pinned to early 2025 to exercise the new UI against real set data.

## Verification

- `npm run typecheck` ✅ · `npm run build` ✅ · `npx vitest run` ✅ (177 tests, incl. new `setRelease.test.ts`)

## Screenshots

**Set Completion — toggle ON** (active "✓ Unreleased (10)" + purple UNRELEASED badges on SPM, TLA, SOS, EOE, FIN, …):
![Set completion, unreleased shown](https://raw.githubusercontent.com/wingedsheep/argentum-engine/unreleased-sets-filter-screenshots/setcompletion-on.png)

**Set Completion — toggle OFF** (10 future-dated sets hidden; grid starts at FDN 2024):
![Set completion, unreleased hidden](https://raw.githubusercontent.com/wingedsheep/argentum-engine/unreleased-sets-filter-screenshots/setcompletion-off.png)

**Deckbuilder set combobox** (new "Unreleased" toggle beside the Name/Release sort):
![Deckbuilder set combobox](https://raw.githubusercontent.com/wingedsheep/argentum-engine/unreleased-sets-filter-screenshots/deckbuilder-combo.png)

_The `unreleased-sets-filter-screenshots` branch is a throwaway image host, not part of this change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)