### PR TITLE
Add draft/sealed archetypes for Final Fantasy (FIN)

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
@@ -330,6 +330,33 @@ object SetArchetypes {
                     creatureTypes = listOf("Shapeshifter")),
             )
         ),
+        "FIN" to SetSynergies(
+            setCode = "FIN",
+            setName = "Final Fantasy",
+            archetypes = listOf(
+                Archetype("Artifacts", listOf(Color.WHITE, Color.BLUE),
+                    "Flood the board with artifacts — Equipment, Treasures, and artifact creatures — then cash in go-wide payoffs while card filtering keeps the gas flowing. A tempo-value deck that snowballs as its trinkets pile up."),
+                Archetype("Sacrifice", listOf(Color.WHITE, Color.BLACK),
+                    "Feed a steady stream of creatures and tokens to sacrifice outlets, wringing two-for-one value and drain out of everything that dies. A grindy attrition deck built on the set's villains."),
+                Archetype("Equipment Aggro", listOf(Color.WHITE, Color.RED),
+                    "Suit up aggressive creatures with Equipment — much of it attached to a body already — and push damage through with combat keywords like double strike. A fast go-tall aggro deck that's hard to block profitably."),
+                Archetype("Go-Wide Tokens", listOf(Color.WHITE, Color.GREEN),
+                    "Summons and lower-rarity Eikons flood the board with tokens, then mass pump and anthem effects close the game before attrition sets in. A go-wide aggro deck that ends games early."),
+                Archetype("Control", listOf(Color.BLUE, Color.BLACK),
+                    "Prolong the game with removal and counters, recurring your spells with flashback before taking over with powerful late-game bombs. A grindy control deck that out-values the table."),
+                Archetype("Big Spells", listOf(Color.BLUE, Color.RED),
+                    "Lean on expensive instants and sorceries, where spending four or more mana on a noncreature spell unlocks extra value. A spell-velocity tempo deck that rewards going big."),
+                Archetype("Towns Ramp", listOf(Color.BLUE, Color.GREEN),
+                    "Play Towns and other nonbasic lands for repeatable value, ramping into the format's largest threats. A two-for-one ramp deck that out-resources opponents in the late game."),
+                Archetype("Black Mages", listOf(Color.BLACK, Color.RED),
+                    "A cheap removal package spits out Wizard tokens that add reach and combat math, recreating the Black Mage dream of slinging elemental damage. An aggressive tempo deck backed by relentless burn.",
+                    creatureTypes = listOf("Wizard")),
+                Archetype("Graveyard", listOf(Color.BLACK, Color.GREEN),
+                    "Fill your graveyard, then grind the game out with recursion and graveyard payoffs that flip into game-ending threats. A patient value-midrange that simply refuses to stay dead."),
+                Archetype("Landfall", listOf(Color.RED, Color.GREEN),
+                    "Trigger landfall every time a land enters, turning even late-game land draws into damage with angry Chocobos and big beaters. A ramp-and-aggro deck that overwhelms with raw board presence."),
+            )
+        ),
     )
 
     /** Get archetypes for a specific set code, or null if not found. */

--- a/web-client/src/components/draft/SetSynergiesOverlay.tsx
+++ b/web-client/src/components/draft/SetSynergiesOverlay.tsx
@@ -738,6 +738,73 @@ const SET_SYNERGIES: Record<string, SetSynergies> = {
       },
     ],
   },
