### PR TITLE
Add Summon: G.F. Cerberus and Summon: Leviathan (FIN)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonGfCerberus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonGfCerberus.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Summon: G.F. Cerberus
+ * {2}{R}{R}
+ * Enchantment Creature — Saga Dog
+ * 3/3
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Surveil 1.
+ * II — Double — When you next cast an instant or sorcery spell this turn, copy it. You may choose
+ *      new targets for the copy.
+ * III — Triple — When you next cast an instant or sorcery spell this turn, copy it twice. You may
+ *       choose new targets for the copies.
+ *
+ * Chapters II and III each install a one-shot "copy your next instant/sorcery this turn" delayed
+ * trigger via [Effects.CopyNextSpellCast] — the same primitive Ether uses. The only difference
+ * between them is the number of copies (1 vs 2); the copy machinery (CR 707.10c) pauses per copy
+ * with targets so the controller may choose new targets, satisfying the "you may choose new
+ * targets" clause for both. Each entry waits until a matching cast and is consumed once.
+ */
+val SummonGfCerberus = card("Summon: G.F. Cerberus") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment Creature — Saga Dog"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n" +
+        "II — Double — When you next cast an instant or sorcery spell this turn, copy it. You may choose new targets for the copy.\n" +
+        "III — Triple — When you next cast an instant or sorcery spell this turn, copy it twice. You may choose new targets for the copies."
+    power = 3
+    toughness = 3
+
+    sagaChapter(1) { effect = Effects.Surveil(1) }
+    sagaChapter(2) { effect = Effects.CopyNextSpellCast(copies = 1) }
+    sagaChapter(3) { effect = Effects.CopyNextSpellCast(copies = 2) }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "162"
+        artist = "Kevin Glint"
+        flavorText = "\"Pretty confident. Let's see how you do.\""
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0e5cbd4-401b-4456-80bf-d90beadfd1f8.jpg?1782686479"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonLeviathan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SummonLeviathan.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Summon: Leviathan
+ * {4}{U}{U}
+ * Enchantment Creature — Saga Leviathan
+ * 6/6
+ * (As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)
+ * I — Return each creature that isn't a Kraken, Leviathan, Merfolk, Octopus, or Serpent to its
+ *     owner's hand.
+ * II, III — Until end of turn, whenever a Kraken, Leviathan, Merfolk, Octopus, or Serpent attacks,
+ *     draw a card.
+ * Ward {2}
+ *
+ * Chapter I is a filtered mass-return: gather every battlefield creature whose subtype is none of
+ * the five "sea" types and bounce them (the Sunderflock template). Leviathan itself carries the
+ * Leviathan subtype, so the filter excludes it without needing `excludeSelf`.
+ *
+ * Chapters II and III each install an end-of-turn delayed triggered ability that fires *every* time
+ * (`fireOnce = false`) a sea creature attacks — regardless of controller, matching "whenever a
+ * [type] attacks" — and draws the Saga controller a card. Each chapter creates its own copy, so on
+ * the turn chapter II resolves and again on the turn chapter III resolves there is a fresh
+ * until-end-of-turn watcher.
+ */
+val SummonLeviathan = card("Summon: Leviathan") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment Creature — Saga Leviathan"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\n" +
+        "I — Return each creature that isn't a Kraken, Leviathan, Merfolk, Octopus, or Serpent to its owner's hand.\n" +
+        "II, III — Until end of turn, whenever a Kraken, Leviathan, Merfolk, Octopus, or Serpent attacks, draw a card.\n" +
+        "Ward {2}"
+    power = 6
+    toughness = 6
+
+    keywordAbility(KeywordAbility.ward("{2}"))
+
+    // "Return each creature that isn't a Kraken, Leviathan, Merfolk, Octopus, or Serpent."
+    sagaChapter(1) {
+        effect = Patterns.Group.returnAllToHand(
+            GroupFilter(
+                GameObjectFilter.Creature
+                    .notSubtype(Subtype.KRAKEN)
+                    .notSubtype(Subtype.LEVIATHAN)
+                    .notSubtype(Subtype.MERFOLK)
+                    .notSubtype(Subtype.OCTOPUS)
+                    .notSubtype(Subtype.SERPENT),
+            ),
+        )
+    }
+
+    sagaChapter(2) { effect = seaCreatureAttackDraw() }
+    sagaChapter(3) { effect = seaCreatureAttackDraw() }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "77"
+        artist = "OTUMAMI"
+        imageUri = "https://cards.scryfall.io/normal/front/e/a/ea7f26a9-b203-4ee7-88f1-3d9c77a25bcb.jpg?1782686537"
+    }
+}
+
+/**
+ * "Until end of turn, whenever a Kraken, Leviathan, Merfolk, Octopus, or Serpent attacks, draw a
+ * card." A repeating (`fireOnce = false`) end-of-turn delayed trigger watching attack declarations
+ * by any sea creature. A fresh instance is built per chapter so II and III spawn independent
+ * watchers.
+ */
+private fun seaCreatureAttackDraw(): Effect = CreateDelayedTriggerEffect(
+    trigger = TriggerSpec(
+        event = EventPattern.AttackEvent(
+            filter = GameObjectFilter.Creature.withAnySubtype(
+                "Kraken", "Leviathan", "Merfolk", "Octopus", "Serpent",
+            ),
+        ),
+    ),
+    fireOnce = false,
+    expiry = DelayedTriggerExpiry.EndOfTurn,
+    effect = Effects.DrawCards(1),
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -15734,6 +15734,50 @@
     ]
 }
 
