### PR TITLE
Unify cost-based Forage: let the player choose mode + which cards

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -226,6 +226,17 @@ excluded.
 - `Costs.ExileFromGraveyard(count, filter)` — exile N matching cards from your graveyard.
 - `Costs.ExileXFromGraveyard(filter)` — exile X cards from your graveyard (X = the ability's
   chosen X value).
+- `Costs.Forage()` (ability cost) / `Costs.additional.Forage` (additional cost) — Forage (CR
+  701.61): "exile three cards from your graveyard **or** sacrifice a Food." A *choice* between two
+  sub-costs that belongs to the player. All cost-shaped forage payment is unified in the engine's
+  `ForageCostResolver`: the enumerators surface the available modes as separate legal actions (the
+  same multi-action pattern the "OrPay" costs use — `ExileFromGraveyard` and `SacrificePermanent`
+  cost-info, so the client's existing pickers let the player choose the mode *and* which cards/Food),
+  and payment honors that choice, only auto-paying a legal mode when none was supplied (AI /
+  engine-direct). Used as an activated/mana-ability cost (Camellia, Thornvault Forager), a modal
+  additional cost (Feed the Cycle), and the graveyard-cast permission (Osteomancer Adept, where the
+  card being cast is excluded from the exile pool). For a "you may forage" *effect* (not a cost) use
+  `Patterns.Mechanic.forage(afterEffect?)` instead.
 - `Costs.Craft(filter, minCount = 1)` — Craft material cost (CR 702.167a): exile this permanent
   **and** exile at least `minCount` cards matching `filter` selected from the combined pool of
   permanents you control and cards in your graveyard. Atomic because CR 702.167a pairs the
@@ -1536,7 +1547,10 @@ one-off pipeline belongs inline in the card file via `Effects.Pipeline { }` (§5
   `GatedEffect(WhenCondition(Not(CollectionContainsMatch("explored", Land))))` over counter + optional
   graveyard move. The gate is "no land revealed" (not "a nonland was revealed") so an empty library still
   yields the counter, per CR 701.44a/b.
-- `forage(afterEffect?)` — Forage cost; choose card-from-hand to play.
+- `forage(afterEffect?)` — Forage as an *effect* ("you may forage"): a `ChooseActionEffect` letting
+  the player choose to exile three cards from their graveyard or sacrifice a Food (each gated by a
+  feasibility check), with `afterEffect` appended to whichever mode is taken (Bushy Bodyguard, Curious
+  Forager). For forage as a *cost*, use `Costs.Forage()` / `Costs.additional.Forage` (§3).
 - `loot(draw?, discard?)` — "draw N, discard M" loop.
 - `rummage(count?)` — discard then draw.
 - `connive(target?)` — draw 1, discard 1, then put a +1/+1 counter on `target` (default Self) if the discard was a nonland (CR 702.166). Also exposed as `Effects.Connive(target)`.
@@ -6007,7 +6021,11 @@ Card authors rarely reference these directly; they are created/updated by the ma
   is `DynamicAmount.Fixed` for "endure 2" or any dynamic value for "endure X" (e.g. Warden of the Grove reads
   `EntityProperty(Source, CounterCount(...))`); `target` defaults to `Self` ("it endures") but takes
   `EffectTarget.TriggeringEntity` when a card endures the creature that triggered it.
-- **Forage** — `Patterns.Mechanic.forage`; cast-from-graveyard permissions need a branch in `CastSpellHandler.validate`.
+- **Forage** — effect form is `Patterns.Mechanic.forage` (`ChooseActionEffect`). All *cost* forms
+  (`Costs.Forage()`, `Costs.additional.Forage`, and the cast-from-graveyard permission) route their
+  payment, candidate-finding, and per-mode legal-action cost-info through the single
+  `ForageCostResolver`, so the player chooses exile-vs-sacrifice and which cards/Food everywhere
+  (CR 701.61).
 - **Blight X** — `Costs.additional.BlightVariable` + `DynamicAmount.AdditionalCostBlightAmount` +
   `Conditions.BlightWasPaid(n)`.
 - **Divvy (Fact-or-Fiction)** — `Patterns.Library.factOrFiction(...)`; `SplitPilesDecision` stays dormant until N > 2.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -169,17 +169,8 @@ class CostHandler(
                 val counterType = resolveNamedCounterType(cost.counterType)
                 (counters?.getCount(counterType) ?: 0) >= cost.count
             }
-            is AbilityCost.Forage -> {
-                // Can forage if: 3+ cards in graveyard OR a Food artifact on battlefield
-                val graveyardSize = state.getZone(ZoneKey(controllerId, Zone.GRAVEYARD)).size
-                val projected = state.projectedState
-                val hasFood = state.getBattlefield().any { permId ->
-                    state.getEntity(permId) ?: return@any false
-                    projected.getController(permId) == controllerId &&
-                        projected.hasSubtype(permId, Subtype.FOOD.value)
-                }
-                graveyardSize >= 3 || hasFood
-            }
+            is AbilityCost.Forage ->
+                com.wingedsheep.engine.handlers.costs.ForageCostResolver.canPay(state, controllerId)
             is AbilityCost.Blight -> {
                 // Blight requires at least one creature you control that can have -1/-1 counters
                 // put on it. A creature that "can't have counters put on it" (Blossombind) is not
@@ -428,57 +419,18 @@ class CostHandler(
                 CostPaymentResult.success(newState, manaPool)
             }
             is AbilityCost.Forage -> {
-                val projected = state.projectedState
-                val graveyardZone = ZoneKey(controllerId, Zone.GRAVEYARD)
-                val graveyardCards = state.getZone(graveyardZone)
-                val foods = state.getBattlefield().filter { permId ->
-                    state.getEntity(permId) ?: return@filter false
-                    projected.getController(permId) == controllerId &&
-                        projected.hasSubtype(permId, Subtype.FOOD.value)
-                }
-
-                // Player explicitly picked 3 graveyard cards to exile — honor that path.
-                val playerExile = choices.exileChoices.takeIf { it.size >= 3 && it.all { id -> id in graveyardCards } }
-                if (playerExile != null) {
-                    val toExile = playerExile.take(3)
-                    var newState = state
-                    val events = mutableListOf<GameEvent>()
-                    for (cardId in toExile) {
-                        val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
-                            newState, cardId, Zone.EXILE
-                        )
-                        newState = transitionResult.state
-                        events.addAll(transitionResult.events)
-                    }
-                    CostPaymentResult.success(newState, manaPool, events)
-                } else if (foods.isNotEmpty()) {
-                    // Sacrifice a Food (respecting player's choice if provided).
-                    val foodId = choices.sacrificeChoices.firstOrNull()?.takeIf { it in foods } ?: foods.first()
-                    val foodName = state.getEntity(foodId)?.get<CardComponent>()?.name ?: "Food"
-                    val foodController = state.getEntity(foodId)?.get<ControllerComponent>()?.playerId ?: controllerId
-
-                    var newState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.trackPermanentSacrifice(state, listOf(foodId), foodController)
-                    val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
-                        newState, foodId, Zone.GRAVEYARD
-                    )
-                    val events = mutableListOf<GameEvent>()
-                    events.add(PermanentsSacrificedEvent(foodController, listOf(foodId), listOf(foodName)))
-                    events.addAll(transitionResult.events)
-                    CostPaymentResult.success(transitionResult.state, manaPool, events)
-                } else if (graveyardCards.size >= 3) {
-                    val toExile = graveyardCards.take(3)
-                    var newState = state
-                    val events = mutableListOf<GameEvent>()
-                    for (cardId in toExile) {
-                        val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
-                            newState, cardId, Zone.EXILE
-                        )
-                        newState = transitionResult.state
-                        events.addAll(transitionResult.events)
-                    }
-                    CostPaymentResult.success(newState, manaPool, events)
-                } else {
-                    CostPaymentResult.failure("Cannot forage: need 3 cards in graveyard or a Food")
+                // Unified forage payment — honors the player's mode + card/Food choice, falling
+                // back to a legal auto-payment only when no valid choice was supplied. See
+                // [com.wingedsheep.engine.handlers.costs.ForageCostResolver].
+                when (val result = com.wingedsheep.engine.handlers.costs.ForageCostResolver.pay(
+                    state, controllerId,
+                    exileChoices = choices.exileChoices,
+                    sacrificeChoices = choices.sacrificeChoices,
+                )) {
+                    is com.wingedsheep.engine.handlers.costs.ForageCostResolver.Result.Success ->
+                        CostPaymentResult.success(result.state, manaPool, result.events)
+                    is com.wingedsheep.engine.handlers.costs.ForageCostResolver.Result.Failure ->
+                        CostPaymentResult.failure(result.reason)
                 }
             }
             is AbilityCost.Blight -> {
@@ -881,17 +833,8 @@ class CostHandler(
                 // Always payable - sacrificing 0 creatures is valid
                 true
             }
-            is AdditionalCost.Forage -> {
-                // Can forage if: 3+ cards in graveyard OR a Food artifact on battlefield
-                val graveyardSize = state.getZone(ZoneKey(controllerId, Zone.GRAVEYARD)).size
-                val projected = state.projectedState
-                val hasFood = state.getBattlefield().any { permId ->
-                    state.getEntity(permId) ?: return@any false
-                    projected.getController(permId) == controllerId &&
-                        projected.hasSubtype(permId, Subtype.FOOD.value)
-                }
-                graveyardSize >= 3 || hasFood
-            }
+            is AdditionalCost.Forage ->
+                com.wingedsheep.engine.handlers.costs.ForageCostResolver.canPay(state, controllerId)
             is AdditionalCost.Behold -> {
                 // Can behold if matching permanent on battlefield or matching card in hand
                 val projected = state.projectedState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -215,7 +215,9 @@ class CastSpellHandler(
         castPermissionUtils.reasonCannotCast(state, action.playerId, action.cardId)?.let { return it }
 
         if (hasForageFromGraveyard) {
-            if (!costHandler.canPayAdditionalCost(state, AdditionalCost.Forage, action.playerId)) {
+            // The spell being cast can't be one of the three cards it exiles to pay for itself, so
+            // it's excluded from the forage exile pool here just as it is at payment time.
+            if (!com.wingedsheep.engine.handlers.costs.ForageCostResolver.canPay(state, action.playerId, excludeCardId = action.cardId)) {
                 return "Cannot forage: need 3 other cards in graveyard or a Food"
             }
         }
@@ -2401,6 +2403,24 @@ class CastSpellHandler(
                             }
                         }
                     }
+                    is AdditionalCost.Forage -> {
+                        // Forage as an additional cost to cast (e.g. Feed the Cycle's forage mode).
+                        // Honors the player's mode + card/Food choice via additionalCostPayment,
+                        // falling back to a legal auto-payment otherwise. The spell is cast from
+                        // hand here, so it's not in the exile pool — no exclusion needed.
+                        when (val forageResult = com.wingedsheep.engine.handlers.costs.ForageCostResolver.pay(
+                            currentState, action.playerId,
+                            exileChoices = action.additionalCostPayment.exiledCards,
+                            sacrificeChoices = action.additionalCostPayment.sacrificedPermanents,
+                        )) {
+                            is com.wingedsheep.engine.handlers.costs.ForageCostResolver.Result.Success -> {
+                                currentState = forageResult.state
+                                events.addAll(forageResult.events)
+                            }
+                            is com.wingedsheep.engine.handlers.costs.ForageCostResolver.Result.Failure ->
+                                return ExecutionResult.error(currentState, forageResult.reason)
+                        }
+                    }
                     else -> {}
                 }
             }
@@ -2532,44 +2552,27 @@ class CastSpellHandler(
         }
 
         // Pay forage additional cost when casting a creature from graveyard via
-        // MayCastCreaturesFromGraveyardWithForageComponent (e.g., Osteomancer Adept).
-        // Auto-pay: prefer sacrificing a Food; otherwise exile 3 other graveyard cards.
+        // MayCastCreaturesFromGraveyardWithForageComponent (e.g., Osteomancer Adept). The spell
+        // being cast is excluded from the exile pool — it has left the graveyard for the stack and
+        // can't be one of the three cards it exiles to pay for itself. The player's mode + card/Food
+        // choice (when supplied via additionalCostPayment) is honored; otherwise a legal mode is
+        // auto-paid. See [com.wingedsheep.engine.handlers.costs.ForageCostResolver].
         val isForageCast = zoneResolver.hasMayCastCreaturesFromGraveyardWithForage(
             currentState, action.playerId, action.cardId, cardComponent
         ) && action.cardId in currentState.getZone(ZoneKey(action.playerId, Zone.GRAVEYARD))
         if (isForageCast) {
-            val projected = currentState.projectedState
-            val foods = currentState.getBattlefield().filter { permId ->
-                currentState.getEntity(permId) != null &&
-                    projected.getController(permId) == action.playerId &&
-                    projected.hasSubtype(permId, Subtype.FOOD.value)
-            }
-            if (foods.isNotEmpty()) {
-                val foodId = foods.first()
-                val foodContainer = currentState.getEntity(foodId)
-                val foodName = foodContainer?.get<CardComponent>()?.name ?: "Food"
-                val foodController = foodContainer?.get<ControllerComponent>()?.playerId ?: action.playerId
-                currentState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                    .trackPermanentSacrifice(currentState, listOf(foodId), foodController)
-                val transition = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                    .moveToZone(currentState, foodId, Zone.GRAVEYARD)
-                currentState = transition.state
-                events.add(PermanentsSacrificedEvent(foodController, listOf(foodId), listOf(foodName)))
-                events.addAll(transition.events)
-            } else {
-                val graveyardZone = ZoneKey(action.playerId, Zone.GRAVEYARD)
-                val toExile = currentState.getZone(graveyardZone)
-                    .filter { it != action.cardId }
-                    .take(3)
-                if (toExile.size < 3) {
-                    return ExecutionResult.error(currentState, "Cannot forage: need 3 other cards in graveyard or a Food")
+            when (val forageResult = com.wingedsheep.engine.handlers.costs.ForageCostResolver.pay(
+                currentState, action.playerId,
+                exileChoices = action.additionalCostPayment?.exiledCards ?: emptyList(),
+                sacrificeChoices = action.additionalCostPayment?.sacrificedPermanents ?: emptyList(),
+                excludeCardId = action.cardId,
+            )) {
+                is com.wingedsheep.engine.handlers.costs.ForageCostResolver.Result.Success -> {
+                    currentState = forageResult.state
+                    events.addAll(forageResult.events)
                 }
-                for (exileId in toExile) {
-                    val transition = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
-                        .moveToZone(currentState, exileId, Zone.EXILE)
-                    currentState = transition.state
-                    events.addAll(transition.events)
-                }
+                is com.wingedsheep.engine.handlers.costs.ForageCostResolver.Result.Failure ->
+                    return ExecutionResult.error(currentState, forageResult.reason)
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/ForageCostResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/costs/ForageCostResolver.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.handlers.costs
+
+import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.PermanentsSacrificedEvent
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.legalactions.AdditionalCostData
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+
+/**
+ * Single source of truth for the **cost-based** Forage mechanic (CR 701.61 — "To forage,
+ * exile three cards from your graveyard or sacrifice a Food").
+ *
+ * Forage is a *choice* between two sub-costs, and that choice belongs to the foraging player.
+ * Before this resolver each cost-shaped forage entry point reimplemented payment independently
+ * and all of them dropped the player's choice on the floor: the activated-ability path
+ * ([com.wingedsheep.sdk.scripting.AbilityCost.Forage]) auto-picked the exile mode, the
+ * graveyard-cast path ([com.wingedsheep.engine.state.components.player.MayCastCreaturesFromGraveyardWithForageComponent])
+ * auto-sacrificed the first Food (or exiled the first three cards), and the modal additional-cost
+ * path ([com.wingedsheep.sdk.scripting.AdditionalCost.Forage], Feed the Cycle) silently paid
+ * nothing at all. This object unifies all of them:
+ *
+ *  - [candidates] / [canPay] — what the player could forage with right now.
+ *  - [costInfos] — the legal-action payload(s): one [AdditionalCostData] per *available* mode so
+ *    the enumerators can surface the mode choice as separate legal actions (the same multi-action
+ *    pattern the "OrPay" costs use). The client already renders an exile-from-graveyard picker for
+ *    `ExileFromGraveyard` and a sacrifice picker for `SacrificePermanent`, so the player picks the
+ *    mode *and* which cards/Food with zero new UI.
+ *  - [pay] — the one payment implementation. It honors whatever the player chose and only falls
+ *    back to an arbitrary legal payment when no valid choice was supplied (AI / engine-direct).
+ *
+ * The *effect*-based forage (`Patterns.Mechanic.forage()` → `ChooseActionEffect`, used by the
+ * "you may forage" ETB cards) already resolves the choice correctly through the normal effect
+ * pipeline and is intentionally left alone.
+ */
+object ForageCostResolver {
+
+    /** A forage payment always exiles exactly this many cards in the exile mode. */
+    const val EXILE_COUNT: Int = 3
+
+    /** The permanents/cards the foraging player could spend on a forage cost. */
+    data class Candidates(
+        val exileCards: List<EntityId>,
+        val foods: List<EntityId>,
+    ) {
+        val canExile: Boolean get() = exileCards.size >= EXILE_COUNT
+        val canSacrifice: Boolean get() = foods.isNotEmpty()
+        val canPay: Boolean get() = canExile || canSacrifice
+    }
+
+    /**
+     * Forage candidates for [playerId]. [excludeCardId] drops a card from the exile pool — used by
+     * the graveyard-cast path, where the spell being cast is still in the graveyard at enumeration
+     * time but can't be one of the three cards it exiles to pay for itself.
+     */
+    fun candidates(state: GameState, playerId: EntityId, excludeCardId: EntityId? = null): Candidates {
+        val projected = state.projectedState
+        val exileCards = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD)).filter { it != excludeCardId }
+        val foods = state.getBattlefield().filter { permId ->
+            state.getEntity(permId) ?: return@filter false
+            projected.getController(permId) == playerId &&
+                projected.hasSubtype(permId, Subtype.FOOD.value)
+        }
+        return Candidates(exileCards, foods)
+    }
+
+    /** Convenience: can [playerId] pay a forage cost right now? */
+    fun canPay(state: GameState, playerId: EntityId, excludeCardId: EntityId? = null): Boolean =
+        candidates(state, playerId, excludeCardId).canPay
+
+    /**
+     * The legal-action cost payloads for the available forage modes — exile first, then sacrifice.
+     * Returns 0, 1, or 2 entries; an enumerator emits one legal action per entry so the player gets
+     * to choose the mode (when both are possible) and which cards/Food (within a mode).
+     */
+    fun costInfos(candidates: Candidates): List<AdditionalCostData> = buildList {
+        if (candidates.canExile) {
+            add(
+                AdditionalCostData(
+                    description = "Forage — exile three cards from your graveyard",
+                    costType = "ExileFromGraveyard",
+                    validExileTargets = candidates.exileCards,
+                    exileMinCount = EXILE_COUNT,
+                    exileMaxCount = EXILE_COUNT,
+                )
+            )
+        }
+        if (candidates.canSacrifice) {
+            add(
+                AdditionalCostData(
+                    description = "Forage — sacrifice a Food",
+                    costType = "SacrificePermanent",
+                    validSacrificeTargets = candidates.foods,
+                    sacrificeCount = 1,
+                )
+            )
+        }
+    }
+
+    /** Outcome of paying a forage cost. */
+    sealed interface Result {
+        data class Success(val state: GameState, val events: List<GameEvent>) : Result
+        data class Failure(val reason: String) : Result
+    }
+
+    /**
+     * Pay the forage cost for [playerId].
+     *
+     * Priority:
+     *  1. If [exileChoices] names at least [EXILE_COUNT] valid graveyard cards, the player chose the
+     *     exile mode — exile exactly those three.
+     *  2. Else if [sacrificeChoices] names a valid Food, the player chose the sacrifice mode —
+     *     sacrifice it.
+     *  3. Else no valid choice was supplied (AI / engine-direct): pay an arbitrary legal mode,
+     *     preferring to sacrifice a Food (keeps a Food's other uses for the player no worse off than
+     *     the historical default) and otherwise exiling the first three cards.
+     */
+    fun pay(
+        state: GameState,
+        playerId: EntityId,
+        exileChoices: List<EntityId> = emptyList(),
+        sacrificeChoices: List<EntityId> = emptyList(),
+        excludeCardId: EntityId? = null,
+    ): Result {
+        val candidates = candidates(state, playerId, excludeCardId)
+
+        val validExile = exileChoices.filter { it in candidates.exileCards }
+        if (validExile.size >= EXILE_COUNT) {
+            return exile(state, validExile.take(EXILE_COUNT))
+        }
+
+        val chosenFood = sacrificeChoices.firstOrNull { it in candidates.foods }
+        if (chosenFood != null) {
+            return sacrifice(state, playerId, chosenFood)
+        }
+
+        if (candidates.canSacrifice) return sacrifice(state, playerId, candidates.foods.first())
+        if (candidates.canExile) return exile(state, candidates.exileCards.take(EXILE_COUNT))
+        return Result.Failure("Cannot forage: need three cards in your graveyard or a Food")
+    }
+
+    private fun exile(state: GameState, cardIds: List<EntityId>): Result {
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        for (cardId in cardIds) {
+            val transition = ZoneTransitionService.moveToZone(newState, cardId, Zone.EXILE)
+            newState = transition.state
+            events.addAll(transition.events)
+        }
+        return Result.Success(newState, events)
+    }
+
+    private fun sacrifice(state: GameState, playerId: EntityId, foodId: EntityId): Result {
+        val container = state.getEntity(foodId)
+        val foodName = container?.get<CardComponent>()?.name ?: "Food"
+        val foodController = container?.get<ControllerComponent>()?.playerId ?: playerId
+        val tracked = ZoneTransitionService.trackPermanentSacrifice(state, listOf(foodId), foodController)
+        val transition = ZoneTransitionService.moveToZone(tracked, foodId, Zone.GRAVEYARD)
+        val events = buildList {
+            add(PermanentsSacrificedEvent(foodController, listOf(foodId), listOf(foodName)))
+            addAll(transition.events)
+        }
+        return Result.Success(transition.state, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -649,6 +649,16 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                     tapBatchMaxActivations
                 )
 
+                // Forage offers a choice of sub-costs (exile three cards / sacrifice a Food).
+                // [costInfo] holds the primary mode; when both modes are available the emitted
+                // legal action(s) are duplicated below — one per mode — so the player picks which.
+                val forageModes = if (hasForageCost) {
+                    com.wingedsheep.engine.handlers.costs.ForageCostResolver.costInfos(
+                        com.wingedsheep.engine.handlers.costs.ForageCostResolver.Candidates(forageGraveyardCards, forageFoodTargets)
+                    )
+                } else emptyList()
+                val forageEmissionStart = result.size
+
                 // Calculate X cost info for activated abilities with X in their mana cost
                 // or X determined by a variable cost (e.g., RemoveXPlusOnePlusOneCounters).
                 // Use [effectiveCost] so generic-cost reductions (e.g., The Dominion Bracelet,
@@ -828,6 +838,29 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                         hasWaterbend = ability.hasWaterbend,
                         waterbendPermanents = abilityWaterbendPermanents
                     ))
+                }
+
+                // When forage can be paid both ways, the emission above used the primary (exile)
+                // mode; emit a sibling legal action for the alternate (sacrifice) mode and label
+                // both with their mode so the action menu offers the choice (the same multi-action
+                // pattern used by the "OrPay" costs). Reuses the client's existing
+                // ExileFromGraveyard / SacrificePermanent cost pickers — no new UI.
+                if (forageModes.size > 1) {
+                    val primaryMode = forageModes[0]
+                    val alternateMode = forageModes[1]
+                    val emitted = result.subList(forageEmissionStart, result.size).toList()
+                    for ((offset, la) in emitted.withIndex()) {
+                        if (la.action !is ActivateAbility || !la.affordable) continue
+                        result[forageEmissionStart + offset] = la.copy(
+                            description = "${la.description} — ${primaryMode.description}"
+                        )
+                        result.add(
+                            la.copy(
+                                description = "${la.description} — ${alternateMode.description}",
+                                additionalCostInfo = alternateMode
+                            )
+                        )
+                    }
                 }
             }
         }
