### PR TITLE
Add 5 Foundations cards (Hare Apparent, Squad Rallier, Sun-Blessed Healer, Wardens of the Cycle, Spinner of Souls)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1461,6 +1461,11 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
 **Reveal patterns**
 
 - `revealUntilNonlandDealDamage(target)` — Bonecrusher Giant shape.
+- `revealUntilMatchToHand(filter, restDestination?, restOrder?)` — Spinner of Souls / Wirewood Herald
+  shape: reveal from the top of your library until you reveal a card matching `filter`; that card goes to
+  hand and the cards revealed before it go to `restDestination` (default: bottom of library) in `restOrder`
+  (default: random). If the library empties before a match, nothing goes to hand and every revealed card
+  goes to the rest destination.
 - `wheelEffect(players)` — each player shuffles hand into library, draws that many.
 - `factOrFiction(count = 5, keepZone, otherZone, ...)` — reveal/look at the top `count`, an
   opponent splits them into two piles, then you choose which pile goes to `keepZone` (hand) and

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/LibraryPatterns.kt
@@ -530,6 +530,49 @@ object LibraryPatterns {
         )
     )
 
+    /**
+     * "Reveal cards from the top of your library until you reveal a card matching [filter].
+     * Put that card into your hand and the rest [restDestination] (defaults to the bottom of
+     * your library) [restOrder] (defaults to a random order)." — Spinner of Souls / Wirewood
+     * Herald shape.
+     *
+     * The [filter] partition is reused twice: [GatherUntilMatchEffect] stops the reveal at the
+     * first match, then a [FilterCollectionEffect] over every revealed card splits the single
+     * match (→ hand) from the cards revealed before it (→ [restDestination]). If the library
+     * empties before a match is found, nothing goes to hand and every revealed card goes to the
+     * rest destination.
+     */
+    fun revealUntilMatchToHand(
+        filter: GameObjectFilter,
+        restDestination: CardDestination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+        restOrder: CardOrder = CardOrder.Random
+    ): CompositeEffect = CompositeEffect(
+        listOf(
+            GatherUntilMatchEffect(
+                filter = filter,
+                storeMatch = "ignored",
+                storeRevealed = "revealed"
+            ),
+            RevealCollectionEffect(from = "revealed"),
+            FilterCollectionEffect(
+                from = "revealed",
+                filter = CollectionFilter.MatchesFilter(filter),
+                storeMatching = "matchedToHand",
+                storeNonMatching = "rest"
+            ),
+            MoveCollectionEffect(
+                from = "matchedToHand",
+                destination = CardDestination.ToZone(Zone.HAND),
+                revealed = true
+            ),
+            MoveCollectionEffect(
+                from = "rest",
+                destination = restDestination,
+                order = restOrder
+            )
+        )
+    )
+
     fun revealUntilNonlandDealDamageEachTarget(): ForEachEffect = ForEachTargetEffect(
         listOf(
             GatherUntilMatchEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HareApparent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HareApparent.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hare Apparent
+ * {1}{W}
+ * Creature — Rabbit Noble
+ * 2/2
+ * When this creature enters, create a number of 1/1 white Rabbit creature tokens equal to
+ * the number of other creatures you control named Hare Apparent.
+ * A deck can have any number of cards named Hare Apparent.
+ *
+ * The "any number in a deck" clause is a deck-construction rule (CR 100.2a exception); like
+ * Rat Colony it carries no in-game behavior, so it lives only in the oracle text.
+ */
+val HareApparent = card("Hare Apparent") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Rabbit Noble"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, create a number of 1/1 white Rabbit creature tokens equal to the number of other creatures you control named Hare Apparent.\nA deck can have any number of cards named Hare Apparent."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            count = DynamicAmount.AggregateBattlefield(
+                Player.You,
+                GameObjectFilter.Creature.named("Hare Apparent"),
+                excludeSelf = true
+            ),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Rabbit"),
+            imageUri = "https://cards.scryfall.io/normal/front/8/1/81de52ef-7515-4958-abea-fb8ebdcef93c.jpg?1721431122"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Milivoj Ćeran"
+        flavorText = "Most families have trees. His has an entire forest."
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12.jpg?1782689251"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SpinnerOfSouls.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SpinnerOfSouls.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Spinner of Souls
+ * {2}{G}
+ * Creature — Spider Spirit
+ * 4/3
+ * Reach
+ * Whenever another nontoken creature you control dies, you may reveal cards from the top of
+ * your library until you reveal a creature card. Put that card into your hand and the rest on
+ * the bottom of your library in a random order.
+ */
+val SpinnerOfSouls = card("Spinner of Souls") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Spider Spirit"
+    power = 4
+    toughness = 3
+    oracleText = "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order."
+
+    keywords(Keyword.REACH)
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.youControl().nontoken(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER
+        )
+        optional = true
+        effect = Patterns.Library.revealUntilMatchToHand(
+            filter = GameObjectFilter.Creature
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "112"
+        artist = "Xavier Ribeiro"
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f50a8dec-b079-4192-9098-6cdc1026c693.jpg?1782689168"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SquadRallier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SquadRallier.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Squad Rallier
+ * {3}{W}
+ * Creature — Human Scout
+ * 3/4
+ * {2}{W}: Look at the top four cards of your library. You may reveal a creature card with
+ * power 2 or less from among them and put it into your hand. Put the rest on the bottom of
+ * your library in a random order.
+ */
+val SquadRallier = card("Squad Rallier") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    power = 3
+    toughness = 4
+    oracleText = "{2}{W}: Look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order."
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{W}")
+        effect = Patterns.Library.lookAtTopRevealMatchingToHand(
+            count = DynamicAmount.Fixed(4),
+            filter = GameObjectFilter.Creature.powerAtMost(2),
+            prompt = "You may reveal a creature card with power 2 or less to put into your hand"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Edgar Sánchez Hidalgo"
+        flavorText = "Between the call of the bugler and the shrill squawk of her mount, not a soul slept through morning muster."
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/65e1ee86-6f08-4aa0-bf63-ae12028ef080.jpg?1782689245"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SunBlessedHealer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SunBlessedHealer.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sun-Blessed Healer
+ * {1}{W}
+ * Creature — Human Cleric
+ * 3/1
+ * Kicker {1}{W}
+ * Lifelink
+ * When this creature enters, if it was kicked, return target nonland permanent card with
+ * mana value 2 or less from your graveyard to the battlefield.
+ */
+val SunBlessedHealer = card("Sun-Blessed Healer") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    power = 3
+    toughness = 1
+    oracleText = "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\n" +
+        "Lifelink\n" +
+        "When this creature enters, if it was kicked, return target nonland permanent card with mana value 2 or less from your graveyard to the battlefield."
+
+    keywordAbility(KeywordAbility.kicker("{1}{W}"))
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = WasKicked
+        val t = target(
+            "target",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.NonlandPermanent.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                ).manaValueAtMost(2)
+            )
+        )
+        effect = Effects.Move(t, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "25"
+        artist = "Mark Zug"
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/323d029e-9a88-4188-b3a4-38ef32cffc9f.jpg?1782689245"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/WardensOfTheCycle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/WardensOfTheCycle.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wardens of the Cycle
+ * {1}{B}{G}{G}
+ * Creature — Elf Warlock
+ * 3/4
+ * Morbid — At the beginning of your end step, if a creature died this turn, choose one —
+ * • You gain 2 life.
+ * • You draw a card and you lose 1 life.
+ *
+ * "Morbid" is an ability word (no rules meaning); the intervening-if "if a creature died this
+ * turn" is modeled as [Conditions.CreatureDiedThisTurn] (CR 603.4 — checked on trigger and at
+ * resolution).
+ */
+val WardensOfTheCycle = card("Wardens of the Cycle") {
+    manaCost = "{1}{B}{G}{G}"
+    colorIdentity = "BG"
+    typeLine = "Creature — Elf Warlock"
+    power = 3
+    toughness = 4
+    oracleText = "Morbid — At the beginning of your end step, if a creature died this turn, choose one —\n• You gain 2 life.\n• You draw a card and you lose 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.CreatureDiedThisTurn
+        effect = ModalEffect.chooseOne(
+            Mode(
+                effect = Effects.GainLife(2),
+                description = "You gain 2 life"
+            ),
+            Mode(
+                effect = Effects.DrawCards(1).then(Effects.LoseLife(1, EffectTarget.Controller)),
+                description = "You draw a card and you lose 1 life"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Caroline Gariba"
+        flavorText = "\"The wheel turns, and what meets its end begins again.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83ea9b2c-5723-4eff-88ac-6669975939e3.jpg?1782689157"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -1626,6 +1626,56 @@
     ]
 }
 
+// Hare Apparent
+{
+    "name": "Hare Apparent",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Rabbit Noble",
+    "oracleText": "When this creature enters, create a number of 1/1 white Rabbit creature tokens equal to the number of other creatures you control named Hare Apparent.\nA deck can have any number of cards named Hare Apparent.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature name:Hare Apparent",
+                        "excludeSelf": true
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Rabbit"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/8/1/81de52ef-7515-4958-abea-fb8ebdcef93c.jpg?1721431122"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Milivoj Ćeran",
+        "flavorText": "Most families have trees. His has an entire forest.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fc6f0e9-eb5f-4bc0-b3d7-756644b66d12.jpg?1782689251"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Healer's Hawk
 {
     "name": "Healer's Hawk",
@@ -3346,6 +3396,89 @@
     ]
 }
 
+// Spinner of Souls
+{
+    "name": "Spinner of Souls",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Spider Spirit",
+    "oracleText": "Reach\nWhenever another nontoken creature you control dies, you may reveal cards from the top of your library until you reveal a creature card. Put that card into your hand and the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "REACH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherUntilMatch",
+                            "filter": "creature",
+                            "storeMatch": "ignored",
+                            "storeRevealed": "revealed"
+                        },
+                        {
+                            "type": "RevealCollection",
+                            "from": "revealed"
+                        },
+                        {
+                            "type": "FilterCollection",
+                            "from": "revealed",
+                            "filter": {
+                                "type": "MatchesFilter",
+                                "filter": "creature"
+                            },
+                            "storeMatching": "matchedToHand",
+                            "storeNonMatching": "rest"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "matchedToHand",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                },
+                "optional": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "112",
+        "rarity": "RARE",
+        "artist": "Xavier Ribeiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f50a8dec-b079-4192-9098-6cdc1026c693.jpg?1782689168"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Springbloom Druid
 {
     "name": "Springbloom Druid",
@@ -3426,6 +3559,92 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Squad Rallier
+{
+    "name": "Squad Rallier",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "{2}{W}: Look at the top four cards of your library. You may reveal a creature card with power 2 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 4
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "creature pow<=2",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may reveal a creature card with power 2 or less to put into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Edgar Sánchez Hidalgo",
+        "flavorText": "Between the call of the bugler and the shrill squawk of her mount, not a soul slept through morning muster.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/65e1ee86-6f08-4aa0-bf63-ae12028ef080.jpg?1782689245"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -3561,6 +3780,65 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Sun-Blessed Healer
+{
+    "name": "Sun-Blessed Healer",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Kicker {1}{W} (You may pay an additional {1}{W} as you cast this spell.)\nLifelink\nWhen this creature enters, if it was kicked, return target nonland permanent card with mana value 2 or less from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "manaCost": "{1}{W}"
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Battlefield",
+                    "fromZone": "Graveyard"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "nonland permanent mv<=2 own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                },
+                "triggerCondition": "WasKicked"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "rarity": "UNCOMMON",
+        "artist": "Mark Zug",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/323d029e-9a88-4188-b3a4-38ef32cffc9f.jpg?1782689245"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -4078,5 +4356,78 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Wardens of the Cycle
+{
+    "name": "Wardens of the Cycle",
+    "manaCost": "{1}{B}{G}{G}",
+    "typeLine": "Creature — Elf Warlock",
+    "oracleText": "Morbid — At the beginning of your end step, if a creature died this turn, choose one —\n• You gain 2 life.\n• You draw a card and you lose 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "LoseLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": "Controller"
+                                    }
+                                ]
+                            },
+                            "description": "You draw a card and you lose 1 life"
+                        }
+                    ]
+                },
+                "triggerCondition": "CreatureDiedThisTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Caroline Gariba",
+        "flavorText": "\"The wheel turns, and what meets its end begins again.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83ea9b2c-5723-4eff-88ac-6669975939e3.jpg?1782689157"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
     ]
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HareApparentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HareApparentScenarioTest.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hare Apparent — "{1}{W} 2/2. When this creature enters, create a number of 1/1 white Rabbit
+ * creature tokens equal to the number of OTHER creatures you control named Hare Apparent."
+ *
+ * Proves the `excludeSelf` name-count: the entering copy never counts itself, so the token count
+ * is the number of pre-existing Hare Apparents you control.
+ */
+class HareApparentScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("ETB makes one Rabbit per OTHER Hare Apparent you control") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Hare Apparent")
+                .withCardOnBattlefield(1, "Hare Apparent")
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withCardInHand(1, "Hare Apparent")
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            game.castSpell(1, "Hare Apparent").error shouldBe null
+            game.resolveStack()
+
+            // Two other Hare Apparents already in play → two Rabbit tokens.
+            game.findPermanents("Rabbit Token").size shouldBe 2
+            game.findPermanents("Hare Apparent").size shouldBe 3
+        }
+
+        test("ETB with no other Hare Apparent makes no tokens") {
+            val game = scenario()
+                .withPlayers()
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withCardInHand(1, "Hare Apparent")
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            game.castSpell(1, "Hare Apparent").error shouldBe null
+            game.resolveStack()
+
+            game.findPermanents("Rabbit Token").size shouldBe 0
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpinnerOfSoulsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpinnerOfSoulsScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.matchers.shouldBe
+
+/**
+ * Spinner of Souls — "{2}{G} 4/3 Reach. Whenever another nontoken creature you control dies, you may
+ * reveal cards from the top of your library until you reveal a creature card. Put that card into
+ * your hand and the rest on the bottom of your library in a random order."
+ *
+ * Exercises the new `Patterns.Library.revealUntilMatchToHand` composition. The optional "may" is a
+ * YesNoDecision in interactive play; the scenario harness auto-accepts it, so these tests assert the
+ * resulting board (the revealed creature goes to hand, the non-creature cards stay in the library).
+ */
+class SpinnerOfSoulsScenarioTest : ScenarioTestBase() {
+
+    init {
+        // {0} sorcery to send a chosen creature to the graveyard on demand.
+        val slay = card("Slay") {
+            manaCost = "{0}"
+            typeLine = "Sorcery"
+            spell {
+                val c = target("target creature", Targets.Creature)
+                effect = Effects.Destroy(c)
+            }
+        }
+        cardRegistry.register(listOf(slay))
+
+        test("a nontoken creature you control dies: dig to the first creature, rest stays in library") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Spinner of Souls")
+                .withCardOnBattlefield(1, "Aegis Turtle")    // the nontoken creature that dies
+                .withCardInHand(1, "Slay")
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Bear Cub")            // the creature to reveal
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            val turtle = game.findPermanent("Aegis Turtle")!!
+            game.castSpell(1, "Slay", targetId = turtle).error shouldBe null
+            game.resolveStack()
+
+            // The revealed creature is put into hand; the non-creature cards go to the bottom.
+            game.isInHand(1, "Bear Cub") shouldBe true
+            game.findCardsInLibrary(1, "Plains").size shouldBe 2
+            game.findCardsInLibrary(1, "Bear Cub").size shouldBe 0
+        }
+
+        test("a creature an OPPONENT controls dies: Spinner does not trigger") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Spinner of Souls")
+                .withCardOnBattlefield(2, "Aegis Turtle")    // opponent's creature
+                .withCardInHand(1, "Slay")
+                .withCardInLibrary(1, "Bear Cub")
+                .build()
+
+            val turtle = game.findPermanent("Aegis Turtle")!!
+            game.castSpell(1, "Slay", targetId = turtle).error shouldBe null
+            game.resolveStack()
+
+            // "creature you control" — an opponent's death doesn't reveal anything.
+            game.isInHand(1, "Bear Cub") shouldBe false
+            game.findCardsInLibrary(1, "Bear Cub").size shouldBe 1
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SquadRallierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SquadRallierScenarioTest.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.SquadRallier
+import io.kotest.matchers.shouldBe
+
+/**
+ * Squad Rallier — "{3}{W} 3/4. {2}{W}: Look at the top four cards of your library. You may reveal a
+ * creature card with power 2 or less from among them and put it into your hand. Put the rest on the
+ * bottom of your library in a random order."
+ */
+class SquadRallierScenarioTest : ScenarioTestBase() {
+
+    private val abilityId = SquadRallier.activatedAbilities.first().id
+
+    init {
+        test("dig reveals a creature with power 2 or less to hand") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Squad Rallier")
+                .withLandsOnBattlefield(1, "Plains", 3)
+                .withCardInLibrary(1, "Plains")
+                .withCardInLibrary(1, "Bear Cub")   // 2/2 — power 2, eligible
+                .withCardInLibrary(1, "Plains")
+                .build()
+
+            val rallier = game.findPermanent("Squad Rallier")!!
+            val bearCub = game.findCardsInLibrary(1, "Bear Cub").first()
+
+            game.execute(
+                ActivateAbility(playerId = game.player1Id, sourceId = rallier, abilityId = abilityId)
+            ).error shouldBe null
+            game.resolveStack()
+
+            // The pipeline pauses to let us choose the (optional) creature to keep.
+            game.hasPendingDecision() shouldBe true
+            game.selectCards(listOf(bearCub))
+            game.resolveStack()
+
+            game.isInHand(1, "Bear Cub") shouldBe true
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SunBlessedHealerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SunBlessedHealerScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sun-Blessed Healer — "{1}{W} 3/1. Kicker {1}{W}. Lifelink. When this creature enters, if it was
+ * kicked, return target nonland permanent card with mana value 2 or less from your graveyard to the
+ * battlefield."
+ */
+class SunBlessedHealerScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("kicked: reanimates a nonland permanent with mana value 2 or less") {
+            val game = scenario()
+                .withPlayers()
+                .withLandsOnBattlefield(1, "Plains", 4)   // {1}{W} + kicker {1}{W}
+                .withCardInHand(1, "Sun-Blessed Healer")
+                .withCardInGraveyard(1, "Bear Cub")        // 2/2, MV 2
+                .build()
+
+            val healer = game.findCardsInHand(1, "Sun-Blessed Healer").first()
+            game.execute(
+                CastSpell(playerId = game.player1Id, cardId = healer, wasKicked = true)
+            ).error shouldBe null
+            game.resolveStack()
+
+            // The kicked ETB trigger targets the only legal graveyard card.
+            val bearCub = game.findCardsInGraveyard(1, "Bear Cub").first()
+            val td = game.getPendingDecision() as? ChooseTargetsDecision
+                ?: error("expected a ChooseTargetsDecision for the kicked ETB; got ${game.getPendingDecision()}")
+            game.submitDecision(TargetsResponse(td.id, mapOf(0 to listOf(bearCub))))
+            game.resolveStack()
+
+            game.isOnBattlefield("Bear Cub") shouldBe true
+            game.isInGraveyard(1, "Bear Cub") shouldBe false
+        }
+
+        test("unkicked: ETB does nothing, graveyard card stays put") {
+            val game = scenario()
+                .withPlayers()
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withCardInHand(1, "Sun-Blessed Healer")
+                .withCardInGraveyard(1, "Bear Cub")
+                .build()
+
+            game.castSpell(1, "Sun-Blessed Healer").error shouldBe null
+            game.resolveStack()
+
+            game.isInGraveyard(1, "Bear Cub") shouldBe true
+            game.isOnBattlefield("Bear Cub") shouldBe false
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WardensOfTheCycleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WardensOfTheCycleScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.matchers.shouldBe
+
+/**
+ * Wardens of the Cycle — "{1}{B}{G}{G} 3/4. Morbid — At the beginning of your end step, if a
+ * creature died this turn, choose one — • You gain 2 life. • You draw a card and you lose 1 life."
+ */
+class WardensOfTheCycleScenarioTest : ScenarioTestBase() {
+
+    init {
+        // {0} sorcery to send a chosen creature to the graveyard, arming Morbid.
+        val slay = card("Slay") {
+            manaCost = "{0}"
+            typeLine = "Sorcery"
+            spell {
+                val c = target("target creature", Targets.Creature)
+                effect = Effects.Destroy(c)
+            }
+        }
+        cardRegistry.register(listOf(slay))
+
+        test("a creature died this turn: choose 'gain 2 life'") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Wardens of the Cycle")
+                .withCardOnBattlefield(2, "Aegis Turtle")
+                .withCardInHand(1, "Slay")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val turtle = game.findPermanent("Aegis Turtle")!!
+            game.castSpell(1, "Slay", targetId = turtle).error shouldBe null
+            game.resolveStack()
+            game.isOnBattlefield("Aegis Turtle") shouldBe false
+
+            val lifeBefore = game.getLifeTotal(1)
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()   // drain the end-step trigger; pauses at the mode choice
+
+            val dec = game.getPendingDecision() as? ChooseOptionDecision
+                ?: error("expected a ChooseOptionDecision for the Morbid modal; got ${game.getPendingDecision()}")
+            game.submitDecision(OptionChosenResponse(dec.id, optionIndex = 0))   // gain 2 life
+            game.resolveStack()
+
+            game.getLifeTotal(1) shouldBe lifeBefore + 2
+        }
+
+        test("no creature died: the Morbid trigger does not fire") {
+            val game = scenario()
+                .withPlayers()
+                .withCardOnBattlefield(1, "Wardens of the Cycle")
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val lifeBefore = game.getLifeTotal(1)
+            game.passUntilPhase(Phase.ENDING, Step.END)
+            game.resolveStack()
+
+            game.hasPendingDecision() shouldBe false
+            game.getLifeTotal(1) shouldBe lifeBefore
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements a handful of **Foundations (FDN)** cards via the `add-card` skill. All five are original to FDN, so each canonical `CardDefinition` lives in FDN — no reprint scaffolding required. FDN coverage: 141 → 146 implemented (54% → 56%).

| Card | Cost | What it does |
|------|------|--------------|
| **Hare Apparent** | `{1}{W}` | ETB makes 1/1 white Rabbit tokens = number of **other** Hare Apparents you control. "Any number in a deck" is oracle text only (matches Rat Colony). |
| **Squad Rallier** | `{3}{W}` | `{2}{W}`: dig the top four, reveal a creature with power ≤ 2 to hand, rest to bottom. |
| **Sun-Blessed Healer** | `{1}{W}` | Kicker `{1}{W}`, Lifelink; kicked ETB returns a nonland permanent card with MV ≤ 2 from your graveyard to the battlefield. |
| **Wardens of the Cycle** | `{1}{B}{G}{G}` | Morbid — end-step modal: gain 2 life, or draw a card and lose 1 life. |
| **Spinner of Souls** | `{2}{G}` | Reach; when another nontoken creature you control dies, reveal until a creature, that creature to hand, rest to bottom. |

## Approach

Everything composes existing, already-tested primitives:
- Hare Apparent uses `DynamicAmount.AggregateBattlefield(..., excludeSelf = true)` with a name filter.
- Squad Rallier reuses `Patterns.Library.lookAtTopRevealMatchingToHand`.
- Sun-Blessed Healer reuses kicker (`KeywordAbility.kicker` + `WasKicked`) and `Effects.Move(..., fromZone = GRAVEYARD)` to the battlefield.
- Wardens reuses the end-step trigger + `Conditions.CreatureDiedThisTurn` + `ModalEffect.chooseOne`.
- Spinner introduces one **reusable composition** — `Patterns.Library.revealUntilMatchToHand` (`GatherUntilMatch` + a `FilterCollection` partition → match to hand, rest to bottom). No new serialized effect types or executors; documented in `card-sdk-language-reference.md` §5.

## Testing

- Scenario tests in `rules-engine` for all five cards (9 tests, all green) — token name-count incl. the zero-others case, the dig, kicked reanimation + unkicked no-op, the Morbid modal + the no-death no-fire case, and the reveal-until incl. the `you control` filter.
- FDN card snapshot re-blessed (`CardDefinitionSnapshotTest`); diff adds only these five cards.
- `just build` passes (compile + `CardLintTest` + all module tests); `just check-card-printing` ok for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)