+// Summon: G.F. Cerberus
+{
+    "name": "Summon: G.F. Cerberus",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Enchantment Creature — Saga Dog",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\nII — Double — When you next cast an instant or sorcery spell this turn, copy it. You may choose new targets for the copy.\nIII — Triple — When you next cast an instant or sorcery spell this turn, copy it twice. You may choose new targets for the copies.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": "CopyNextSpellCast"
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "CopyNextSpellCast",
+                    "copies": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "RARE",
+        "artist": "Kevin Glint",
+        "flavorText": "\"Pretty confident. Let's see how you do.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0e5cbd4-401b-4456-80bf-d90beadfd1f8.jpg?1782686479"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Summon: G.F. Ifrit
 {
     "name": "Summon: G.F. Ifrit",
@@ -16017,6 +16061,129 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Summon: Leviathan
+{
+    "name": "Summon: Leviathan",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Enchantment Creature — Saga Leviathan",
+    "oracleText": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Return each creature that isn't a Kraken, Leviathan, Merfolk, Octopus, or Serpent to its owner's hand.\nII, III — Until end of turn, whenever a Kraken, Leviathan, Merfolk, Octopus, or Serpent attacks, draw a card.\nWard {2}",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "sagaChapters": [
+            {
+                "chapter": 1,
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "NotSubtype",
+                                            "subtype": "Kraken"
+                                        },
+                                        {
+                                            "type": "NotSubtype",
+                                            "subtype": "Leviathan"
+                                        },
+                                        {
+                                            "type": "NotSubtype",
+                                            "subtype": "Merfolk"
+                                        },
+                                        {
+                                            "type": "NotSubtype",
+                                            "subtype": "Octopus"
+                                        },
+                                        {
+                                            "type": "NotSubtype",
+                                            "subtype": "Serpent"
+                                        }
+                                    ]
+                                }
+                            },
+                            "storeAs": "returnAllToHand_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "returnAllToHand_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "chapter": 2,
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "AttackEvent",
+                            "filter": "creature Kraken|Leviathan|Merfolk|Octopus|Serpent"
+                        }
+                    }
+                }
+            },
+            {
+                "chapter": 3,
+                "effect": {
+                    "type": "CreateDelayedTrigger",
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "trigger": {
+                        "event": {
+                            "type": "AttackEvent",
+                            "filter": "creature Kraken|Leviathan|Merfolk|Octopus|Serpent"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "77",
+        "rarity": "RARE",
+        "artist": "OTUMAMI",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/a/ea7f26a9-b203-4ee7-88f1-3d9c77a25bcb.jpg?1782686537"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonGfCerberusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonGfCerberusScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonGfCerberus
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Summon: G.F. Cerberus — {2}{R}{R} Enchantment Creature — Saga Dog, 3/3 (FIN).
+ *
+ *   I   — Surveil 1.
+ *   II  — Double — When you next cast an instant or sorcery spell this turn, copy it.
+ *   III — Triple — When you next cast an instant or sorcery spell this turn, copy it twice.
+ *
+ * Generic saga-creature machinery (lore accrual, chapter triggers, sacrifice after the final
+ * chapter) is covered by CreatureSagaTest, and the copy-your-next-spell rider itself by
+ * EtherScenarioTest; this pins Cerberus's chapters II and III producing one / two copies of the
+ * next instant cast, doubling / tripling Shock's damage.
+ */
+class SummonGfCerberusScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun GameTestDriver.loreCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.LORE) ?: 0
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SummonGfCerberus))
+        driver.initMirrorMatch(Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveAll() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard++ < 60) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+        }
+    }
+
+    fun GameTestDriver.castCerberus(me: EntityId): EntityId {
+        val spell = putCardInHand(me, "Summon: G.F. Cerberus")
+        giveColorlessMana(me, 2)
+        giveMana(me, Color.RED, 2)
+        castSpell(me, spell)
+        return spell
+    }
+
+    fun GameTestDriver.advanceUntil(maxSteps: Int = 2000, predicate: GameTestDriver.() -> Boolean) {
+        var guard = 0
+        while (guard++ < maxSteps && !predicate()) {
+            val pd = state.pendingDecision
+            when {
+                pd != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> {
+                    autoSubmitCombatDeclarationIfNeeded()
+                    passPriority(state.priorityPlayerId!!)
+                }
+            }
+        }
+    }
+
+    /** Cast Shock at [opp], resolving every copy (keeping [opp] as the target) and the original. */
+    fun GameTestDriver.castShockAt(me: EntityId, opp: EntityId) {
+        val shock = putCardInHand(me, "Shock")
+        giveMana(me, Color.RED, 1)
+        castSpell(me, shock, listOf(opp)).isSuccess shouldBe true
+        var guard = 0
+        while (stackSize > 0 && guard++ < 30) {
+            if (state.pendingDecision is ChooseTargetsDecision) submitTargetSelection(me, listOf(opp))
+            else bothPass()
+        }
+    }
+
+    test("enters as a 3/3 Saga Dog creature") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.castCerberus(me)
+        driver.resolveAll()
+
+        val cerberus = driver.findPermanent(me, "Summon: G.F. Cerberus")!!
+        val projected = projector.project(driver.state)
+        projected.isCreature(cerberus) shouldBe true
+        projected.hasType(cerberus, "Saga") shouldBe true
+        projected.getPower(cerberus) shouldBe 3
+        projected.getToughness(cerberus) shouldBe 3
+    }
+
+    test("chapter II — copies the next instant once, doubling Shock's damage") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.player2
+        driver.castCerberus(me)
+        driver.resolveAll()
+
+        // Advance to the turn chapter II resolves (second lore counter).
+        driver.advanceUntil {
+            val s = findPermanent(me, "Summon: G.F. Cerberus") ?: return@advanceUntil true
+            loreCounters(s) >= 2
+        }
+        driver.resolveAll()
+
+        val before = driver.getLifeTotal(opp)
+        driver.castShockAt(me, opp)
+        // 2 (original) + 2 (one copy) = 4.
+        driver.getLifeTotal(opp) shouldBe before - 4
+    }
+
+    test("chapter III — copies the next instant twice, tripling Shock's damage") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.player2
+        driver.castCerberus(me)
+        driver.resolveAll()
+
+        // Advance to the turn chapter III resolves (third lore counter). Chapter II's rider was
+        // cast-free that turn and expired, so only chapter III's "copy twice" rider is live now.
+        driver.advanceUntil {
+            val s = findPermanent(me, "Summon: G.F. Cerberus") ?: return@advanceUntil false
+            loreCounters(s) >= 3
+        }
+        driver.resolveAll()
+
+        val before = driver.getLifeTotal(opp)
+        driver.castShockAt(me, opp)
+        // 2 (original) + 2 + 2 (two copies) = 6.
+        driver.getLifeTotal(opp) shouldBe before - 6
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonLeviathanScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SummonLeviathanScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SummonLeviathan
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Summon: Leviathan — {4}{U}{U} Enchantment Creature — Saga Leviathan, 6/6, Ward {2} (FIN).
+ *
+ *   I       — Return each creature that isn't a Kraken, Leviathan, Merfolk, Octopus, or Serpent to
+ *             its owner's hand.
+ *   II, III — Until end of turn, whenever a [sea creature] attacks, draw a card.
+ *
+ * Generic saga-creature machinery is covered by CreatureSagaTest and the end-of-turn delayed
+ * attack-trigger primitive by SummonFenrirScenarioTest; this pins chapter I's *filtered* mass
+ * bounce — non-sea creatures are returned while sea creatures (and Leviathan itself, a Leviathan)
+ * stay put.
+ */
+class SummonLeviathanScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SummonLeviathan))
+        driver.initMirrorMatch(Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.resolveAll() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || state.pendingDecision != null) && guard++ < 60) {
+            if (state.pendingDecision != null) autoResolveDecision() else bothPass()
+        }
+    }
+
+    fun GameTestDriver.castLeviathan(me: EntityId): EntityId {
+        val spell = putCardInHand(me, "Summon: Leviathan")
+        giveColorlessMana(me, 4)
+        giveMana(me, Color.BLUE, 2)
+        castSpell(me, spell)
+        return spell
+    }
+
+    test("enters as a 6/6 Saga Leviathan creature") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.castLeviathan(me)
+        driver.resolveAll()
+
+        val leviathan = driver.findPermanent(me, "Summon: Leviathan")!!
+        val projected = projector.project(driver.state)
+        projected.isCreature(leviathan) shouldBe true
+        projected.hasType(leviathan, "Saga") shouldBe true
+        projected.getPower(leviathan) shouldBe 6
+        projected.getToughness(leviathan) shouldBe 6
+    }
+
+    test("chapter I — returns non-sea creatures but not sea creatures or Leviathan itself") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // A non-sea creature (Centaur) and a sea creature (Island Walker is a Merfolk).
+        driver.putPermanentOnBattlefield(me, "Centaur Courser")
+        driver.putPermanentOnBattlefield(me, "Island Walker")
+        val handBefore = driver.getHandSize(me)
+
+        driver.castLeviathan(me)
+        driver.resolveAll()
+
+        // The Centaur was returned to its owner's hand; the Merfolk and the Leviathan stayed.
+        driver.findPermanent(me, "Centaur Courser") shouldBe null
+        (driver.findPermanent(me, "Island Walker") != null) shouldBe true
+        (driver.findPermanent(me, "Summon: Leviathan") != null) shouldBe true
+        // Leviathan is cast hand-neutral (drawn into hand, then cast), so the only net change is
+        // the bounced Centaur returning to hand: handBefore + 1.
+        driver.getHandSize(me) shouldBe handBefore + 1
+    }
+})


