### PR TITLE
Fix Skirk Prospector wrong art (ONS)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/SkirkProspector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/SkirkProspector.kt
@@ -1,41 +1,23 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
-import com.wingedsheep.sdk.core.Color
-import com.wingedsheep.sdk.dsl.Costs
-import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Printing
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.AbilityCost
-import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.TimingRule
-import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 
 /**
- * Skirk Prospector
- * {R}
- * Creature — Goblin
- * 1/1
- * Sacrifice a Goblin: Add {R}.
+ * Skirk Prospector reprint in DOM.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * ONS's `cards/` package (the card's earliest real printing). This file contributes
+ * only the DOM-specific presentation row.
  */
-val SkirkProspector = card("Skirk Prospector") {
-    manaCost = "{R}"
-    colorIdentity = "R"
-    typeLine = "Creature — Goblin"
-    power = 1
-    toughness = 1
-    oracleText = "Sacrifice a Goblin: Add {R}."
-
-    activatedAbility {
-        cost = Costs.Sacrifice(GameObjectFilter.Creature.withSubtype("Goblin"))
-        effect = AddManaEffect(Color.RED)
-        manaAbility = true
-        timing = TimingRule.ManaAbility
-    }
-
-    metadata {
-        rarity = Rarity.COMMON
-        collectorNumber = "144"
-        artist = "Slawomir Maniak"
-        flavorText = "\"Deep beneath the ruined continent of Otaria, there's a mine where goblins still work, ignorant of the destruction above.\""
-        imageUri = "https://cards.scryfall.io/normal/front/1/6/1636d138-aa63-476f-a930-41b1be988032.jpg?1562731846"
-    }
-}
+val SkirkProspectorReprint = Printing(
+    oracleId = "c18013e4-0b99-44e3-a2b2-027ace68723a",
+    name = "Skirk Prospector",
+    setCode = "DOM",
+    collectorNumber = "144",
+    scryfallId = "1636d138-aa63-476f-a930-41b1be988032",
+    artist = "Slawomir Maniak",
+    imageUri = "https://cards.scryfall.io/normal/front/1/6/1636d138-aa63-476f-a930-41b1be988032.jpg?1562731846",
+    releaseDate = "2018-04-27",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -10853,47 +10853,6 @@
     ]
 }
 
-// Skirk Prospector
-{
-    "name": "Skirk Prospector",
-    "manaCost": "{R}",
-    "typeLine": "Creature — Goblin",
-    "oracleText": "Sacrifice a Goblin: Add {R}.",
-    "creatureStats": {
-        "power": 1,
-        "toughness": 1
-    },
-    "script": {
-        "activatedAbilities": [
-            {
-                "id": "ability_1",
-                "cost": {
-                    "type": "CostAtomWrapper",
-                    "atom": {
-                        "type": "AtomSacrifice",
-                        "filter": "creature Goblin"
-                    }
-                },
-                "effect": {
-                    "type": "AddMana",
-                    "color": "RED"
-                },
-                "timing": "ManaAbility",
-                "isManaAbility": true
-            }
-        ]
-    },
-    "metadata": {
-        "collectorNumber": "144",
-        "artist": "Slawomir Maniak",
-        "flavorText": "\"Deep beneath the ruined continent of Otaria, there's a mine where goblins still work, ignorant of the destruction above.\"",
-        "imageUri": "https://cards.scryfall.io/normal/front/1/6/1636d138-aa63-476f-a930-41b1be988032.jpg?1562731846"
-    },
-    "colorIdentityOverride": [
-        "RED"
-    ]
-}
-
 // Skittering Surveyor
 {
     "name": "Skittering Surveyor",


### PR DESCRIPTION
## Problem

`Skirk Prospector` in Onslaught displayed the wrong art (the Dominaria art by Slawomir Maniak instead of the Onslaught art by Doug Chaffee).

## Root cause

Both `ons/cards/SkirkProspector.kt` and `dom/cards/SkirkProspector.kt` defined a full `card("Skirk Prospector")`. Two card definitions registered under the same name collide, and the Dominaria definition was overriding the Onslaught one — so the ONS card rendered with DOM art.

This violated the reprint rule: only a card's *earliest* real printing gets a full `card(...)`; later sets get a `Printing(...)` row. Onslaught (2002) predates Dominaria (2018), so ONS is the sole canonical.

## Fix

- Convert `dom/cards/SkirkProspector.kt` from a duplicate canonical into a `Printing(...)` row (auto-discovered via `CardDiscovery.findPrintingsIn`), preserving the DOM art/artist/collector number as a presentation variant.
- Re-bless `DOM.json` — the only change is the removal of the duplicate Skirk Prospector card entry.

## Verification

- `just check-card-printing "Skirk Prospector"` → `ok: canonical is in the card's earliest real printing and all scaffolded reprints have rows.` (previously reported drift)
- `CardDefinitionSnapshotTest` + `CardLintTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)