### PR TITLE
Show player connection origin in admin recent games

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -207,6 +207,9 @@ data class AdminGamePlayer(
     val userId: UUID?,
     val isAi: Boolean,
     val won: Boolean,
+    // Coarse connection origin, resolved from the seat's recorded IP via [GeoIpService]. Null for AI
+    // seats and when the IP couldn't be resolved. Raw IPs never reach the client — only the location.
+    val location: GeoLocation? = null,
 )
 
 /** A recorded game for the admin global game list, newest first, with every seat. */
@@ -234,6 +237,7 @@ class StatsQueryService(
     private val deckProfiler: DeckProfiler,
     private val cardRegistry: CardRegistry,
     private val printingRegistry: PrintingRegistry,
+    private val geoIp: GeoIpService,
 ) {
 
     // ---- Per-user ----------------------------------------------------------------------------
@@ -1016,32 +1020,56 @@ class StatsQueryService(
         }
     }
 
-    /** Every seat for a set of match ids, keyed by match id (seat order preserved). */
+    /**
+     * Every seat for a set of match ids, keyed by match id (seat order preserved). Each seat's
+     * recorded IP is resolved to a coarse location via [GeoIpService] (batched across all seats,
+     * cached in-process); the raw IP stays server-side and only the location reaches the DTO.
+     */
     private fun playersForMatches(matchIds: List<Long>): Map<Long, List<AdminGamePlayer>> {
         if (matchIds.isEmpty()) return emptyMap()
         val placeholders = matchIds.joinToString(",") { "?" }
-        val out = LinkedHashMap<Long, MutableList<AdminGamePlayer>>()
-        jdbc.query(
+        data class Seat(
+            val mid: Long,
+            val name: String,
+            val userId: UUID?,
+            val isAi: Boolean,
+            val won: Boolean,
+            val ip: String?,
+        )
+        val seats = jdbc.query(
             """
             SELECT p.match_id AS mid, COALESCE(u.display_name, p.player_name) AS name,
-                   p.user_id AS uid, p.is_ai AS is_ai, p.won AS won
+                   p.user_id AS uid, p.is_ai AS is_ai, p.won AS won, p.client_ip AS client_ip
             FROM match_participants p
             LEFT JOIN users u ON u.id = p.user_id
             WHERE p.match_id IN ($placeholders)
             ORDER BY p.id
             """.trimIndent(),
-            { rs ->
-                out.getOrPut(rs.getLong("mid")) { mutableListOf() }.add(
-                    AdminGamePlayer(
-                        name = rs.getString("name"),
-                        userId = rs.getObject("uid", UUID::class.java),
-                        isAi = rs.getBoolean("is_ai"),
-                        won = rs.getBoolean("won"),
-                    ),
+            { rs, _ ->
+                Seat(
+                    mid = rs.getLong("mid"),
+                    name = rs.getString("name"),
+                    userId = rs.getObject("uid", UUID::class.java),
+                    isAi = rs.getBoolean("is_ai"),
+                    won = rs.getBoolean("won"),
+                    ip = rs.getString("client_ip")?.takeIf { it.isNotBlank() },
                 )
             },
             *matchIds.toTypedArray(),
         )
+        val locations = geoIp.resolve(seats.mapNotNull { it.ip })
+        val out = LinkedHashMap<Long, MutableList<AdminGamePlayer>>()
+        for (seat in seats) {
+            out.getOrPut(seat.mid) { mutableListOf() }.add(
+                AdminGamePlayer(
+                    name = seat.name,
+                    userId = seat.userId,
+                    isAi = seat.isAi,
+                    won = seat.won,
+                    location = seat.ip?.let { locations[it] },
+                ),
+            )
+        }
         return out
     }
 

--- a/web-client/src/api/adminStats.ts
+++ b/web-client/src/api/adminStats.ts
@@ -52,12 +52,21 @@ export interface TournamentSummary {
   readonly winnerName: string | null
 }
 
+/** Coarse connection origin for a seat, resolved from its IP server-side (raw IP never sent). */
+export interface PlayerLocation {
+  readonly country: string | null
+  readonly countryCode: string | null
+  readonly region: string | null
+  readonly city: string | null
+}
+
 /** One seat in a recorded game, for the admin global game list. */
 export interface AdminGamePlayer {
   readonly name: string
   readonly userId: string | null
   readonly isAi: boolean
   readonly won: boolean
+  readonly location: PlayerLocation | null
 }
 
 /** A recorded game in the admin global game list, with every seat. */

--- a/web-client/src/components/admin/AdminActivity.tsx
+++ b/web-client/src/components/admin/AdminActivity.tsx
@@ -184,8 +184,34 @@ function Players({ players, onProfile }: { players: AdminGamePlayer[]; onProfile
               {p.isAi ? <span style={styles.aiTag}> AI</span> : null}
             </span>
           )}
+          <PlayerOrigin location={p.location} />
         </span>
       ))}