@@ -1087,25 +1120,11 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
             )
         }
         if (hasForageCost) {
-            // Prefer the exile path when 3+ cards are in the graveyard — lets the player
-            // pick exactly which cards to exile. Otherwise fall back to sacrificing a Food.
-            if (forageGraveyardCards.size >= 3) {
-                return AdditionalCostData(
-                    description = "Forage — exile 3 cards from your graveyard",
-                    costType = "ExileFromGraveyard",
-                    validExileTargets = forageGraveyardCards,
-                    exileMinCount = 3,
-                    exileMaxCount = 3
-                )
-            }
-            if (forageFoodTargets.isNotEmpty()) {
-                return AdditionalCostData(
-                    description = "Forage — sacrifice a Food",
-                    costType = "SacrificePermanent",
-                    validSacrificeTargets = forageFoodTargets,
-                    sacrificeCount = 1
-                )
-            }
+            // The full per-mode list is emitted as separate legal actions by the caller; this is
+            // just the primary (first available) mode for the single-costInfo slot.
+            return com.wingedsheep.engine.handlers.costs.ForageCostResolver.costInfos(
+                com.wingedsheep.engine.handlers.costs.ForageCostResolver.Candidates(forageGraveyardCards, forageFoodTargets)
+            ).firstOrNull()
         }
         return null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastFromZoneEnumerator.kt
