### PR TITLE
Fix three TLA card bugs: conditional-mana auto-tap, reflexive connive target, token-leave trigger

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1523,7 +1523,8 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 - `forage(afterEffect?)` — Forage cost; choose card-from-hand to play.
 - `loot(draw?, discard?)` — "draw N, discard M" loop.
 - `rummage(count?)` — discard then draw.
-- `connive(target?)` — draw 1, discard 1, then put a +1/+1 counter on `target` if the discard was a nonland (CR 702.166). Also exposed as `Effects.Connive(target)`.
+- `connive(target?)` — draw 1, discard 1, then put a +1/+1 counter on `target` (default Self) if the discard was a nonland (CR 702.166). Also exposed as `Effects.Connive(target)`.
+- `conniveTargeting(requirement, storeAs?)` — connive whose +1/+1 counter lands on a *reflexively chosen* target: "draw a card, then discard a card. When you discard a nonland card this way, put a +1/+1 counter on target creature you control" (Teo, Spirited Glider). The recipient is selected at resolution via `SelectTargetEffect` *inside* the nonland gate — so the player never chooses up front or when the discard is a land. Pass the recipient's `TargetRequirement` (e.g. `Targets.CreatureYouControl`); do **not** also declare it as a cast-time `target(...)`. Exposed as `Effects.ConniveTargeting(requirement)`.
 - `readTheRunes()` — "draw X cards; for each, discard a card unless you sacrifice a permanent." Composes `RepeatDynamicTimesEffect(XValue, ChooseActionEffect(...))` with feasibility guards. Exposed as `Effects.ReadTheRunes()`.
 - `eachOpponentMayPutFromHand(filter?)` — each opponent may dump a matching card.
 - `putFromHand(filter?, count?, entersTapped?, entersAttacking?)` — you may put N from hand onto

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -482,6 +482,19 @@ object Effects {
         HandPatterns.connive(target)
 
     /**
+     * Connive whose +1/+1 counter lands on a *reflexively chosen* target rather than the conniving
+     * permanent — "draw a card, then discard a card. When you discard a nonland card this way, put a
+     * +1/+1 counter on target creature you control" (Teo, Spirited Glider).
+     *
+     * The counter recipient is selected at resolution, *after* a nonland card has actually been
+     * discarded — so the player never picks a target up front or when the discard is a land. Pass the
+     * recipient's [requirement] (e.g. `Targets.CreatureYouControl`); do NOT also declare it as a
+     * cast-time `target(...)` on the ability. See [HandPatterns.conniveTargeting].
+     */
+    fun ConniveTargeting(requirement: TargetRequirement): Effect =
+        HandPatterns.conniveTargeting(requirement)
+
+    /**
      * Each opponent discards N cards.
      * Delegates to the LibraryPatterns/HandPatterns pipeline: ForEachPlayer(EachOpponent) → Gather → Select → Move.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -459,14 +459,13 @@ object HandPatterns {
     )
 
     /**
-     * Connive (CR 702.166): draw a card, then discard a card. If the discarded card
-     * is a nonland, put a +1/+1 counter on [target].
-     *
-     * Pipeline: Draw → Gather(hand) → Select(1) → Move(Discard) → ConditionalOnCollection(Nonland).
-     * SelectFromCollection auto-resolves on empty / single-card hands, matching the
-     * old monolithic executor's short-circuit behavior.
+     * Shared connive pipeline (CR 702.166): draw a card, then discard a card; if the discard was a
+     * nonland, run [onNonland]. Draw → Gather(hand) → Select(1) → Move(Discard) →
+     * ConditionalOnCollection(Nonland). SelectFromCollection auto-resolves on empty / single-card
+     * hands, matching the old monolithic executor's short-circuit behavior. [connive] and
+     * [conniveTargeting] differ only in [onNonland], so they share this body.
      */
-    fun connive(target: EffectTarget = EffectTarget.Self): CompositeEffect = CompositeEffect(
+    private fun connivePipeline(onNonland: Effect): CompositeEffect = CompositeEffect(
         listOf(
             DrawCardsEffect(1, EffectTarget.Controller),
             GatherCardsEffect(
@@ -488,14 +487,22 @@ object HandPatterns {
             ConditionalOnCollectionEffect(
                 collection = "connive_discarded",
                 filter = GameObjectFilter.Nonland,
-                ifNotEmpty = AddCountersEffect(
-                    counterType = Counters.PLUS_ONE_PLUS_ONE,
-                    count = 1,
-                    target = target
-                )
+                ifNotEmpty = onNonland
             )
         ),
         descriptionOverride = "Connive"
+    )
+
+    /**
+     * Connive (CR 702.166): draw a card, then discard a card. If the discarded card
+     * is a nonland, put a +1/+1 counter on [target].
+     */
+    fun connive(target: EffectTarget = EffectTarget.Self): CompositeEffect = connivePipeline(
+        AddCountersEffect(
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            count = 1,
+            target = target
+        )
     )
 
     /**
@@ -515,41 +522,17 @@ object HandPatterns {
     fun conniveTargeting(
         requirement: TargetRequirement,
         storeAs: String = "connive_counter_target",
-    ): CompositeEffect = CompositeEffect(
-        listOf(
-            DrawCardsEffect(1, EffectTarget.Controller),
-            GatherCardsEffect(
-                source = CardSource.FromZone(Zone.HAND, Player.You),
-                storeAs = "connive_hand"
-            ),
-            SelectFromCollectionEffect(
-                from = "connive_hand",
-                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
-                chooser = Chooser.Controller,
-                storeSelected = "connive_discarded",
-                prompt = "Choose a card to discard"
-            ),
-            MoveCollectionEffect(
-                from = "connive_discarded",
-                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
-                moveType = MoveType.Discard
-            ),
-            ConditionalOnCollectionEffect(
-                collection = "connive_discarded",
-                filter = GameObjectFilter.Nonland,
-                ifNotEmpty = CompositeEffect(
-                    listOf(
-                        SelectTargetEffect(requirement = requirement, storeAs = storeAs),
-                        AddCountersEffect(
-                            counterType = Counters.PLUS_ONE_PLUS_ONE,
-                            count = 1,
-                            target = EffectTarget.PipelineTarget(storeAs)
-                        )
-                    )
+    ): CompositeEffect = connivePipeline(
+        CompositeEffect(
+            listOf(
+                SelectTargetEffect(requirement = requirement, storeAs = storeAs),
+                AddCountersEffect(
+                    counterType = Counters.PLUS_ONE_PLUS_ONE,
+                    count = 1,
+                    target = EffectTarget.PipelineTarget(storeAs)
                 )
             )
-        ),
-        descriptionOverride = "Connive"
+        )
     )
 
     /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -23,11 +23,13 @@ import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
 import com.wingedsheep.sdk.scripting.effects.MoveType
 import com.wingedsheep.sdk.scripting.effects.RepeatDynamicTimesEffect
 import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
 import com.wingedsheep.sdk.scripting.effects.SelectionMode
 import com.wingedsheep.sdk.scripting.effects.SelectionRestriction
 import com.wingedsheep.sdk.scripting.effects.ZonePlacement
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetRequirement
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
 /**
@@ -490,6 +492,60 @@ object HandPatterns {
                     counterType = Counters.PLUS_ONE_PLUS_ONE,
                     count = 1,
                     target = target
+                )
+            )
+        ),
+        descriptionOverride = "Connive"
+    )
+
+    /**
+     * Connive variant whose +1/+1 counter lands on a *chosen target* rather than the conniving
+     * permanent itself — the "When you discard a nonland card this way, put a +1/+1 counter on
+     * target creature you control" shape (Teo, Spirited Glider).
+     *
+     * Unlike [connive] (counter goes on a fixed [EffectTarget], default Self), the recipient is a
+     * reflexive target: it is selected at resolution via [SelectTargetEffect] *inside* the nonland
+     * gate, so the player only picks a creature once a nonland card has actually been discarded —
+     * never up front, and never when the discard turns out to be a land (or the hand was empty). The
+     * counter then lands on that [EffectTarget.PipelineTarget].
+     *
+     * @param requirement what the chosen counter recipient must satisfy (e.g.
+     *   `Targets.CreatureYouControl`).
+     */
+    fun conniveTargeting(
+        requirement: TargetRequirement,
+        storeAs: String = "connive_counter_target",
+    ): CompositeEffect = CompositeEffect(
+        listOf(
+            DrawCardsEffect(1, EffectTarget.Controller),
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.You),
+                storeAs = "connive_hand"
+            ),
+            SelectFromCollectionEffect(
+                from = "connive_hand",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                storeSelected = "connive_discarded",
+                prompt = "Choose a card to discard"
+            ),
+            MoveCollectionEffect(
+                from = "connive_discarded",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.You),
+                moveType = MoveType.Discard
+            ),
+            ConditionalOnCollectionEffect(
+                collection = "connive_discarded",
+                filter = GameObjectFilter.Nonland,
+                ifNotEmpty = CompositeEffect(
+                    listOf(
+                        SelectTargetEffect(requirement = requirement, storeAs = storeAs),
+                        AddCountersEffect(
+                            counterType = Counters.PLUS_ONE_PLUS_ONE,
+                            count = 1,
+                            target = EffectTarget.PipelineTarget(storeAs)
+                        )
+                    )
                 )
             )
         ),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TeoSpiritedGlider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tla/cards/TeoSpiritedGlider.kt
@@ -19,8 +19,12 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
  * card. When you discard a nonland card this way, put a +1/+1 counter on target creature you
  * control.
  *
- * The looting + conditional reflexive +1/+1 counter is exactly connive (CR 702.166), modeled via
- * [Effects.Connive] with the counter recipient as the chosen target creature you control.
+ * The looting + conditional +1/+1 counter is connive-shaped (CR 702.166), but the counter lands on
+ * a *chosen target* creature rather than the source. The "When you discard a nonland card this way"
+ * clause is a reflexive trigger: the target creature is chosen only after a nonland card is actually
+ * discarded, so it's modeled via [Effects.ConniveTargeting] (which selects the recipient at
+ * resolution inside the nonland gate) — not an up-front `target(...)`, which would force the choice
+ * before the player knows whether they discarded a nonland.
  */
 val TeoSpiritedGlider = card("Teo, Spirited Glider") {
     manaCost = "{3}{U}"
@@ -39,8 +43,7 @@ val TeoSpiritedGlider = card("Teo, Spirited Glider") {
         trigger = Triggers.YouAttackWithFilter(
             GameObjectFilter.Creature.youControl().withKeyword(Keyword.FLYING)
         )
-        val creature = target("target creature you control", Targets.CreatureYouControl)
-        effect = Effects.Connive(target = creature)
+        effect = Effects.ConniveTargeting(Targets.CreatureYouControl)
     }
 
     metadata {

--- a/mtg-sets/src/test/resources/snapshots/cards/TLA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TLA.json
@@ -15605,25 +15605,33 @@
                             "type": "ConditionalOnCollection",
                             "collection": "connive_discarded",
                             "ifNotEmpty": {
-                                "type": "AddCounters",
-                                "counterType": "+1/+1",
-                                "count": 1,
-                                "target": {
-                                    "type": "BoundVariable",
-                                    "name": "target creature you control"
-                                }
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SelectTarget",
+                                        "requirement": {
+                                            "type": "TargetObject",
+                                            "filter": {
+                                                "baseFilter": "creature ctrl:you"
+                                            }
+                                        },
+                                        "storeAs": "connive_counter_target"
+                                    },
+                                    {
+                                        "type": "AddCounters",
+                                        "counterType": "+1/+1",
+                                        "count": 1,
+                                        "target": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "connive_counter_target"
+                                        }
+                                    }
+                                ]
                             },
                             "filter": "nonland"
                         }
                     ],
                     "descriptionOverride": "Connive"
