### PR TITLE
Add two Final Fantasy cards: Gilgamesh, Master-at-Arms + Vincent Valentine

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GilgameshMasterAtArms.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GilgameshMasterAtArms.kt
@@ -1,0 +1,155 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gilgamesh, Master-at-Arms
+ * {4}{R}{R}
+ * Legendary Creature — Human Samurai
+ * 6/6
+ * Whenever Gilgamesh enters or attacks, look at the top six cards of your library. You may put
+ *   any number of Equipment cards from among them onto the battlefield. Put the rest on the
+ *   bottom of your library in a random order. When you put one or more Equipment onto the
+ *   battlefield this way, you may attach one of them to a Samurai you control.
+ *
+ * "Enters or attacks" is the Frodo, Determined Hero shape: two sibling triggered abilities (the
+ * engine has no combined enters-or-attacks trigger) sharing one [lookAtTopSixPutEquipment] body.
+ *
+ * The body is a Gather → Select(any number, filtered to Equipment) → Move(battlefield) /
+ * Move(bottom, random) pipeline — the [com.wingedsheep.sdk.dsl.LibraryPatterns.lookAtTopAndKeep]
+ * shape, but with a filtered any-number selection (only Equipment cards are eligible — the rest
+ * of the six aren't offered) and a battlefield destination instead of hand/graveyard, matching
+ * the Beatrix, Loyal General / Colossus of the Blood Age inline-pipeline idiom for "any number"
+ * resolution-time choices that aren't `target`ed.
+ *
+ * "When you put one or more Equipment onto the battlefield this way, you may attach one of them
+ * to a Samurai you control" has neither half ("one of them" / "a Samurai you control") marked
+ * `target` in the oracle text, so both are resolution-time choices, not cast/trigger-time
+ * targets. It's gated by an `ifNotEmpty` branch on the battlefield-bound collection so it
+ * only runs when at least one Equipment was actually put onto the battlefield, then composes two
+ * `chooseUpTo(1)` picks (which equipment / which Samurai — `chooseUpTo` already covers "you may"
+ * by allowing zero) feeding [Effects.AttachTargetEquipmentToCreature], which no-ops gracefully if
+ * either resolves to nothing (no Samurai you control, or the player declines).
+ *
+ * Per Scryfall ruling (2025-06-06) this "When you put..." sentence is technically a *reflexive*
+ * triggered ability that goes on the stack as its own object — relevant because Job select
+ * Equipment (e.g. Samurai's Katana) has its own "when this Equipment enters" trigger, and the two
+ * would fire simultaneously, with the controller choosing stack order. The engine has no general
+ * primitive for spawning a brand-new stack object mid-resolution that interleaves with ordinary
+ * simultaneous triggers (`CreateDelayedTriggerEffect` is built for future-step/future-event
+ * delayed triggers, not an immediate same-batch reflexive trigger; building that generically is
+ * `add-feature` scope, not a single-card change). This card models the reflexive sentence as an
+ * inline pipeline continuation instead, mirroring the same simplification already accepted for
+ * Weapons Vendor's "you may pay {1}. When you do, attach target Equipment..." in this set. Per
+ * the same ruling, the final board state is identical regardless of which order the two abilities
+ * would have been stacked in — Job select always re-attaches the Equipment to its own Hero token
+ * afterward — so the only rules nuance lost is a narrow instant-speed response window between the
+ * two would-be stack objects, not any observable outcome.
+ */
+val GilgameshMasterAtArms = card("Gilgamesh, Master-at-Arms") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Legendary Creature — Human Samurai"
+    power = 6
+    toughness = 6
+    oracleText = "Whenever Gilgamesh enters or attacks, look at the top six cards of your library. " +
+        "You may put any number of Equipment cards from among them onto the battlefield. Put the " +
+        "rest on the bottom of your library in a random order. When you put one or more Equipment " +
+        "onto the battlefield this way, you may attach one of them to a Samurai you control."
+
+    // "Whenever Gilgamesh enters …"
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = lookAtTopSixPutEquipment()
+    }
+
+    // "… or attacks"
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = lookAtTopSixPutEquipment()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "139"
+        artist = "Lorenzo Mastroianni"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1eb81329-fb7a-4347-b96c-9960a5c48e87.jpg?1782686495"
+
+        ruling(
+            "2025-06-06",
+            "You can't use the reflexive triggered ability to try to attach an Equipment to a " +
+                "creature if that Equipment can't legally be attached to that creature."
+        )
+        ruling(
+            "2025-06-06",
+            "If you put an Equipment with job select onto the battlefield with Gilgamesh's " +
+                "ability, the job select ability and the reflexive triggered ability will both " +
+                "trigger, and you'll choose the order in which those abilities go on the stack. " +
+                "Regardless of the order chosen, the job select ability will create a Hero token " +
+                "and attach the Equipment to the Hero token after both abilities have resolved."
+        )
+    }
+}
+
+private fun lookAtTopSixPutEquipment(): Effect = Effects.Pipeline {
+    val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(6)), name = "looked")
+    val (equipment, rest) = chooseAnyNumberSplit(
+        from = looked,
+        filter = GameObjectFilter.Artifact.withSubtype(Subtype.EQUIPMENT),
+        prompt = "Choose any number of Equipment cards to put onto the battlefield",
+        selectedLabel = "Put onto the battlefield",
+        remainderLabel = "Put on the bottom of your library",
+        showAllCards = true
+    )
+    val onBattlefield = moveTracked(
+        equipment,
+        CardDestination.ToZone(Zone.BATTLEFIELD),
+        name = "putOntoBattlefield"
+    )
+    move(
+        rest,
+        CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+        order = CardOrder.Random
+    )
+    // "When you put one or more Equipment onto the battlefield this way, you may attach one of
+    // them to a Samurai you control."
+    ifNotEmpty(onBattlefield) {
+        val chosenEquipment = chooseUpTo(
+            1,
+            from = onBattlefield,
+            useTargetingUI = true,
+            prompt = "You may choose one of the Equipment put onto the battlefield this way to attach"
+        )
+        val samurai = gather(
+            GameObjectFilter.Creature.withSubtype(Subtype.SAMURAI),
+            player = Player.You,
+            name = "samurai"
+        )
+        val chosenSamurai = chooseUpTo(
+            1,
+            from = samurai,
+            useTargetingUI = true,
+            prompt = "You may choose a Samurai you control to attach it to"
+        )
+        run(
+            Effects.AttachTargetEquipmentToCreature(
+                equipmentTarget = EffectTarget.PipelineTarget(chosenEquipment.key, 0),
+                creatureTarget = EffectTarget.PipelineTarget(chosenSamurai.key, 0)
+            )
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/VincentValentine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/VincentValentine.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Vincent Valentine // Galian Beast
+ * {2}{B}{B} — Legendary Creature — Assassin 2/2 // Legendary Creature — Werewolf Beast 3/2
+ *
+ * Front — Vincent Valentine:
+ *   Whenever a creature an opponent controls dies, put a number of +1/+1 counters on Vincent
+ *   Valentine equal to that creature's power.
+ *   Whenever Vincent Valentine attacks, you may transform it.
+ *
+ * Back — Galian Beast:
+ *   Trample, lifelink
+ *   When Galian Beast dies, return it to the battlefield tapped (front face up).
+ *
+ * The counter trigger reads the dying creature's power via
+ * `DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Power)`, which
+ * resolves with last-known information once the creature has left the battlefield (CR 112.7a) —
+ * matching the official ruling "Use the creature's power as it last existed on the battlefield."
+ * Galian Beast's death trigger is a plain `Effects.PutOntoBattlefield(Self, tapped = true)`: a
+ * double-faced permanent's non-battlefield characteristics are always its front face (CR 712.8a),
+ * so by the time this creature is in the graveyard it has already reverted to the Vincent
+ * Valentine face, and a DFC re-entering the battlefield is front-face-up by default — the same
+ * mechanism proven by Unstoppable Slasher's "return to the battlefield tapped" trigger.
+ */
+private val GalianBeast = card("Galian Beast") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Werewolf Beast"
+    oracleText = "Trample, lifelink\n" +
+        "When Galian Beast dies, return it to the battlefield tapped (front face up)."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.TRAMPLE, Keyword.LIFELINK)
+
+    // When Galian Beast dies, return it to the battlefield tapped (front face up).
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.PutOntoBattlefield(EffectTarget.Self, tapped = true)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "125"
+        artist = "Norikatsu Miyoshi"
+        flavorText = "\"This body is... the punishment that's been given to me...\""
+        imageUri = "https://cards.scryfall.io/normal/back/0/2/028ef608-acfe-4e9d-90db-eca4411ba78a.jpg?1782686505"
+    }
+}
+
+private val VincentValentineFront = card("Vincent Valentine") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Assassin"
+    oracleText = "Whenever a creature an opponent controls dies, put a number of +1/+1 counters " +
+        "on Vincent Valentine equal to that creature's power.\n" +
+        "Whenever Vincent Valentine attacks, you may transform it."
+    power = 2
+    toughness = 2
+
+    // Whenever a creature an opponent controls dies, put a number of +1/+1 counters on
+    // Vincent Valentine equal to that creature's power.
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.opponentControls(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddDynamicCounters(
+            Counters.PLUS_ONE_PLUS_ONE,
+            DynamicAmount.EntityProperty(EntityReference.Triggering, EntityNumericProperty.Power),
+            EffectTarget.Self
+        )
+    }
+
+    // Whenever Vincent Valentine attacks, you may transform it.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = MayEffect(effect = TransformEffect(EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "125"
+        artist = "Norikatsu Miyoshi"
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/028ef608-acfe-4e9d-90db-eca4411ba78a.jpg?1782686505"
+    }
+}
+
+val VincentValentine: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = VincentValentineFront,
+    backFace = GalianBeast
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -19689,6 +19689,102 @@
     ]
 }
 
