### PR TITLE
Add Foundations cards: Thrill of Possibility, Broken Wings, Slagstorm, Pilfer

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/BrokenWingsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/BrokenWingsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broken Wings reprint in BLC. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BrokenWingsReprint = Printing(
+    oracleId = "5e316864-d55c-496f-8f46-773567896864",
+    name = "Broken Wings",
+    setCode = "BLC",
+    collectorNumber = "208",
+    scryfallId = "bb9136d4-cacd-4e51-a2e8-aaf96d7a546d",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/b/b/bb9136d4-cacd-4e51-a2e8-aaf96d7a546d.jpg?1782690126",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BrokenWingsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dft/cards/BrokenWingsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.dft.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broken Wings reprint in DFT. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BrokenWingsReprint = Printing(
+    oracleId = "5e316864-d55c-496f-8f46-773567896864",
+    name = "Broken Wings",
+    setCode = "DFT",
+    collectorNumber = "156",
+    scryfallId = "1d7d5b71-7c1b-4fc2-a5ec-7285e17ffe0f",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1d7d5b71-7c1b-4fc2-a5ec-7285e17ffe0f.jpg?1782687839",
+    releaseDate = "2025-02-14",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/BrokenWingsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/BrokenWingsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broken Wings reprint in DMU. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BrokenWingsReprint = Printing(
+    oracleId = "5e316864-d55c-496f-8f46-773567896864",
+    name = "Broken Wings",
+    setCode = "DMU",
+    collectorNumber = "157",
+    scryfallId = "0ced8d87-ac22-41b0-a632-298159cbb316",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0ced8d87-ac22-41b0-a632-298159cbb316.jpg?1782700459",
+    releaseDate = "2022-09-09",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/Pilfer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/Pilfer.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Pilfer
+ * {1}{B}
+ * Sorcery
+ *
+ * Target opponent reveals their hand. You choose a nonland card from it.
+ * That player discards that card.
+ *
+ * Canonical printing: Dominaria United (DMU) — the earliest real expansion printing.
+ * The Foundations (FDN) reprint contributes only a `Printing` row.
+ */
+val Pilfer = card("Pilfer") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card."
+
+    spell {
+        val opponent = target("target opponent", TargetOpponent())
+        effect = Effects.Composite(
+            listOf(
+                RevealHandEffect(opponent),
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                    storeAs = "opponentHand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "opponentHand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                    chooser = Chooser.Controller,
+                    filter = GameObjectFilter.Nonland,
+                    storeSelected = "toDiscard",
+                    prompt = "Choose a nonland card to discard",
+                    alwaysPrompt = true,
+                    showAllCards = true
+                ),
+                MoveCollectionEffect(
+                    from = "toDiscard",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                    moveType = MoveType.Discard
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "102"
+        artist = "Pauline Voss"
+        flavorText = "To the merchant, it was nothing more than a few missing trinkets. To Tinybones, it was the greatest heist of all time."
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d872c10-4126-4130-a74a-1331ed418ca8.jpg?1782700494"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ThrillOfPossibilityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dmu/cards/ThrillOfPossibilityReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.dmu.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrill of Possibility reprint in DMU. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ThrillOfPossibilityReprint = Printing(
+    oracleId = "1cb0610b-a731-42c2-b93f-0a29f63cebf4",
+    name = "Thrill of Possibility",
+    setCode = "DMU",
+    collectorNumber = "148",
+    scryfallId = "25e5dc88-9573-4eaa-bd37-eb0dee4add03",
+    artist = "David Auden Nash",
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/25e5dc88-9573-4eaa-bd37-eb0dee4add03.jpg?1782700466",
+    releaseDate = "2022-09-09",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/ThrillOfPossibility.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/ThrillOfPossibility.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrill of Possibility
+ * {1}{R}
+ * Instant
+ *
+ * As an additional cost to cast this spell, discard a card.
+ * Draw two cards.
+ *
+ * Canonical printing: Throne of Eldraine (ELD) — the earliest real expansion printing.
+ * Later reprints (THB, M21, DMU, ONE, FDN, …) contribute only a `Printing` row.
+ */
+val ThrillOfPossibility = card("Thrill of Possibility") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, discard a card.\n" +
+        "Draw two cards."
+
+    additionalCost(Costs.additional.DiscardCards())
+
+    spell {
+        effect = Effects.DrawCards(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "146"
+        artist = "Steve Argyle"
+        flavorText = "\"Remember all the great heroes who were careful and never did anything risky? Me neither.\"\n—Syr Carah, the Bold"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9021f85-7ab4-4a78-a398-1611fe09cd14.jpg?1782707837"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BrokenWingsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BrokenWingsReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broken Wings reprint in Foundations (FDN). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in ZNR's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val BrokenWingsReprint = Printing(
+    oracleId = "5e316864-d55c-496f-8f46-773567896864",
+    name = "Broken Wings",
+    setCode = "FDN",
+    collectorNumber = "214",
+    scryfallId = "61f9cbeb-cc9c-4562-be65-8a77053faefe",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/6/1/61f9cbeb-cc9c-4562-be65-8a77053faefe.jpg?1782689083",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PilferReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PilferReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pilfer reprint in Foundations (FDN). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in DMU's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val PilferReprint = Printing(
+    oracleId = "d13f0907-de39-4a90-940a-831740d7aa9b",
+    name = "Pilfer",
+    setCode = "FDN",
+    collectorNumber = "181",
+    scryfallId = "8c7c88b5-6d09-453b-b9c1-7dcbba8f1080",
+    artist = "Pauline Voss",
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8c7c88b5-6d09-453b-b9c1-7dcbba8f1080.jpg?1782689111",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SlagstormReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SlagstormReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Slagstorm reprint in Foundations (FDN). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in MBS's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val SlagstormReprint = Printing(
+    oracleId = "2ed1879a-83b8-48df-a6d2-fe28e912b4c5",
+    name = "Slagstorm",
+    setCode = "FDN",
+    collectorNumber = "207",
+    scryfallId = "9db2e3a9-b90d-44cd-a2bd-eeb7dbe255b0",
+    artist = "Dan Murayama Scott",
+    imageUri = "https://cards.scryfall.io/normal/front/9/d/9db2e3a9-b90d-44cd-a2bd-eeb7dbe255b0.jpg?1782689087",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ThrillOfPossibilityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ThrillOfPossibilityReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrill of Possibility reprint in Foundations (FDN). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in ELD's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val ThrillOfPossibilityReprint = Printing(
+    oracleId = "1cb0610b-a731-42c2-b93f-0a29f63cebf4",
+    name = "Thrill of Possibility",
+    setCode = "FDN",
+    collectorNumber = "210",
+    scryfallId = "882b348c-076b-41d8-b505-063480636669",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/882b348c-076b-41d8-b505-063480636669.jpg?1782689085",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ThrillOfPossibilityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/ThrillOfPossibilityReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrill of Possibility reprint in J22. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ThrillOfPossibilityReprint = Printing(
+    oracleId = "1cb0610b-a731-42c2-b93f-0a29f63cebf4",
+    name = "Thrill of Possibility",
+    setCode = "J22",
+    collectorNumber = "84",
+    scryfallId = "5c3b2cb7-06a3-4c2e-9684-480b0e4c005f",
+    artist = "Daisuke Tatsuma",
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5c3b2cb7-06a3-4c2e-9684-480b0e4c005f.jpg?1782699309",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BrokenWingsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/khm/cards/BrokenWingsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.khm.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broken Wings reprint in KHM. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BrokenWingsReprint = Printing(
+    oracleId = "5e316864-d55c-496f-8f46-773567896864",
+    name = "Broken Wings",
+    setCode = "KHM",
+    collectorNumber = "164",
+    scryfallId = "6201f78e-ff45-4c59-ac85-c8447c14a496",
+    artist = "Lars Grant-West",
+    imageUri = "https://cards.scryfall.io/normal/front/6/2/6201f78e-ff45-4c59-ac85-c8447c14a496.jpg?1782705451",
+    releaseDate = "2021-02-05",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ThrillOfPossibilityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ThrillOfPossibilityReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrill of Possibility reprint in M21. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ThrillOfPossibilityReprint = Printing(
+    oracleId = "1cb0610b-a731-42c2-b93f-0a29f63cebf4",
+    name = "Thrill of Possibility",
+    setCode = "M21",
+    collectorNumber = "165",
+    scryfallId = "f4af156d-0fbf-4a4e-b0c1-db7e95be4903",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/f/4/f4af156d-0fbf-4a4e-b0c1-db7e95be4903.jpg?1782706912",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/Slagstorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/Slagstorm.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slagstorm
+ * {1}{R}{R}
+ * Sorcery
+ *
+ * Choose one —
+ * • Slagstorm deals 3 damage to each creature.
+ * • Slagstorm deals 3 damage to each player.
+ *
+ * Canonical printing: Mirrodin Besieged (MBS) — the earliest real expansion printing.
+ * The Foundations (FDN) reprint contributes only a `Printing` row.
+ */
+val Slagstorm = card("Slagstorm") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Slagstorm deals 3 damage to each creature.\n" +
+        "• Slagstorm deals 3 damage to each player."
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Slagstorm deals 3 damage to each creature") {
+                effect = Effects.ForEachInGroup(
+                    GroupFilter(GameObjectFilter.Creature),
+                    DealDamageEffect(3, EffectTarget.Self)
+                )
+            }
+            mode("Slagstorm deals 3 damage to each player") {
+                effect = Effects.ForEachPlayer(
+                    Player.Each,
+                    listOf(DealDamageEffect(3, EffectTarget.Controller))
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "75"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"As long as we have the will to fight, we are never without weapons.\"\n—Koth of the Hammer"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e318b03-2aad-462b-a2a9-8b6bdf0e93d6.jpg?1782715224"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/ThrillOfPossibilityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/one/cards/ThrillOfPossibilityReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.one.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrill of Possibility reprint in ONE. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ThrillOfPossibilityReprint = Printing(
+    oracleId = "1cb0610b-a731-42c2-b93f-0a29f63cebf4",
+    name = "Thrill of Possibility",
+    setCode = "ONE",
+    collectorNumber = "151",
+    scryfallId = "1efd4ae5-0076-46a0-a113-58cfff53144f",
+    artist = "PINDURSKI",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1efd4ae5-0076-46a0-a113-58cfff53144f.jpg?1782698335",
+    releaseDate = "2023-02-10",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BrokenWingsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/snc/cards/BrokenWingsReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.snc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Broken Wings reprint in SNC. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val BrokenWingsReprint = Printing(
+    oracleId = "5e316864-d55c-496f-8f46-773567896864",
+    name = "Broken Wings",
+    setCode = "SNC",
+    collectorNumber = "136",
+    scryfallId = "9eb94908-4f4a-487e-87ac-8d5bdefe9983",
+    artist = "Irina Nordsol",
+    imageUri = "https://cards.scryfall.io/normal/front/9/e/9eb94908-4f4a-487e-87ac-8d5bdefe9983.jpg?1782701581",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ThrillOfPossibilityExtendedArtReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ThrillOfPossibilityExtendedArtReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrill of Possibility reprint in THB. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ThrillOfPossibilityExtendedArtReprint = Printing(
+    oracleId = "1cb0610b-a731-42c2-b93f-0a29f63cebf4",
+    name = "Thrill of Possibility",
+    setCode = "THB",
+    collectorNumber = "356",
+    scryfallId = "8a38a0c3-0e1d-487d-99c8-4504d327c64d",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a38a0c3-0e1d-487d-99c8-4504d327c64d.jpg?1782707423",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ThrillOfPossibilityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/ThrillOfPossibilityReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrill of Possibility reprint in THB. The canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in another set's `cards/` package; this file contributes only presentation data.
+ */
+val ThrillOfPossibilityReprint = Printing(
+    oracleId = "1cb0610b-a731-42c2-b93f-0a29f63cebf4",
+    name = "Thrill of Possibility",
+    setCode = "THB",
+    collectorNumber = "159",
+    scryfallId = "2e807edb-838d-44fe-a37e-fb864d59beaa",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2e807edb-838d-44fe-a37e-fb864d59beaa.jpg?1782707557",
+    releaseDate = "2020-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/BrokenWings.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/BrokenWings.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Broken Wings
+ * {2}{G}
+ * Instant
+ *
+ * Destroy target artifact, enchantment, or creature with flying.
+ *
+ * Canonical printing: Zendikar Rising (ZNR) — the earliest real expansion printing.
+ * Later reprints (KHM, SNC, DMU, CMM, FDN, DFT, …) contribute only a `Printing` row.
+ */
+val BrokenWings = card("Broken Wings") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Destroy target artifact, enchantment, or creature with flying."
+
+    spell {
+        val target = target(
+            "target artifact, enchantment, or creature with flying",
+            TargetPermanent(
+                filter = TargetFilter(
+                    GameObjectFilter.Artifact or
+                        GameObjectFilter.Enchantment or
+                        GameObjectFilter.Creature.withKeyword(Keyword.FLYING)
+                )
+            )
+        )
+        effect = Effects.Destroy(target)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "181"
+        artist = "Ekaterina Burmak"
+        flavorText = "Getting airborne with a kitesail is easy. It's everything afterward that takes focus, skill, and luck."
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c0fc2dfd-85b0-4add-be18-b39549235921.jpg?1782706246"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/DMU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DMU.json
@@ -446,6 +446,85 @@
     ]
 }
 
+// Pilfer
+{
+    "name": "Pilfer",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target opponent reveals their hand. You choose a nonland card from it. That player discards that card.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "RevealHand",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "opponentHand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "opponentHand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "nonland",
+                    "storeSelected": "toDiscard",
+                    "prompt": "Choose a nonland card to discard",
+                    "showAllCards": true,
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toDiscard",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target opponent"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "rarity": "UNCOMMON",
+        "artist": "Pauline Voss",
+        "flavorText": "To the merchant, it was nothing more than a few missing trinkets. To Tinybones, it was the greatest heist of all time.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d872c10-4126-4130-a74a-1331ed418ca8.jpg?1782700494"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Prayer of Binding
 {
     "name": "Prayer of Binding",

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -124,3 +124,35 @@
         "WHITE"
     ]
 }
+
+// Thrill of Possibility
+{
+    "name": "Thrill of Possibility",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, discard a card.\nDraw two cards.",
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "Fixed",
+                "amount": 2
+            }
+        },
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": "AtomDiscard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "artist": "Steve Argyle",
+        "flavorText": "\"Remember all the great heroes who were careful and never did anything risky? Me neither.\"\n—Syr Carah, the Bold",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9021f85-7ab4-4a78-a398-1611fe09cd14.jpg?1782707837"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/MBS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MBS.json
@@ -21,6 +21,69 @@
     "colorIdentityOverride": []
 }
 
+// Slagstorm
+{
+    "name": "Slagstorm",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Slagstorm deals 3 damage to each creature.\n• Slagstorm deals 3 damage to each player.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Slagstorm deals 3 damage to each creature"
+                },
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Players",
+                            "players": "Each"
+                        },
+                        "body": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": "Controller"
+                        }
+                    },
+                    "description": "Slagstorm deals 3 damage to each player"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "RARE",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"As long as we have the will to fight, we are never without weapons.\"\n—Koth of the Hammer",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e318b03-2aad-462b-a2a9-8b6bdf0e93d6.jpg?1782715224"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Spine of Ish Sah
 {
     "name": "Spine of Ish Sah",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -1,3 +1,65 @@
+// Broken Wings
+{
+    "name": "Broken Wings",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Destroy target artifact, enchantment, or creature with flying.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target artifact, enchantment, or creature with flying"
+            },
+            "destination": "Graveyard",
+            "byDestruction": true
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "Or",
+                                        "predicates": [
+                                            "IsArtifact",
+                                            "IsEnchantment"
+                                        ]
+                                    },
+                                    {
+                                        "type": "And",
+                                        "predicates": [
+                                            "IsCreature",
+                                            {
+                                                "type": "HasKeyword",
+                                                "keyword": "FLYING"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target artifact, enchantment, or creature with flying"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "artist": "Ekaterina Burmak",
+        "flavorText": "Getting airborne with a kitesail is easy. It's everything afterward that takes focus, skill, and luck.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c0fc2dfd-85b0-4add-be18-b39549235921.jpg?1782706246"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Highborn Vampire
 {
     "name": "Highborn Vampire",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrokenWingsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrokenWingsScenarioTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.znr.cards.BrokenWings
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Broken Wings {2}{G} Instant (ZNR canonical; reprinted in FDN).
+ *
+ * Destroy target artifact, enchantment, or creature with flying.
+ */
+class BrokenWingsScenarioTest : FunSpec({
+
+    val Flyer = CardDefinition.creature(
+        name = "Test Flyer",
+        manaCost = ManaCost.parse("{1}{U}"),
+        subtypes = emptySet(),
+        power = 1,
+        toughness = 1,
+        keywords = setOf(Keyword.FLYING)
+    )
+
+    val Grounder = CardDefinition.creature(
+        name = "Test Grounder",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2
+    )
+
+    val Rock = CardDefinition.artifact(
+        name = "Test Rock",
+        manaCost = ManaCost.parse("{2}")
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BrokenWings, Flyer, Grounder, Rock))
+        return driver
+    }
+
+    fun castWings(driver: GameTestDriver, you: com.wingedsheep.sdk.model.EntityId) {
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveColorlessMana(you, 2)
+    }
+
+    test("destroys a creature with flying") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val flyer = driver.putCreatureOnBattlefield(opp, "Test Flyer")
+        castWings(driver, you)
+        val wings = driver.putCardInHand(you, "Broken Wings")
+
+        driver.castSpellWithTargets(you, wings, listOf(ChosenTarget.Permanent(flyer))).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(opp, "Test Flyer") shouldBe null
+    }
+
+    test("destroys an artifact") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val rock = driver.putPermanentOnBattlefield(opp, "Test Rock")
+        castWings(driver, you)
+        val wings = driver.putCardInHand(you, "Broken Wings")
+
+        driver.castSpellWithTargets(you, wings, listOf(ChosenTarget.Permanent(rock))).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.findPermanent(opp, "Test Rock") shouldBe null
+    }
+
+    test("cannot target a creature without flying") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opp = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val grounder = driver.putCreatureOnBattlefield(opp, "Test Grounder")
+        castWings(driver, you)
+        val wings = driver.putCardInHand(you, "Broken Wings")
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = wings,
+                targets = listOf(ChosenTarget.Permanent(grounder)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe false
+        driver.findPermanent(opp, "Test Grounder") shouldBe grounder
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PilferScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PilferScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dmu.cards.Pilfer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pilfer {1}{B} Sorcery (DMU canonical; reprinted in FDN).
+ *
+ * Target opponent reveals their hand. You choose a nonland card from it.
+ * That player discards that card.
+ */
+class PilferScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Pilfer))
+        return driver
+    }
+
+    test("you choose a nonland card from the opponent's hand and they discard it") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent has a nonland card (chooseable) and a land (not chooseable).
+        val nonland = driver.putCardInHand(opponent, "Grizzly Bears")
+        driver.putCardInHand(opponent, "Plains")
+        val gyBefore = driver.getGraveyard(opponent).size
+
+        val pilfer = driver.putCardInHand(you, "Pilfer")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpell(you, pilfer, targets = listOf(opponent)).isSuccess shouldBe true
+        driver.bothPass() // resolve into the spell's effect
+
+        // Drain decisions: choose the nonland card to discard.
+        var guard = 0
+        while ((driver.state.stack.isNotEmpty() || driver.state.pendingDecision is SelectCardsDecision) && guard++ < 30) {
+            if (driver.state.pendingDecision is SelectCardsDecision) {
+                driver.submitCardSelection(you, listOf(nonland))
+            } else {
+                driver.bothPass()
+            }
+        }
+
+        // The chosen nonland card was discarded to the opponent's graveyard.
+        driver.getGraveyard(opponent).contains(nonland) shouldBe true
+        (driver.getGraveyard(opponent).size - gyBefore) shouldBe 1
+    }
+
+    test("only nonland cards are offered as choices") {
+        val driver = createDriver()
+        // Plains-only deck: every opening-hand card is a land, so the only nonland in the
+        // opponent's hand is the one we add — the choice must offer it and exclude the lands.
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val nonland = driver.putCardInHand(opponent, "Grizzly Bears")
+        val land = driver.putCardInHand(opponent, "Plains")
+
+        val pilfer = driver.putCardInHand(you, "Pilfer")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 1)
+        driver.castSpell(you, pilfer, targets = listOf(opponent)).isSuccess shouldBe true
+        driver.bothPass()
+
+        val decision = driver.state.pendingDecision as? SelectCardsDecision
+            ?: error("Expected a SelectCardsDecision to choose the card to discard")
+        decision.options.contains(nonland) shouldBe true
+        decision.options.contains(land) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlagstormScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlagstormScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mbs.cards.Slagstorm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Slagstorm {1}{R}{R} Sorcery (MBS canonical; reprinted in FDN).
+ *
+ * Choose one —
+ * • Slagstorm deals 3 damage to each creature.
+ * • Slagstorm deals 3 damage to each player.
+ */
+class SlagstormScenarioTest : FunSpec({
+
+    val Bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = emptySet(),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Slagstorm, Bear))
+        return driver
+    }
+
+    test("mode 0 — deals 3 damage to each creature, leaving players untouched") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(me, "Test Bear")
+        driver.putCreatureOnBattlefield(opp, "Test Bear")
+        driver.giveMana(me, Color.RED, 3)
+        val slag = driver.putCardInHand(me, "Slagstorm")
+
+        driver.submit(CastSpell(playerId = me, cardId = slag, chosenModes = listOf(0))).isSuccess shouldBe true
+        driver.bothPass()
+
+        // 3 damage kills every 2/2; both players are untouched.
+        driver.getCreatures(me).size shouldBe 0
+        driver.getCreatures(opp).size shouldBe 0
+        driver.getLifeTotal(me) shouldBe 20
+        driver.getLifeTotal(opp) shouldBe 20
+    }
+
+    test("mode 1 — deals 3 damage to each player, leaving creatures untouched") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(me, "Test Bear")
+        driver.giveMana(me, Color.RED, 3)
+        val slag = driver.putCardInHand(me, "Slagstorm")
+
+        driver.submit(CastSpell(playerId = me, cardId = slag, chosenModes = listOf(1))).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Each player (including the caster) takes 3; the creature survives.
+        driver.getLifeTotal(me) shouldBe 17
+        driver.getLifeTotal(opp) shouldBe 17
+        driver.getCreatures(me).size shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThrillOfPossibilityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThrillOfPossibilityScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eld.cards.ThrillOfPossibility
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thrill of Possibility {1}{R} Instant (ELD canonical; reprinted in FDN).
+ *
+ * As an additional cost to cast this spell, discard a card.
+ * Draw two cards.
+ */
+class ThrillOfPossibilityScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ThrillOfPossibility))
+        return driver
+    }
+
+    test("discards a card as an additional cost, then draws two") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val thrill = driver.putCardInHand(me, "Thrill of Possibility")
+        val fodder = driver.putCardInHand(me, "Mountain")
+        driver.giveMana(me, Color.RED, 2)
+
+        val handBefore = driver.getHand(me).size
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = thrill,
+                additionalCostPayment = AdditionalCostPayment(discardedCards = listOf(fodder)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe true
+
+        // The discarded card is in the graveyard immediately (paid as a cost).
+        driver.getGraveyardCardNames(me) shouldContain "Mountain"
+
+        driver.bothPass()
+
+        // Net hand: spell to stack (-1), fodder discarded (-1), then draw two (+2) => unchanged.
+        driver.getHand(me).size shouldBe handBefore
+    }
+
+    test("cannot be cast without paying the discard cost") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val thrill = driver.putCardInHand(me, "Thrill of Possibility")
+        driver.giveMana(me, Color.RED, 2)
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = thrill,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