-                },
-                "targetRequirement": {
-                    "type": "TargetObject",
-                    "filter": {
-                        "baseFilter": "creature ctrl:you"
-                    },
-                    "id": "target creature you control"
                 }
             }
         ]

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -744,6 +744,17 @@ class TriggerMatcher(
                         val isCreature = isFaceDown || typeLine?.isCreature == true
                         if (!isCreature) return false
                     }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent -> {
+                        // LKI-safe permanent check. Anything that left the battlefield was, by
+                        // definition, a permanent — but a *token* is swept from the game by 704.5s
+                        // before this matcher runs, so its live CardComponent is gone and the generic
+                        // `else` branch below would return false. Read the last-known type line
+                        // (captured on the event, like IsCreature/IsLand above) instead. Without this,
+                        // "whenever another permanent you control leaves the battlefield" (Suki,
+                        // Courageous Rescuer) silently misses a leaving token.
+                        val isPermanent = isFaceDown || typeLine?.isPermanent == true
+                        if (!isPermanent) return false
+                    }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLand -> {
                         if (typeLine?.isLand != true) return false
                     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -746,7 +746,7 @@ class TriggerMatcher(
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent -> {
                         // LKI-safe permanent check. Anything that left the battlefield was, by
-                        // definition, a permanent — but a *token* is swept from the game by 704.5s
+                        // definition, a permanent — but a *token* is swept from the game by 704.5d
                         // before this matcher runs, so its live CardComponent is gone and the generic
                         // `else` branch below would return false. Read the last-known type line
                         // (captured on the event, like IsCreature/IsLand above) instead. Without this,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -84,7 +84,8 @@ class CreateTokenCopyOfSourceExecutor(
                     cardTypes = sourceCard.typeLine.cardTypes + extraCardTypes
                 )
             }
-            // "except it's not legendary" copy clause (CR 707.2) — strip the legendary supertype.
+            // "except it's not legendary" copy clause (CR 707.9b — modify a characteristic as part
+            // of copying) — strip the legendary supertype.
             val unionedTypeLine = if (effect.removeLegendary) {
                 typeLineWithExtras.withoutLegendary()
             } else {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -35,6 +35,8 @@ import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
 import com.wingedsheep.sdk.scripting.values.ManaColorSet
 import com.wingedsheep.sdk.scripting.effects.ManaRestriction
 import com.wingedsheep.sdk.scripting.effects.ManaSpellRider
@@ -887,7 +889,7 @@ class ManaSolver(
             // actual spend.
             val manaAbilities = if (spellContext != null) {
                 rawManaAbilities.filter { ability ->
-                    val r = extractManaRestriction(ability.effect)
+                    val r = extractManaRestriction(ability.effect, state, entityId, playerId)
                     r == null || r.isSatisfiedBy(spellContext)
                 }
             } else {
@@ -1115,16 +1117,7 @@ class ManaSolver(
                 // separately via colorActivationManaCost / colorlessActivationManaCost,
                 // tapping additional sources to cover them.
                 val effectColors = mutableSetOf<Color>()
-                val manaEffect = when (val effect = ability.effect) {
-                    is CompositeEffect -> effect.effects.firstOrNull {
-                        it is AddManaEffect ||
-                            it is AddColorlessManaEffect ||
-                            it is AddManaOfChoiceEffect ||
-                            it is AddAnyColorManaSpendOnChosenTypeEffect ||
-                            it is AddDynamicManaEffect
-                    } ?: effect
-                    else -> effect
-                }
+                val manaEffect = manaProducingEffect(ability.effect, state, entityId, playerId)
                 val effectRestriction: ManaRestriction? = when (val effect = manaEffect) {
                     is AddManaEffect -> {
                         combinedColors.add(effect.color)
@@ -1388,17 +1381,55 @@ class ManaSolver(
      * mana ability. Used to filter abilities by spell/ability payment context before
      * combining multiple abilities on the same source.
      */
-    private fun extractManaRestriction(effect: com.wingedsheep.sdk.scripting.effects.Effect): ManaRestriction? {
-        val manaEffect = when (effect) {
-            is CompositeEffect -> effect.effects.firstOrNull {
-                it is AddManaEffect ||
-                    it is AddColorlessManaEffect ||
-                    it is AddManaOfChoiceEffect ||
-                    it is AddDynamicManaEffect
-            } ?: effect
+    /**
+     * Unwrap an ability's effect down to the mana-producing leaf the solver should read.
+     *
+     * Two wrappers can hide the mana effect from the structural inspection below:
+     *  - [CompositeEffect] — the mana effect sits alongside bookkeeping effects.
+     *  - [GatedEffect] from `Effects`/`ConditionalEffect` — a *conditional* mana ability
+     *    ("{T}: Add {G}. If you control a creature with power 4 or greater, add {G}{G} instead."
+     *    — Raucous Audience) whose branch is chosen at resolution. The battlefield is stable during
+     *    a single payment, so we evaluate the [Gate.WhenCondition] against the current state and read
+     *    the branch that will actually run. Without this the [GatedEffect] falls through unread, the
+     *    solver never sees the green, and the auto-tapper skips the source entirely.
+     */
+    private fun manaProducingEffect(
+        effect: Effect,
+        state: GameState,
+        sourceId: EntityId,
+        playerId: EntityId,
+    ): Effect = when (effect) {
+        is CompositeEffect -> effect.effects.firstOrNull {
+            it is AddManaEffect ||
+                it is AddColorlessManaEffect ||
+                it is AddManaOfChoiceEffect ||
+                it is AddAnyColorManaSpendOnChosenTypeEffect ||
+                it is AddDynamicManaEffect
+        } ?: effect
+        is GatedEffect -> when (val gate = effect.gate) {
+            is Gate.WhenCondition -> {
+                val context = EffectContext(
+                    sourceId = sourceId,
+                    controllerId = playerId,
+                    targets = emptyList(),
+                    xValue = 0,
+                )
+                val branch = if (conditionEvaluator.evaluate(state, gate.condition, context)) effect.then
+                else effect.otherwise
+                branch?.let { manaProducingEffect(it, state, sourceId, playerId) } ?: effect
+            }
             else -> effect
         }
-        return when (manaEffect) {
+        else -> effect
+    }
+
+    private fun extractManaRestriction(
+        effect: Effect,
+        state: GameState,
+        sourceId: EntityId,
+        playerId: EntityId,
+    ): ManaRestriction? {
+        return when (val manaEffect = manaProducingEffect(effect, state, sourceId, playerId)) {
             is AddManaEffect -> manaEffect.restriction
             is AddColorlessManaEffect -> manaEffect.restriction
             is AddManaOfChoiceEffect -> manaEffect.restriction

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/ConniveTargetingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/ConniveTargetingTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.CreatureStats
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.util.UUID
+
+/**
+ * BDD: connive whose +1/+1 counter lands on a *reflexively chosen* target — the Teo, Spirited
+ * Glider shape ("...When you discard a nonland card this way, put a +1/+1 counter on target
+ * creature you control"). The recipient must be chosen only AFTER a nonland card is discarded,
+ * never up front, and not at all when the discard is a land. Regression for the bug where the
+ * target was declared as a cast-time `target(...)`, forcing the choice before the discard.
+ */
+class ConniveTargetingTest : FunSpec({
+
+    val abilityId = AbilityId(UUID.randomUUID().toString())
+
+    // {T}: draw a card, then discard a card. When you discard a nonland card this way, put a
+    // +1/+1 counter on target creature you control.
+    val Conniver = CardDefinition(
+        name = "Targeting Conniver",
+        manaCost = ManaCost.parse("{2}{U}"),
+        typeLine = TypeLine.creature(setOf(Subtype("Human"))),
+        oracleText = "{T}: Connive onto target creature you control.",
+        creatureStats = CreatureStats(2, 2),
+        script = CardScript.permanent(
+            ActivatedAbility(
+                id = abilityId,
+                cost = AbilityCost.Tap,
+                effect = Effects.ConniveTargeting(Targets.CreatureYouControl)
+            )
+        )
+    )
+
+    // (driver, conniver, other creature, card-to-discard) — paused on the discard selection.
+    data class Setup(
+        val driver: GameTestDriver,
+        val conniver: EntityId,
+        val other: EntityId,
+        val toDiscard: EntityId,
+    )
+
+    fun setup(handCardName: String): Setup {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(Conniver))
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 30, "Forest" to 30),
+            startingLife = 20
+        )
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val player = driver.activePlayer!!
+        driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val handCard = driver.putCardInHand(player, handCardName)
+        val conniver = driver.putCreatureOnBattlefield(player, "Targeting Conniver")
+        // A second creature you control, so the counter target is a genuine choice (not auto-select).
+        val other = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.removeSummoningSickness(conniver)
+
+        driver.submit(
+            ActivateAbility(playerId = player, sourceId = conniver, abilityId = abilityId)
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // First pause is the DISCARD selection — the counter target has NOT been chosen yet.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        return Setup(driver, conniver, other, handCard)
+    }
+
+    fun GameTestDriver.counters(id: EntityId) =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("nonland discard: target is chosen AFTER the discard, then gets the counter") {
+        val (driver, conniver, other, nonland) = setup("Grizzly Bears")
+        val player = driver.activePlayer!!
+
+        // Discard the nonland.
+        val discard = driver.pendingDecision as SelectCardsDecision
+        driver.submitDecision(
+            player,
+            CardsSelectedResponse(decisionId = discard.id, selectedCards = listOf(nonland))
+        )
+
+        // Only NOW — after a nonland was discarded — are we asked to choose the counter recipient.
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+
+        // Put the counter on the OTHER creature, not the conniver — proving it's a free target.
+        driver.submitTargetSelection(player, listOf(other))
+        driver.isPaused shouldBe false
+
+        driver.counters(other) shouldBe 1
+        driver.counters(conniver) shouldBe 0
+    }
+
+    test("land discard: no target is ever requested and no counter is placed") {
+        val (driver, conniver, other, land) = setup("Forest")
+        val player = driver.activePlayer!!
+
+        val discard = driver.pendingDecision as SelectCardsDecision
+        driver.submitDecision(
+            player,
+            CardsSelectedResponse(decisionId = discard.id, selectedCards = listOf(land))
+        )
+
+        // Land discard → reflexive trigger doesn't fire → no target prompt, resolution completes.
+        driver.isPaused shouldBe false
+
+        driver.counters(other) shouldBe 0
+        driver.counters(conniver) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerMatcherIsPermanentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerMatcherIsPermanentTest.kt
@@ -24,7 +24,7 @@ import io.kotest.matchers.collections.shouldHaveSize
  * Suki's filter is [GameObjectFilter.Permanent] (carrying [CardPredicate.IsPermanent]). In
  * [TriggerMatcher.matchesZoneChangeTrigger], IsPermanent had no dedicated case and fell into the
  * generic `else` branch, which does `if (cardComponent == null) return false`. A token is swept
- * from the game by CR 704.5s state-based actions in the same pass that puts it in the graveyard,
+ * from the game by CR 704.5d state-based actions in the same pass that puts it in the graveyard,
  * so by trigger-detection time its live CardComponent is gone — the matcher returned false and the
  * trigger never fired. A nontoken permanent's card is still in the graveyard, so it worked; only
  * tokens were affected (exactly the user's "Ally Token died in combat, no new token" report).
@@ -71,7 +71,7 @@ class TriggerMatcherIsPermanentTest : FunSpec({
     test("fires when a TOKEN you control dies — the entity is swept, so LKI must carry the type line") {
         val driver = createDriver()
 
-        // The token has already been removed from the game (CR 704.5s), so it is NOT in state.
+        // The token has already been removed from the game (CR 704.5d), so it is NOT in state.
         // The matcher must rely on the event's last-known info.
         val sweptToken = EntityId.generate()
         val event = ZoneChangeEvent(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerMatcherIsPermanentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/event/TriggerMatcherIsPermanentTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.event
+
+import com.wingedsheep.engine.core.ZoneChangeEvent
+import com.wingedsheep.engine.state.components.stack.EntitySnapshot
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+
+/**
+ * Regression for the bug where "Whenever another permanent you control leaves the battlefield"
+ * (Suki, Courageous Rescuer) silently missed a leaving **token**.
+ *
+ * Suki's filter is [GameObjectFilter.Permanent] (carrying [CardPredicate.IsPermanent]). In
+ * [TriggerMatcher.matchesZoneChangeTrigger], IsPermanent had no dedicated case and fell into the
+ * generic `else` branch, which does `if (cardComponent == null) return false`. A token is swept
+ * from the game by CR 704.5s state-based actions in the same pass that puts it in the graveyard,
+ * so by trigger-detection time its live CardComponent is gone — the matcher returned false and the
+ * trigger never fired. A nontoken permanent's card is still in the graveyard, so it worked; only
+ * tokens were affected (exactly the user's "Ally Token died in combat, no new token" report).
+ *
+ * The fix gives IsPermanent an LKI-safe case that reads the event's last-known type line.
+ */
+class TriggerMatcherIsPermanentTest : FunSpec({
+
+    // Observer mirroring Suki's trigger: "whenever another permanent you control leaves the
+    // battlefield, draw a card." (Effect simplified to a draw — we assert detection, not output.)
+    val permanentLeaveWatcher = card("Permanent Leave Watcher") {
+        manaCost = "{2}"
+        colorIdentity = ""
+        typeLine = "Enchantment"
+        oracleText = "Whenever another permanent you control leaves the battlefield, draw a card."
+
+        spell {}
+
+        triggeredAbility {
+            trigger = TriggerSpec(
+                event = EventPattern.ZoneChangeEvent(
+                    filter = GameObjectFilter.Permanent.youControl(),
+                    from = Zone.BATTLEFIELD,
+                ),
+                binding = TriggerBinding.OTHER,
+            )
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + permanentLeaveWatcher)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        driver.putPermanentOnBattlefield(driver.player1, "Permanent Leave Watcher")
+        return driver
+    }
+
+    fun zoneChanges(driver: GameTestDriver, event: ZoneChangeEvent) =
+        TriggerDetector(driver.cardRegistry)
+            .detectTriggers(driver.state, listOf(event))
+            .filter { it.ability.trigger is EventPattern.ZoneChangeEvent }
+
+    test("fires when a TOKEN you control dies — the entity is swept, so LKI must carry the type line") {
+        val driver = createDriver()
+
+        // The token has already been removed from the game (CR 704.5s), so it is NOT in state.
+        // The matcher must rely on the event's last-known info.
+        val sweptToken = EntityId.generate()
+        val event = ZoneChangeEvent(
+            entityId = sweptToken,
+            entityName = "Ally Token",
+            fromZone = Zone.BATTLEFIELD,
+            toZone = Zone.GRAVEYARD,
+            ownerId = driver.player1,
+            lastKnown = EntitySnapshot(
+                entityId = sweptToken,
+                controllerId = driver.player1,
+                typeLine = TypeLine.parse("Creature - Ally"),
+                wasToken = true,
+            ),
+        )
+
+        zoneChanges(driver, event) shouldHaveSize 1
+    }
+
+    test("fires when a nontoken permanent you control leaves (baseline — card still in graveyard)") {
+        val driver = createDriver()
+
+        val creature = driver.putCardInHand(driver.player1, "Grizzly Bears")
+        val event = ZoneChangeEvent(
+            entityId = creature,
+            entityName = "Grizzly Bears",
+            fromZone = Zone.BATTLEFIELD,
+            toZone = Zone.GRAVEYARD,
+            ownerId = driver.player1,
+            lastKnown = EntitySnapshot(
+                entityId = creature,
+                controllerId = driver.player1,
+                typeLine = TypeLine.parse("Creature - Bear"),
+                wasToken = false,
+            ),
+        )
+
+        zoneChanges(driver, event) shouldHaveSize 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/mana/ConditionalManaAbilityAutoTapTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/mechanics/mana/ConditionalManaAbilityAutoTapTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.mechanics.mana
+
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+/**
+ * Regression: the auto-tapper (ManaSolver) must recognize a *conditional* mana ability as a mana
+ * source — Raucous Audience: "{T}: Add {G}. If you control a creature with power 4 or greater, add
+ * {G}{G} instead."
+ *
+ * `ConditionalEffect` lowers to a [com.wingedsheep.sdk.scripting.effects.GatedEffect], which the
+ * solver's effect-extraction did not handle — the gate fell through unread, the solver never saw
+ * the green, and the source was silently skipped (player couldn't auto-tap it). The fix evaluates
+ * the gate's condition against current state (stable during a payment) and reads the branch that
+ * will actually run.
+ */
+class ConditionalManaAbilityAutoTapTest : FunSpec({
+
+    // Faithful copy of Raucous Audience's conditional mana ability.
+    val raucous = card("Raucous Tester") {
+        typeLine = "Creature — Human Citizen"
+        manaCost = "{1}{G}"
+        colorIdentity = "G"
+        power = 2
+        toughness = 1
+        oracleText = "{T}: Add {G}. If you control a creature with power 4 or greater, add {G}{G} instead."
+
+        activatedAbility {
+            cost = Costs.Tap
+            effect = ConditionalEffect(
+                condition = Conditions.YouControl(GameObjectFilter.Creature.powerAtLeast(4)),
+                effect = Effects.AddMana(Color.GREEN, 2),
+                elseEffect = Effects.AddMana(Color.GREEN),
+            )
+            manaAbility = true
+            timing = TimingRule.ManaAbility
+        }
+    }
+
+    // A vanilla 5/5 to flip the gate's "creature with power 4 or greater" condition on.
+    val bruiser = CardDefinition.creature(
+        name = "Big Bruiser",
+        manaCost = ManaCost.parse("{4}{G}"),
+        subtypes = setOf(com.wingedsheep.sdk.core.Subtype("Bear")),
+        power = 5,
+        toughness = 5,
+    )
+
+    val allCards = TestCards.all + listOf(raucous, bruiser)
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(allCards)
+        return driver
+    }
+
+    fun createRegistry(): CardRegistry = CardRegistry().also { it.register(allCards) }
+
+    test("conditional mana ability is found as a green source (else branch — 1 green)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val player = driver.player1
+
+        val src = driver.putCreatureOnBattlefield(player, "Raucous Tester")
+        driver.removeSummoningSickness(src)
+
+        val solution = ManaSolver(createRegistry()).solve(driver.state, player, ManaCost.parse("{G}"))
+
+        solution.shouldNotBeNull()
+        solution.sources shouldHaveSize 1
+        solution.sources.map { it.name } shouldContain "Raucous Tester"
+    }
+
+    test("gate's then-branch is read: with a power-4+ creature it alone pays {G}{G}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true)
+        val player = driver.player1
+
+        val src = driver.putCreatureOnBattlefield(player, "Raucous Tester")
+        driver.removeSummoningSickness(src)
+        // Controlling a 5/5 flips the condition → the ability now yields {G}{G} from one tap.
+        driver.putCreatureOnBattlefield(player, "Big Bruiser")
+
+        val solution = ManaSolver(createRegistry()).solve(driver.state, player, ManaCost.parse("{G}{G}"))
+
+        solution.shouldNotBeNull()
+        // A single tap of Raucous Tester covers both green — no other green source needed.
+        solution.sources shouldHaveSize 1
+        solution.sources.map { it.name } shouldContain "Raucous Tester"
+    }
+})


### PR DESCRIPTION
Three TLA card bugs, each with a paired regression test. Adds two small reusable
SDK/engine capabilities and one HandPatterns composition — no card-specific types.

### Fixes
- **Raucous Audience** — auto-tapper now recognizes a *conditional* mana ability as a
  source. `ManaSolver` unwraps the `GatedEffect` that `ConditionalEffect` lowers to,
  evaluating its gate against current state (stable during a payment) and reading the
  branch that will run. Before, the gate fell through unread and the source was skipped.
- **Teo, Spirited Glider** — the +1/+1 counter now lands on a *reflexively chosen*
  target: `Effects.ConniveTargeting` selects the recipient at resolution, inside the
  nonland gate, so the player only picks a creature after actually discarding a nonland
  (not up front, and never on a land). Replaces the up-front `target(...)`.
- **Suki, Courageous Rescuer** — "whenever another permanent you control leaves the
  battlefield" now fires for a leaving **token**. `TriggerMatcher` gets an LKI-safe
  `CardPredicate.IsPermanent` case that reads the event's last-known type line, since the
  token entity is swept by SBA (CR 704.5d) before trigger detection.

### Tests
- `ConditionalManaAbilityAutoTapTest` — both gate branches (1 green / {G}{G}).
- `ConniveTargetingTest` — nonland → target after discard; land → no target.
- `TriggerMatcherIsPermanentTest` — swept token (LKI) + nontoken baseline.

Also de-dups the connive pipeline (shared `connivePipeline` helper), updates the SDK
reference, and re-blesses the TLA snapshot for Teo. CR citations verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)