### PR TITLE
Fix partial replays: record per-ability yields; gzip replay responses

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -670,6 +670,7 @@ class GamePlayHandler(
                 tournamentRound = tournamentRound,
                 setup = replaySetup,
                 actions = gameSession.getRecordedActions(),
+                yields = gameSession.getReplayYields(),
             )
             // AI-only games (e.g. the LLM tournament) stay in the in-memory cache for live viewing
             // but aren't persisted — they never appear in any account's history.

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/GameSessionConverter.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/GameSessionConverter.kt
@@ -37,6 +37,7 @@ fun GameSession.toPersistent(
         lobbyId = lobbyId,
         replaySetup = getReplaySetup(),
         recordedActions = getRecordedActions(),
+        recordedYields = getReplayYields(),
         replayStartedAt = replayStartedAt?.toString(),
     )
 }
@@ -87,6 +88,7 @@ fun restoreGameSession(
         setup = persistent.replaySetup,
         actions = persistent.recordedActions,
         startedAtIso = persistent.replayStartedAt,
+        yields = persistent.recordedYields,
     )
 
     // Restore player persistence info

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentGameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/dto/PersistentGameSession.kt
@@ -24,6 +24,7 @@ data class PersistentGameSession(
     // setup = a game started before this field existed, or an injected dev scenario (not replayable).
     val replaySetup: ReplaySetup? = null,
     val recordedActions: List<GameAction> = emptyList(),
+    val recordedYields: List<com.wingedsheep.gameserver.replay.ReplayYieldEntry> = emptyList(),
     val replayStartedAt: String? = null,  // ISO-8601 instant
 )
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/CompactReplay.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/CompactReplay.kt
@@ -1,10 +1,12 @@
 package com.wingedsheep.gameserver.replay
 
 import com.wingedsheep.engine.core.GameAction
+import com.wingedsheep.engine.state.YieldKind
 import com.wingedsheep.gameserver.protocol.ServerMessage
 import com.wingedsheep.sdk.core.AttackMode
 import com.wingedsheep.sdk.core.Format
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AbilityIdentity
 import kotlinx.serialization.Serializable
 
 /**
@@ -38,6 +40,15 @@ data class CompactReplay(
     val setup: ReplaySetup,
     /** The ordered input stream applied to the game, replayed verbatim to reconstruct it. */
     val actions: List<GameAction>,
+    /**
+     * Persistent-yield mutations (MTGO right-click "always yes/no" / "yield" preferences) applied to
+     * the game out-of-band of the [actions] stream. They live on [com.wingedsheep.engine.state.GameState]
+     * and are *consumed* by the pure engine during resolution (auto-answering optional triggers), so a
+     * game where a player set such a yield re-simulates differently unless we re-apply the yields at the
+     * exact point they were set — hence [ReplayYieldEntry.afterActionCount]. Empty for games without any
+     * yields (the overwhelming majority), and for replays recorded before this field existed.
+     */
+    val yields: List<ReplayYieldEntry> = emptyList(),
 ) {
     /** Number of reconstructable frames: the initial state plus one per applied action. */
     val frameCount: Int get() = 1 + actions.size
@@ -47,6 +58,26 @@ data class CompactReplay(
         const val CURRENT_VERSION = 1
     }
 }
+
+/** Which yield mutation a [ReplayYieldEntry] records. */
+@Serializable
+enum class ReplayYieldOp { SET, CLEAR_ABILITY, CLEAR_ALL }
+
+/**
+ * A single persistent-yield mutation captured in turn order against the [actions] stream.
+ * [afterActionCount] is the number of recorded actions that had been applied when the yield was set,
+ * so [ReplayReconstructor] re-applies it at the same point and the engine's auto-answers reproduce
+ * exactly. [identity]/[kind] are populated per [op] (both for SET, [identity] only for CLEAR_ABILITY,
+ * neither for CLEAR_ALL).
+ */
+@Serializable
+data class ReplayYieldEntry(
+    val afterActionCount: Int,
+    val playerId: String,
+    val op: ReplayYieldOp,
+    val identity: AbilityIdentity? = null,
+    val kind: YieldKind? = null,
+)
 
 /** A single seat in a recorded replay, in turn order. */
 @Serializable

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayReconstructor.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/replay/ReplayReconstructor.kt
@@ -60,7 +60,7 @@ class ReplayReconstructor(
         val setup = replay.setup
         val seats = setup.players.map { SpectatorSeat(EntityId(it.playerId), it.name) }
 
-        var state = initialState(replay)
+        var state = applyYields(initialState(replay), replay.yields, afterActionCount = 0)
         var previous = spectatorStateBuilder.buildState(state, seats, setup.seatRoster, replay.gameId)
         val initial = previous
         val deltas = ArrayList<SpectatorReplayDelta>(replay.actions.size)
@@ -74,7 +74,9 @@ class ReplayReconstructor(
                 )
                 break
             }
