### PR TITLE
Add three Final Fantasy cards: The Lunar Whale, Beatrix, Louisoix's Sacrifice

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -362,14 +362,14 @@ Implemented (all pure authoring, no engine change):
   "whenever a Mutant you control dies during your turn, draw cards equal to its power"
   (`Triggers.leavesBattlefield` filtered to Mutants + `Conditions.IsYourTurn` + `DynamicAmounts.triggeringPower`).
 
-Deferred (needs `add-feature`, not pure authoring):
-- **The Lunar Whale** (#60) — Vehicle; Flying/Crew 1 + "you may look at the top card" + "as long as it
-  attacked this turn, you may play the top card of your library." The look-at-top and the conditional
-  *cast* permission compose today via `LookAtTopOfLibrary` and
-  `ConditionalStaticAbility(PlayFromTopOfLibrary, Conditions.SourceAttackedThisTurn)`, **but playing a
-  *land* from the top is blocked**: `PlayLandHandler.hasPlayFromTopOfLibrary` only matches a bare
-  `PlayFromTopOfLibrary` static and never unwraps `ConditionalStaticAbility` (it special-cases only
-  `MayPlayLandsFromGraveyard`). Fix is a small reusable engine change — unwrap
-  `ConditionalStaticAbility` around `PlayFromTopOfLibrary`/`PlayLandsAndCastFilteredFromTopOfLibrary`
-  in `PlayLandHandler` (and mirror in `CastPermissionUtils.hasPlayFromTopOfLibrary`), evaluating the
-  gating condition — exactly like the existing graveyard-play conditional handling.
+Resolved (was deferred):
+- **The Lunar Whale** (#60) — ✅ implemented. Vehicle; Flying/Crew 1 + `LookAtTopOfLibrary` +
+  `ConditionalStaticAbility(PlayLandsAndCastFilteredFromTopOfLibrary(GameObjectFilter.Any),
+  Conditions.SourceAttackedThisTurn)`. The non-revealing "play the top card" (any type) is modeled as
+  the filtered play-top permission with an unrestricted `GameObjectFilter.Any` spell filter. The engine
+  change that unblocked it: the four play/cast-from-top readers — `CastPermissionUtils.hasPlayLandsFromTopOfLibrary`
+  / `getCastFilteredFromTopOfLibraryFilter`, `PlayLandHandler.hasPlayFromTopOfLibrary`, and
+  `CastZoneResolver.hasCastFromTopOfLibraryPermission` — now unwrap `ConditionalStaticAbility` and
+  evaluate the gate against the granting permanent (mirroring the existing graveyard-play / equip
+  conditional handling), so the land-play and spell-cast paths both honor the "attacked this turn"
+  gate. Scenario test: `TheLunarWhaleScenarioTest`.

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -289,6 +289,17 @@ definitions construct these through the facade, e.g. `Costs.additional.Sacrifice
   folded in). The chosen path is recovered at payment time from whether the cast action's
   `additionalCostPayment.exiledCards` is non-empty; the exile path is only offered when the
   graveyard holds at least `exileCount` matching cards.
+- `Costs.additional.SacrificeOrPay(filter = Filters.Any, alternativeManaCost, count = 1)` — "as an
+  additional cost to cast this spell, sacrifice a [filter] or pay {mana}" (Louisoix's Sacrifice:
+  "sacrifice a legendary creature or pay {2}"). The sibling of `ExileFromGraveyardOrPay` /
+  `BlightOrPay` / `BeholdOrPay` for the "sacrifice a permanent or pay mana" shape. The enumerator
+  offers up to two cast paths: the **sacrifice path** (base cost + a battlefield selection of
+  exactly `count` permanents you control matching `filter`, surfaced as a `costType =
+  "SacrificePermanent"` cost — the same on-battlefield picker used by a plain sacrifice cost like
+  Natural Order) and the **pay path** (base cost + `alternativeManaCost` folded in). The chosen path
+  is recovered at payment time from whether the cast action's `additionalCostPayment.sacrificedPermanents`
+  is non-empty; the sacrifice path is only offered when you control at least `count` matching
+  permanents, so with nothing to sacrifice only the pay path is castable.
 
 **`Costs.pay.*`** (wraps `PayCost`) — payable costs used by [`PayOrSufferEffect`](#15-replacement-effects) ("do X
 unless you Y") and by `morphCost` (non-mana face-up cost). Distinct from `AbilityCost` / `Costs.*`
@@ -3777,8 +3788,13 @@ concerns — the `ClientStateTransformer` reveals the top card for `PlayFromTopO
 - `PlayFromTopOfLibrary` — public reveal **and** "play lands and cast spells from the top of your
   library" (all card types). (Future Sight)
 - `PlayLandsAndCastFilteredFromTopOfLibrary(spellFilter)` — like `PlayFromTopOfLibrary` but only
-  spells matching `spellFilter` are castable (lands always playable). (Glarb, Calamity's Augur =
-  `GameObjectFilter.Any.manaValueAtLeast(4)`)
+  spells matching `spellFilter` are castable (lands always playable), and **no public reveal** (pair
+  with `LookAtTopOfLibrary` to let just the controller see). `spellFilter = GameObjectFilter.Any`
+  means "play the top card" of any type non-revealingly. (Glarb, Calamity's Augur =
+  `GameObjectFilter.Any.manaValueAtLeast(4)`; The Lunar Whale = `GameObjectFilter.Any`.) Honors a
+  `ConditionalStaticAbility` wrapper — the play/cast-from-top readers unwrap the conditional and
+  evaluate its gate against the granting permanent, so the permission can be time-restricted (The
+  Lunar Whale: `condition = Conditions.SourceAttackedThisTurn` — only after the Whale attacked).
 - `CastSpellTypesFromTopOfLibrary(filter)` — cast only matching spell types from the top; no land
   play, no full public reveal. (Precognition Field = instants/sorceries)
 - `LookAtTopOfLibrary` — *private*: the controller may look at their own top card any time (revealed

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -416,6 +416,17 @@ object Costs {
         ): AdditionalCost =
             AdditionalCost.ExileFromGraveyardOrPay(exileCount, alternativeManaCost, filter)
 
+        /**
+         * Sacrifice [count] permanent(s) matching [filter] you control, or pay
+         * [alternativeManaCost] instead (Louisoix's Sacrifice).
+         */
+        fun SacrificeOrPay(
+            filter: GameObjectFilter = GameObjectFilter.Any,
+            alternativeManaCost: String,
+            count: Int = 1,
+        ): AdditionalCost =
+            AdditionalCost.SacrificeOrPay(filter, alternativeManaCost, count)
+
         /** "Behold a [filter] and exile it" — [Behold] + [ExileFromStorage] composed. */
         fun BeholdAndExile(
             filter: GameObjectFilter,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/AdditionalCost.kt
@@ -328,6 +328,53 @@ sealed interface AdditionalCost : TextReplaceable<AdditionalCost> {
     }
 
     /**
+     * Sacrifice [count] permanent(s) matching [filter] you control, or pay additional mana: the
+     * caster must either sacrifice that many matching permanents, or pay extra mana on top of the
+     * spell's base mana cost. The sibling of [BlightOrPay] / [BeholdOrPay] /
+     * [ExileFromGraveyardOrPay] for the "sacrifice a permanent or pay" shape (e.g. Louisoix's
+     * Sacrifice — "sacrifice a legendary creature or pay {2}").
+     *
+     * The enumerator produces up to two legal actions: one for the sacrifice path (base cost +
+     * permanent selection from the battlefield, surfaced with `costType = "SacrificePermanent"`
+     * like Natural Order's plain sacrifice cost) and one for the pay path (base cost +
+     * [alternativeManaCost]). The sacrifice path is only offered when the caster controls at least
+     * [count] permanents matching [filter]. The chosen path is recovered at payment time from
+     * whether [AdditionalCostPayment.sacrificedPermanents] is non-empty.
+     *
+     * @property filter Which permanents you control qualify (e.g. legendary creature)
+     * @property alternativeManaCost Extra mana to pay instead of sacrificing (e.g. "{2}")
+     * @property count How many matching permanents to sacrifice on the sacrifice path
+     */
+    @SerialName("SacrificeOrPay")
+    @Serializable
+    data class SacrificeOrPay(
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val alternativeManaCost: String,
+        val count: Int = 1,
+    ) : AdditionalCost {
+        override val description: String = buildString {
+            append("Sacrifice ")
+            if (count == 1) {
+                val filterDesc = filter.description
+                val article = if (filterDesc.firstOrNull()?.lowercase() in listOf("a", "e", "i", "o", "u")) "an" else "a"
+                append("$article ")
+                append(filterDesc)
+            } else {
+                append("$count ")
+                append(filter.description)
+                append("s")
+            }
+            append(" or pay ")
+            append(alternativeManaCost)
+        }
+
+        override fun applyTextReplacement(replacer: TextReplacer): AdditionalCost {
+            val newFilter = filter.applyTextReplacement(replacer)
+            return if (newFilter !== filter) copy(filter = newFilter) else this
+        }
+    }
+
+    /**
      * Exile cards from a named pipeline collection and optionally link them to the
      * source spell/permanent via LinkedExileComponent.
      *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BeatrixLoyalGeneral.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BeatrixLoyalGeneral.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachInCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Beatrix, Loyal General
+ * {4}{W}{W}
+ * Legendary Creature — Human Soldier
+ * 4/4
+ * Vigilance
+ * At the beginning of combat on your turn, you may attach any number of Equipment you control
+ * to target creature you control.
+ *
+ * Implementation notes — this is pure composition over existing primitives, no new engine type:
+ *
+ *  - **Trigger** — [Triggers.BeginCombat] is "at the beginning of combat on your turn"
+ *    (`StepEvent(BEGIN_COMBAT, Player.You)`).
+ *  - **"you may"** — a [MayEffect] wrapper: one yes/no decided up front (before targeting); "no"
+ *    skips the whole effect. Beatrix always controls at least herself, so a legal target always
+ *    exists and the may-question is always asked.
+ *  - **Target** — only the creature is a *target* (the oracle says "target creature you control");
+ *    the Equipment are **not** targeted ("any number of Equipment you control" — no "target"), so
+ *    they are chosen at resolution, not when the ability goes on the stack. A required single
+ *    target means an illegal target by resolution fizzles the ability (CR 608.2c).
+ *  - **Any number** — a resolution-time `chooseAnyNumber` (0..all) over the Equipment you control,
+ *    then [ForEachInCollectionEffect] runs [Effects.AttachTargetEquipmentToCreature] once per
+ *    chosen Equipment — `EffectTarget.Self` binds to each iterated Equipment, `ContextTarget(0)`
+ *    to the target creature. The attach executor detaches each Equipment from its current host
+ *    first, so re-attaching an already-equipped Equipment is correct.
+ *
+ * Edge cases: choosing zero Equipment (or controlling none) makes the iteration a no-op — the
+ * legitimate way to decline beyond the "may"; the target creature may be Beatrix herself.
+ *
+ * Per the 2025-06-06 ruling, an Equipment that can't legally be attached to the target creature
+ * (e.g. an Equipment that may only be attached to a specific kind of creature) can't be chosen;
+ * the engine performs only legal attaches.
+ */
+val BeatrixLoyalGeneral = card("Beatrix, Loyal General") {
+    manaCost = "{4}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "At the beginning of combat on your turn, you may attach any number of Equipment you " +
+        "control to target creature you control."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        // "you may …" — a single yes/no decided before targeting; declining skips the whole effect.
+        effect = MayEffect(
+            Effects.Pipeline {
+                // Look at the Equipment you control; choose any number of them.
+                val equipment = gather(
+                    GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT),
+                    player = Player.You
+                )
+                val chosen = chooseAnyNumber(
+                    from = equipment,
+                    useTargetingUI = true,
+                    prompt = "Choose any number of Equipment you control to attach to the target creature"
+                )
+                // Attach each chosen Equipment to the target creature.
+                run(
+                    ForEachInCollectionEffect(
+                        collection = chosen.key,
+                        effect = Effects.AttachTargetEquipmentToCreature(
+                            equipmentTarget = EffectTarget.Self,
+                            creatureTarget = creature
+                        )
+                    )
+                )
+            }
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "554"
+        artist = "Bachzim"
+        flavorText = "\"I commend your courage, but I will show you no mercy.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9da83b07-4978-4af7-be51-8aa8f35ec0bb.jpg?1782686128"
+
+        ruling("2025-06-06", "You can't use Beatrix's last ability to try to attach an Equipment to a creature if that Equipment can't legally be attached to that creature.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LouisoixsSacrifice.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/LouisoixsSacrifice.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Louisoix's Sacrifice — Final Fantasy #59
+ * {U} · Instant
+ *
+ * As an additional cost to cast this spell, sacrifice a legendary creature or pay {2}.
+ * Counter target activated ability, triggered ability, or noncreature spell.
+ *
+ * The additional cost is the alternative "sacrifice a [filter] or pay {N}" shape, modeled with
+ * [Costs.additional.SacrificeOrPay]: the enumerator offers two cast paths — sacrifice a legendary
+ * creature you control (base {U}), or pay {2} on top of the base cost. With no legendary creature
+ * to sacrifice, only the pay path is offered (CR 601.2b/f — the player picks which way to pay).
+ *
+ * The target is the union "(any activated/triggered ability) OR (noncreature spell)" — a creature
+ * spell is NOT a legal target, while abilities and noncreature spells are. Expressed as
+ * [TargetFilter.anyOf] of the prebuilt stack-ability and noncreature-spell clauses; the targeting
+ * system enumerates each clause and unions the results (TargetFinder), and the counter dispatches
+ * by what's actually on the stack at resolution via [Effects.CounterSpellOrAbility].
+ */
+val LouisoixsSacrifice = card("Louisoix's Sacrifice") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "As an additional cost to cast this spell, sacrifice a legendary creature or pay {2}.\n" +
+        "Counter target activated ability, triggered ability, or noncreature spell."
+
+    additionalCost(
+        Costs.additional.SacrificeOrPay(
+            filter = GameObjectFilter.Creature.legendary(),
+            alternativeManaCost = "{2}",
+        )
+    )
+
+    spell {
+        target = TargetObject(
+            filter = TargetFilter.anyOf(
+                TargetFilter.ActivatedOrTriggeredAbilityOnStack,
+                TargetFilter.NoncreatureSpellOnStack,
+            )
+        )
+        effect = Effects.CounterSpellOrAbility()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "59"
+        artist = "Mintautas Šukys"
+        flavorText = "\"Thank you... for everything... Pray take your rest, Grandfather... You deserve it.\"\n" +
+            "—Alisaie Leveilleur"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4a6976f2-0bd5-449a-8fcf-f5a732ce22c1.jpg?1782686550"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheLunarWhale.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheLunarWhale.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
+
+/**
+ * The Lunar Whale
+ * {3}{U}
+ * Legendary Artifact — Vehicle
+ * 3/5
+ *
+ * Flying
+ * You may look at the top card of your library any time.
+ * As long as The Lunar Whale attacked this turn, you may play the top card of your library.
+ * Crew 1
+ *
+ * The "play the top card" permission is non-revealing — only the controller sees the top card
+ * (via [LookAtTopOfLibrary]); it is NOT publicly revealed like Future Sight's
+ * [com.wingedsheep.sdk.scripting.PlayFromTopOfLibrary]. "Play the top card" (any card type) is
+ * modeled as [PlayLandsAndCastFilteredFromTopOfLibrary] with an unrestricted [GameObjectFilter.Any]
+ * spell filter — play lands and cast any spell from the top — gated by a
+ * [Conditions.SourceAttackedThisTurn] conditional static so the permission only applies after the
+ * Whale has attacked this turn.
+ */
+val TheLunarWhale = card("The Lunar Whale") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Artifact — Vehicle"
+    power = 3
+    toughness = 5
+    oracleText = "Flying\n" +
+        "You may look at the top card of your library any time.\n" +
+        "As long as The Lunar Whale attacked this turn, you may play the top card of your library.\n" +
+        "Crew 1"
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+
+    staticAbility {
+        condition = Conditions.SourceAttackedThisTurn
+        ability = PlayLandsAndCastFilteredFromTopOfLibrary(spellFilter = GameObjectFilter.Any)
+    }
+
+    keywordAbility(KeywordAbility.Numeric(Keyword.CREW, 1))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "60"
+        artist = "Fiona Hsieh"
+        imageUri = "https://cards.scryfall.io/normal/front/a/e/ae875471-346c-4a76-b26f-b7205dad5b80.jpg?1782686550"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1526,6 +1526,97 @@
     ]
 }
 
+// Beatrix, Loyal General
+{
+    "name": "Beatrix, Loyal General",
+    "manaCost": "{4}{W}{W}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nAt the beginning of combat on your turn, you may attach any number of Equipment you control to target creature you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "BattlefieldMatching",
+                                    "filter": "artifact Equipment",
+                                    "player": "You"
+                                },
+                                "storeAs": "gathered0"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "gathered0",
+                                "selection": "ChooseAnyNumber",
+                                "storeSelected": "selected1",
+                                "prompt": "Choose any number of Equipment you control to attach to the target creature",
+                                "useTargetingUI": true
+                            },
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Collection",
+                                    "collection": "selected1"
+                                },
+                                "body": {
+                                    "type": "AttachTargetEquipmentToCreature",
+                                    "equipmentTarget": "Self",
+                                    "creatureTarget": {
+                                        "type": "BoundVariable",
+                                        "name": "target creature you control"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "554",
+        "rarity": "RARE",
+        "artist": "Bachzim",
+        "flavorText": "\"I commend your courage, but I will show you no mercy.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9da83b07-4978-4af7-be51-8aa8f35ec0bb.jpg?1782686128",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "You can't use Beatrix's last ability to try to attach an Equipment to a creature if that Equipment can't legally be attached to that creature."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Black Mage's Rod
 {
     "name": "Black Mage's Rod",
@@ -8732,6 +8823,61 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Louisoix's Sacrifice
+{
+    "name": "Louisoix's Sacrifice",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "As an additional cost to cast this spell, sacrifice a legendary creature or pay {2}.\nCounter target activated ability, triggered ability, or noncreature spell.",
+    "script": {
+        "spellEffect": {
+            "type": "Counter",
+            "target": "CounterTarget.SpellOrAbility"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsActivatedOrTriggeredAbility"
+                        ]
+                    },
+                    "zone": "Stack",
+                    "alternatives": [
+                        {
+                            "baseFilter": "noncreature",
+                            "zone": "Stack"
+                        }
+                    ]
+                }
+            }
+        ],
+        "additionalCosts": [
+            {
+                "type": "SacrificeOrPay",
+                "filter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        "IsLegendary"
+                    ]
+                },
+                "alternativeManaCost": "{2}"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "RARE",
+        "artist": "Mintautas Šukys",
+        "flavorText": "\"Thank you... for everything... Pray take your rest, Grandfather... You deserve it.\"\n—Alisaie Leveilleur",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4a6976f2-0bd5-449a-8fcf-f5a732ce22c1.jpg?1782686550"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -17064,6 +17210,59 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/3/5363c881-443d-43df-afd8-f81e1a1741a2.jpg?1748706827"
     },
     "colorIdentityOverride": []
+}
+
+// The Lunar Whale
+{
+    "name": "The Lunar Whale",
+    "manaCost": "{3}{U}",
+    "typeLine": "Legendary Artifact — Vehicle",
+    "oracleText": "Flying\nYou may look at the top card of your library any time.\nAs long as The Lunar Whale attacked this turn, you may play the top card of your library.\nCrew 1",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 1
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "PlayLandsAndCastFilteredFromTopOfLibrary",
+                    "spellFilter": {}
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "AttackedThisTurn"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "rarity": "RARE",
+        "artist": "Fiona Hsieh",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/e/ae875471-346c-4a76-b26f-b7205dad5b80.jpg?1782686550"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
 }
 
 // The Prima Vista

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -944,6 +944,10 @@ class CostHandler(
                 // Always payable: player can always choose the "pay mana" path
                 true
             }
+            is AdditionalCost.SacrificeOrPay -> {
+                // Always payable: player can always choose the "pay mana" path
+                true
+            }
             is AdditionalCost.RemoveCountersFromYourCreatures -> {
                 val projected = state.projectedState
                 val total = state.getBattlefield().sumOf { permId ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -465,10 +465,16 @@ class PlayLandHandler(
         for (entityId in state.getBattlefield(playerId)) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.any {
-                it is PlayFromTopOfLibrary || it is PlayLandsAndCastFilteredFromTopOfLibrary
-            }) {
-                return true
+            for (ability in cardDef.script.staticAbilities) {
+                // Honor a conditional gate (e.g. The Lunar Whale's "as long as it attacked this
+                // turn") against the granting permanent before allowing the land play from top.
+                val unwrapped = if (ability is ConditionalStaticAbility) {
+                    if (!evaluateStaticGate(state, ability.condition, entityId, playerId)) continue
+                    ability.ability
+                } else ability
+                if (unwrapped is PlayFromTopOfLibrary || unwrapped is PlayLandsAndCastFilteredFromTopOfLibrary) {
+                    return true
+                }
             }
         }
         return false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -545,6 +545,19 @@ class CastSpellHandler(
             }
         }
 
+        // Apply SacrificeOrPay "pay mana" adjustment in validation
+        if (cardDef != null && !playForFree) {
+            val sacOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.SacrificeOrPay>()
+                .firstOrNull()
+            if (sacOrPay != null) {
+                val choseSacrifice = action.additionalCostPayment?.sacrificedPermanents?.isNotEmpty() == true
+                if (!choseSacrifice) {
+                    effectiveCost = effectiveCost + ManaCost.parse(sacOrPay.alternativeManaCost)
+                }
+            }
+        }
+
         // Apply spell-level waterbend additional cost (Avatar: The Last Airbender). Adds the
         // waterbend amount {N} (or {X}) as generic mana; the tapped artifacts/creatures in
         // alternativePayment reduce that generic below, capped at N.
@@ -1506,6 +1519,31 @@ class CastSpellHandler(
                     }
                     // If exiledCards is empty, the player is paying extra mana instead
                 }
+                is AdditionalCost.SacrificeOrPay -> {
+                    // SacrificeOrPay: player chose the sacrifice path if sacrificedPermanents is
+                    // non-empty, otherwise they pay extra mana (validated via mana payment).
+                    val sacrificed = action.additionalCostPayment?.sacrificedPermanents ?: emptyList()
+                    if (sacrificed.isNotEmpty()) {
+                        if (sacrificed.size != additionalCost.count) {
+                            val spellName = state.getEntity(action.cardId)?.get<CardComponent>()?.name ?: "this spell"
+                            return "You must sacrifice exactly ${additionalCost.count} permanent(s) for $spellName"
+                        }
+                        val context = PredicateContext(controllerId = action.playerId)
+                        for (permId in sacrificed) {
+                            if (permId !in state.getBattlefield()) {
+                                return "Permanent to sacrifice is not on the battlefield"
+                            }
+                            if (projected.getController(permId) != action.playerId) {
+                                return "You can only sacrifice permanents you control"
+                            }
+                            if (!predicateEvaluator.matches(state, projected, permId, additionalCost.filter, context)) {
+                                val permName = state.getEntity(permId)?.get<CardComponent>()?.name ?: "Permanent"
+                                return "$permName doesn't match the required filter: ${additionalCost.filter.description}"
+                            }
+                        }
+                    }
+                    // If sacrificedPermanents is empty, the player is paying extra mana instead
+                }
                 is AdditionalCost.RemoveCountersFromYourCreatures -> {
                     // Web client sends a typed list of (entity, counterType, count)
                     // entries so the player picks which counter type comes off each
@@ -1804,6 +1842,20 @@ class CastSpellHandler(
                 val choseExile = action.additionalCostPayment?.exiledCards?.isNotEmpty() == true
                 if (!choseExile) {
                     effectiveCost = effectiveCost + ManaCost.parse(exileOrPay.alternativeManaCost)
+                }
+            }
+        }
+
+        // Apply SacrificeOrPay: if player chose the "pay mana" path (no sacrificed permanents),
+        // add the extra mana on top of the base cost.
+        if (cardDef != null && !playForFreeInExecute) {
+            val sacOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.SacrificeOrPay>()
+                .firstOrNull()
+            if (sacOrPay != null) {
+                val choseSacrifice = action.additionalCostPayment?.sacrificedPermanents?.isNotEmpty() == true
+                if (!choseSacrifice) {
+                    effectiveCost = effectiveCost + ManaCost.parse(sacOrPay.alternativeManaCost)
                 }
             }
         }
@@ -2265,6 +2317,42 @@ class CastSpellHandler(
                             ))
                         }
                         exiledCardCount += exiledCards.size