@@ -1590,14 +1590,6 @@ class CastFromZoneEnumerator : ActionEnumerator {
 
         val graveyardCards = state.getZone(ZoneKey(playerId, Zone.GRAVEYARD))
 
-        // Check if forage can be paid at all (Food on battlefield)
-        val projected = state.projectedState
-        val hasFood = state.getBattlefield().any { permId ->
-            state.getEntity(permId) ?: return@any false
-            projected.getController(permId) == playerId &&
-                projected.hasSubtype(permId, Subtype.FOOD.value)
-        }
-
         for (cardId in graveyardCards) {
             val container = state.getEntity(cardId) ?: continue
             val cardComponent = container.get<CardComponent>() ?: continue
@@ -1607,9 +1599,14 @@ class CastFromZoneEnumerator : ActionEnumerator {
 
             val cardDef = context.cardRegistry.getCard(cardComponent.name) ?: continue
 
-            // Don't offer forage if it can't be paid (< 3 other graveyard cards and no Food)
-            val otherGraveyardCards = graveyardCards.filter { it != cardId }
-            if (otherGraveyardCards.size < 3 && !hasFood) continue
+            // Don't offer forage if it can't be paid (< 3 other graveyard cards and no Food).
+            // The card being cast can't be one of the three it exiles, so it's excluded from the
+            // exile pool — both for affordability and for the card-picker the client renders.
+            val forageCandidates = com.wingedsheep.engine.handlers.costs.ForageCostResolver
+                .candidates(state, playerId, excludeCardId = cardId)
+            if (!forageCandidates.canPay) continue
+            val forageModes = com.wingedsheep.engine.handlers.costs.ForageCostResolver.costInfos(forageCandidates)
+            val primaryForageMode = forageModes.firstOrNull()
 
             if (context.cantCastSpell(cardId)) {
                 result.add(
@@ -1636,6 +1633,11 @@ class CastFromZoneEnumerator : ActionEnumerator {
             val costString = effectiveCost.toString()
             val affordable = context.manaSolver.canPay(state, playerId, effectiveCost, precomputedSources = context.availableManaSources)
 
+            // Affordable emissions advertise the forage cost so the client lets the player pick
+            // which cards/Food to forage with (rather than the engine silently taking the first
+            // three). When both modes are payable, a sibling action per mode is emitted below.
+            val forageEmissionStart = result.size
+
             if (affordable) {
                 val targetReqs = buildList {
                     addAll(cardDef.script.targetRequirements)
@@ -1661,7 +1663,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                                 targetRequirements = if (targetInfos.size > 1) targetInfos else null,
                                 manaCostString = costString,
                                 sourceZone = "GRAVEYARD",
-                                requiresForage = true
+                                requiresForage = true,
+                                additionalCostInfo = primaryForageMode
                             )
                         )
                     }
@@ -1673,7 +1676,8 @@ class CastFromZoneEnumerator : ActionEnumerator {
                             action = CastSpell(playerId, cardId),
                             manaCostString = costString,
                             sourceZone = "GRAVEYARD",
-                            requiresForage = true
+                            requiresForage = true,
+                            additionalCostInfo = primaryForageMode
                         )
                     )
                 }
@@ -1689,6 +1693,25 @@ class CastFromZoneEnumerator : ActionEnumerator {
                         requiresForage = true
                     )
                 )
+            }
+
+            // Emit a sibling action for the alternate forage mode (exile vs. sacrifice a Food) so
+            // the player picks the mode in the action menu, mirroring the activated-ability path.
+            if (affordable && forageModes.size > 1) {
+                val alternateMode = forageModes[1]
+                val emitted = result.subList(forageEmissionStart, result.size).toList()
+                for ((offset, la) in emitted.withIndex()) {
+                    if (la.action !is CastSpell || !la.affordable) continue
+                    result[forageEmissionStart + offset] = la.copy(
+                        description = "${la.description} — ${forageModes[0].description}"
+                    )
+                    result.add(
+                        la.copy(
+                            description = "${la.description} — ${alternateMode.description}",
+                            additionalCostInfo = alternateMode
+                        )
+                    )
+                }
             }
         }
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -2253,10 +2253,19 @@ class CastSpellEnumerator : ActionEnumerator {
         }
 
         val modeCostInfo = if (modeAdditionalCosts != null) {
-            buildAdditionalCostData(
-                modeAdditionalCosts, modeSacrificeTargets, emptyList(),
-                modeExileTargets, modeExileMinCount, modeDiscardTargets, modeDiscardCount
-            )
+            // A forage additional cost on a mode (e.g. Feed the Cycle's forage mode) surfaces the
+            // forage cost picker so the player chooses which cards to exile / Food to sacrifice,
+            // rather than the cost resolving silently. Prefer the exile mode when both are payable.
+            if (modeAdditionalCosts.any { it is AdditionalCost.Forage }) {
+                com.wingedsheep.engine.handlers.costs.ForageCostResolver.costInfos(
+                    com.wingedsheep.engine.handlers.costs.ForageCostResolver.candidates(state, playerId)
+                ).firstOrNull()
+            } else {
+                buildAdditionalCostData(
+                    modeAdditionalCosts, modeSacrificeTargets, emptyList(),
+                    modeExileTargets, modeExileMinCount, modeDiscardTargets, modeDiscardCount
+                )
+            }
         } else {
             cardLevelAdditionalCostInfo
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ForageCostUnificationTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ForageCostUnificationTest.kt
@@ -1,0 +1,261 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.legalactions.EnumerationMode
+import com.wingedsheep.engine.legalactions.LegalActionEnumerator
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.SummoningSicknessComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.BonebindOrator
+import com.wingedsheep.mtg.sets.definitions.blb.cards.CamelliaTheSeedmiser
+import com.wingedsheep.mtg.sets.definitions.blb.cards.FeedTheCycle
+import com.wingedsheep.mtg.sets.definitions.blb.cards.OsteomancerAdept
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.collections.shouldNotContainAnyOf
+import io.kotest.matchers.shouldBe
+
+/**
+ * Forage is "exile three cards from your graveyard or sacrifice a Food" — a *choice* cost. These
+ * tests pin the unified cost-based forage behaviour (see
+ * [com.wingedsheep.engine.handlers.costs.ForageCostResolver]): when both modes are payable the
+ * player gets to choose the mode, and within a mode the player picks which cards / Food — the
+ * engine never silently picks for them.
+ *
+ * Covers the activated-ability path ([com.wingedsheep.sdk.scripting.AbilityCost.Forage], Camellia)
+ * and the graveyard-cast path (Osteomancer Adept). The auto-pay fallback (no choice supplied) is
+ * covered by [CamelliaTheSeedmiserForageTest] and [OsteomancerAdeptForageCastTest].
+ */
+class ForageCostUnificationTest : FunSpec({
+
+    val camelliaAbilityId = CamelliaTheSeedmiser.activatedAbilities.first().id
+    val osteomancerAbilityId = OsteomancerAdept.activatedAbilities.first().id
+
+    // ---------------------------------------------------------------------------------------------
+    // Activated-ability forage (Camellia, the Seedmiser): {2}, Forage
+    // ---------------------------------------------------------------------------------------------
+
+    fun camelliaDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CamelliaTheSeedmiser, PredefinedTokens.Food))
+        return driver
+    }
+
+    test("Forage offers both modes (exile 3 / sacrifice a Food) as separate actions when both are payable") {
+        val driver = camelliaDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Swamp" to 20))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val camellia = driver.putCreatureOnBattlefield(active, "Camellia, the Seedmiser")
+        driver.replaceState(driver.state.updateEntity(camellia) { it.without<SummoningSicknessComponent>() })
+        val graveCards = (1..5).map { driver.putCardInGraveyard(active, "Forest") }
+        val food = driver.putPermanentOnBattlefield(active, "Food")
+        repeat(3) { driver.putLandOnBattlefield(active, "Forest") }
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val forageActions = enumerator.enumerate(driver.state, active, EnumerationMode.FULL).filter {
+            val a = it.action
+            a is ActivateAbility && a.sourceId == camellia && a.abilityId == camelliaAbilityId
+        }
+
+        // One legal action per available forage mode — the player picks in the action menu.
+        forageActions.size shouldBe 2
+        val exileMode = forageActions.single { it.additionalCostInfo?.costType == "ExileFromGraveyard" }.additionalCostInfo!!
+        val sacrificeMode = forageActions.single { it.additionalCostInfo?.costType == "SacrificePermanent" }.additionalCostInfo!!
+
+        exileMode.exileMinCount shouldBe 3
+        exileMode.exileMaxCount shouldBe 3
+        exileMode.validExileTargets shouldContainAll graveCards
+
+        sacrificeMode.sacrificeCount shouldBe 1
+        sacrificeMode.validSacrificeTargets shouldContain food
+    }
+
+    test("Choosing the sacrifice mode sacrifices the chosen Food and leaves the graveyard untouched") {
+        val driver = camelliaDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Swamp" to 20))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val camellia = driver.putCreatureOnBattlefield(active, "Camellia, the Seedmiser")
+        driver.replaceState(driver.state.updateEntity(camellia) { it.without<SummoningSicknessComponent>() })
+        val graveCards = (1..5).map { driver.putCardInGraveyard(active, "Forest") }
+        val food = driver.putPermanentOnBattlefield(active, "Food")
+        repeat(3) { driver.putLandOnBattlefield(active, "Forest") }
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = active,
+                sourceId = camellia,
+                abilityId = camelliaAbilityId,
+                costPayment = AdditionalCostPayment(sacrificedPermanents = listOf(food))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        // The Food was sacrificed; not a single graveyard card was exiled.
+        driver.state.getBattlefield(active) shouldNotContain food
+        driver.state.getGraveyard(active) shouldContain food
+        driver.state.getExile(active) shouldNotContainAnyOf graveCards
+        driver.state.getGraveyard(active) shouldContainAll graveCards
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Graveyard-cast forage (Osteomancer Adept) — the cast card is excluded from the exile pool.
+    // ---------------------------------------------------------------------------------------------
+
+    fun osteomancerDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OsteomancerAdept, BonebindOrator, PredefinedTokens.Food))
+        return driver
+    }
+
+    fun grantForageAndAdvanceToCast(driver: GameTestDriver): Pair<com.wingedsheep.sdk.model.EntityId, com.wingedsheep.sdk.model.EntityId> {
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val adept = driver.putCreatureOnBattlefield(active, "Osteomancer Adept")
+        driver.removeSummoningSickness(adept)
+        driver.submitSuccess(ActivateAbility(playerId = active, sourceId = adept, abilityId = osteomancerAbilityId))
+        driver.bothPass()
+        driver.giveMana(active, Color.BLACK, 2)
+        return active to adept
+    }
+
+    test("Graveyard-cast forage advertises which graveyard cards can be exiled, excluding the cast card") {
+        val driver = osteomancerDriver()
+        val (active, _) = grantForageAndAdvanceToCast(driver)
+        val orator = driver.putCardInGraveyard(active, "Bonebind Orator")
+        val filler = (1..5).map { driver.putCardInGraveyard(active, "Swamp") }
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val forageCast = enumerator.enumerate(driver.state, active, EnumerationMode.FULL).single {
+            val a = it.action
+            a is CastSpell && a.cardId == orator && it.requiresForage
+        }
+
+        val cost = forageCast.additionalCostInfo!!
+        cost.costType shouldBe "ExileFromGraveyard"
+        cost.exileMinCount shouldBe 3
+        cost.exileMaxCount shouldBe 3
+        cost.validExileTargets shouldContainAll filler
+        // The creature being cast can't be one of the three cards it exiles to pay for itself.
+        cost.validExileTargets shouldNotContain orator
+    }
+
+    test("Graveyard-cast forage exiles exactly the player-chosen three cards, not the first three") {
+        val driver = osteomancerDriver()
+        val (active, _) = grantForageAndAdvanceToCast(driver)
+        val orator = driver.putCardInGraveyard(active, "Bonebind Orator")
+        val filler = (1..5).map { driver.putCardInGraveyard(active, "Swamp") }
+
+        val chosen = listOf(filler[1], filler[3], filler[4])
+        val result = driver.submit(
+            CastSpell(
+                playerId = active,
+                cardId = orator,
+                additionalCostPayment = AdditionalCostPayment(exiledCards = chosen)
+            )
+        )
+        result.isSuccess shouldBe true
+
+        val exile = driver.state.getZone(ZoneKey(active, Zone.EXILE))
+        exile.size shouldBe 3
+        exile shouldContainAll chosen
+        exile shouldNotContain filler[0]
+        exile shouldNotContain filler[2]
+        // The creature being cast went to the stack, not exile.
+        exile shouldNotContain orator
+        driver.state.stack shouldContain orator
+    }
+
+    test("Graveyard-cast forage offers both modes when a Food is also available") {
+        val driver = osteomancerDriver()
+        val (active, _) = grantForageAndAdvanceToCast(driver)
+        val orator = driver.putCardInGraveyard(active, "Bonebind Orator")
+        (1..3).map { driver.putCardInGraveyard(active, "Swamp") }
+        driver.putPermanentOnBattlefield(active, "Food")
+
+        val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
+        val forageCasts = enumerator.enumerate(driver.state, active, EnumerationMode.FULL).filter {
+            val a = it.action
+            a is CastSpell && a.cardId == orator && it.requiresForage
+        }
+
+        forageCasts.size shouldBe 2
+        forageCasts.count { it.additionalCostInfo?.costType == "ExileFromGraveyard" } shouldBe 1
+        forageCasts.count { it.additionalCostInfo?.costType == "SacrificePermanent" } shouldBe 1
+    }
+
+    test("Graveyard-cast forage with a chosen Food sacrifices that Food and exiles nothing") {
+        val driver = osteomancerDriver()
+        val (active, _) = grantForageAndAdvanceToCast(driver)
+        val orator = driver.putCardInGraveyard(active, "Bonebind Orator")
+        val filler = (1..3).map { driver.putCardInGraveyard(active, "Swamp") }
+        val food = driver.putPermanentOnBattlefield(active, "Food")
+
+        val result = driver.submit(
+            CastSpell(
+                playerId = active,
+                cardId = orator,
+                additionalCostPayment = AdditionalCostPayment(sacrificedPermanents = listOf(food))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.state.getBattlefield(active) shouldNotContain food
+        driver.state.getZone(ZoneKey(active, Zone.EXILE)) shouldNotContainAnyOf filler
+        driver.state.getZone(ZoneKey(active, Zone.GRAVEYARD)) shouldContainAll filler
+        driver.state.stack shouldContain orator
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Modal additional-cost forage (Feed the Cycle — "forage or pay {B}"). Regression: paying the
+    // forage mode used to be a silent no-op (no forage case in the cast cost-payment loop).
+    // ---------------------------------------------------------------------------------------------
+
+    test("Casting Feed the Cycle's forage mode actually pays forage by exiling the chosen three cards") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FeedTheCycle, BonebindOrator, PredefinedTokens.Food))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val feed = driver.putCardInHand(active, "Feed the Cycle")
+        val victim = driver.putCreatureOnBattlefield(active, "Bonebind Orator")
+        val filler = (1..5).map { driver.putCardInGraveyard(active, "Swamp") }
+        driver.giveMana(active, Color.BLACK, 2) // {1}{B}, forage covers the rest of the cost
+
+        val chosen = listOf(filler[0], filler[2], filler[4])
+        val result = driver.submit(
+            CastSpell(
+                playerId = active,
+                cardId = feed,
+                targets = listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(victim)),
+                chosenModes = listOf(1), // mode index 1 = the forage mode
+                modeTargetsOrdered = listOf(
+                    listOf(com.wingedsheep.engine.state.components.stack.ChosenTarget.Permanent(victim))
+                ),
+                additionalCostPayment = AdditionalCostPayment(exiledCards = chosen)
+            )
+        )
+        result.isSuccess shouldBe true
+
+        // Forage was paid: exactly the three chosen cards were exiled (not silently skipped).
+        val exile = driver.state.getZone(ZoneKey(active, Zone.EXILE))
+        exile shouldContainAll chosen
+        exile.size shouldBe 3
+        driver.state.stack shouldContain feed
+    }
+})


