### PR TITLE
Add 4 Foundations cards (Armasaur Guide, Death Baron, Kargan Dragonrider, Mentor of the Meek)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DeathBaron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ala/cards/DeathBaron.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.ala.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Death Baron
+ * {1}{B}{B}
+ * Creature — Zombie Wizard
+ * 2/2
+ * Skeletons you control and other Zombies you control get +1/+1 and have deathtouch.
+ *
+ * Modeled as two lord static abilities over the same group: every Skeleton or
+ * Zombie you control, excluding Death Baron itself ("other Zombies"). Because
+ * Death Baron is a Zombie (not a Skeleton), `excludeSelf = true` over a
+ * Zombie-OR-Skeleton filter is rules-faithful — it drops only this permanent
+ * from the Zombie clause while leaving every Skeleton unaffected.
+ */
+val DeathBaron = card("Death Baron") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Wizard"
+    oracleText = "Skeletons you control and other Zombies you control get +1/+1 and have deathtouch. " +
+        "(Any amount of damage they deal to a creature is enough to destroy it.)"
+    power = 2
+    toughness = 2
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.youControl().withAnySubtype("Zombie", "Skeleton"),
+                excludeSelf = true
+            )
+        )
+    }
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.DEATHTOUCH,
+            GroupFilter(
+                GameObjectFilter.Creature.youControl().withAnySubtype("Zombie", "Skeleton"),
+                excludeSelf = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "70"
+        artist = "Nils Hamm"
+        flavorText = "For the necromancer barons, killing and recruitment are one and the same."
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d59b5e5-fc16-4f1a-9f17-f42908473531.jpg?1782715970"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ArmasaurGuide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ArmasaurGuide.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern.YouAttackEvent
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+
+/**
+ * Armasaur Guide
+ * {4}{W}
+ * Creature — Dinosaur
+ * 4/4
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * Whenever you attack with three or more creatures, put a +1/+1 counter on target creature you control.
+ */
+val ArmasaurGuide = card("Armasaur Guide") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Dinosaur"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "Whenever you attack with three or more creatures, put a +1/+1 counter on target creature you control."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = TriggerSpec(YouAttackEvent(minAttackers = 3), TriggerBinding.ANY)
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Loïc Canavaggia"
+        flavorText = "The armasaur was skittish about the lanterns, until it noticed the captivating dance of its shadow along the walls."
+        imageUri = "https://cards.scryfall.io/normal/front/c/8/c80fc380-0499-4499-8a60-c43844c02c9b.jpg?1782689262"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DeathBaronReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DeathBaronReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Death Baron reprint in FDN. Canonical CardDefinition lives in ALA (the card's
+ * earliest real printing).
+ */
+val DeathBaronReprint = Printing(
+    oracleId = "99024aa8-5687-4d38-8a4b-feef42d6c1ff",
+    name = "Death Baron",
+    setCode = "FDN",
+    collectorNumber = "521",
+    scryfallId = "34a27142-cf45-4164-9e10-373e5c8bf7c6",
+    artist = "Nils Hamm",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34a27142-cf45-4164-9e10-373e5c8bf7c6.jpg?1782688813",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KarganDragonriderReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KarganDragonriderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kargan Dragonrider reprint in FDN. Canonical CardDefinition lives in its earliest real
+ * printing (Core Set 2019, M19); this file contributes only presentation data.
+ */
+val KarganDragonriderReprint = Printing(
+    oracleId = "df366871-8ed7-4183-8b0c-414ca361a711",
+    name = "Kargan Dragonrider",
+    setCode = "FDN",
+    collectorNumber = "541",
+    scryfallId = "701aef07-4291-4dfd-b9b2-bfc26745341c",
+    artist = "Greg Opalinski",
+    imageUri = "https://cards.scryfall.io/normal/front/7/0/701aef07-4291-4dfd-b9b2-bfc26745341c.jpg?1782688794",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MentorOfTheMeekReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MentorOfTheMeekReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mentor of the Meek reprint in FDN. Canonical CardDefinition lives in its earliest set (ISD).
+ */
+val MentorOfTheMeekReprint = Printing(
+    oracleId = "b9f4f96b-6e54-4fe6-8df7-623e0fc72409",
+    name = "Mentor of the Meek",
+    setCode = "FDN",
+    collectorNumber = "578",
+    scryfallId = "60790977-efd4-470a-823a-6929f84016e7",
+    artist = "Jana Schirmer & Johannes Voss",
+    imageUri = "https://cards.scryfall.io/normal/front/6/0/60790977-efd4-470a-823a-6929f84016e7.jpg?1782688761",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/MentorOfTheMeek.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/MentorOfTheMeek.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Mentor of the Meek
+ * {2}{W}
+ * Creature — Human Soldier
+ * 3/2
+ * Whenever another creature you control with power 2 or less enters, you may pay {1}.
+ * If you do, draw a card.
+ *
+ * Canonical printing lives here (Innistrad, 2011 — earliest real-expansion printing). FDN, M19,
+ * 2X2, INR, etc. are reprints (Printing rows only).
+ *
+ * "Power 2 or less" is a battlefield-state characteristic, so the trigger filter resolves through
+ * projected state. The optional {1} payment is modeled with [MayPayManaEffect] (the engine's
+ * "you may pay {cost}; if you do, <effect>" gate) wrapping [Effects.DrawCards].
+ */
+val MentorOfTheMeek = card("Mentor of the Meek") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 2
+    oracleText = "Whenever another creature you control with power 2 or less enters, you may pay {1}. " +
+        "If you do, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.youControl().powerAtMost(2),
+            binding = TriggerBinding.OTHER
+        )
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "21"
+        artist = "Jana Schirmer & Johannes Voss"
+        flavorText = "\"In these halls there is no pass or fail. Your true test comes with the first full moon.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd8f179a-f6ab-4d4c-8195-ed077a7770d3.jpg?1782714825"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KarganDragonrider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/KarganDragonrider.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+
+/**
+ * Kargan Dragonrider
+ * {1}{R}
+ * Creature — Human Warrior
+ * 2/2
+ * As long as you control a Dragon, this creature has flying.
+ *
+ * Canonical earliest real printing: Core Set 2019 (M19). Reprinted in Foundations (FDN).
+ *
+ * Modeled as a conditional static ability: GrantKeyword(FLYING, Self) gated by
+ * YouControl(a Dragon). The continuous keyword grant is re-evaluated by the layer system
+ * whenever the controlled-Dragon condition changes, matching "as long as".
+ */
+val KarganDragonrider = card("Kargan Dragonrider") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    power = 2
+    toughness = 2
+    oracleText = "As long as you control a Dragon, this creature has flying."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FLYING, Filters.Self),
+            condition = Conditions.YouControl(GameObjectFilter.Creature.withSubtype(Subtype.DRAGON))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "297"
+        artist = "Greg Opalinski"
+        flavorText = "\"Only those who give the dragons the respect they deserve may bear our title.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/34750304-c536-47d4-922d-a3654c37ffbc.jpg?1782709434"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ALA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ALA.json
@@ -1,3 +1,46 @@
+// Death Baron
+{
+    "name": "Death Baron",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Creature — Zombie Wizard",
+    "oracleText": "Skeletons you control and other Zombies you control get +1/+1 and have deathtouch. (Any amount of damage they deal to a creature is enough to destroy it.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Zombie|Skeleton ctrl:you",
+                    "excludeSelf": true
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "DEATHTOUCH",
+                "filter": {
+                    "baseFilter": "creature Zombie|Skeleton ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "rarity": "RARE",
+        "artist": "Nils Hamm",
+        "flavorText": "For the necromancer barons, killing and recruitment are one and the same.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d59b5e5-fc16-4f1a-9f17-f42908473531.jpg?1782715970"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dispeller's Capsule
 {
     "name": "Dispeller's Capsule",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -284,6 +284,58 @@
     ]
 }
 
+// Armasaur Guide
+{
+    "name": "Armasaur Guide",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhenever you attack with three or more creatures, put a +1/+1 counter on target creature you control.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "minAttackers": 3
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Loïc Canavaggia",
+        "flavorText": "The armasaur was skittish about the lanterns, until it noticed the captivating dance of its shadow along the walls.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/8/c80fc380-0499-4499-8a60-c43844c02c9b.jpg?1782689262"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ashroot Animist
 {
     "name": "Ashroot Animist",

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -2033,6 +2033,58 @@
     ]
 }
 
+// Mentor of the Meek
+{
+    "name": "Mentor of the Meek",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever another creature you control with power 2 or less enters, you may pay {1}. If you do, draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature pow<=2 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "21",
+        "rarity": "RARE",
+        "artist": "Jana Schirmer & Johannes Voss",
+        "flavorText": "\"In these halls there is no pass or fail. Your true test comes with the first full moon.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd8f179a-f6ab-4d4c-8195-ed077a7770d3.jpg?1782714825"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Midnight Haunting
 {
     "name": "Midnight Haunting",

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -282,6 +282,48 @@
     ]
 }
 
+// Kargan Dragonrider
+{
+    "name": "Kargan Dragonrider",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "As long as you control a Dragon, this creature has flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Dragon"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "297",
+        "artist": "Greg Opalinski",
+        "flavorText": "\"Only those who give the dragons the respect they deserve may bear our title.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/34750304-c536-47d4-922d-a3654c37ffbc.jpg?1782709434"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Lathliss, Dragon Queen
 {
     "name": "Lathliss, Dragon Queen",


### PR DESCRIPTION
Implements a handful of Foundations (FDN) cards via the `add-card` skill. Each composes **existing SDK primitives only** — no engine/SDK changes.

## Cards

| Card | Canonical set | FDN | Mechanic |
|------|---------------|-----|----------|
| **Armasaur Guide** `{4}{W}` 4/4 | FDN (earliest) | canonical | Vigilance; attack-with-3+ trigger → +1/+1 counter on target creature you control |
| **Death Baron** `{1}{B}{B}` 2/2 | ALA | reprint row | Lord: Skeletons + *other* Zombies you control get +1/+1 and deathtouch (two static abilities over a Zombie/Skeleton group with `excludeSelf`) |
| **Kargan Dragonrider** `{1}{R}` 2/2 | M19 | reprint row | `ConditionalStaticAbility` granting flying while you control a Dragon |
| **Mentor of the Meek** `{2}{W}` 3/2 | ISD | reprint row | ETB trigger on another power-2-or-less creature you control → `MayPayManaEffect({1})` to draw |

## Placement
Per the skill's canonical-placement rule, each reprint's canonical `CardDefinition` lives in its **earliest real printing** (an already-scaffolded set), and FDN receives a `Printing` row. Armasaur Guide is original to FDN. `check-card-printing` reports no canonical-placement errors for any of the four; the only advisories are the usual optional missing-row coverage in *other* scaffolded sets (m19/j22/c14/jmp/inr) — the same partial coverage long-standing cards like Lightning Bolt already have, so it's left out of scope.

## Testing
- `just build` passes; the only failure was the expected `CardDefinitionSnapshotTest` diff, re-blessed for ALA/ISD/M19 (Armasaur added to FDN.json). Each golden diff is purely additive — only the new card, nothing else changed.
- No scenario tests added: every card reuses mature, already-tested primitives (no new mechanic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)