+  FIN: {
+    setCode: 'FIN',
+    setName: 'Final Fantasy',
+    archetypes: [
+      {
+        name: 'Artifacts',
+        colors: ['W', 'U'],
+        keyCard: 'Cid, Timeless Artificer',
+        description: 'Flood the board with artifacts — Equipment, Treasures, and artifact creatures — then cash in go-wide payoffs while card filtering keeps the gas flowing. A tempo-value deck that snowballs as its trinkets pile up.',
+      },
+      {
+        name: 'Sacrifice',
+        colors: ['W', 'B'],
+        keyCard: 'Judge Magister Gabranth',
+        description: "Feed a steady stream of creatures and tokens to sacrifice outlets, wringing two-for-one value and drain out of everything that dies. A grindy attrition deck built on the set's villains.",
+      },
+      {
+        name: 'Equipment Aggro',
+        colors: ['W', 'R'],
+        keyCard: 'Adelbert Steiner',
+        description: "Suit up aggressive creatures with Equipment — much of it attached to a body already — and push damage through with combat keywords like double strike. A fast go-tall aggro deck that's hard to block profitably.",
+      },
+      {
+        name: 'Go-Wide Tokens',
+        colors: ['W', 'G'],
+        keyCard: 'Rinoa Heartilly',
+        description: 'Summons and lower-rarity Eikons flood the board with tokens, then mass pump and anthem effects close the game before attrition sets in. A go-wide aggro deck that ends games early.',
+      },
+      {
+        name: 'Control',
+        colors: ['U', 'B'],
+        keyCard: "Jill, Shiva's Dominant",
+        description: 'Prolong the game with removal and counters, recurring your spells with flashback before taking over with powerful late-game bombs. A grindy control deck that out-values the table.',
+      },
+      {
+        name: 'Big Spells',
+        colors: ['U', 'R'],
+        keyCard: 'Tellah, Great Sage',
+        description: 'Lean on expensive instants and sorceries, where spending four or more mana on a noncreature spell unlocks extra value. A spell-velocity tempo deck that rewards going big.',
+      },
+      {
+        name: 'Towns Ramp',
+        colors: ['U', 'G'],
+        keyCard: 'Ignis Scientia',
+        description: "Play Towns and other nonbasic lands for repeatable value, ramping into the format's largest threats. A two-for-one ramp deck that out-resources opponents in the late game.",
+      },
+      {
+        name: 'Black Mages',
+        colors: ['B', 'R'],
+        creatureTypes: ['Wizard'],
+        keyCard: 'Black Waltz No. 3',
+        description: 'A cheap removal package spits out Wizard tokens that add reach and combat math, recreating the Black Mage dream of slinging elemental damage. An aggressive tempo deck backed by relentless burn.',
+      },
+      {
+        name: 'Graveyard',
+        colors: ['B', 'G'],
+        keyCard: 'Jenova, Ancient Calamity',
+        description: 'Fill your graveyard, then grind the game out with recursion and graveyard payoffs that flip into game-ending threats. A patient value-midrange that simply refuses to stay dead.',
+      },
+      {
+        name: 'Landfall',
+        colors: ['R', 'G'],
+        keyCard: 'Sazh Katzroy',
+        description: 'Trigger landfall every time a land enters, turning even late-game land draws into damage with angry Chocobos and big beaters. A ramp-and-aggro deck that overwhelms with raw board presence.',
+      },
+    ],
+  },
 }
 
 /**


### PR DESCRIPTION
## Summary

The Final Fantasy set (`FIN`) was missing from both the backend `SetArchetypes.kt` and the frontend `SetSynergiesOverlay.tsx`, so the draft/sealed **Archetypes** overlay and the AI deckbuilder had no synergy data for the format. This adds all ten two-color Limited archetypes, kept in lockstep across both files (same names, colors, and descriptions).

## Archetypes

| Colors | Name | Theme |
|--------|------|-------|
| WU | Artifacts | Go-wide artifacts + filtering |
| WB | Sacrifice | Two-for-one sac value (the villains) |
| WR | Equipment Aggro | Equipment-with-a-body beatdown |
| WG | Go-Wide Tokens | Summons/Eikons flood the board |
| UB | Control | Removal, counters, flashback recursion |
| UR | Big Spells | 4+ mana noncreature payoffs |
| UG | Towns Ramp | Towns/nonbasics into big threats |
| BR | Black Mages | Removal package + Wizard tokens (`creatureTypes`) |
| BG | Graveyard | Recursion that flips into finishers |
| RG | Landfall | Land drops + angry Chocobos |

Archetype themes and signpost cards were sourced from the published FIN Limited guides. Each frontend entry's `keyCard` names a real FIN signpost card (verified against the set's card definitions) so the tile art crop resolves; **Black Mages** carries `creatureTypes = ["Wizard"]` for the in-pool counter.

## Verification

- `web-client` `npm run typecheck` — clean.
- `:ai:compileKotlin` — `BUILD SUCCESSFUL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)