### PR TITLE
Fix battlefield grouping of same-named creatures with different P/T

### DIFF
--- a/web-client/src/store/cardGrouping.ts
+++ b/web-client/src/store/cardGrouping.ts
@@ -49,9 +49,17 @@ export function computeCardGroupKey(card: ClientCard): string {
     parts.push(`counters:${JSON.stringify(sortedCounters)}`)
   }
 
-  // Cards with modified P/T are different
-  if (card.power !== card.basePower || card.toughness !== card.baseToughness) {
+  // Creatures with different (projected) P/T render differently and must never share a
+  // stack. Keying off "modified vs own base" alone is wrong: a 4/4 creature and a 1/1 token
+  // copy of it each match their own base P/T, so neither would contribute P/T to the key and
+  // they'd wrongly merge. Key off the *current* P/T directly, then add base P/T when it
+  // diverges so a pumped creature (which shows buff indicators) still splits from an unbuffed
+  // twin sitting at the same current P/T.
+  if (card.power !== null || card.toughness !== null) {
     parts.push(`pt:${card.power}/${card.toughness}`)
+    if (card.power !== card.basePower || card.toughness !== card.baseToughness) {
+      parts.push(`basept:${card.basePower}/${card.baseToughness}`)
+    }
   }
 
   // Cards with attachments (auras/equipment) should never be grouped — use unique ID

--- a/web-client/src/store/groupCards.test.ts
+++ b/web-client/src/store/groupCards.test.ts
@@ -87,6 +87,28 @@ describe('groupCards — token quantity aggregation (display layer)', () => {
     expect(groups.find((g) => g.cardIds.includes(entityId('enchanted')))!.count).toBe(1)
   })
 
+  it('never groups same-named creatures with different P/T (4/4 vs 1/1 token copy)', () => {
+    // Rust-Shield Rampager (4/4, base 4/4) and its Offspring 1/1 token copy (1/1, base 1/1)
+    // share a name and each sits at its own base P/T — they must still render separately.
+    const groups = groupCards([
+      token({ id: 'orig', name: 'Rust-Shield Rampager', power: 4, toughness: 4, basePower: 4, baseToughness: 4 }),
+      token({ id: 'offspring', name: 'Rust-Shield Rampager', power: 1, toughness: 1, basePower: 1, baseToughness: 1 }),
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups.every((g) => g.count === 1)).toBe(true)
+  })
+
+  it('splits a pumped creature from an unbuffed twin at the same current P/T', () => {
+    // A 2/2 pumped to 3/3 (base 1/1) shows buff indicators; a vanilla 3/3 (base 3/3) does not —
+    // same current P/T, but they must not share a stack.
+    const groups = groupCards([
+      token({ id: 'vanilla', name: 'Bear', power: 3, toughness: 3, basePower: 3, baseToughness: 3 }),
+      token({ id: 'pumped', name: 'Bear', power: 3, toughness: 3, basePower: 1, baseToughness: 1 }),
+    ])
+    expect(groups).toHaveLength(2)
+    expect(groups.every((g) => g.count === 1)).toBe(true)
+  })
+
   it('keeps distinct token kinds in separate groups', () => {
     const groups = groupCards([
       token({ id: 's1', name: 'Saproling' }),


### PR DESCRIPTION
## Problem

Rust-Shield Rampager (4/4) and its Offspring **1/1 token copy** were collapsed into a single visual battlefield stack, even though they render at different sizes. Any creature alongside a differently-sized token copy of itself hit this.

## Cause

The display-layer grouping key (`web-client/src/store/cardGrouping.ts`) only appended P/T to the key when a creature's *current* P/T differed from its **own** base P/T:

```ts
if (card.power !== card.basePower || card.toughness !== card.baseToughness) {
  parts.push(`pt:${card.power}/${card.toughness}`)
}
```

The 4/4 (base 4/4) and the 1/1 token copy (base 1/1) each match their *own* base, so neither contributed P/T to the key. They shared the name-only key `Rust-Shield Rampager` and merged.

## Fix

Key off the **current** P/T directly so genuinely different P/T always splits, and add base P/T to the key only when it diverges — preserving the existing behaviour that a pumped creature (which shows buff indicators) stays distinct from an unbuffed twin sitting at the same current P/T.

## Tests

- Added a regression test: a 4/4 and a 1/1 token copy of the same card render as two groups.
- Added a test that a pumped 3/3 (base 1/1) still splits from a vanilla 3/3 (base 3/3).
- Full client unit suite green (175 tests); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)