### PR TITLE
Add 3 Final Fantasy cards: Seymour Flux, Sephiroth Planet's Heir, The Earth Crystal

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SephirothPlanetsHeir.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SephirothPlanetsHeir.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sephiroth, Planet's Heir
+ * {4}{U}{B}
+ * Legendary Creature — Human Avatar Soldier
+ * 4/4
+ * Vigilance
+ * When Sephiroth enters, creatures your opponents control get -2/-2 until end of turn.
+ * Whenever a creature an opponent controls dies, put a +1/+1 counter on Sephiroth.
+ *
+ * The enters debuff applies a per-creature -2/-2 floating effect to every creature an
+ * opponent controls at resolution ([Effects.ForEachInGroup] over [GroupFilter], with the
+ * iterated creature as [EffectTarget.Self]); creatures that enter later are unaffected, as
+ * the affected set is fixed when the ability resolves. The death trigger is a
+ * [Triggers.leavesBattlefield] to the graveyard, filtered to opponent-controlled creatures
+ * with [TriggerBinding.ANY].
+ */
+val SephirothPlanetsHeir = card("Sephiroth, Planet's Heir") {
+    manaCost = "{4}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human Avatar Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "When Sephiroth enters, creatures your opponents control get -2/-2 until end of turn.\n" +
+        "Whenever a creature an opponent controls dies, put a +1/+1 counter on Sephiroth."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.opponentControls()),
+            Effects.ModifyStats(power = -2, toughness = -2, target = EffectTarget.Self)
+        )
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.opponentControls(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "553"
+        artist = "Magali Villeneuve"
+        flavorText = "\"This is the end... for all of you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abd73e52-62f0-4e89-9dc6-90ff0bc2a9b7.jpg?1782686131"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SeymourFlux.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SeymourFlux.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Seymour Flux
+ * {4}{B}
+ * Legendary Creature — Spirit Avatar
+ * 5/5
+ * At the beginning of your upkeep, you may pay 1 life. If you do, draw a card and put a
+ * +1/+1 counter on Seymour Flux.
+ *
+ * The "you may pay 1 life. If you do, …" pay-then-payoff is a [GatedEffect] with a
+ * [Gate.MayPay] paying life ([PayLifeEffect]); the [then] branch draws and adds the counter
+ * to the source ([EffectTarget.Self]).
+ */
+val SeymourFlux = card("Seymour Flux") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Spirit Avatar"
+    power = 5
+    toughness = 5
+    oracleText = "At the beginning of your upkeep, you may pay 1 life. If you do, draw a card and " +
+        "put a +1/+1 counter on Seymour Flux."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = GatedEffect(
+            gate = Gate.MayPay(PayLifeEffect(1)),
+            then = Effects.Composite(
+                Effects.DrawCards(1),
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "558"
+        artist = "K-SUWABE"
+        flavorText = "\"Your hope ends here. And your meaningless existence with it.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/5/c5fdc78e-0815-443c-8c26-35387b6f4f37.jpg?1782686125"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheEarthCrystal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheEarthCrystal.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.DoubleCounterPlacement
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * The Earth Crystal
+ * {2}{G}{G}
+ * Legendary Artifact
+ * Green spells you cast cost {1} less to cast.
+ * If one or more +1/+1 counters would be put on a creature you control, twice that many
+ * +1/+1 counters are put on that creature instead.
+ * {4}{G}{G}, {T}: Distribute two +1/+1 counters among one or two target creatures you control.
+ *
+ * The cost reduction is a [ModifySpellCost] static over green spells the controller casts
+ * ([CostModification.ReduceGeneric]). The +1/+1 doubling is a [DoubleCounterPlacement]
+ * replacement scoped to +1/+1 counters on creatures the controller controls (a
+ * Doubling-Season-style "place twice that many" effect, regardless of who places them).
+ */
+val TheEarthCrystal = card("The Earth Crystal") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Artifact"
+    oracleText = "Green spells you cast cost {1} less to cast.\n" +
+        "If one or more +1/+1 counters would be put on a creature you control, twice that many " +
+        "+1/+1 counters are put on that creature instead.\n" +
+        "{4}{G}{G}, {T}: Distribute two +1/+1 counters among one or two target creatures you control."
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.GREEN)),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    replacementEffect(
+        DoubleCounterPlacement(
+            placedByYou = false,
+            appliesTo = EventPattern.CounterPlacementEvent(
+                counterType = CounterTypeFilter.PlusOnePlusOne,
+                recipient = RecipientFilter.Matching(GameObjectFilter.Creature.youControl())
+            )
+        )
+    )
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{G}{G}"), Costs.Tap)
+        target = TargetCreature(count = 2, minCount = 1, filter = TargetFilter.CreatureYouControl)
+        effect = Effects.DistributeCountersAmongTargets(totalCounters = 2)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "184"
+        artist = "Pablo Mendoza"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d585e218-3dc8-4fbd-8ad2-795fbc9b2155.jpg?1782686462"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -13947,6 +13947,142 @@
     ]
 }
 