-            state = result.state
+            // Re-apply any yields set right after this action was originally applied, so the engine's
+            // auto-answers reproduce on the next iteration exactly as they did live.
+            state = applyYields(result.state, replay.yields, afterActionCount = index + 1)
             val snapshot = spectatorStateBuilder.buildState(state, seats, setup.seatRoster, replay.gameId)
             deltas.add(SpectatorReplayDiffCalculator.computeDelta(previous, snapshot))
             previous = snapshot
@@ -90,7 +92,7 @@ class ReplayReconstructor(
      */
     fun reconstructStateAt(replay: CompactReplay, frame: Int): GameState? {
         if (frame < 0 || frame > replay.actions.size) return null
-        var state = initialState(replay)
+        var state = applyYields(initialState(replay), replay.yields, afterActionCount = 0)
         for (index in 0 until frame) {
             val action = replay.actions[index]
             val result = actionProcessor.process(state, rebind(action, state)).result
@@ -101,9 +103,30 @@ class ReplayReconstructor(
                 )
                 return null
             }
-            state = result.state
+            state = applyYields(result.state, replay.yields, afterActionCount = index + 1)
         }
         return state
+    }
+
+    /**
+     * Re-apply every recorded yield whose [ReplayYieldEntry.afterActionCount] equals [afterActionCount]
+     * (i.e. it was originally set right after that many actions had been applied). Mirrors
+     * [com.wingedsheep.gameserver.session.GameSession.setAbilityYield] and friends so the engine's
+     * auto-answers reproduce identically. Almost always a no-op (most games carry no yields).
+     */
+    private fun applyYields(state: GameState, yields: List<ReplayYieldEntry>, afterActionCount: Int): GameState {
+        if (yields.isEmpty()) return state
+        var current = state
+        for (entry in yields) {
+            if (entry.afterActionCount != afterActionCount) continue
+            val playerId = EntityId(entry.playerId)
+            current = when (entry.op) {
+                ReplayYieldOp.SET -> current.withYield(playerId, entry.identity!!, entry.kind!!)
+                ReplayYieldOp.CLEAR_ABILITY -> current.withoutYield(playerId, entry.identity!!)
+                ReplayYieldOp.CLEAR_ALL -> current.withoutYields(playerId)
+            }
+        }
+        return current
     }
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/GameSession.kt
@@ -219,6 +219,9 @@ class GameSession(
     @Volatile
     private var replaySetup: com.wingedsheep.gameserver.replay.ReplaySetup? = null
     private val recordedActions = CopyOnWriteArrayList<GameAction>()
+    // Persistent-yield mutations applied out-of-band of [recordedActions]. Captured in turn order so
+    // the reconstructor can re-apply each at the action position it was set (see [CompactReplay.yields]).
+    private val recordedYields = CopyOnWriteArrayList<com.wingedsheep.gameserver.replay.ReplayYieldEntry>()
     var replayStartedAt: Instant? = null
         private set
 
@@ -922,9 +925,13 @@ class GameSession(
     // Persistent Yields (MTGO right-click yields — backlog §C)
     // =========================================================================
     //
-    // Yields live on the immutable GameState (not a session-side map), so the pure engine can
-    // consult auto-answers during resolution and they replay deterministically. Mutations are pure
-    // GameState transforms applied under the state lock.
+    // Yields live on the immutable GameState (not a session-side map), so the pure engine can consult
+    // auto-answers during resolution. Because the engine *consumes* them while resolving (it silently
+    // auto-answers an optional trigger's may-question, emitting no GameAction), they are NOT captured
+    // by the [recordedActions] stream — so we also record every yield mutation against the current
+    // action count ([recordedYields]) and re-apply it during reconstruction. Without this, any game in
+    // which a player set an "always answer" yield re-simulates differently and the replay truncates at
+    // the first auto-answered trigger. Mutations are pure GameState transforms applied under the lock.
 
     /** Set a persistent yield for [playerId] against [identity]. */
     fun setAbilityYield(
@@ -933,6 +940,7 @@ class GameSession(
         kind: com.wingedsheep.engine.state.YieldKind
     ) = synchronized(stateLock) {
         gameState = gameState?.withYield(playerId, identity, kind)
+        recordYield(com.wingedsheep.gameserver.replay.ReplayYieldOp.SET, playerId, identity, kind)
     }
 
     /** Revoke every yield [playerId] holds against [identity]. */
@@ -941,11 +949,13 @@ class GameSession(
         identity: com.wingedsheep.sdk.scripting.AbilityIdentity
     ) = synchronized(stateLock) {
         gameState = gameState?.withoutYield(playerId, identity)
+        recordYield(com.wingedsheep.gameserver.replay.ReplayYieldOp.CLEAR_ABILITY, playerId, identity, null)
     }
 
     /** Drop all of [playerId]'s yields. */
     fun clearAllYields(playerId: EntityId) = synchronized(stateLock) {
         gameState = gameState?.withoutYields(playerId)
+        recordYield(com.wingedsheep.gameserver.replay.ReplayYieldOp.CLEAR_ALL, playerId, null, null)
     }
 
     // =========================================================================
@@ -1035,9 +1045,11 @@ class GameSession(
 
         gameState = checkpoint
         // Roll the replay log back to the actions that produced the restored state, so a later
-        // reconstruction replays exactly this history.
+        // reconstruction replays exactly this history. Yields recorded after the rollback point are
+        // dropped too — they were set against actions that no longer exist.
         undoCheckpointActionCount?.let { target ->
             while (recordedActions.size > target) recordedActions.removeAt(recordedActions.size - 1)
+            recordedYields.removeIf { it.afterActionCount > target }
         }
         clearCheckpoint()
         logger.info("Player $playerId undid their last action")
@@ -1224,6 +1236,29 @@ class GameSession(
     }
 
     /**
+     * Capture a persistent-yield mutation against the current action count, but only while the game is
+     * being recorded for replay (a [replaySetup] exists). Injected dev-scenario/hotseat sessions aren't
+     * replayable, so their yields needn't be recorded.
+     */
+    private fun recordYield(
+        op: com.wingedsheep.gameserver.replay.ReplayYieldOp,
+        playerId: EntityId,
+        identity: com.wingedsheep.sdk.scripting.AbilityIdentity?,
+        kind: com.wingedsheep.engine.state.YieldKind?,
+    ) {
+        if (replaySetup == null) return
+        recordedYields.add(
+            com.wingedsheep.gameserver.replay.ReplayYieldEntry(
+                afterActionCount = recordedActions.size,
+                playerId = playerId.value,
+                op = op,
+                identity = identity,
+                kind = kind,
+            )
+        )
+    }
+
+    /**
      * The reproducible setup captured at [startGame], or null for games whose state was injected
      * directly (dev scenarios / hotseat) and therefore can't be re-simulated from inputs.
      */
@@ -1231,6 +1266,9 @@ class GameSession(
 
     /** The ordered input stream applied to this game. */
     fun getRecordedActions(): List<GameAction> = recordedActions.toList()
+
+    /** The persistent-yield mutations applied to this game, in order, for replay reconstruction. */
+    fun getReplayYields(): List<com.wingedsheep.gameserver.replay.ReplayYieldEntry> = recordedYields.toList()
 
     /**
      * Total number of replay frames: the initial state plus one per recorded action. Zero until the
@@ -1405,11 +1443,14 @@ class GameSession(
         setup: com.wingedsheep.gameserver.replay.ReplaySetup?,
         actions: List<GameAction>,
         startedAtIso: String?,
+        yields: List<com.wingedsheep.gameserver.replay.ReplayYieldEntry> = emptyList(),
     ) {
         synchronized(stateLock) {
             replaySetup = setup
             recordedActions.clear()
             recordedActions.addAll(actions)
+            recordedYields.clear()
+            recordedYields.addAll(yields)
             replayStartedAt = startedAtIso?.let { runCatching { Instant.parse(it) }.getOrNull() }
         }
     }

--- a/game-server/src/main/resources/application.yml
+++ b/game-server/src/main/resources/application.yml
@@ -1,5 +1,14 @@
 server:
   port: 8080
+  # Gzip HTTP responses. The replay endpoints reconstruct the full snapshot+delta stream on demand,
+  # which for a long game is ~1MB of highly repetitive JSON (the same card objects, rulings, and both
+  # players' full blocks repeat every frame) — it compresses ~90%. Only applies when the client sends
+  # Accept-Encoding: gzip (all browsers do) and the body exceeds min-response-size; small responses and
+  # the WebSocket path are untouched.
+  compression:
+    enabled: true
+    mime-types: application/json,application/octet-stream,text/plain,text/html,text/css,application/javascript
+    min-response-size: 2KB
 
 spring:
   application:

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/ReplayDivergenceReproTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/ReplayDivergenceReproTest.kt
@@ -1,0 +1,367 @@
+package com.wingedsheep.gameserver.replay
+
+import com.wingedsheep.ai.engine.buildHeuristicSealedDeck
+import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.gameserver.ScenarioTestBase
+import com.wingedsheep.gameserver.session.GameSession
+import com.wingedsheep.gameserver.session.PlayerSession
+import com.wingedsheep.mtg.sets.MtgSetCatalog
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.model.Rarity
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.web.socket.WebSocketSession
+import java.time.Instant
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Repro harness: play many real, decision-heavy games through the [GameSession] recording path, then
+ * reconstruct each [CompactReplay] and assert the viewer stream is NOT truncated — i.e. the
+ * reconstruction reaches `1 + actions.size` frames with no mid-replay divergence. A failure here is
+ * exactly the "only part of the replay was saved" symptom: a recorded action that no longer applies
+ * on re-simulation makes [ReplayReconstructor] stop early.
+ */
+class ReplayDivergenceReproTest : ScenarioTestBase() {
+
+    private fun mockWs(id: String): WebSocketSession =
+        mockk(relaxed = true) { every { this@mockk.id } returns id }
+
+    private val numGames = System.getProperty("reproGames")?.toIntOrNull() ?: 5
+    private val setCodes = (System.getProperty("reproSet")?.split(",")
+        ?: listOf("EOE", "TDM", "DFT", "BLB", "DSK", "MOM"))
+
+    init {
+        test("recorded games reconstruct to the full frame stream (no truncation)").config(timeout = 60.minutes) {
+            val enumerator = LegalActionEnumerator.create(cardRegistry)
+            val reconstructor = ReplayReconstructor(cardRegistry, null)
+            val rng = Random(0x5EED)
+            val diverged = mutableListOf<String>()
+
+            for (setCode in setCodes) {
+              val set = runCatching { MtgSetCatalog.requireByCode(setCode) }.getOrNull() ?: continue
+              val nonBasics = set.cards.filter { !it.typeLine.isBasicLand }
+              if (nonBasics.size < 30) continue
+              for (i in 0 until numGames) {
+                val gi = "$setCode-$i"
+                val deck1 = buildHeuristicSealedDeck(generateSealedPool(nonBasics, rng))
+                val deck2 = buildHeuristicSealedDeck(generateSealedPool(nonBasics, rng))
+
+                val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
+                val p1 = EntityId.of("p1-game$gi")
+                val p2 = EntityId.of("p2-game$gi")
+                session.addPlayer(PlayerSession(mockWs("ws1-$gi"), p1, "Alice"), deck1)
+                session.addPlayer(PlayerSession(mockWs("ws2-$gi"), p2, "Bob"), deck2)
+                session.startGame()
+                session.keepHand(p1)
+                session.keepHand(p2)
+
+                playRandomGame(session, enumerator, rng, maxTurns = 25)
+
+                val setup = session.getReplaySetup() ?: continue
+                val liveFinal = session.getStateForTesting()
+                val actions = session.getRecordedActions()
+                val replay = CompactReplay(
+                    gameId = session.sessionId,
+                    players = session.getPlayers().map { ReplayPlayerInfo(it.playerId.value, it.playerName) },
+                    startedAt = Instant.now().toString(),
+                    endedAt = Instant.now().toString(),
+                    winnerName = null,
+                    setup = setup,
+                    actions = actions,
+                    yields = session.getReplayYields(),
+                )
+
+                // The durable store + the in-progress Redis snapshot both serialize the action log
+                // via persistenceJson. If any recorded action/response type fails to round-trip, the
+                // saved replay is silently short — exactly the "partial replay" symptom.
+                val roundTripped = runCatching { ReplayCodec.decode(ReplayCodec.encode(replay)) }
+                if (roundTripped.getOrNull() != replay) {
+                    val msg = "game $gi: action log does NOT round-trip through the codec " +
+                        "(${roundTripped.exceptionOrNull()?.let { it::class.simpleName + ": " + it.message } ?: "value mismatch"})"
+                    println("DIVERGED: $msg")
+                    diverged.add(msg)
+                }
+
+                val reconstructed = reconstructor.reconstruct(replay)
+                val expected = 1 + actions.size
+                if (reconstructed.frameCount != expected) {
+                    val truncIdx = reconstructed.frameCount - 1
+                    val msg = "game $gi: reconstructed ${reconstructed.frameCount}/" +
+                        "$expected frames (truncated at action $truncIdx = " +
+                        "${actions.getOrNull(truncIdx)})"
+                    println("DIVERGED: $msg")
+                    diverged.add(msg)
+                } else if (liveFinal != null) {
+                    // No truncation — but did it re-simulate to the SAME state? A silent mismatch
+                    // means the saved action log doesn't reproduce what actually happened.
+                    val reconFinal = reconstructor.reconstructStateAt(replay, actions.size)
+                    if (reconFinal == null || reconFinal.entities != liveFinal.entities ||
+                        reconFinal.zones != liveFinal.zones) {
+                        val msg = "game $gi: reconstructed final state differs from live (silent divergence)"
+                        println("DIVERGED: $msg")
+                        diverged.add(msg)
+                    }
+                }
+              }
+            }
+
+            if (diverged.isNotEmpty()) {
+                throw AssertionError(
+                    "${diverged.size} games truncated on reconstruction:\n" +
+                        diverged.joinToString("\n")
+                )
+            }
+        }
+
+        // A persistent "always answer" yield is written into GameState and consumed by the pure engine
+        // when it auto-answers an optional trigger — but it is NOT a GameAction, so it must be captured
+        // separately and re-applied during reconstruction. Without that, the reconstructed game starts
+        // with no yields, pauses for a trigger the live game auto-answered, and truncates. This pins the
+        // recording + re-application of yields directly.
+        test("a persistent yield set mid-game is captured and reproduced on reconstruction") {
+            val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
+            val p1 = EntityId.of("yield-p1")
+            val p2 = EntityId.of("yield-p2")
+            session.addPlayer(PlayerSession(mockWs("yw1"), p1, "Alice"), mapOf("Forest" to 40))
+            session.addPlayer(PlayerSession(mockWs("yw2"), p2, "Bob"), mapOf("Forest" to 40))
+            session.startGame()
+            session.keepHand(p1)
+            session.keepHand(p2)
+
+            fun pass(times: Int) = repeat(times) {
+                val s = session.getStateForTesting() ?: return@repeat
+                if (s.gameOver) return@repeat
+                s.priorityPlayerId?.let { session.executeAutoPass(it) }
+            }
+
+            // Play a few turns, then set an "always yes" yield, then play a few more.
+            pass(20)
+            val identity = com.wingedsheep.sdk.scripting.AbilityIdentity(
+                "Some Card#TST-1", com.wingedsheep.sdk.scripting.AbilityId("ability_test_1")
+            )
+            session.setAbilityYield(p1, identity, com.wingedsheep.engine.state.YieldKind.ALWAYS_ANSWER_YES)
+            pass(20)
+
+            val setup = session.getReplaySetup().shouldNotBeNull()
+            val recordedYields = session.getReplayYields()
+            recordedYields.shouldNotBeEmpty()
+
+            val replay = CompactReplay(
+                gameId = session.sessionId,
+                players = session.getPlayers().map { ReplayPlayerInfo(it.playerId.value, it.playerName) },
+                startedAt = Instant.now().toString(),
+                endedAt = Instant.now().toString(),
+                winnerName = null,
+                setup = setup,
+                actions = session.getRecordedActions(),
+                yields = recordedYields,
+            )
+
+            // Round-trips through the durable codec (carrying the yield entries).
+            ReplayCodec.decode(ReplayCodec.encode(replay)) shouldBe replay
+
+            // The reconstructed final state carries the same yields the live game ended with — proof the
+            // out-of-band yield was captured and re-applied at the right action position.
+            val liveFinal = session.getStateForTesting().shouldNotBeNull()
+            val reconstructor = ReplayReconstructor(cardRegistry, null)
+            val reconFinal = reconstructor.reconstructStateAt(replay, replay.actions.size).shouldNotBeNull()
+            reconFinal.yieldsFor(p1) shouldBe liveFinal.yieldsFor(p1)
+            reconFinal.autoAnswerFor(p1, identity) shouldBe true
+        }
+    }
+
+    private fun playRandomGame(
+        session: GameSession,
+        enumerator: LegalActionEnumerator,
+        rng: Random,
+        maxTurns: Int,
+    ) {
+        var actionCount = 0
+        var lastProgressTurn = 0
+        var lastProgressAction = 0
+        var stuckCount = 0
+
+        while (true) {
+            val state = session.getStateForTesting() ?: break
+            if (state.gameOver || state.turnNumber >= maxTurns) break
+
+            if (actionCount - lastProgressAction > 1000 && state.turnNumber == lastProgressTurn) {
+                stuckCount++
+                if (stuckCount >= 3) break
+            }
+            if (state.turnNumber > lastProgressTurn) {
+                lastProgressTurn = state.turnNumber
+                lastProgressAction = actionCount
+                stuckCount = 0
+            }
+
+            val pendingDecision = state.pendingDecision
+            val action: GameAction = if (pendingDecision != null) {
+                // Right-click "always yes/no" yields are written into GameState but are NOT part of
+                // the recorded action stream. The first time we see an optional ability's may-question
+                // we register a persistent auto-answer for it; if that ability ever triggers again the
+                // engine resolves it silently (no recorded action), so the reconstructed game — which
+                // starts with no yields — pauses instead and diverges. This reproduces the production
+                // "partial replay" symptom.
+                if (pendingDecision is YesNoDecision || pendingDecision is BatchYesNoDecision) {
+                    pendingDecision.context.abilityIdentity?.let { id ->
+                        session.setAbilityYield(pendingDecision.playerId, id, com.wingedsheep.engine.state.YieldKind.ALWAYS_ANSWER_YES)
+                    }
+                }
+                SubmitDecision(pendingDecision.playerId, randomDecisionResponse(pendingDecision, rng))
+            } else {
+                val priorityPlayer = state.priorityPlayerId ?: break
+                val affordable = enumerator.enumerate(state, priorityPlayer).filter { it.affordable }
+                if (affordable.isEmpty()) break
+                affordable[rng.nextInt(affordable.size)].action
+            }
+
+            val result = session.executeAction(action.playerId, action)
+            if (result is GameSession.ActionResult.Failure) {
+                val fallback = session.executeAutoPass(action.playerId)
+                if (fallback is GameSession.ActionResult.Failure) break
+            }
+            actionCount++
+
+            // Occasionally exercise undo — the one path that *removes* recorded actions. The
+            // priority player after this action attempts to roll back; most attempts fail (no
+            // checkpoint), but the ones that succeed truncate the replay log and must keep it
+            // replay-consistent with the restored state.
+            if (rng.nextInt(5) == 0) {
+                val cur = session.getStateForTesting() ?: break
+                val pp = cur.priorityPlayerId
+                if (pp != null) session.executeUndo(pp)
+            }
+        }
+    }
+
+    private fun randomDecisionResponse(decision: PendingDecision, rng: Random): DecisionResponse {
+        return when (decision) {
+            is ChooseTargetsDecision -> {
+                val targets = decision.targetRequirements.associate { req ->
+                    val valid = decision.legalTargets[req.index] ?: emptyList()
+                    val count = rng.nextInt(req.minTargets, req.maxTargets + 1).coerceAtMost(valid.size)
+                    req.index to valid.shuffled(rng).take(count)
+                }
+                TargetsResponse(decision.id, targets)
+            }
+
+            is SelectCardsDecision -> {
+                val count = rng.nextInt(decision.minSelections, decision.maxSelections + 1)
+                    .coerceAtMost(decision.options.size)
+                CardsSelectedResponse(decision.id, decision.options.shuffled(rng).take(count))
+            }
+
+            is YesNoDecision -> YesNoResponse(decision.id, rng.nextBoolean())
+
+            is BatchYesNoDecision -> BatchYesNoResponse(decision.id, choice = rng.nextBoolean(), applyToAll = true)
+
+            is ChooseReplacementDecision -> {
+                val fromIndex = rng.nextInt(decision.fromOptions.size)
+                val allowed = decision.allowedToByFrom.getOrNull(fromIndex)
+                val toIndex = if (allowed != null && allowed.isNotEmpty()) allowed[rng.nextInt(allowed.size)]
+                else rng.nextInt(decision.toOptions.size)
+                ReplacementChosenResponse(decision.id, fromIndex, toIndex)
+            }
+
+            is ChooseModeDecision -> {
+                val available = decision.modes.filter { it.available }
+                val count = rng.nextInt(decision.minModes, decision.maxModes + 1).coerceAtMost(available.size)
+                ModesChosenResponse(decision.id, available.shuffled(rng).take(count).map { it.index })
+            }
+
+            is ChooseColorDecision -> {
+                val colors = decision.availableColors.toList()
+                ColorChosenResponse(decision.id, colors[rng.nextInt(colors.size)])
+            }
+
+            is ChooseNumberDecision ->
+                NumberChosenResponse(decision.id, rng.nextInt(decision.minValue, decision.maxValue + 1))
+
+            is DistributeDecision -> {
+                val dist = mutableMapOf<EntityId, Int>()
+                var remaining = decision.totalAmount
+                for (target in decision.targets) {
+                    dist[target] = decision.minPerTarget
+                    remaining -= decision.minPerTarget
+                }
+                while (remaining > 0 && decision.targets.isNotEmpty()) {
+                    val target = decision.targets[rng.nextInt(decision.targets.size)]
+                    dist[target] = (dist[target] ?: 0) + 1
+                    remaining--
+                }
+                DistributionResponse(decision.id, dist)
+            }
+
+            is OrderObjectsDecision ->
+                OrderedResponse(decision.id, decision.objects.shuffled(rng))
+
+            is SplitPilesDecision -> {
+                val shuffled = decision.cards.shuffled(rng)
+                val splitPoint = if (shuffled.size > 1) rng.nextInt(1, shuffled.size) else 1
+                PilesSplitResponse(decision.id, listOf(shuffled.take(splitPoint), shuffled.drop(splitPoint)))
+            }
+
+            is ChooseOptionDecision ->
+                OptionChosenResponse(decision.id, rng.nextInt(decision.options.size))
+
+            is AssignDamageDecision ->
+                DamageAssignmentResponse(decision.id, decision.defaultAssignments)
+
+            is CombatResolutionDecision ->
+                CombatResolutionResponse(decision.id, decision.edges.map { DamageEdgeAmount(it.id, it.amount) })
+
+            is BudgetModalDecision -> {
+                val selected = mutableListOf<Int>()
+                var budget = decision.budget
+                val affordable = decision.modes.withIndex().filter { it.value.cost <= budget }
+                if (affordable.isNotEmpty()) {
+                    val pick = affordable[rng.nextInt(affordable.size)]
+                    selected.add(pick.index)
+                    budget -= pick.value.cost
+                }
+                BudgetModalResponse(decision.id, selected)
+            }
+
+            is SearchLibraryDecision -> {
+                val count = rng.nextInt(decision.minSelections, decision.maxSelections + 1)
+                    .coerceAtMost(decision.options.size)
+                CardsSelectedResponse(decision.id, decision.options.shuffled(rng).take(count))
+            }
+
+            is ReorderLibraryDecision ->
+                OrderedResponse(decision.id, decision.cards.shuffled(rng))
+
+            is SelectManaSourcesDecision ->
+                ManaSourcesSelectedResponse(decision.id, emptyList(), autoPay = true)
+        }
+    }
+
+    private fun generateSealedPool(nonBasics: List<CardDefinition>, rng: Random): List<CardDefinition> {
+        val commons = nonBasics.filter { it.metadata.rarity == Rarity.COMMON }
+        val uncommons = nonBasics.filter { it.metadata.rarity == Rarity.UNCOMMON }
+        val rares = nonBasics.filter { it.metadata.rarity == Rarity.RARE }
+        val mythics = nonBasics.filter { it.metadata.rarity == Rarity.MYTHIC }
+
+        val pool = mutableListOf<CardDefinition>()
+        repeat(6) {
+            val usedNames = mutableSetOf<String>()
+            fun pick(from: List<CardDefinition>): CardDefinition? {
+                val available = from.filter { it.name !in usedNames }
+                if (available.isEmpty()) return null
+                return available[rng.nextInt(available.size)].also { usedNames.add(it.name) }
+            }
+            repeat(11) { pick(commons)?.let { pool.add(it) } }
+            repeat(3) { pick(uncommons)?.let { pool.add(it) } }
+            val rare = if (mythics.isNotEmpty() && rng.nextDouble() < 0.125) pick(mythics) else null
+            (rare ?: pick(rares) ?: pick(uncommons) ?: pick(commons))?.let { pool.add(it) }
+        }
+        return pool
+    }
+}


### PR DESCRIPTION
## Problem

Two issues with game replays, both surfaced from a real cut-off replay (`31ff7387-…`, Edge of Eternities): the game finished with a recorded winner, but playback stopped at turn 6 with both players still at 20 life after exactly `snapshotCount: 200` frames — and the reconstructed JSON sent to the client was ~1.1 MB.

## A — "only part of a replay is saved" (the truncation)

Persistent **yields** — the MTGO-style right-click *"always answer yes/no"* / *"yield"* preferences — are written into `GameState` and **consumed by the pure engine** when it auto-answers an optional trigger's may-question (`TriggerProcessor`/`GatedEffectExecutor` read `state.autoAnswerFor(...)`, emitting `AbilityAutoAnsweredEvent`). But they were **never part of the recorded action stream** — they're applied out-of-band via `GameState.withYield`.

So a game where a player set such a yield re-simulates differently:

- **Live:** the yielded trigger is auto-answered inside `process()` — no `GameAction` recorded.
- **Reconstruction:** starts with no yields → the engine *pauses* for that trigger → the next recorded action is illegal → `ReplayReconstructor` silently truncates to the last good frame.

Because `snapshotCount` is the *reconstructed* frame count, the truncation is invisible from the response and the viewer just stops mid-game even though a winner was saved. This is "sometimes" (only when a player yields) and EOE-heavy (swarming with optional *"may"* triggers: Void, reflexive ETBs, dies-triggers).

**Fix:** capture every yield mutation in turn order against the action count (`CompactReplay.yields` / `ReplayYieldEntry`) and re-apply each at the exact action position during reconstruction, so the engine's auto-answers reproduce. Threaded through `GameSession` recording (incl. undo truncation + restart restore) and the persisted snapshot. **Back-compatible:** replays without yields decode to an empty list = today's behavior, no version bump.

## B — payload size

The replay REST endpoints reconstruct the full snapshot+delta stream on demand — ~1 MB of highly repetitive JSON for a long game (the same card objects, `rulings`, and both players' full blocks repeat every frame). Enabled **gzip HTTP response compression** (`server.compression`); it compresses ~90%, taking the wire payload to **~100 KB**. Only applies to large responses when the client sends `Accept-Encoding: gzip`; the WebSocket path is untouched.

Further structural cuts (stripping static `rulings`, not re-sending unchanged player blocks) would shrink the *uncompressed* size too but touch the shared card DTO — left as follow-ups.

## Tests

- New deterministic test: *a persistent yield set mid-game is captured and reproduced on reconstruction* (proves the yield survives recording → codec round-trip → reconstruction).
- The random fidelity harness (`ReplayDivergenceReproTest`) now records + replays yields and round-trips them through the codec, across EOE + recent sets.
- Full `:game-server:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)