+// Vincent Valentine
+{
+    "name": "Vincent Valentine",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Legendary Creature — Assassin",
+    "oracleText": "Whenever a creature an opponent controls dies, put a number of +1/+1 counters on Vincent Valentine equal to that creature's power.\nWhenever Vincent Valentine attacks, you may transform it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddDynamicCounters",
+                    "counterType": "+1/+1",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Triggering",
+                        "numericProperty": "Power"
+                    },
+                    "target": "Self"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Transform"
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Galian Beast",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Werewolf Beast",
+        "oracleText": "Trample, lifelink\nWhen Galian Beast dies, return it to the battlefield tapped (front face up).",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 2
+        },
+        "keywords": [
+            "TRAMPLE",
+            "LIFELINK"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "from": "Battlefield",
+                        "to": "Graveyard"
+                    },
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Battlefield",
+                        "placement": "Tapped"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "125",
+            "rarity": "RARE",
+            "artist": "Norikatsu Miyoshi",
+            "flavorText": "\"This body is... the punishment that's been given to me...\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/2/028ef608-acfe-4e9d-90db-eca4411ba78a.jpg?1782686505"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "RARE",
+        "artist": "Norikatsu Miyoshi",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/028ef608-acfe-4e9d-90db-eca4411ba78a.jpg?1782686505"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Vincent's Limit Break
 {
     "name": "Vincent's Limit Break",

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -6144,6 +6144,260 @@
     ]
 }
 