+                    }
+                    is AdditionalCost.SacrificeOrPay -> {
+                        // Sacrifice the chosen permanents if the player chose the sacrifice path.
+                        // If sacrificedPermanents is empty, "pay mana" path — extra mana already
+                        // added above. Mirrors the CostAtom.Sacrifice payment, including the
+                        // last-known-information snapshot (CR 112.7a / 608.2h) so a sacrificed
+                        // permanent's stats survive onto downstream effects/triggers.
+                        val sacrificed = action.additionalCostPayment.sacrificedPermanents
+                        if (sacrificed.isNotEmpty()) {
+                            val projectedBeforeSacrifice = currentState.projectedState
+                            sacrificedSnapshots.addAll(
+                                captureEntitySnapshots(sacrificed, projectedBeforeSacrifice)
+                            )
+                            for (permId in sacrificed) {
+                                val permContainer = currentState.getEntity(permId) ?: continue
+                                val permCard = permContainer.get<CardComponent>() ?: continue
+                                val controllerId = permContainer.get<ControllerComponent>()?.playerId ?: action.playerId
+                                val ownerId = permCard.ownerId ?: action.playerId
+                                val battlefieldZone = ZoneKey(controllerId, Zone.BATTLEFIELD)
+                                val graveyardZone = ZoneKey(ownerId, Zone.GRAVEYARD)
+
+                                currentState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                                    .trackPermanentSacrifice(currentState, listOf(permId), action.playerId)
+                                currentState = currentState.removeFromZone(battlefieldZone, permId)
+                                currentState = currentState.addToZone(graveyardZone, permId)
+
+                                events.add(PermanentsSacrificedEvent(action.playerId, listOf(permId), listOf(permCard.name)))
+                                events.add(ZoneChangeEvent(
+                                    entityId = permId,
+                                    entityName = permCard.name,
+                                    fromZone = Zone.BATTLEFIELD,
+                                    toZone = Zone.GRAVEYARD,
+                                    ownerId = ownerId
+                                ))
+                            }
+                        }
                     }
                     is AdditionalCost.RemoveCountersFromYourCreatures -> {
                         // Remove the chosen counters from the designated creatures.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastZoneResolver.kt
@@ -25,6 +25,7 @@ import com.wingedsheep.engine.state.components.player.MayCastCreaturesFromGravey
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
 import com.wingedsheep.sdk.scripting.GrantMayCastFromLinkedExile
@@ -431,11 +432,18 @@ class CastZoneResolver(
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             for (ability in cardDef.script.staticAbilities) {
-                if (ability is CastSpellTypesFromTopOfLibrary) {
-                    if (matchesCardFilter(cardComponent, ability.filter)) return true
+                // Honor a conditional gate (e.g. The Lunar Whale's "as long as it attacked this
+                // turn") against the granting permanent before allowing the cast from top.
+                val unwrapped = if (ability is ConditionalStaticAbility) {
+                    val ctx = EffectContext(sourceId = entityId, controllerId = playerId)
+                    if (!conditionEvaluator.evaluate(state, ability.condition, ctx)) continue
+                    ability.ability
+                } else ability
+                if (unwrapped is CastSpellTypesFromTopOfLibrary) {
+                    if (matchesCardFilter(cardComponent, unwrapped.filter)) return true
                 }
-                if (ability is PlayLandsAndCastFilteredFromTopOfLibrary) {
-                    if (matchesCardFilter(cardComponent, ability.spellFilter)) return true
+                if (unwrapped is PlayLandsAndCastFilteredFromTopOfLibrary) {
+                    if (matchesCardFilter(cardComponent, unwrapped.spellFilter)) return true
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -175,6 +175,8 @@ class CastSpellEnumerator : ActionEnumerator {
             var beholdOrPayTargets = emptyList<EntityId>()
             var exileOrPayCost: AdditionalCost.ExileFromGraveyardOrPay? = null
             var exileOrPayTargets = emptyList<EntityId>()
+            var sacOrPayCost: AdditionalCost.SacrificeOrPay? = null
+            var sacOrPayTargets = emptyList<EntityId>()
             var canPayAdditionalCosts = true
             val flattenedCosts = additionalCosts.flatMap {
                 if (it is AdditionalCost.Composite) it.steps else listOf(it)
@@ -319,6 +321,14 @@ class CastSpellEnumerator : ActionEnumerator {
                             state, playerId, cost.filter, Zone.GRAVEYARD
                         )
                     }
+                    is AdditionalCost.SacrificeOrPay -> {
+                        // Always payable: player can always choose the "pay mana" path.
+                        // Surface the permanents you control eligible for the sacrifice path.
+                        sacOrPayCost = cost
+                        sacOrPayTargets = context.costUtils.findSacrificeTargets(
+                            state, playerId, CostAtom.Sacrifice(cost.filter, cost.count)
+                        )
+                    }
                     is AdditionalCost.ChooseEntity -> {
                         // Search each (zone, filter) pair in `cost.zoneFilters`. Battlefield
                         // uses projected state (continuous effects matter); hidden / card
@@ -380,6 +390,12 @@ class CastSpellEnumerator : ActionEnumerator {
             val exileOrPayBaseCost = effectiveCost
             if (exileOrPayCost != null) {
                 effectiveCost = effectiveCost + ManaCost.parse(exileOrPayCost.alternativeManaCost)
+            }
+
+            // Save base cost for sacrifice path, then add extra mana for the "pay" path
+            val sacOrPayBaseCost = effectiveCost
+            if (sacOrPayCost != null) {
+                effectiveCost = effectiveCost + ManaCost.parse(sacOrPayCost.alternativeManaCost)
             }
 
             // Spell-level waterbend additional cost (Avatar: The Last Airbender). A *mandatory*
@@ -502,11 +518,17 @@ class CastSpellEnumerator : ActionEnumerator {
                 context.manaSolver.canPay(state, playerId, exileOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
             } else false
 
+            // Check sacrifice path affordability (base cost without the extra mana, but needs
+            // enough matching permanents on the battlefield to sacrifice).
+            val canAffordSacOrPayPath = if (sacOrPayCost != null && sacOrPayTargets.size >= sacOrPayCost.count) {
+                context.manaSolver.canPay(state, playerId, sacOrPayBaseCost, spellContext = spellContext, precomputedSources = cachedSources)
+            } else false
+
             // A `MayCastWithoutPayingManaCost` battlefield permission (e.g. Weftwalking) makes the
             // spell affordable for {0} when its gates are open. Emitted by its own branch below;
             // don't continue out before reaching it.
             val canAffordFreeCast = context.freeCastPermissionFor(cardId)
-            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordBlightPath && !canAffordBeholdPath && !canAffordExileOrPayPath && !canAffordFreeCast) {
+            if (!canAfford && !canAffordAlternative && !canAffordSelfAlternative && !canAffordEvoke && !canAffordImpending && !canAffordBlightPath && !canAffordBeholdPath && !canAffordExileOrPayPath && !canAffordSacOrPayPath && !canAffordFreeCast) {
                 // The primary face can't be paid for by any path. Normally we skip it entirely.
                 // But if this is an Adventure/Omen/modal-DFC card whose *secondary* face is
                 // affordable, surface a grayed-out placeholder for the primary face so the
@@ -587,6 +609,24 @@ class CastSpellEnumerator : ActionEnumerator {
                     exileMaxCount = exileOrPayCost.exileCount,
                 )
                 Triple(exileManaCostString, exileAutoTapPreview, exileCostInfo)
+            } else null
+
+            // Compute sacrifice path info (separate legal action with lower mana cost + permanent
+            // selection). Reuses the "SacrificePermanent" cost type so the client drives the same
+            // on-battlefield sacrifice selection used by Natural Order's plain sacrifice cost.
+            val sacOrPayPathInfo = if (canAffordSacOrPayPath && sacOrPayCost != null) {
+                val sacManaCostString = sacOrPayBaseCost.toString()
+                val sacAutoTapPreview = if (context.skipAutoTapPreview) null else {
+                    context.manaSolver.solve(state, playerId, sacOrPayBaseCost, precomputedSources = cachedSources)
+                        ?.sources?.map { it.entityId }
+                }
+                val sacCostInfo = AdditionalCostData(
+                    description = sacOrPayCost.description,
+                    costType = "SacrificePermanent",
+                    validSacrificeTargets = sacOrPayTargets,
+                    sacrificeCount = sacOrPayCost.count,
+                )
+                Triple(sacManaCostString, sacAutoTapPreview, sacCostInfo)
             } else null
 
             // Calculate X cost info if the spell has X in its cost (printed, or the waterbend {X}
@@ -1086,6 +1126,19 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = exileOrPayPathInfo.second
                             ))
                         }
+                        if (sacOrPayPathInfo != null) {
+                            result.add(LegalAction(
+                                actionType = "CastSpell",
+                                description = "Cast ${cardComponent.name} (Sacrifice)",
+                                action = CastSpell(playerId, cardId, targets = listOf(autoSelectedTarget)),
+                                additionalCostInfo = sacOrPayPathInfo.third,
+                                manaCostString = sacOrPayPathInfo.first,
+                                requiresDamageDistribution = requiresDamageDistribution,
+                                totalDamageToDistribute = totalDamageToDistribute,
+                                minDamagePerTarget = minDamagePerTarget,
+                                autoTapPreview = sacOrPayPathInfo.second
+                            ))
+                        }
                     } else {
                         if (canAfford) {
                             result.add(LegalAction(
@@ -1290,6 +1343,27 @@ class CastSpellEnumerator : ActionEnumerator {
                                 autoTapPreview = exileOrPayPathInfo.second
                             ))
                         }
+                        if (sacOrPayPathInfo != null) {
+                            result.add(LegalAction(
+                                actionType = "CastSpell",
+                                description = "Cast ${cardComponent.name} (Sacrifice)",
+                                action = CastSpell(playerId, cardId),
+                                validTargets = firstReqInfo.validTargets,
+                                requiresTargets = true,
+                                targetCount = firstReq.count,
+                                minTargets = firstReq.effectiveMinCount,
+                                targetDescription = firstReq.description,
+                                targetRequirements = if (targetReqInfos.size > 1) targetReqInfos else null,
+                                xConstrainsTargetManaValue = firstReqInfo.xConstrainsManaValue,
+                                xConstrainsTargetCount = firstReqInfo.xConstrainsCount,
+                                additionalCostInfo = sacOrPayPathInfo.third,
+                                manaCostString = sacOrPayPathInfo.first,
+                                requiresDamageDistribution = requiresDamageDistribution,
+                                totalDamageToDistribute = totalDamageToDistribute,
+                                minDamagePerTarget = minDamagePerTarget,
+                                autoTapPreview = sacOrPayPathInfo.second
+                            ))
+                        }
                     }
                 }
             } else {
@@ -1394,6 +1468,16 @@ class CastSpellEnumerator : ActionEnumerator {
                         additionalCostInfo = exileOrPayPathInfo.third,
                         manaCostString = exileOrPayPathInfo.first,
                         autoTapPreview = exileOrPayPathInfo.second
+                    ))
+                }
+                if (sacOrPayPathInfo != null) {
+                    result.add(LegalAction(
+                        actionType = "CastSpell",
+                        description = "Cast ${cardComponent.name} (Sacrifice)",
+                        action = CastSpell(playerId, cardId),
+                        additionalCostInfo = sacOrPayPathInfo.third,
+                        manaCostString = sacOrPayPathInfo.first,
+                        autoTapPreview = sacOrPayPathInfo.second
                     ))
                 }
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/utils/CastPermissionUtils.kt
@@ -359,11 +359,34 @@ class CastPermissionUtils(
         return false
     }
 
+    /**
+     * Resolve a static ability that may be gated by a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility]
+     * (e.g. The Lunar Whale's "as long as it attacked this turn, you may play the top card of your
+     * library"). Returns the underlying ability when it is currently active: unconditional abilities
+     * pass through unchanged, while a conditional one is honored only while its condition holds
+     * against the granting permanent ([sourceId], controlled by [playerId]). Returns null when a
+     * conditional gate is currently false.
+     */
+    private fun activeStaticAbility(
+        state: GameState,
+        ability: com.wingedsheep.sdk.scripting.StaticAbility,
+        sourceId: EntityId,
+        playerId: EntityId
+    ): com.wingedsheep.sdk.scripting.StaticAbility? = when (ability) {
+        is com.wingedsheep.sdk.scripting.ConditionalStaticAbility -> {
+            val context = EffectContext(sourceId = sourceId, controllerId = playerId)
+            if (conditionEvaluator.evaluate(state, ability.condition, context)) ability.ability else null
+        }
+        else -> ability
+    }
+
     fun hasPlayLandsFromTopOfLibrary(state: GameState, playerId: EntityId): Boolean {
         for (entityId in state.getBattlefield(playerId)) {
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.any { it is PlayLandsAndCastFilteredFromTopOfLibrary }) {
+            if (cardDef.script.staticAbilities.any {
+                    activeStaticAbility(state, it, entityId, playerId) is PlayLandsAndCastFilteredFromTopOfLibrary
+                }) {
                 return true
             }
         }
@@ -375,8 +398,9 @@ class CastPermissionUtils(
             val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
             for (ability in cardDef.script.staticAbilities) {
-                if (ability is PlayLandsAndCastFilteredFromTopOfLibrary) {
-                    return ability.spellFilter
+                val active = activeStaticAbility(state, ability, entityId, playerId)
+                if (active is PlayLandsAndCastFilteredFromTopOfLibrary) {
+                    return active.spellFilter
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeatrixLoyalGeneralScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BeatrixLoyalGeneralScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Beatrix, Loyal General (FIN #554).
+ *
+ * Beatrix, Loyal General {4}{W}{W} Legendary Creature — Human Soldier 4/4
+ * Vigilance
+ * At the beginning of combat on your turn, you may attach any number of Equipment you control
+ * to target creature you control.
+ *
+ * The ability is a pure composition: a begin-combat trigger targeting a creature you control,
+ * wrapped in a "you may" (a yes/no decided before targeting). On "yes" its resolution gathers the
+ * Equipment you control, lets you choose any number (0..all) of them, and attaches each chosen
+ * Equipment to the target creature via a ForEach over the selection. These tests prove the
+ * multi-attach (two Equipment onto one creature), the zero-choice no-op (the "any number = 0"
+ * path), and declining the optional trigger up front.
+ */
+class BeatrixLoyalGeneralScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        test("attaches any number of Equipment (two) to the target creature you control") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Beatrix, Loyal General", summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Buster Sword")   // +3/+2
+                .withCardOnBattlefield(1, "Buster Sword")   // +3/+2
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+            val swords = game.findPermanents("Buster Sword")
+            swords.size shouldBe 2
+
+            game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+            // The begin-combat "you may" asks yes/no first.
+            val mayDecision = game.getPendingDecision()
+            withClue("begin-combat trigger asks the 'you may' yes/no") {
+                (mayDecision is YesNoDecision) shouldBe true
+            }
+            game.answerYesNo(true)
+
+            // Then choose the target creature you control (slot 0).
+            val targetDecision = game.getPendingDecision()
+            targetDecision shouldNotBe null
+            game.submitDecision(TargetsResponse(targetDecision!!.id, mapOf(0 to listOf(bears))))
+            game.resolveStack()
+
+            // The ability resolves and pauses to choose any number of Equipment you control.
+            val selectDecision = game.getPendingDecision()
+            withClue("resolution pauses to choose any number of Equipment") {
+                (selectDecision is SelectCardsDecision) shouldBe true
+            }
+            (selectDecision as SelectCardsDecision).minSelections shouldBe 0
+            game.submitDecision(CardsSelectedResponse(selectDecision.id, swords))
+            game.resolveStack()
+
+            withClue("both Buster Swords (+3/+2 each) attach to Grizzly Bears: 2/2 + 6/4 = 8/6") {
+                val projected = stateProjector.project(game.state)
+                projected.getPower(bears) shouldBe 8
+                projected.getToughness(bears) shouldBe 6
+            }
+        }
+
+        test("choosing zero Equipment is a legal no-op (the 'any number' lower bound)") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Beatrix, Loyal General", summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Buster Sword")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+            (game.getPendingDecision() is YesNoDecision) shouldBe true
+            game.answerYesNo(true)
+
+            val targetDecision = game.getPendingDecision()!!
+            game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(bears))))
+            game.resolveStack()
+
+            val selectDecision = game.getPendingDecision()
+            (selectDecision is SelectCardsDecision) shouldBe true
+            game.submitDecision(CardsSelectedResponse(selectDecision!!.id, emptyList()))
+            game.resolveStack()
+
+            withClue("no Equipment chosen — Grizzly Bears stays 2/2, the Buster Sword stays unattached") {
+                val projected = stateProjector.project(game.state)
+                projected.getPower(bears) shouldBe 2
+                projected.getToughness(bears) shouldBe 2
+            }
+        }
+
+        test("declining the 'you may' up front does nothing") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Beatrix, Loyal General", summoningSickness = false)
+                .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                .withCardOnBattlefield(1, "Buster Sword")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+
+            // Decline the "you may" — no targeting, no Equipment selection, no attach.
+            (game.getPendingDecision() is YesNoDecision) shouldBe true
+            game.answerYesNo(false)
+            game.resolveStack()
+
+            withClue("declined — no Equipment-selection decision, Grizzly Bears stays 2/2") {
+                (game.getPendingDecision() is SelectCardsDecision) shouldBe false
+                val projected = stateProjector.project(game.state)
+                projected.getPower(bears) shouldBe 2
+                projected.getToughness(bears) shouldBe 2
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LouisoixsSacrificeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LouisoixsSacrificeScenarioTest.kt
@@ -1,0 +1,220 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Louisoix's Sacrifice (FIN).
+ *
+ * {U} Instant
+ * As an additional cost to cast this spell, sacrifice a legendary creature or pay {2}.
+ * Counter target activated ability, triggered ability, or noncreature spell.
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.AdditionalCost.SacrificeOrPay] additional cost
+ * (sacrifice path vs pay path) and the union target "(ability) OR (noncreature spell)" that
+ * excludes creature spells.
+ */
+class LouisoixsSacrificeScenarioTest : ScenarioTestBase() {
+
+    // Custom proof cards (no quirky abilities to confound the cost/target checks).
+    private val testLegend = card("Louisoix Test Legend") {
+        manaCost = "{1}"
+        typeLine = "Legendary Creature — Avatar"
+        power = 2
+        toughness = 2
+    }
+    private val testVanillaCreature = card("Louisoix Test Bear") {
+        manaCost = "{R}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    init {
+        cardRegistry.register(listOf(testLegend, testVanillaCreature))
+
+        context("SacrificeOrPay additional cost") {
+            test("sacrifice path counters a noncreature spell and sacrifices the legendary creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(2, "Louisoix's Sacrifice")
+                    .withCardOnBattlefield(2, "Louisoix Test Legend")
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 1 casts Lightning Bolt at Player 2 (a noncreature spell on the stack).
+                val boltCardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Lightning Bolt"
+                }
+                game.execute(CastSpell(game.player1Id, boltCardId, listOf(ChosenTarget.Player(game.player2Id))))
+                game.execute(PassPriority(game.player1Id))
+
+                val boltOnStack = game.state.stack.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Lightning Bolt"
+                }
+                val legendId = game.state.getBattlefield().first {
+                    val c = game.state.getEntity(it)
+                    c?.get<CardComponent>()?.name == "Louisoix Test Legend" &&
+                        c.get<ControllerComponent>()?.playerId == game.player2Id
+                }
+                val louisoixId = game.state.getHand(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Louisoix's Sacrifice"
+                }
+
+                // Cast via the sacrifice path (pay {U}, sacrifice the legendary creature).
+                val result = game.execute(
+                    CastSpell(
+                        game.player2Id,
+                        louisoixId,
+                        listOf(ChosenTarget.Spell(boltOnStack)),
+                        additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(legendId)),
+                    )
+                )
+                withClue("Louisoix's Sacrifice should cast via the sacrifice path: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("The legendary creature should be sacrificed") {
+                    game.isInGraveyard(2, "Louisoix Test Legend") shouldBe true
+                }
+
+                game.resolveStack()
+
+                withClue("Lightning Bolt should be countered (in Player 1's graveyard)") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                }
+                withClue("Player 2 took no damage — the bolt never resolved") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("pay path counters a noncreature spell when no legendary creature is sacrificed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(2, "Louisoix's Sacrifice")
+                    .withLandsOnBattlefield(2, "Island", 3) // enough for {U} + {2}
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val boltCardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Lightning Bolt"
+                }
+                game.execute(CastSpell(game.player1Id, boltCardId, listOf(ChosenTarget.Player(game.player2Id))))
+                game.execute(PassPriority(game.player1Id))
+
+                val boltOnStack = game.state.stack.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Lightning Bolt"
+                }
+                val louisoixId = game.state.getHand(game.player2Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Louisoix's Sacrifice"
+                }
+
+                // Cast via the pay path (no sacrifice payment): the engine adds {2} to the cost.
+                val result = game.execute(
+                    CastSpell(game.player2Id, louisoixId, listOf(ChosenTarget.Spell(boltOnStack)))
+                )
+                withClue("Louisoix's Sacrifice should cast via the pay path: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Lightning Bolt should be countered (in Player 1's graveyard)") {
+                    game.isInGraveyard(1, "Lightning Bolt") shouldBe true
+                }
+                withClue("Player 2 took no damage — the bolt never resolved") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+
+            test("with no legendary creature, only the pay path is castable") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(2, "Louisoix's Sacrifice")
+                    .withLandsOnBattlefield(2, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val boltCardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Lightning Bolt"
+                }
+                game.execute(CastSpell(game.player1Id, boltCardId, listOf(ChosenTarget.Player(game.player2Id))))
+                game.execute(PassPriority(game.player1Id))
+
+                val louisoixActions = game.getLegalActions(2)
+                    .filter { it.description.startsWith("Cast Louisoix's Sacrifice") }
+                withClue("Louisoix's Sacrifice should be castable (pay path)") {
+                    louisoixActions.isNotEmpty() shouldBe true
+                }
+                withClue("No sacrifice path should be offered without a legendary creature") {
+                    louisoixActions.none { it.description.endsWith("(Sacrifice)") } shouldBe true
+                }
+            }
+        }
+
+        context("union target excludes creature spells") {
+            test("a creature spell on the stack is not a legal target; a noncreature spell is") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Louisoix Test Bear")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInHand(2, "Louisoix's Sacrifice")
+                    .withCardOnBattlefield(2, "Louisoix Test Legend")
+                    .withLandsOnBattlefield(2, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Player 1 casts a creature spell, then (retaining priority) a noncreature spell.
+                game.castSpell(1, "Louisoix Test Bear")
+                val boltCardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Lightning Bolt"
+                }
+                game.execute(CastSpell(game.player1Id, boltCardId, listOf(ChosenTarget.Player(game.player2Id))))
+                game.execute(PassPriority(game.player1Id))
+
+                val creatureSpellId = game.state.stack.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Louisoix Test Bear"
+                }
+                val boltOnStack = game.state.stack.first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Lightning Bolt"
+                }
+
+                val louisoixAction = game.getLegalActions(2)
+                    .first { it.description.startsWith("Cast Louisoix's Sacrifice") }
+                val validTargets = louisoixAction.validTargets
+                withClue("Louisoix's Sacrifice should have valid targets") {
+                    (validTargets != null && validTargets.isNotEmpty()) shouldBe true
+                }
+                withClue("The noncreature spell (Lightning Bolt) should be a legal target") {
+                    validTargets!! shouldContain boltOnStack
+                }
+                withClue("The creature spell should NOT be a legal target") {
+                    validTargets!! shouldNotContain creatureSpellId
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLunarWhaleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLunarWhaleScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.TheLunarWhale
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for The Lunar Whale.
+ *
+ * The Lunar Whale: {3}{U}
+ * Legendary Artifact — Vehicle
+ * 3/5
+ * Flying
+ * You may look at the top card of your library any time.
+ * As long as The Lunar Whale attacked this turn, you may play the top card of your library.
+ * Crew 1
+ *
+ * The "play the top card" permission is a [com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary]
+ * (unrestricted spell filter) gated by a [com.wingedsheep.sdk.scripting.ConditionalStaticAbility] on
+ * "this attacked this turn". These tests exercise the gate: the permission is dormant until the
+ * Whale is crewed and attacks, then becomes active for the rest of the turn.
+ */
+class TheLunarWhaleScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TheLunarWhale)
+        return driver
+    }
+
+    test("cannot play the top card of library before The Lunar Whale attacks") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Plains" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        // Whale present but it has not attacked this turn — the conditional gate is false.
+        driver.putPermanentOnBattlefield(you, "The Lunar Whale")
+        val forestOnTop = driver.putCardOnTopOfLibrary(you, "Forest")
+
+        // A land on top of library can only be played via the (currently inactive) permission.
+        driver.playLand(you, forestOnTop).isSuccess shouldBe false
+        driver.findPermanent(you, "Forest") shouldBe null
+    }
+
+    test("can play a land from the top of library after The Lunar Whale attacks") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Plains" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+
+        // Crew partner: Grizzly Bears (power 2 satisfies Crew 1).
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val whale = driver.putPermanentOnBattlefield(you, "The Lunar Whale")
+        driver.removeSummoningSickness(whale)
+
+        // Crew the Whale (it becomes a creature) and declare it as an attacker.
+        driver.submitSuccess(CrewVehicle(you, whale, listOf(bears)))
+        driver.bothPass() // resolve the crew activation
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.submitSuccess(DeclareAttackers(you, mapOf(whale to opponent)))
+
+        // Move to the postcombat main phase — the Whale "attacked this turn", so the gate is open.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        val forestOnTop = driver.putCardOnTopOfLibrary(you, "Forest")
+        driver.playLand(you, forestOnTop).isSuccess shouldBe true
+        driver.findPermanent(you, "Forest") shouldNotBe null
+    }
+
+    test("can cast a spell from the top of library after The Lunar Whale attacks") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Plains" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        val whale = driver.putPermanentOnBattlefield(you, "The Lunar Whale")
+        driver.removeSummoningSickness(whale)
+
+        driver.submitSuccess(CrewVehicle(you, whale, listOf(bears)))
+        driver.bothPass()
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.submitSuccess(DeclareAttackers(you, mapOf(whale to opponent)))
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // Frogmite (an artifact creature) on top — any spell type may be cast from the top.
+        val frogmiteOnTop = driver.putCardOnTopOfLibrary(you, "Frogmite")
+        driver.giveMana(you, Color.BLUE, 4)
+
+        driver.castSpell(you, frogmiteOnTop).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getBattlefield(you).contains(frogmiteOnTop) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements a handful of cards from the **Final Fantasy (FIN)** set, each with a scenario test. Full `just build` is green (all modules, card-lint + snapshot nets, three new scenario tests).

