### PR TITLE
Fix ungroup icons rendering above in-progress action banner

### DIFF
--- a/web-client/src/components/ui/OpponentDecisionIndicator.tsx
+++ b/web-client/src/components/ui/OpponentDecisionIndicator.tsx
@@ -48,7 +48,9 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     gap: 12,
-    zIndex: 100,
+    // Above battlefield card-stack ungroup toggles (zIndex 1000) so the
+    // indicator banner isn't obscured by them; still below modal selectors (1500+).
+    zIndex: 1100,
     pointerEvents: 'none',
   },
   spinner: {


### PR DESCRIPTION
## Problem

The battlefield card-stack **ungroup toggle** buttons (the small circular diagonal-arrow icons, `StackToggle` in `CardStack.tsx`) render at `zIndex: 1000`, while the **in-progress action banner** (`OpponentDecisionIndicator`, e.g. *"Erik is assigning combat damage"*) was at `zIndex: 100`.

Result: the ungroup arrows render *in front of* the banner, overlapping and partially covering its text — as in the reported screenshot where the two arrow chips punch through the banner edges.

## Fix

Raise `OpponentDecisionIndicator`'s container to `zIndex: 1100` — above the stack toggles (1000), but still below modal selectors (1500+) and full-screen zone browsers (2000+). The banner already has `pointerEvents: 'none'`, so this is purely a visual layering change.

One-line change in `web-client/src/components/ui/OpponentDecisionIndicator.tsx`. `npm run typecheck` passes.

## Note on screenshot
This z-index fix needs the specific state of an opponent assigning combat damage with a stacked group of lands beneath the banner to reproduce visually; the change is a single CSS layering value with no behavioral effect, so no capture is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)