### PR DESCRIPTION
## Summary

Implements a handful of **Final Fantasy (FIN)** cards via the `add-card` flow. Both are
Saga creatures composed entirely from **existing SDK primitives** — no engine/SDK changes,
so the change set is two card files, two scenario tests, and a re-blessed snapshot.

### Cards

- **Summon: G.F. Cerberus** `{2}{R}{R}` — Enchantment Creature — Saga Dog, 3/3
  - I — Surveil 1
  - II — *Double* — copy your next instant/sorcery this turn (`Effects.CopyNextSpellCast(copies = 1)`)
  - III — *Triple* — copy it twice (`copies = 2`)
- **Summon: Leviathan** `{4}{U}{U}` — Enchantment Creature — Saga Leviathan, 6/6, Ward {2}
  - I — Return each creature that isn't a Kraken/Leviathan/Merfolk/Octopus/Serpent (filtered mass bounce)
  - II, III — Until end of turn, whenever a sea creature attacks, draw a card (end-of-turn delayed trigger)

### Tests

- `SummonGfCerberusScenarioTest` — enters as a 3/3 Saga Dog; chapters II/III double/triple Shock's damage.
- `SummonLeviathanScenarioTest` — enters as a 6/6 Saga Leviathan; chapter I bounces non-sea creatures while sea creatures (and Leviathan itself) stay.
- Re-blessed `FIN.json` card snapshot (purely additive — only the two new cards).

### Scope note

The remaining unimplemented FIN cards I evaluated (Gilgamesh, Absolute Virtue, Ultima,
Zodiark, Edgar, Firion, Kain, Sin, …) each require **new engine capability** rather than
pure card authoring — e.g. attach-from-collection, controller-level protection statics,
"end the turn" (CR 720), half-rounded sacrifice, coin-flip replacement. Those belong in
`add-feature` work and were intentionally left out to keep this PR composition-only and faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)