### PR TITLE
Add 5 Foundations cards (Gorehorn Raider, Goblin Boarders, Battlesong Berserker, Felidar Savior, Clinquant Skymage)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BattlesongBerserker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BattlesongBerserker.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Battlesong Berserker
+ * {3}{R}
+ * Creature — Human Berserker
+ * 3/4
+ *
+ * Whenever you attack, target creature you control gets +1/+0 and gains menace
+ * until end of turn.
+ *
+ * "Whenever you attack" is the [Triggers.YouAttack] combat trigger (fires once per
+ * declare-attackers, not per attacker). The boost and the menace grant are composed
+ * and both expire at end of turn.
+ */
+val BattlesongBerserker = card("Battlesong Berserker") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Berserker"
+    power = 3
+    toughness = 4
+    oracleText = "Whenever you attack, target creature you control gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)"
+
+    triggeredAbility {
+        trigger = Triggers.YouAttack
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, t),
+            Effects.GrantKeyword(Keyword.MENACE, t),
+        )
+        description = "Whenever you attack, target creature you control gets +1/+0 and gains menace until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "78"
+        artist = "Mirko Failoni"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1f8b199-5d62-485f-b1c3-b30aa550595b.jpg?1782689197"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ClinquantSkymage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ClinquantSkymage.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Clinquant Skymage
+ * {3}{U}
+ * Creature — Bird Wizard
+ * 1/1
+ *
+ * Flying
+ * Whenever you draw a card, put a +1/+1 counter on this creature.
+ *
+ * The draw trigger ([Triggers.YouDraw]) fires once per card drawn (CR 121.2), so
+ * multi-card draws stack multiple counters.
+ */
+val ClinquantSkymage = card("Clinquant Skymage") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Wizard"
+    power = 1
+    toughness = 1
+    oracleText = "Flying\nWhenever you draw a card, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.YouDraw
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "33"
+        artist = "Kevin Sidharta"
+        imageUri = "https://cards.scryfall.io/normal/front/3/6/36012810-0e83-4640-8ba7-7262229f1b84.jpg?1782689236"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FelidarSavior.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FelidarSavior.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Felidar Savior
+ * {3}{W}
+ * Creature — Cat Beast
+ * 2/3
+ *
+ * Lifelink
+ * When this creature enters, put a +1/+1 counter on each of up to two other
+ * target creatures you control.
+ *
+ * The ETB uses an optional `count = 2` [TargetCreature] (0–2 targets) filtered to
+ * [TargetFilter.OtherCreatureYouControl] (excludes itself, restricted to creatures
+ * you control), fanned out with [ForEachTargetEffect] so each chosen creature
+ * receives one +1/+1 counter.
+ */
+val FelidarSavior = card("Felidar Savior") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Beast"
+    power = 2
+    toughness = 3
+    oracleText = "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\n" +
+        "When this creature enters, put a +1/+1 counter on each of up to two other target creatures you control."
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to two other target creatures you control",
+            TargetCreature(count = 2, optional = true, filter = TargetFilter.OtherCreatureYouControl),
+        )
+        effect = ForEachTargetEffect(
+            listOf(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0))),
+        )
+        description = "When this creature enters, put a +1/+1 counter on each of up to two other target creatures you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "12"
+        artist = "Ilse Gort"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cd092b14-d72f-4de0-8f19-1338661b9e3b.jpg?1782689256"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GoblinBoarders.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GoblinBoarders.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Goblin Boarders
+ * {2}{R}
+ * Creature — Goblin Pirate
+ * 3/2
+ *
+ * Raid — This creature enters with a +1/+1 counter on it if you attacked this turn.
+ *
+ * Raid enters-with-counter follows the engine's established convention (War-Name
+ * Aspirant): an enters-the-battlefield trigger gated by the intervening-if condition
+ * [Conditions.YouAttackedThisTurn], adding one +1/+1 counter to itself.
+ */
+val GoblinBoarders = card("Goblin Boarders") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Pirate"
+    power = 3
+    toughness = 2
+    oracleText = "Raid — This creature enters with a +1/+1 counter on it if you attacked this turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouAttackedThisTurn
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "87"
+        artist = "Filipe Pagliuso"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/4409a063-bf2a-4a49-803e-3ce6bd474353.jpg?1782689191"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GorehornRaider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GorehornRaider.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gorehorn Raider
+ * {4}{R}
+ * Creature — Minotaur Pirate
+ * 4/4
+ *
+ * Raid — When this creature enters, if you attacked this turn, this creature
+ * deals 2 damage to any target.
+ *
+ * Raid is modeled as an enters-the-battlefield trigger gated by the intervening-if
+ * condition [Conditions.YouAttackedThisTurn] (mirrors Mardu Heart-Piercer). The
+ * condition is re-checked on resolution, so the trigger does nothing if the
+ * "you attacked this turn" state no longer holds.
+ */
+val GorehornRaider = card("Gorehorn Raider") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Minotaur Pirate"
+    power = 4
+    toughness = 4
+    oracleText = "Raid — When this creature enters, if you attacked this turn, this creature deals 2 damage to any target."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouAttackedThisTurn
+        val t = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "89"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78ce6c40-3452-4aa0-a45b-dbfd70f8d220.jpg?1782689188"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -356,6 +356,72 @@
     ]
 }
 
