### PR TITLE
Fix gift handing the gift to the caster instead of the opponent

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/BloomingBlast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/BloomingBlast.kt
@@ -41,7 +41,7 @@ val BloomingBlast = card("Blooming Blast") {
             ),
             // Mode 2: Gift a Treasure — opponent creates Treasure, 2 damage to creature, 3 damage to controller
             Mode.withTarget(
-                CreatePredefinedTokenEffect("Treasure", 1, EffectTarget.PlayerRef(Player.EachOpponent))
+                CreatePredefinedTokenEffect("Treasure", 1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(Effects.DealDamage(2, EffectTarget.ContextTarget(0)))
                     .then(Effects.DealDamage(3, EffectTarget.TargetController))
                     .then(Effects.GiftGiven()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CoilingRebirth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CoilingRebirth.kt
@@ -47,7 +47,7 @@ val CoilingRebirth = card("Coiling Rebirth") {
             ),
             // Mode 2: Gift a card — opponent draws, return creature, then if nonlegendary create 1/1 copy
             Mode(
-                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(returnEffect)
                     .then(
                         ConditionalEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ConsumedByGreed.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ConsumedByGreed.kt
@@ -47,7 +47,7 @@ val ConsumedByGreed = card("Consumed by Greed") {
             Mode(
                 effect = Effects.Composite(
                     listOf(
-                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
                         sacrificeEffect,
                         Effects.ReturnToHand(EffectTarget.ContextTarget(1)),
                         Effects.GiftGiven()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CrumbAndGetIt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CrumbAndGetIt.kt
@@ -43,7 +43,7 @@ val CrumbAndGetIt = card("Crumb and Get It") {
             ),
             // Mode 2: Gift a Food — opponent creates Food, +2/+2 and indestructible until end of turn
             Mode.withTarget(
-                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(baseEffect)
                     .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.ContextTarget(0)))
                     .then(Effects.GiftGiven()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DawnsTruce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DawnsTruce.kt
@@ -44,7 +44,7 @@ val DawnsTruce = card("Dawn's Truce") {
             ),
             // Mode 2: Gift a card — opponent draws, hexproof + indestructible until end of turn
             Mode.noTarget(
-                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(hexproofEffects)
                     .then(Patterns.Group.grantKeywordToAll(Keyword.INDESTRUCTIBLE, Filters.Group.permanentsYouControl))
                     .then(Effects.GiftGiven()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DewdropCure.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DewdropCure.kt
@@ -49,7 +49,7 @@ val DewdropCure = card("Dewdrop Cure") {
             ),
             // Mode 2: Gift a card — opponent draws, return up to 3 creature cards with MV ≤ 2
             Mode(
-                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(returnEffect)
                     .then(Effects.GiftGiven()),
                 targetRequirements = listOf(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Kitnap.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Kitnap.kt
@@ -48,7 +48,7 @@ val Kitnap = card("Kitnap") {
             ),
             // Mode 2: Gift a card — opponent draws a card, tap enchanted creature (no stun counters)
             Mode.noTarget(
-                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(Effects.Tap(EffectTarget.EnchantedCreature))
                     .then(Effects.GiftGiven()),
                 "Promise a gift — an opponent draws a card, tap enchanted creature"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LongRiversPull.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LongRiversPull.kt
@@ -35,7 +35,7 @@ val LongRiversPull = card("Long River's Pull") {
             // Mode 1: Gift promised — opponent draws a card, then counter target spell
             Mode.withTarget(
                 effect = Effects.Composite(listOf(
-                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
                     Effects.CounterSpell(),
                     Effects.GiftGiven()
                 )),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/NocturnalHunger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/NocturnalHunger.kt
@@ -40,7 +40,7 @@ val NocturnalHunger = card("Nocturnal Hunger") {
             ),
             // Mode 2: Gift a Food — opponent creates Food token, then destroy target creature
             Mode.withTarget(
-                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(destroyEffect)
                     .then(Effects.GiftGiven()),
                 Targets.Creature,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/PeerlessRecycling.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/PeerlessRecycling.kt
@@ -43,7 +43,7 @@ val PeerlessRecycling = card("Peerless Recycling") {
             // Mode 1: Gift — opponent draws a card, return 2 target permanent cards to hand
             Mode(
                 effect = Effects.Composite(listOf(
-                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
                     Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
                     Effects.ReturnToHand(EffectTarget.ContextTarget(1)),
                     Effects.GiftGiven()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Scrapshooter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Scrapshooter.kt
@@ -46,7 +46,7 @@ val Scrapshooter = card("Scrapshooter") {
             ),
             // Mode 2: Gift a card — opponent draws, destroy target artifact or enchantment
             Mode(
-                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(Effects.Destroy(EffectTarget.ContextTarget(0)))
                     .then(Effects.GiftGiven()),
                 targetRequirements = listOf(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarfallInvocation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarfallInvocation.kt
@@ -43,7 +43,7 @@ val StarfallInvocation = card("Starfall Invocation") {
             // Mode 2: Gift a card — opponent draws, destroy all creatures, then return one of yours
             Mode.noTarget(
                 Effects.Composite(listOf(
-                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
                     Effects.DestroyAll(GameObjectFilter.Creature, storeDestroyedAs = "destroyed"),
                     SelectFromCollectionEffect(
                         from = "destroyed",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ValleyRally.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ValleyRally.kt
@@ -39,7 +39,7 @@ val ValleyRally = card("Valley Rally") {
             ),
             // Mode 2: Gift a Food — opponent creates Food, creatures get +2/+0, target creature gains first strike
             Mode.withTarget(
-                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.EachOpponent))
+                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.AnOpponent))
                     .then(pumpAll)
                     .then(Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.ContextTarget(0)))
                     .then(Effects.GiftGiven()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WearDown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WearDown.kt
@@ -42,7 +42,7 @@ val WearDown = card("Wear Down") {
             Mode(
                 effect = Effects.Composite(
                     listOf(
-                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
                         Effects.Destroy(EffectTarget.ContextTarget(0)),
                         Effects.Destroy(EffectTarget.ContextTarget(1)),
                         Effects.GiftGiven()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WildfireHowl.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WildfireHowl.kt
@@ -48,7 +48,7 @@ val WildfireHowl = card("Wildfire Howl") {
             Mode.withTarget(
                 Effects.Composite(
                     listOf(
-                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
                         DealDamageEffect(1, EffectTarget.ContextTarget(0)),
                         damageToEachCreature,
                         Effects.GiftGiven()

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -1415,7 +1415,7 @@
                                 "tokenType": "Treasure",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -3386,7 +3386,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -3625,7 +3625,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -4072,7 +4072,7 @@
                                 "tokenType": "Food",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -4523,7 +4523,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -4701,7 +4701,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -10029,7 +10029,7 @@
                                         },
                                         "target": {
                                             "type": "PlayerRef",
-                                            "player": "EachOpponent"
+                                            "player": "AnOpponent"
                                         }
                                     },
                                     {
@@ -10753,7 +10753,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             "Counter",
@@ -12598,7 +12598,7 @@
                                 "tokenType": "Food",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -13350,7 +13350,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -15872,7 +15872,7 @@
                                         },
                                         "target": {
                                             "type": "PlayerRef",
-                                            "player": "EachOpponent"
+                                            "player": "AnOpponent"
                                         }
                                     },
                                     {
@@ -17515,7 +17515,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -20678,7 +20678,7 @@
                                 "tokenType": "Food",
                                 "controller": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -21596,7 +21596,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {
@@ -22170,7 +22170,7 @@
                                 },
                                 "target": {
                                     "type": "PlayerRef",
-                                    "player": "EachOpponent"
+                                    "player": "AnOpponent"
                                 }
                             },
                             {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NocturnalHungerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NocturnalHungerTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.NocturnalHunger
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Nocturnal Hunger — a Gift a Food instant from Bloomburrow.
+ *
+ * Mode 0: No gift — destroy target creature, you lose 2 life.
+ * Mode 1: Gift — the opponent (not you) creates a Food token, then destroy target creature.
+ *
+ * Regression: the gift Food used `Player.EachOpponent`, a list-only reference that has no single
+ * resolution as a token controller. The token executor fell back to the spell's controller, so the
+ * caster received the Food instead of the promised opponent. The fix is `Player.AnOpponent`.
+ */
+class NocturnalHungerTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(PredefinedTokens.allTokens)
+        driver.registerCard(NocturnalHunger)
+        return driver
+    }
+
+    test("mode 1 (gift): the OPPONENT creates the Food token, not the caster") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+
+        driver.giveMana(activePlayer, Color.BLACK, 3)
+        val spell = driver.putCardInHand(activePlayer, "Nocturnal Hunger")
+
+        val result = driver.submit(CastSpell(
+            playerId = activePlayer,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(theirs)),
+            chosenModes = listOf(1),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(theirs)))
+        ))
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        // The Food belongs to the opponent — never the caster.
+        driver.findPermanent(opponent, "Food").shouldNotBeNull()
+        driver.findPermanent(activePlayer, "Food").shouldBeNull()
+
+        // Target creature destroyed; gift was promised so the caster does NOT lose life.
+        (theirs in driver.state.getZone(opponent, Zone.GRAVEYARD)) shouldBe true
+        driver.getLifeTotal(activePlayer) shouldBe 20
+    }
+
+    test("mode 0 (no gift): no Food is created and the caster loses 2 life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20), startingLife = 20)
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val theirs = driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+
+        driver.giveMana(activePlayer, Color.BLACK, 3)
+        val spell = driver.putCardInHand(activePlayer, "Nocturnal Hunger")
+
+        val result = driver.submit(CastSpell(
+            playerId = activePlayer,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(theirs)),
+            chosenModes = listOf(0),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(theirs)))
+        ))
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        driver.findPermanent(opponent, "Food").shouldBeNull()
+        driver.findPermanent(activePlayer, "Food").shouldBeNull()
+
+        (theirs in driver.state.getZone(opponent, Zone.GRAVEYARD)) shouldBe true
+        driver.getLifeTotal(activePlayer) shouldBe 18
+    }
+})


### PR DESCRIPTION
## Problem

`NocturnalHunger.kt` gave the gift **Food to the caster, not the opponent**. Tracing it down, this is a systematic bug across **every** Bloomburrow gift card.

Gift promises *a single* opponent ("you may promise **an** opponent a gift"), and that one opponent receives the gift. All BLB gift cards modeled the recipient as `Player.EachOpponent`, which is wrong in two ways:

- **Token gifts (Food, Treasure)** resolve their controller through the *single-player* resolution path (`resolvePlayerRef`). `EachOpponent` is a **list-only** reference (`Player.EachOpponent -> null` in `TargetResolutionUtils.resolvePlayerRef`), so it returned null and `CreatePredefinedTokenExecutor`'s fallback (`resolvePlayerTarget(...) ?: context.controllerId`) created the token under the **caster's** control. Visibly wrong even in 1v1 — Nocturnal Hunger handed *you* the Food.
- **Draw gifts** resolve through the *list* path (`resolvePlayerTargets`), so the lone opponent draws correctly in 1v1, but in **multiplayer every opponent drew** instead of the single promised one.

## Fix

Switch all BLB gift recipients from `Player.EachOpponent` to `Player.AnOpponent` — the chooser-only single-opponent reference already used by the canonical gift card (Longstalk Brawl). Behavior is identical in 1v1 for the draw cards, and now correct for the token cards and for multiplayer.

### Cards fixed (15)
Nocturnal Hunger, Crumb and Get It, Valley Rally, Blooming Blast (Treasure), Wildfire Howl, Dewdrop Cure, Scrapshooter, Coiling Rebirth, Wear Down, Starfall Invocation, Kitnap, Dawn's Truce, Consumed by Greed, Long River's Pull, Peerless Recycling.

## Tests
- New `NocturnalHungerTest`: gift mode creates the Food **for the opponent, not the caster**; no-gift mode creates no Food and the caster loses 2 life.
- Re-blessed the BLB card snapshot golden.
- `CardDefinitionSnapshotTest`, `CardLintTest`, `LongstalkBrawlTest`, `BloomingBlastTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)