Implements four Foundations (FDN) cards. Each is a reprint, so the canonical `CardDefinition` lives in the card's **earliest real expansion** and FDN (plus the other scaffolded sets that reprint it) get `Printing` rows only — per the repo's reprint convention.

| Card | Cost | Type | Canonical set | Mechanic |
|------|------|------|---------------|----------|
| **Thrill of Possibility** | `{1}{R}` | Instant | ELD | Discard a card (additional cost), draw two |
| **Broken Wings** | `{2}{G}` | Instant | ZNR | Destroy target artifact, enchantment, or creature with flying |
| **Slagstorm** | `{1}{R}{R}` | Sorcery | MBS | Modal — 3 damage to each creature, or 3 to each player |
| **Pilfer** | `{1}{B}` | Sorcery | DMU | Target opponent reveals hand, you choose a nonland card, they discard it |

All four compose existing SDK primitives:
- Thrill → `Costs.additional.DiscardCards()` + `Effects.DrawCards(2)`
- Broken Wings → `TargetPermanent` with a heterogeneous `GameObjectFilter.Artifact or Enchantment or Creature.withKeyword(FLYING)`
- Slagstorm → `modal { }` with `Effects.ForEachInGroup` (creatures) / `Effects.ForEachPlayer` (players)
- Pilfer → `RevealHand → Gather → SelectFromCollection(Nonland) → MoveCollection(Discard)` (same shape as Duress)

**No new engine types** were introduced, so no `card-sdk-language-reference.md` change.

## Testing

- New scenario tests for each card (9 tests, all passing): `ThrillOfPossibilityScenarioTest`, `BrokenWingsScenarioTest`, `SlagstormScenarioTest`, `PilferScenarioTest`.
- Re-blessed the ELD/ZNR/MBS/DMU card snapshots — diffs are pure additions of only the four new cards.
- Filled missing `Printing` rows across the other scaffolded sets that reprint Thrill/Broken Wings (THB×2, M21, DMU, J22, ONE / KHM, SNC, DMU, BLC, DFT) so `just check-card-printing` passes for all four.
- `just build` green; all card images verified HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)