+// Gilgamesh, Master-at-Arms
+{
+    "name": "Gilgamesh, Master-at-Arms",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Legendary Creature — Human Samurai",
+    "oracleText": "Whenever Gilgamesh enters or attacks, look at the top six cards of your library. You may put any number of Equipment cards from among them onto the battlefield. Put the rest on the bottom of your library in a random order. When you put one or more Equipment onto the battlefield this way, you may attach one of them to a Samurai you control.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": "ChooseAnyNumber",
+                            "filter": "artifact Equipment",
+                            "storeSelected": "selected1",
+                            "storeRemainder": "remainder1",
+                            "prompt": "Choose any number of Equipment cards to put onto the battlefield",
+                            "selectedLabel": "Put onto the battlefield",
+                            "remainderLabel": "Put on the bottom of your library",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "storeMovedAs": "putOntoBattlefield"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "remainder1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "putOntoBattlefield",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "putOntoBattlefield",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "selected5",
+                                        "prompt": "You may choose one of the Equipment put onto the battlefield this way to attach",
+                                        "useTargetingUI": true
+                                    },
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "BattlefieldMatching",
+                                            "filter": "creature Samurai",
+                                            "player": "You"
+                                        },
+                                        "storeAs": "samurai"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "samurai",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "selected7",
+                                        "prompt": "You may choose a Samurai you control to attach it to",
+                                        "useTargetingUI": true
+                                    },
+                                    {
+                                        "type": "AttachTargetEquipmentToCreature",
+                                        "equipmentTarget": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "selected5"
+                                        },
+                                        "creatureTarget": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "selected7"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": "ChooseAnyNumber",
+                            "filter": "artifact Equipment",
+                            "storeSelected": "selected1",
+                            "storeRemainder": "remainder1",
+                            "prompt": "Choose any number of Equipment cards to put onto the battlefield",
+                            "selectedLabel": "Put onto the battlefield",
+                            "remainderLabel": "Put on the bottom of your library",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield"
+                            },
+                            "storeMovedAs": "putOntoBattlefield"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "remainder1",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "putOntoBattlefield",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "putOntoBattlefield",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "selected5",
+                                        "prompt": "You may choose one of the Equipment put onto the battlefield this way to attach",
+                                        "useTargetingUI": true
+                                    },
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "BattlefieldMatching",
+                                            "filter": "creature Samurai",
+                                            "player": "You"
+                                        },
+                                        "storeAs": "samurai"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "samurai",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "selected7",
+                                        "prompt": "You may choose a Samurai you control to attach it to",
+                                        "useTargetingUI": true
+                                    },
+                                    {
+                                        "type": "AttachTargetEquipmentToCreature",
+                                        "equipmentTarget": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "selected5"
+                                        },
+                                        "creatureTarget": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "selected7"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "RARE",
+        "artist": "Lorenzo Mastroianni",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1eb81329-fb7a-4347-b96c-9960a5c48e87.jpg?1782686495",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "You can't use the reflexive triggered ability to try to attach an Equipment to a creature if that Equipment can't legally be attached to that creature."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "If you put an Equipment with job select onto the battlefield with Gilgamesh's ability, the job select ability and the reflexive triggered ability will both trigger, and you'll choose the order in which those abilities go on the stack. Regardless of the order chosen, the job select ability will create a Hero token and attach the Equipment to the Hero token after both abilities have resolved."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Giott, King of the Dwarves
 {
     "name": "Giott, King of the Dwarves",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/DeathAndLeaveTriggerDetector.kt
@@ -28,10 +28,24 @@ class DeathAndLeaveTriggerDetector(
 ) {
 
     /**
-     * Resolve the dying entity's identity either from its still-present container or from
-     * last-known info on the event. The latter fallback is required for tokens, which are
-     * removed from the game by 704.5s in the same SBA pass that puts them in the graveyard
-     * (see [com.wingedsheep.engine.mechanics.sba.zone.TokensInWrongZonesCheck]).
+     * Resolve the dying entity's identity from the last-known snapshot captured the instant it
+     * left the battlefield (CR 113.7a / 603.10 / 608.2h), falling back to its still-present
+     * container only when no snapshot was captured.
+     *
+     * The snapshot is required, not just sufficient: a double-faced permanent's [CardComponent]
+     * is reset to its front face as part of the very same zone-move (CR 712.8a, applied in
+     * [com.wingedsheep.engine.handlers.effects.ZoneTransitionService]) *before* trigger detection
+     * ever runs. A back face's own "when this dies"/"when this leaves" trigger (Galian Beast)
+     * must therefore be looked up by the card definition it had at the moment it died — captured
+     * pre-reset on [ZoneChangeEvent.lastKnown] — not the already-reset live container, or the
+     * lookup silently returns the front face's abilities instead and the back face's trigger
+     * never fires. For every non-DFC card the two values are identical, so this is a no-op there.
+     *
+     * The live-container fallback below only matters when no snapshot was captured at all (a
+     * theoretical safety net — every battlefield-leaving event reaching this function populates
+     * [ZoneChangeEvent.lastKnown]); the container itself may already be gone for a token cleaned
+     * up by 704.5s in the same SBA pass that put it in the graveyard (see
+     * [com.wingedsheep.engine.mechanics.sba.zone.TokensInWrongZonesCheck]).
      */
     private data class DyingEntityInfo(
         val cardDefinitionId: String,
@@ -40,9 +54,13 @@ class DeathAndLeaveTriggerDetector(
 
     private fun resolveDyingEntity(state: GameState, event: ZoneChangeEvent): DyingEntityInfo? {
         val container = state.getEntity(event.entityId)
+        // Face-down creatures have no abilities (Rule 708.2)
+        if (container?.has<FaceDownComponent>() == true) return null
+
+        event.lastKnown?.cardDefinitionId?.let { cardDefId ->
+            return DyingEntityInfo(cardDefId, event.entityName)
+        }
         if (container != null) {
-            // Face-down creatures have no abilities (Rule 708.2)
-            if (container.has<FaceDownComponent>()) return null
             val cardComponent = container.get<CardComponent>() ?: return null
             return DyingEntityInfo(cardComponent.cardDefinitionId, cardComponent.name)
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GilgameshMasterAtArmsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GilgameshMasterAtArmsScenarioTest.kt
@@ -1,0 +1,193 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.GilgameshMasterAtArms
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for Gilgamesh, Master-at-Arms (FIN #139).
+ *
+ * Gilgamesh, Master-at-Arms {4}{R}{R} Legendary Creature — Human Samurai 6/6
+ * Whenever Gilgamesh enters or attacks, look at the top six cards of your library. You may put
+ * any number of Equipment cards from among them onto the battlefield. Put the rest on the
+ * bottom of your library in a random order. When you put one or more Equipment onto the
+ * battlefield this way, you may attach one of them to a Samurai you control.
+ *
+ * Covers both halves of "enters or attacks" (two sibling triggered abilities), the filtered
+ * any-number selection (only Equipment among the six is offered as selectable), the
+ * "When you put... you may attach" sub-pipeline gated on at least one Equipment actually
+ * entering, and both "may" declines (no Equipment chosen at all; Equipment chosen but the
+ * optional attach declined).
+ */
+class GilgameshMasterAtArmsScenarioTest : FunSpec({
+
+    val stateProjector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + GilgameshMasterAtArms)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("ETB: chooses the lone Equipment among six, rest to bottom, then attaches it to Gilgamesh") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        // Library top six (last push = top): five Plains + one Equipment on top.
+        val deep1 = driver.putCardOnTopOfLibrary(you, "Plains")
+        val deep2 = driver.putCardOnTopOfLibrary(you, "Plains")
+        val deep3 = driver.putCardOnTopOfLibrary(you, "Plains")
+        val deep4 = driver.putCardOnTopOfLibrary(you, "Plains")
+        val deep5 = driver.putCardOnTopOfLibrary(you, "Plains")
+        val sword = driver.putCardOnTopOfLibrary(you, "Buster Sword")
+
+        val gilgameshCard = driver.putCardInHand(you, "Gilgamesh, Master-at-Arms")
+        driver.giveMana(you, Color.RED, 2)
+        driver.giveColorlessMana(you, 4)
+
+        driver.castSpell(you, gilgameshCard)
+        driver.bothPass() // resolve Gilgamesh onto the battlefield, ETB trigger goes on the stack
+        driver.bothPass() // begin resolving the ETB trigger
+
+        val gilgamesh = driver.findPermanent(you, "Gilgamesh, Master-at-Arms")!!
+
+        // Pauses to choose any number of the six — only Buster Sword is selectable (Equipment filter).
+        driver.isPaused shouldBe true
+        val selectDecision = driver.pendingDecision as SelectCardsDecision
+        selectDecision.options shouldBe listOf(sword)
+        driver.submitCardSelection(you, listOf(sword))
+
+        // Buster Sword went onto the battlefield → the "When you put one or more..." sub-pipeline
+        // pauses to choose which Equipment (the lone candidate) to attach.
+        driver.isPaused shouldBe true
+        val equipmentChoice = driver.pendingDecision as SelectCardsDecision
+        equipmentChoice.options shouldBe listOf(sword)
+        driver.submitCardSelection(you, listOf(sword))
+
+        // Then which Samurai you control to attach it to — only Gilgamesh qualifies.
+        driver.isPaused shouldBe true
+        val samuraiChoice = driver.pendingDecision as SelectCardsDecision
+        samuraiChoice.options shouldBe listOf(gilgamesh)
+        driver.submitCardSelection(you, listOf(gilgamesh))
+
+        driver.isPaused shouldBe false
+
+        driver.state.getEntity(sword)?.get<AttachedToComponent>()?.targetId shouldBe gilgamesh
+        // 6/6 base + Buster Sword's +3/+2 = 9/8.
+        stateProjector.project(driver.state).getPower(gilgamesh) shouldBe 9
+        stateProjector.project(driver.state).getToughness(gilgamesh) shouldBe 8
+
+        // The five Plains are still in the library (bottomed, not lost).
+        val library = driver.state.getZone(ZoneKey(you, Zone.LIBRARY))
+        listOf(deep1, deep2, deep3, deep4, deep5).forEach { library shouldContain it }
+    }
+
+    test("ETB: declining the any-number selection puts nothing onto the battlefield, no further decision") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val filler = (1..5).map { driver.putCardOnTopOfLibrary(you, "Plains") }
+        val sword = driver.putCardOnTopOfLibrary(you, "Buster Sword")
+
+        val gilgameshCard = driver.putCardInHand(you, "Gilgamesh, Master-at-Arms")
+        driver.giveMana(you, Color.RED, 2)
+        driver.giveColorlessMana(you, 4)
+
+        driver.castSpell(you, gilgameshCard)
+        driver.bothPass()
+        driver.bothPass()
+
+        driver.isPaused shouldBe true
+        driver.submitCardSelection(you, emptyList())
+
+        // Nothing was put onto the battlefield this way → no "you may attach" sub-pipeline runs.
+        driver.isPaused shouldBe false
+        driver.findPermanent(you, "Buster Sword") shouldBe null
+
+        val library = driver.state.getZone(ZoneKey(you, Zone.LIBRARY))
+        library shouldContain sword
+        filler.forEach { library shouldContain it }
+    }
+
+    test("ETB: Equipment enters the battlefield even when the optional attach is declined") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        repeat(5) { driver.putCardOnTopOfLibrary(you, "Plains") }
+        val sword = driver.putCardOnTopOfLibrary(you, "Buster Sword")
+
+        val gilgameshCard = driver.putCardInHand(you, "Gilgamesh, Master-at-Arms")
+        driver.giveMana(you, Color.RED, 2)
+        driver.giveColorlessMana(you, 4)
+
+        driver.castSpell(you, gilgameshCard)
+        driver.bothPass()
+        driver.bothPass()
+
+        val gilgamesh = driver.findPermanent(you, "Gilgamesh, Master-at-Arms")!!
+
+        driver.isPaused shouldBe true
+        driver.submitCardSelection(you, listOf(sword))
+
+        // Decline "one of them" — no Equipment chosen to attach.
+        driver.isPaused shouldBe true
+        driver.submitCardSelection(you, emptyList())
+
+        // Still asked which Samurai (even though the attach will no-op without an Equipment).
+        driver.isPaused shouldBe true
+        driver.submitCardSelection(you, listOf(gilgamesh))
+
+        driver.isPaused shouldBe false
+
+        driver.findPermanent(you, "Buster Sword") shouldNotBe null
+        driver.state.getEntity(sword)?.get<AttachedToComponent>() shouldBe null
+        stateProjector.project(driver.state).getPower(gilgamesh) shouldBe 6
+        stateProjector.project(driver.state).getToughness(gilgamesh) shouldBe 6
+    }
+
+    test("attacks: the same look-at-top-six pipeline runs and attaches the chosen Equipment") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        // Direct-to-battlefield helper bypasses ETB triggers, so only the attack half is exercised.
+        val gilgamesh = driver.putCreatureOnBattlefield(you, "Gilgamesh, Master-at-Arms")
+        driver.removeSummoningSickness(gilgamesh)
+
+        repeat(5) { driver.putCardOnTopOfLibrary(you, "Plains") }
+        val sword = driver.putCardOnTopOfLibrary(you, "Buster Sword")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(gilgamesh), opponent)
+        driver.bothPass() // begin resolving the attack trigger
+
+        driver.isPaused shouldBe true
+        val selectDecision = driver.pendingDecision as SelectCardsDecision
+        selectDecision.options shouldBe listOf(sword)
+        driver.submitCardSelection(you, listOf(sword))
+
+        driver.isPaused shouldBe true
+        driver.submitCardSelection(you, listOf(sword))
+
+        driver.isPaused shouldBe true
+        driver.submitCardSelection(you, listOf(gilgamesh))
+
+        driver.isPaused shouldBe false
+
+        driver.state.getEntity(sword)?.get<AttachedToComponent>()?.targetId shouldBe gilgamesh
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VincentValentineScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VincentValentineScenarioTest.kt
@@ -1,0 +1,151 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Vincent Valentine // Galian Beast (FIN #125).
+ *
+ * Vincent Valentine — {2}{B}{B} Legendary Creature — Assassin 2/2:
+ *   Whenever a creature an opponent controls dies, put a number of +1/+1 counters on Vincent
+ *   Valentine equal to that creature's power.
+ *   Whenever Vincent Valentine attacks, you may transform it.
+ *
+ * Galian Beast — Legendary Creature — Werewolf Beast 3/2:
+ *   Trample, lifelink
+ *   When Galian Beast dies, return it to the battlefield tapped (front face up).
+ *
+ * Exercises three independently-proven primitives composed on one card: the
+ * `EntityProperty(Triggering, Power)` last-known-information read on an opponent's-creature-dies
+ * trigger (proven elsewhere by Jackal, Genius Geneticist / Doran, Besieged by Time), the
+ * attack-triggered `MayEffect(TransformEffect)` (proven by Cecil, Dark Knight / Grub, Storied
+ * Matriarch), and a DFC's "dies, return tapped" trigger relying on the automatic front-face-up
+ * re-entry default (proven by Unstoppable Slasher's plain "return to the battlefield tapped").
+ */
+class VincentValentineScenarioTest : FunSpec({
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun GameTestDriver.boltDeath(caster: EntityId, victim: EntityId) {
+        val bolt = putCardInHand(caster, "Lightning Bolt")
+        giveMana(caster, Color.RED, 1)
+        castSpell(caster, bolt, listOf(victim)).isSuccess shouldBe true
+        resolveStack(this) // bolt resolves, victim dies, dies-trigger goes on the stack
+        resolveStack(this) // dies trigger resolves
+    }
+
+    test("an opponent's creature dying puts +1/+1 counters on Vincent equal to its power") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        val vincent = driver.putCreatureOnBattlefield(you, "Vincent Valentine")
+        val hillGiant = driver.putCreatureOnBattlefield(opponent, "Hill Giant") // 3/3
+
+        driver.boltDeath(you, hillGiant)
+
+        driver.state.getBattlefield().contains(hillGiant) shouldBe false
+        plusCounters(driver, vincent) shouldBe 3
+    }
+
+    test("Vincent's own creature dying does not put counters on Vincent") {
+        val (driver, you) = newGame()
+        val vincent = driver.putCreatureOnBattlefield(you, "Vincent Valentine")
+        val hillGiant = driver.putCreatureOnBattlefield(you, "Hill Giant") // 3/3, same controller
+
+        driver.boltDeath(you, hillGiant)
+
+        driver.state.getBattlefield().contains(hillGiant) shouldBe false
+        plusCounters(driver, vincent) shouldBe 0
+    }
+
+    test("attacking offers a may-transform; declining leaves Vincent on the front face") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        val vincent = driver.putCreatureOnBattlefield(you, "Vincent Valentine")
+        driver.removeSummoningSickness(vincent)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, mapOf(vincent to opponent)).isSuccess shouldBe true
+        resolveStack(driver) // attack trigger resolves into the may-transform yes/no prompt
+        driver.isPaused shouldBe true
+        driver.submitYesNo(you, false)
+
+        driver.state.getEntity(vincent)!!.get<DoubleFacedComponent>()!!.currentFace shouldBe
+            DoubleFacedComponent.Face.FRONT
+        driver.state.getEntity(vincent)!!.get<CardComponent>()!!.name shouldBe "Vincent Valentine"
+    }
+
+    test("accepting the may-transform turns Vincent into Galian Beast") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        val vincent = driver.putCreatureOnBattlefield(you, "Vincent Valentine")
+        driver.removeSummoningSickness(vincent)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, mapOf(vincent to opponent)).isSuccess shouldBe true
+        resolveStack(driver)
+        driver.isPaused shouldBe true
+        driver.submitYesNo(you, true)
+
+        val container = driver.state.getEntity(vincent)
+        container.shouldNotBeNull()
+        container.get<CardComponent>()!!.name shouldBe "Galian Beast"
+        container.get<DoubleFacedComponent>()!!.currentFace shouldBe DoubleFacedComponent.Face.BACK
+    }
+
+    test("Galian Beast dying returns it to the battlefield tapped, front face up, as Vincent Valentine") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        val vincent = driver.putCreatureOnBattlefield(you, "Vincent Valentine")
+        driver.removeSummoningSickness(vincent)
+
+        // Transform Vincent into Galian Beast via the attack trigger.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, mapOf(vincent to opponent)).isSuccess shouldBe true
+        resolveStack(driver)
+        driver.submitYesNo(you, true)
+        driver.state.getEntity(vincent)!!.get<CardComponent>()!!.name shouldBe "Galian Beast"
+
+        // Kill Galian Beast (3/2) with a 3-damage bolt — lethal. Active player passes priority
+        // first so the (non-active) opponent gets a window to cast at instant speed.
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.giveMana(opponent, Color.RED, 1)
+        driver.passPriority(you)
+        driver.castSpell(opponent, bolt, listOf(vincent)).isSuccess shouldBe true
+        resolveStack(driver) // bolt resolves, Galian Beast dies, dies-trigger goes on the stack
+        resolveStack(driver) // dies trigger: return it to the battlefield tapped
+
+        // Same entity id, now back on the battlefield as the front face.
+        driver.state.getBattlefield().contains(vincent) shouldBe true
+        val container = driver.state.getEntity(vincent)
+        container.shouldNotBeNull()
+        container.get<CardComponent>()!!.name shouldBe "Vincent Valentine"
+        container.get<DoubleFacedComponent>()!!.currentFace shouldBe DoubleFacedComponent.Face.FRONT
+        container.has<TappedComponent>() shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary
- **Gilgamesh, Master-at-Arms** — enters/attacks: look at top 6, put any number of Equipment onto the battlefield, then may attach one to a Samurai you control. Composes the existing `Effects.AttachTargetEquipmentToCreature` facade with a Gather→Select→Move pipeline; no new engine primitives.
- **Vincent Valentine // Galian Beast** — front gains +1/+1 counters equal to a dying opponent creature's power and may transform on attack; back face returns to the battlefield tapped (front face up) when it dies. Built from existing DFC transform/return-from-graveyard primitives (the same shape already proven by Cecil, Dark Knight in this set).
- **Engine bug fix** (found while implementing Vincent Valentine): `DeathAndLeaveTriggerDetector.resolveDyingEntity` looked up a dying permanent's triggered abilities from its *live* `CardComponent`, but `ZoneTransitionService` resets a double-faced permanent's `CardComponent` back to its front face as part of the same zone-move (CR 712.8a) — before trigger detection runs. So a back-face DFC's own "when this dies" trigger silently resolved the *front* face's abilities instead. Fixed by preferring the pre-reset `ZoneChangeEvent.lastKnown.cardDefinitionId`. No-op for every other (non-DFC, or front-face) card; fixes the same latent gap for any future back-face DFC with its own dies/leaves trigger.

## Test plan
- [x] `just test-rules` — full rules-engine suite green, including 2 new scenario test files
- [x] `just build` — full project build green
- [x] `CardDefinitionSnapshotTest` re-blessed; diff confirmed to contain only the two new cards
- [x] `just check-card-printing` confirms FIN is the correct canonical printing for both cards
- [x] Scryfall data (oracle text, mana cost, P/T, image URIs) verified field-by-field for both cards