+    </span>
+  )
+}
+
+/** A 2-letter ISO country code → flag emoji (regional-indicator letters); '' when not a real code. */
+function flagEmoji(countryCode: string | null): string {
+  if (!countryCode || countryCode.length !== 2) return ''
+  const base = 0x1f1e6 // 🇦
+  return String.fromCodePoint(...[...countryCode.toUpperCase()].map((c) => base + c.charCodeAt(0) - 65))
+}
+
+/** Where a seat connected from, as a compact muted tag with the full detail on hover. AI seats and
+ *  unresolved IPs (every field null) render nothing. */
+function PlayerOrigin({ location }: { location: AdminGamePlayer['location'] }) {
+  if (!location) return null
+  const { city, region, country, countryCode } = location
+  const detail = [city, region, country].filter(Boolean).join(', ')
+  if (!detail) return null
+  const flag = flagEmoji(countryCode)
+  const short = city ?? region ?? country ?? ''
+  return (
+    <span style={styles.origin} title={detail}>
+      {' '}
+      {flag ? `${flag} ` : ''}
+      {short}
     </span>
   )
 }
@@ -205,6 +231,7 @@ const styles: Record<string, React.CSSProperties> = {
   playerLink: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 'inherit', padding: 0 },
   playerLinkWon: { background: 'none', border: 'none', color: adminTheme.accent, cursor: 'pointer', fontSize: 'inherit', padding: 0, fontWeight: 600 },
   aiTag: { color: adminTheme.textMuted, fontSize: 11 },
+  origin: { color: adminTheme.textMuted, fontSize: 11, whiteSpace: 'nowrap' },
   clickableRow: { cursor: 'pointer' },
   pager: { display: 'inline-flex', alignItems: 'center', gap: 10 },
   pageInfo: { color: adminTheme.textMuted, fontSize: 12, fontVariantNumeric: 'tabular-nums' },


### PR DESCRIPTION
## What

The admin dashboard's **Activity → Recent games** list now shows **where each player connected from**.

![placeholder — UI shows a muted "🇳🇱 Amsterdam" style tag beside each player name]

## How

Seats already record the connecting IP in `match_participants.client_ip` (captured at the WebSocket handshake, admin-only, never sent to clients). This change:

- **Backend** (`StatsQueryService.playersForMatches`): also selects `client_ip`, batch-resolves all of a page's IPs to coarse locations via the existing `GeoIpService` (in-process cache, so repeat loads hit the network only for new IPs), and attaches the result to each `AdminGamePlayer` as a new `location` field. Raw IPs stay server-side — only the resolved country/region/city is serialized, the same privacy posture as the existing `/geo` dashboard.
- **Frontend** (`AdminActivity.tsx`): renders a compact muted tag beside each player name — flag emoji + city/region/country, with the full location on hover (`title`). AI seats and unresolved IPs render nothing.

## Notes

- Reuses existing infrastructure (`GeoIpService`, the `client_ip` column) — no new dependencies, no schema change, no new endpoint.
- Gated behind `accounts.enabled` like the rest of the admin stats stack.
- Verified: `web-client` typecheck and `:game-server` Kotlin compile both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)