### PR DESCRIPTION
## Problem

Forage (CR 701.61) is *"exile three cards from your graveyard **or** sacrifice a Food"* — a **choice** that belongs to the foraging player. But the cost-shaped forage paths each reimplemented payment independently and dropped that choice:

- **Camellia, the Seedmiser** (`{2}, Forage`) — when both modes were payable the enumerator only ever offered the exile mode; you could never choose to sacrifice a Food.
- **Osteomancer Adept** (cast a creature from your graveyard by foraging) — the engine auto-sacrificed the first Food, or exiled the *first three* graveyard cards. You could never pick **which** cards to exile.
- **Feed the Cycle** (modal "forage or pay {B}") — the forage mode had no case in the cast cost-payment loop, so choosing it paid **nothing at all** (silent no-op).

## Fix — one shared resolver

New `ForageCostResolver` is the single source of truth for cost-based forage:

- `candidates` / `canPay` — what you can forage with right now (with an `excludeCardId` for the graveyard-cast, since the spell can't be one of the three cards it exiles to pay for itself).
- `costInfos` — one `AdditionalCostData` per **available** mode, so the enumerators surface the choice as **separate legal actions** (the same multi-action pattern the "OrPay" costs already use). They carry the existing `ExileFromGraveyard` / `SacrificePermanent` cost types, so the client's existing card/permanent pickers let the player choose the mode **and** which cards/Food — **no client changes**.
- `pay` — the one payment implementation. Honors the player's choice; only auto-pays a legal mode when none was supplied (AI / engine-direct), preserving prior behaviour.

All three entry points (`AbilityCost.Forage`, `AdditionalCost.Forage`, the graveyard-cast permission) now route payment + `canPay` through the resolver. `CostHandler` shed ~75 lines of duplicated logic.

The *effect*-based forage (`Patterns.Mechanic.forage` → `ChooseActionEffect`, the "you may forage" ETB cards) already resolved the choice correctly and is untouched.

## Tests

`ForageCostUnificationTest` (rules-engine scenarios), all green, plus every existing forage test (`CamelliaTheSeedmiserForageTest`, `OsteomancerAdeptForageCastTest`, `ThornvaultForagerTest`, `YgraEaterOfAllTest`, `CastFromZoneEnumeratorTest`):

- Camellia offers **both** modes as separate actions when graveyard + Food are both available; choosing sacrifice sacrifices the chosen Food and leaves the graveyard untouched.
- Osteomancer advertises the exact exile candidates (excluding the cast card) and exiles **exactly the player-chosen three**, not the first three; offers both modes when a Food is present; sacrifices a chosen Food.
- Feed the Cycle's forage mode now **actually pays** (exiles the chosen three) — regression for the silent no-op.

Full `just test-rules` and `just build` (incl. game-server + `CardDefinitionSnapshotTest`/`CardLintTest`) pass. No SDK or card-definition changes.

## Note on the client

This relies entirely on the client's existing generic cost machinery (per-`costType` pickers + multi-legal-action rendering in `ActionMenu`), so no client code changed. Worth a quick in-app sanity check that the two forage buttons render and the graveyard exile picker appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)