## Cards

### The Lunar Whale — {3}{U} Legendary Artifact — Vehicle (3/5)
Flying · look at the top card of your library any time · crew 1 · *"As long as The Lunar Whale attacked this turn, you may play the top card of your library."*

The conditional play-from-top permission surfaced a real **engine gap**: the play/cast-from-top permission readers matched the static-ability type directly and never unwrapped `ConditionalStaticAbility`, so a *gated* play-top permission was silently invisible. Fixed all four read sites (`CastPermissionUtils`, `PlayLandHandler`, `CastZoneResolver`) to evaluate the gate (`SourceAttackedThisTurn`) against the granting permanent. The permission is **non-revealing** — it uses `PlayLandsAndCastFilteredFromTopOfLibrary` (not the Future Sight public-reveal variant), so opponents don't see the top card; the controller sees it privately via `LookAtTopOfLibrary`.

### Beatrix, Loyal General — {4}{W}{W} Legendary Creature — Human Soldier (4/4)
Vigilance · *"At the beginning of combat on your turn, you may attach any number of Equipment you control to target creature you control."*

**Pure composition, no new types**: `MayEffect` (the "you may", decided before targeting) → `gather` Equipment you control → `chooseAnyNumber` (0..all) → `ForEachInCollection` running `AttachTargetEquipmentToCreature`. Only the creature is targeted; the Equipment are chosen at resolution. Covers the 0-equipment no-op and the up-front decline.

### Louisoix's Sacrifice — {U} Instant
*"As an additional cost to cast this spell, sacrifice a legendary creature or pay {2}. Counter target activated ability, triggered ability, or noncreature spell."*

Adds a general-purpose **`AdditionalCost.SacrificeOrPay`** (sibling of `BlightOrPay` / `BeholdOrPay` / `ExileFromGraveyardOrPay`) — enumerator offers two cast paths (sacrifice a matching permanent, or fold the alternative mana cost onto the base), with handler validation + payment reusing the existing `SacrificePermanent` UI flow. The union target `(activated/triggered ability) OR (noncreature spell)` is modeled with `TargetFilter.anyOf`, so a **creature spell is not a legal target** while abilities and noncreature spells are.

## Notes
- FIN uses `CardDiscovery.findIn(...)` auto-discovery, so no set-registration edits.
- FIN snapshot golden reblessed — **purely additive** (199 insertions, 0 removals; only the three new card trees).
- `docs/card-sdk-language-reference.md` updated for the new building blocks (conditional play-top gating; `SacrificeOrPay`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)