+// Battlesong Berserker
+{
+    "name": "Battlesong Berserker",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Human Berserker",
+    "oracleText": "Whenever you attack, target creature you control gets +1/+0 and gains menace until end of turn. (It can't be blocked except by two or more creatures.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "YouAttackEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "MENACE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "descriptionOverride": "Whenever you attack, target creature you control gets +1/+0 and gains menace until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "UNCOMMON",
+        "artist": "Mirko Failoni",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1f8b199-5d62-485f-b1c3-b30aa550595b.jpg?1782689197"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Beast-Kin Ranger
 {
     "name": "Beast-Kin Ranger",
@@ -693,6 +759,45 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Clinquant Skymage
+{
+    "name": "Clinquant Skymage",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Bird Wizard",
+    "oracleText": "Flying\nWhenever you draw a card, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "DrawEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "rarity": "UNCOMMON",
+        "artist": "Kevin Sidharta",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/6/36012810-0e83-4640-8ba7-7262229f1b84.jpg?1782689236"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -1260,6 +1365,64 @@
     ]
 }
 
+// Felidar Savior
+{
+    "name": "Felidar Savior",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Cat Beast",
+    "oracleText": "Lifelink (Damage dealt by this creature also causes you to gain that much life.)\nWhen this creature enters, put a +1/+1 counter on each of up to two other target creatures you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "up to two other target creatures you control"
+                },
+                "descriptionOverride": "When this creature enters, put a +1/+1 counter on each of up to two other target creatures you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "12",
+        "artist": "Ilse Gort",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cd092b14-d72f-4de0-8f19-1338661b9e3b.jpg?1782689256"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Felling Blow
 {
     "name": "Felling Blow",
@@ -1446,6 +1609,56 @@
     ]
 }
 
+// Goblin Boarders
+{
+    "name": "Goblin Boarders",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Pirate",
+    "oracleText": "Raid — This creature enters with a +1/+1 counter on it if you attacked this turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "PLAYER_ATTACKED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "artist": "Filipe Pagliuso",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/4409a063-bf2a-4a49-803e-3ce6bd474353.jpg?1782689191"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Goblin Surprise
 {
     "name": "Goblin Surprise",
@@ -1506,6 +1719,65 @@
         "artist": "Kevin Sidharta",
         "flavorText": "\"Hey, your door's broken!\"",
         "imageUri": "https://cards.scryfall.io/normal/front/5/2/527dd5d4-5f72-40bb-8a9d-1f5ac3f81e2e.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Gorehorn Raider
+{
+    "name": "Gorehorn Raider",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Minotaur Pirate",
+    "oracleText": "Raid — When this creature enters, if you attacked this turn, this creature deals 2 damage to any target.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "PLAYER_ATTACKED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78ce6c40-3452-4aa0-a45b-dbfd70f8d220.jpg?1782689188"
     },
     "colorIdentityOverride": [
         "RED"


### PR DESCRIPTION
## Summary

Implements five Foundations (FDN) cards via the `add-card` flow. All are FDN-original printings (canonical `CardDefinition` lives in FDN, verified with `just check-card-printing`) and compose entirely from **existing SDK primitives** — no new engine features, effects, triggers, or conditions.

| Card | Cost | P/T | Behavior | Reuses pattern from |
|------|------|-----|----------|---------------------|
| Gorehorn Raider | {4}{R} | 4/4 | Raid — ETB deal 2 to any target if you attacked | Mardu Heart-Piercer |
| Goblin Boarders | {2}{R} | 3/2 | Raid — enters with a +1/+1 counter if you attacked | War-Name Aspirant |
| Battlesong Berserker | {3}{R} | 3/4 | Whenever you attack, target creature you control gets +1/+0 and gains menace EOT | Warren Warleader / Axgard Cavalry |
| Felidar Savior | {3}{W} | 2/3 | Lifelink; ETB +1/+1 on up to two other target creatures you control | Byrke, Long Ear of the Law |
| Clinquant Skymage | {3}{U} | 1/1 | Flying; whenever you draw a card, +1/+1 counter on itself | Ajani's Pridemate |

Raid is modeled as the engine's established convention: an `EntersBattlefield` trigger gated by the `Conditions.YouAttackedThisTurn` intervening-if (re-checked at resolution). Battlesong's boost + menace are a `Composite` of `ModifyStats` + `GrantKeyword`, both expiring end of turn. Felidar uses an optional `count = 2` `TargetCreature(OtherCreatureYouControl)` fanned out via `ForEachTargetEffect`.

## Verification

- Each field checked against the Scryfall FDN printing (mana cost, type line, P/T, oracle text, rarity, collector number, artist); image URIs are the exact `image_uris.normal` and all return HTTP 200.
- `:mtg-sets:compileKotlin` + `:rules-engine:compileTestKotlin` clean.
- `CardLintTest` passes (pipeline vars / target bindings / choice slots resolve).
- `CardDefinitionSnapshotTest` re-blessed — diff is **only** the 5 new card trees added to `FDN.json` (272 insertions); no other card moved, so no shared SDK behavior changed.

No new effects were introduced, so per the `add-card` recipe no dedicated scenario tests are required; correctness rests on the corpus-wide snapshot/lint nets plus reuse of already-proven card patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)