+// Sephiroth, Planet's Heir
+{
+    "name": "Sephiroth, Planet's Heir",
+    "manaCost": "{4}{U}{B}",
+    "typeLine": "Legendary Creature — Human Avatar Soldier",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhen Sephiroth enters, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, put a +1/+1 counter on Sephiroth.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "target": "Self"
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "553",
+        "rarity": "MYTHIC",
+        "artist": "Magali Villeneuve",
+        "flavorText": "\"This is the end... for all of you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abd73e52-62f0-4e89-9dc6-90ff0bc2a9b7.jpg?1782686131"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
+// Seymour Flux
+{
+    "name": "Seymour Flux",
+    "manaCost": "{4}{B}",
+    "typeLine": "Legendary Creature — Spirit Avatar",
+    "oracleText": "At the beginning of your upkeep, you may pay 1 life. If you do, draw a card and put a +1/+1 counter on Seymour Flux.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayLife",
+                            "amount": 1
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "558",
+        "rarity": "RARE",
+        "artist": "K-SUWABE",
+        "flavorText": "\"Your hope ends here. And your meaningless existence with it.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/5/c5fdc78e-0815-443c-8c26-35387b6f4f37.jpg?1782686125"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Shambling Cie'th
 {
     "name": "Shambling Cie'th",
@@ -16630,6 +16766,83 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// The Earth Crystal
+{
+    "name": "The Earth Crystal",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Green spells you cast cost {1} less to cast.\nIf one or more +1/+1 counters would be put on a creature you control, twice that many +1/+1 counters are put on that creature instead.\n{4}{G}{G}, {T}: Distribute two +1/+1 counters among one or two target creatures you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{G}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "DistributeCountersAmongTargets",
+                    "totalCounters": 2
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "minCount": 1,
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        }
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "green"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "DoubleCounterPlacement",
+                "appliesTo": {
+                    "type": "CounterPlacementEvent",
+                    "counterType": "PlusOnePlusOne",
+                    "recipient": {
+                        "type": "RecipientMatching",
+                        "filter": "creature ctrl:you"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "184",
+        "rarity": "RARE",
+        "artist": "Pablo Mendoza",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d585e218-3dc8-4fbd-8ad2-795fbc9b2155.jpg?1782686462"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SephirothPlanetsHeirScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SephirothPlanetsHeirScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SephirothPlanetsHeir
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sephiroth, Planet's Heir (FIN #553) — {4}{U}{B} Legendary Creature 4/4, Vigilance.
+ *
+ *   When Sephiroth enters, creatures your opponents control get -2/-2 until end of turn.
+ *   Whenever a creature an opponent controls dies, put a +1/+1 counter on Sephiroth.
+ *
+ * Exercises the enters group debuff (a per-creature -2/-2 floating effect over opponents'
+ * creatures) and the opponent-creature-dies counter trigger — including the case where the
+ * debuff itself kills a creature and feeds the trigger.
+ */
+class SephirothPlanetsHeirScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SephirothPlanetsHeir))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun GameTestDriver.castSephiroth(you: EntityId): EntityId {
+        val card = putCardInHand(you, "Sephiroth, Planet's Heir")
+        giveMana(you, Color.BLUE, 1)
+        giveMana(you, Color.BLACK, 1)
+        giveColorlessMana(you, 4)
+        castSpell(you, card).isSuccess shouldBe true
+        bothPass()
+        return card
+    }
+
+    test("enters gives opponents' creatures -2/-2 until end of turn") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        val giant = driver.putCreatureOnBattlefield(opponent, "Hill Giant") // 3/3
+
+        driver.castSephiroth(you)
+        resolveStack(driver)
+
+        val projected = projector.project(driver.state)
+        projected.getPower(giant) shouldBe 1
+        projected.getToughness(giant) shouldBe 1
+    }
+
+    test("the enters debuff kills a 2/2 and that death puts a +1/+1 counter on Sephiroth") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        val bears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2
+
+        val sephiroth = driver.castSephiroth(you)
+        resolveStack(driver)
+
+        // 2/2 with -2/-2 becomes 0/0 and is put into the graveyard as a state-based action.
+        driver.state.getBattlefield().contains(bears) shouldBe false
+        // That death is a creature an opponent controls dying -> +1/+1 on Sephiroth.
+        plusCounters(driver, sephiroth) shouldBe 1
+    }
+
+    test("a surviving opponent creature does not add a counter") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        driver.putCreatureOnBattlefield(opponent, "Hill Giant") // 3/3 -> 1/1, survives
+
+        val sephiroth = driver.castSephiroth(you)
+        resolveStack(driver)
+
+        plusCounters(driver, sephiroth) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeymourFluxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeymourFluxScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SeymourFlux
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Seymour Flux (FIN #558) — {4}{B} Legendary Creature 5/5.
+ *
+ *   At the beginning of your upkeep, you may pay 1 life. If you do, draw a card and put a
+ *   +1/+1 counter on Seymour Flux.
+ *
+ * Exercises the optional pay-then-payoff: the [com.wingedsheep.sdk.scripting.effects.Gate.MayPay]
+ * gate pays 1 life, the [then] branch draws and adds a counter; declining does nothing.
+ */
+class SeymourFluxScenarioTest : FunSpec({
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SeymourFlux))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    // From my turn's main phase, advance to my *next* upkeep (skips the opponent's turn).
+    fun advanceToMyNextUpkeep(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.UPKEEP)         // opponent's upkeep (no trigger)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN) // opponent's main
+        driver.passPriorityUntil(Step.UPKEEP)         // my next upkeep — Seymour triggers
+    }
+
+    test("paying 1 life draws a card and puts a +1/+1 counter on Seymour") {
+        val (driver, you) = newGame()
+        val seymour = driver.putCreatureOnBattlefield(you, "Seymour Flux")
+
+        advanceToMyNextUpkeep(driver)
+        val lifeBefore = driver.getLifeTotal(you)
+        val handBefore = driver.getHandSize(you)
+
+        // Resolve the upkeep trigger -> "you may pay 1 life" decision.
+        driver.bothPass()
+        driver.submitYesNo(you, true)
+        var guard = 0
+        while (guard++ < 10 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+
+        driver.getLifeTotal(you) shouldBe lifeBefore - 1
+        driver.getHandSize(you) shouldBe handBefore + 1
+        plusCounters(driver, seymour) shouldBe 1
+    }
+
+    test("declining pays no life, draws nothing, and adds no counter") {
+        val (driver, you) = newGame()
+        val seymour = driver.putCreatureOnBattlefield(you, "Seymour Flux")
+
+        advanceToMyNextUpkeep(driver)
+        val lifeBefore = driver.getLifeTotal(you)
+        val handBefore = driver.getHandSize(you)
+
+        driver.bothPass()
+        driver.submitYesNo(you, false)
+
+        driver.getLifeTotal(you) shouldBe lifeBefore
+        driver.getHandSize(you) shouldBe handBefore
+        plusCounters(driver, seymour) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheEarthCrystalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheEarthCrystalScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.TheEarthCrystal
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Earth Crystal (FIN #184) — {2}{G}{G} Legendary Artifact.
+ *
+ *   Green spells you cast cost {1} less to cast.
+ *   If one or more +1/+1 counters would be put on a creature you control, twice that many
+ *   +1/+1 counters are put on that creature instead.
+ *   {4}{G}{G}, {T}: Distribute two +1/+1 counters among one or two target creatures you control.
+ *
+ * Exercises the activated distribute together with the +1/+1 counter-doubling replacement:
+ * the two distributed counters are doubled to four on a creature its controller controls.
+ */
+class TheEarthCrystalScenarioTest : FunSpec({
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheEarthCrystal))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    test("the distribute ability's two counters are doubled to four on a creature you control") {
+        val (driver, you) = newGame()
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val crystal = driver.putPermanentOnBattlefield(you, "The Earth Crystal")
+
+        driver.giveMana(you, Color.GREEN, 2)
+        driver.giveColorlessMana(you, 4)
+        val abilityId = TheEarthCrystal.activatedAbilities.first().id
+        driver.submit(
+            ActivateAbility(you, crystal, abilityId, targets = listOf(ChosenTarget.Permanent(bears)))
+        ).isSuccess shouldBe true
+        resolveStack(driver)
+
+        // 2 counters distributed onto Grizzly Bears, doubled by The Earth Crystal -> 4.
+        plusCounters(driver, bears) shouldBe 4
+    }
+})


### PR DESCRIPTION
Implements a handful of Final Fantasy (FIN) cards, each composed entirely from **existing SDK primitives** — no new effects, triggers, conditions, keywords, or engine changes. All three are auto-discovered by `FinalFantasySet` (no manual registration).

## Cards

| Card | Cost | Type | Modeling |
|------|------|------|----------|
| **Seymour Flux** | `{4}{B}` | Legendary Creature — Spirit Avatar (5/5) | Upkeep `GatedEffect(Gate.MayPay(PayLifeEffect(1)))` → draw a card + a `+1/+1` counter on itself |
| **Sephiroth, Planet's Heir** | `{4}{U}{B}` | Legendary Creature — Human Avatar Soldier (4/4) | Vigilance; enters `ForEachInGroup` `-2/-2` (EOT) over opponents' creatures; opponent-creature-dies → `+1/+1` counter |
| **The Earth Crystal** | `{2}{G}{G}` | Legendary Artifact | `ModifySpellCost` reduction for green spells; `DoubleCounterPlacement` (+1/+1 doubling) replacement; activated `{4}{G}{G}, {T}` distribute two `+1/+1` counters |

## Verification

- Card data, oracle text, P/T, collector numbers, artists, and image URIs taken from Scryfall (`&set=fin`); images HEAD-checked 200. Earth Crystal is a draft-booster card (#184); Seymour (#558) and Sephiroth (#553) are FIN non-booster "Extra" cards — collector numbers match their standard (non-extended) printings.
- `CardDefinitionSnapshotTest` re-blessed — diff adds **only** the three new card trees, nothing else moved.
- `just build` + full `:mtg-sets:test` (snapshot + `CardLintTest`) green.
- New scenario tests, all passing:
  - `SephirothPlanetsHeirScenarioTest` — `-2/-2` debuff; debuff-kills-a-2/2 feeds the dies-counter; surviving creature adds no counter.
  - `SeymourFluxScenarioTest` — pay-1-life draws + counters; declining does nothing.
  - `TheEarthCrystalScenarioTest` — distributed two counters get doubled to four.

No SDK additions, so no `card-sdk-language-reference.md` change; FIN has no `backlog/sets` checklist file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)