### PR TITLE
Add FIN cards: Absolute Virtue, Zodiark, Omega

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3003,6 +3003,12 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
   of it) resolves against its last-known information in the graveyard. This is exactly the wording "whenever you
   sacrifice this permanent or another <filter>" (Esoteric Duplicator) as well as the plain "whenever you sacrifice
   a <filter>" (Mayhem Devil). For the "another" exclusion use an `OTHER`-binding trigger instead.
+  By default the ANY-binding form watches only the source *controller's* sacrifices ("whenever **you**
+  sacrifice…"). For the "whenever **a player** sacrifices…" scope set
+  `EventPattern.PermanentsSacrificedEvent(filter, byAnyPlayer = true)` (Zodiark, Umbral God — "Whenever a
+  player sacrifices another creature, put a +1/+1 counter on Zodiark"): the detector then fires the trigger
+  once per sacrificing player in the batch, regardless of who controls the source, binding
+  `triggeringPlayerId` to that player.
 - `Sacrificed` — source is sacrificed.
 - `PlusOneCountersPlacedOnYourCreature` — Hardened Scales shape (+1/+1 only).
 - `countersPlacedOn(filter = Creature.youControl(), counterType = Counters.ANY, firstTimeEachTurn = true, binding = ANY)`
@@ -3592,6 +3598,15 @@ staticAbility {
   less life" alongside its "if you have no cards in hand, you lose the game" clause, which still fires).
   Projected to `GrantsCantLoseGameFromLifeComponent`, read only by `PlayerLifeLossCheck` (controller-
   scoped, not a team-wide grant).
+- `GrantProtectionToController(scope = ProtectionScope.EachOpponent)` — controller "has protection from
+  [scope]" while this permanent is on the battlefield (Absolute Virtue: "You have protection from each
+  of your opponents."). The continuous, static counterpart of the one-shot `GrantPlayerProtection`
+  (The One Ring) — for a player only the **D**amage and **T**argeting legs of DEBT apply. Projected to
+  `GrantsControllerProtectionComponent(scopes)`; `PlayerProtectionRules.isProtectedFromSource` unions
+  these battlefield-sourced scopes with any one-shot `PlayerProtectionComponent` on the player, so the
+  protection appears/disappears with the permanent (no cleanup). General over any `ProtectionScope`
+  (single color, `Everything`, `EachOpponent`, …), mirroring the controller-grant statics
+  `GrantHexproofToController` / `GrantShroudToController`.
 - `SetMaximumHandSize(player, amount)` — sets the maximum hand size of a `player` scope (`You` /
   `EachOpponent` / `Each`, resolved relative to the source's controller) to a `DynamicAmount`, read at
   cleanup. Most restrictive (smallest) value wins when several apply; a `NoMaximumHandSize` controlled

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1656,19 +1656,27 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
      * Batching trigger — fires at most once per event batch regardless of how many
      * permanents were sacrificed.
      *
+     * By default the trigger watches only the controller's own sacrifices ("Whenever *you*
+     * sacrifice…"). Set [byAnyPlayer] = true for the "Whenever *a player* sacrifices…" scope
+     * (Zodiark, Umbral God) — then the ANY-binding detector fires the trigger once per player
+     * who sacrificed a matching permanent in the batch, regardless of who controls the source.
+     *
      * Examples:
      *   → PermanentsSacrificedEvent(filter = GameObjectFilter.Food)
      *     "Whenever you sacrifice one or more Foods"
      *   → PermanentsSacrificedEvent()
      *     "Whenever you sacrifice a permanent"
+     *   → PermanentsSacrificedEvent(filter = GameObjectFilter.Creature, byAnyPlayer = true)
+     *     "Whenever a player sacrifices a creature"
      */
     @SerialName("PermanentsSacrificedEvent")
     @Serializable
     data class PermanentsSacrificedEvent(
-        val filter: GameObjectFilter = GameObjectFilter.Any
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        val byAnyPlayer: Boolean = false
     ) : EventPattern {
         override val description: String = buildString {
-            append("you sacrifice one or more ")
+            append(if (byAnyPlayer) "a player sacrifices one or more " else "you sacrifice one or more ")
             if (filter != GameObjectFilter.Any) {
                 append(filter.cardPredicates.joinToString(" ") { it.description })
                 append("s")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ProtectionStaticAbilities.kt
@@ -210,6 +210,38 @@ data object GrantHexproofToController : StaticAbility {
 }
 
 /**
+ * You have protection from [scope] (CR 702.16).
+ *
+ * Grants player-level protection to the permanent's controller — the continuous, static
+ * counterpart of the one-shot [com.wingedsheep.sdk.scripting.effects.GrantPlayerProtectionEffect]
+ * (The One Ring). For a player only the **D**amage and **T**argeting legs of DEBT apply: while
+ * this permanent is on the battlefield its controller can't be dealt damage by, nor be the target
+ * of spells/abilities from, a source matching [scope]. When the permanent leaves the battlefield
+ * the protection goes with it — no cleanup needed.
+ *
+ * General-purpose over any [ProtectionScope]: `EachOpponent` (Absolute Virtue —
+ * "You have protection from each of your opponents."), a single color, `Everything`, etc.
+ *
+ * @property scope The quality the controller is protected from.
+ */
+@SerialName("GrantProtectionToController")
+@Serializable
+data class GrantProtectionToController(
+    val scope: ProtectionScope = ProtectionScope.EachOpponent
+) : StaticAbility {
+    override val description: String =
+        "You have protection from " + when (val s = scope) {
+            is ProtectionScope.Color -> s.color.displayName.lowercase()
+            is ProtectionScope.Colors -> s.colors.joinToString(" and ") { it.displayName.lowercase() }
+            is ProtectionScope.CardType -> s.cardType.lowercase() + "s"
+            is ProtectionScope.Subtype -> s.subtype + "s"
+            is ProtectionScope.Supertype -> s.supertype.lowercase() + " permanents"
+            ProtectionScope.Everything -> "everything"
+            ProtectionScope.EachOpponent -> "each of your opponents"
+        }
+}
+
+/**
  * This permanent can't be the target of abilities your opponents control.
  * Unlike hexproof, this does NOT prevent targeting by spells — only by activated
  * and triggered abilities.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AbsoluteVirtue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AbsoluteVirtue.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantProtectionToController
+import com.wingedsheep.sdk.scripting.ProtectionScope
+
+/**
+ * Absolute Virtue
+ * {6}{W}{U}
+ * Legendary Creature — Avatar Warrior
+ * 8/8
+ * This spell can't be countered.
+ * Flying
+ * You have protection from each of your opponents. (You can't be dealt damage, enchanted, or
+ * targeted by anything controlled by your opponents.)
+ *
+ * Modeling: "can't be countered" is the intrinsic spell flag ([cantBeCountered]); flying is an
+ * intrinsic keyword; the protection clause grants the *controller* (not the creature) player-level
+ * protection via the continuous static [GrantProtectionToController] with
+ * [ProtectionScope.EachOpponent] — the static counterpart of The One Ring's one-shot
+ * `GrantPlayerProtectionEffect`. The protection lasts only while Absolute Virtue is on the
+ * battlefield.
+ */
+val AbsoluteVirtue = card("Absolute Virtue") {
+    manaCost = "{6}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Legendary Creature — Avatar Warrior"
+    power = 8
+    toughness = 8
+    oracleText = "This spell can't be countered.\n" +
+        "Flying\n" +
+        "You have protection from each of your opponents. (You can't be dealt damage, enchanted, " +
+        "or targeted by anything controlled by your opponents.)"
+
+    cantBeCountered = true
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = GrantProtectionToController(ProtectionScope.EachOpponent)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "212"
+        artist = "Toni Infante"
+        imageUri = "https://cards.scryfall.io/normal/front/a/a/aa192912-c9ee-403f-8a46-a338c9edb4b9.jpg?1782686436"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/OmegaHeartlessEvolution.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/OmegaHeartlessEvolution.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Omega, Heartless Evolution
+ * {5}{G}{U}
+ * Legendary Artifact Creature — Robot
+ * 8/8
+ *
+ * Wave Cannon — When Omega enters, for each opponent, tap up to one target nonland permanent that
+ * opponent controls. Put X stun counters on each of those permanents and you gain X life, where X
+ * is the number of nonbasic lands you control.
+ *
+ * Modeling:
+ *  - "Wave Cannon" is an ability word (flavor only). The clause is an enter trigger with an
+ *    optional target — "up to one target nonland permanent that opponent controls" via
+ *    `TargetPermanent(optional = true, filter = NonlandPermanentOpponentControls)`. Following the
+ *    corpus convention for "for each opponent, … target … that player controls" (Blatant Thievery),
+ *    the per-opponent structure is modeled as a single optional target — exactly right in 1v1 and
+ *    the shape multiplayer targeting will generalize.
+ *  - X = the number of nonbasic lands you control (`Count(You, BATTLEFIELD, NonbasicLand)`), read
+ *    once at resolution. The chosen permanent is tapped, gets X stun counters (`AddDynamicCounters`
+ *    with `Counters.STUN`, so it stays tapped through its controller's next untap), and you gain X
+ *    life. The life gain is independent of whether a permanent was chosen, so it uses its own step.
+ *    With no target chosen the tap/counters steps simply no-op and you still gain X life.
+ */
+val OmegaHeartlessEvolution = card("Omega, Heartless Evolution") {
+    manaCost = "{5}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Legendary Artifact Creature — Robot"
+    power = 8
+    toughness = 8
+    oracleText = "Wave Cannon — When Omega enters, for each opponent, tap up to one target nonland " +
+        "permanent that opponent controls. Put X stun counters on each of those permanents and you " +
+        "gain X life, where X is the number of nonbasic lands you control. (If a permanent with a " +
+        "stun counter would become untapped, remove one from it instead.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "permanent",
+            TargetPermanent(optional = true, filter = TargetFilter.NonlandPermanentOpponentControls)
+        )
+        val nonbasicLands = DynamicAmount.Count(
+            Player.You,
+            Zone.BATTLEFIELD,
+            GameObjectFilter.NonbasicLand
+        )
+        effect = Effects.Composite(
+            Effects.Tap(permanent),
+            Effects.AddDynamicCounters(Counters.STUN, nonbasicLands, permanent),
+            Effects.GainLife(nonbasicLands)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "236"
+        artist = "Josu Solano"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9a8eb7e6-0c0b-42d0-aa90-2d3d29bc15aa.jpg?1782686412"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZodiarkUmbralGod.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZodiarkUmbralGod.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggerSpec
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Zodiark, Umbral God
+ * {B}{B}{B}{B}{B}
+ * Legendary Creature — God
+ * 5/5
+ *
+ * Indestructible
+ * When Zodiark enters, each player sacrifices half the non-God creatures they control of their
+ * choice, rounded down.
+ * Whenever a player sacrifices another creature, put a +1/+1 counter on Zodiark.
+ *
+ * Modeling:
+ *  - The enter trigger is a per-player edict composed from existing primitives — no new effect.
+ *    [ForEachPlayerEffect] with `Player.Each` rebinds the iterated player as the controller, so
+ *    inside the loop `Player.You` means *that* player. Each player force-sacrifices, of their own
+ *    choice, `Effects.Sacrifice` with a dynamic count of `Divide(<their non-God creatures>, 2,
+ *    roundUp = false)` — the same shape Rush of Dread uses for "half … rounded up", flipped to
+ *    round down. The non-God filter is `Creature.notSubtype(GOD)`, so a player's own Gods (and
+ *    Zodiark) are never sacrificed and don't count toward the half.
+ *  - The counter trigger uses the "a player sacrifices" scope
+ *    ([EventPattern.PermanentsSacrificedEvent.byAnyPlayer] = true, ANY binding): it fires for any
+ *    player's sacrifices, not just Zodiark's controller's. Following the engine's batching
+ *    convention for sacrifice triggers, it fires once per sacrificing player per batch. The filter
+ *    is `Creature`; "another" is satisfied in practice because Zodiark is indestructible and, as a
+ *    God, is excluded from its own edict — the only way it would count itself is if some other
+ *    effect sacrifices it, at which point the counter is moot.
+ */
+val ZodiarkUmbralGod = card("Zodiark, Umbral God") {
+    manaCost = "{B}{B}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — God"
+    power = 5
+    toughness = 5
+    oracleText = "Indestructible\n" +
+        "When Zodiark enters, each player sacrifices half the non-God creatures they control of " +
+        "their choice, rounded down.\n" +
+        "Whenever a player sacrifices another creature, put a +1/+1 counter on Zodiark."
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                Effects.Sacrifice(
+                    filter = GameObjectFilter.Creature.notSubtype(Subtype.GOD),
+                    count = DynamicAmount.Divide(
+                        numerator = DynamicAmount.AggregateBattlefield(
+                            Player.You,
+                            GameObjectFilter.Creature.notSubtype(Subtype.GOD)
+                        ),
+                        denominator = DynamicAmount.Fixed(2),
+                        roundUp = false
+                    ),
+                    target = EffectTarget.PlayerRef(Player.You)
+                )
+            )
+        )
+    }
+
+    triggeredAbility {
+        trigger = TriggerSpec(
+            event = EventPattern.PermanentsSacrificedEvent(
+                filter = GameObjectFilter.Creature,
+                byAnyPlayer = true
+            ),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "128"
+        artist = "AKAGI"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9ba292d5-5139-42ea-950d-0a638445277f.jpg?1782686502"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -34,6 +34,37 @@
     ]
 }
 
+// Absolute Virtue
+{
+    "name": "Absolute Virtue",
+    "manaCost": "{6}{W}{U}",
+    "typeLine": "Legendary Creature — Avatar Warrior",
+    "oracleText": "This spell can't be countered.\nFlying\nYou have protection from each of your opponents. (You can't be dealt damage, enchanted, or targeted by anything controlled by your opponents.)",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            "GrantProtectionToController"
+        ],
+        "cantBeCountered": true
+    },
+    "metadata": {
+        "collectorNumber": "212",
+        "rarity": "MYTHIC",
+        "artist": "Toni Infante",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/a/aa192912-c9ee-403f-8a46-a338c9edb4b9.jpg?1782686436"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Adelbert Steiner
 {
     "name": "Adelbert Steiner",
@@ -10814,6 +10845,98 @@
     ]
 }
 
+// Omega, Heartless Evolution
+{
+    "name": "Omega, Heartless Evolution",
+    "manaCost": "{5}{G}{U}",
+    "typeLine": "Legendary Artifact Creature — Robot",
+    "oracleText": "Wave Cannon — When Omega enters, for each opponent, tap up to one target nonland permanent that opponent controls. Put X stun counters on each of those permanents and you gain X life, where X is the number of nonbasic lands you control. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 8
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "permanent"
+                            }
+                        },
+                        {
+                            "type": "AddDynamicCounters",
+                            "counterType": "stun",
+                            "amount": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Battlefield",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsLand",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsBasicLand"
+                                        }
+                                    ]
+                                }
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "permanent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Battlefield",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsLand",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsBasicLand"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "nonland permanent ctrl:opponent"
+                    },
+                    "id": "permanent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "236",
+        "rarity": "UNCOMMON",
+        "artist": "Josu Solano",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9a8eb7e6-0c0b-42d0-aa90-2d3d29bc15aa.jpg?1782686412"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Opera Love Song
 {
     "name": "Opera Love Song",
@@ -21320,5 +21443,99 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Zodiark, Umbral God
+{
+    "name": "Zodiark, Umbral God",
+    "manaCost": "{B}{B}{B}{B}{B}",
+    "typeLine": "Legendary Creature — God",
+    "oracleText": "Indestructible\nWhen Zodiark enters, each player sacrifices half the non-God creatures they control of their choice, rounded down.\nWhenever a player sacrifices another creature, put a +1/+1 counter on Zodiark.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "ForceSacrifice",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                {
+                                    "type": "NotSubtype",
+                                    "subtype": "God"
+                                }
+                            ]
+                        },
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "You"
+                        },
+                        "dynamicCount": {
+                            "type": "Divide",
+                            "numerator": {
+                                "type": "AggregateBattlefield",
+                                "player": "You",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsCreature",
+                                        {
+                                            "type": "NotSubtype",
+                                            "subtype": "God"
+                                        }
+                                    ]
+                                }
+                            },
+                            "denominator": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "roundUp": false
+                        }
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "PermanentsSacrificedEvent",
+                    "filter": "creature",
+                    "byAnyPlayer": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "rarity": "RARE",
+        "artist": "AKAGI",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9ba292d5-5139-42ea-950d-0a638445277f.jpg?1782686502"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -396,6 +396,7 @@ val engineSerializersModule = SerializersModule {
         subclass(GrantsCantLoseGameComponent::class)
         subclass(GrantsCantLoseGameFromLifeComponent::class)
         subclass(GrantsControllerHexproofComponent::class)
+        subclass(GrantsControllerProtectionComponent::class)
         subclass(GrantsControllerShroudComponent::class)
         subclass(GrantsStationUsingToughnessComponent::class)
         subclass(SuppressesHexproofForGroupComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -1782,33 +1782,44 @@ class TriggerDetector(
                 if (trigger !is EventPattern.PermanentsSacrificedEvent) continue
                 if (ability.binding != TriggerBinding.ANY) continue
 
-                // This trigger watches the controller's own sacrifices
+                // By default the trigger watches only the source controller's own sacrifices
+                // ("Whenever you sacrifice…"). When byAnyPlayer is set it watches every player's
+                // ("Whenever a player sacrifices…", Zodiark) — fire once per sacrificing player.
                 val controllerId = entry.controllerId
-                val controllerEvents = sacrificeByController[controllerId] ?: continue
-
-                // Find the matching sacrificed permanents. The first match is bound as the
-                // triggering entity so payoffs can read "its mana value / power" off the
-                // sacrificed creature (e.g. Rakdos, the Muscle — "exile cards equal to its mana
-                // value"). Characteristics like mana value survive in the graveyard via the
-                // card's CardComponent; P/T payoffs should use a captured snapshot instead.
-                val matchingSacrificed = controllerEvents.flatMap { event ->
-                    event.permanentIds.filter { permanentId ->
-                        sacrificedPermanentMatchesFilter(state, permanentId, trigger.filter)
-                    }
+                val watchedPlayers = if (trigger.byAnyPlayer) {
+                    sacrificeByController.keys.toList()
+                } else {
+                    if (sacrificeByController.containsKey(controllerId)) listOf(controllerId) else emptyList()
                 }
 
-                if (matchingSacrificed.isNotEmpty()) {
-                    triggers.add(
-                        PendingTrigger(
-                            ability = ability,
-                            sourceId = entry.entityId,
-                            sourceName = entry.cardComponent.name,
-                            controllerId = controllerId,
-                            triggerContext = TriggerContext(
-                                triggeringEntityId = matchingSacrificed.first()
+                for (sacrificingPlayerId in watchedPlayers) {
+                    val playerEvents = sacrificeByController[sacrificingPlayerId] ?: continue
+
+                    // Find the matching sacrificed permanents. The first match is bound as the
+                    // triggering entity so payoffs can read "its mana value / power" off the
+                    // sacrificed creature (e.g. Rakdos, the Muscle — "exile cards equal to its mana
+                    // value"). Characteristics like mana value survive in the graveyard via the
+                    // card's CardComponent; P/T payoffs should use a captured snapshot instead.
+                    val matchingSacrificed = playerEvents.flatMap { event ->
+                        event.permanentIds.filter { permanentId ->
+                            sacrificedPermanentMatchesFilter(state, permanentId, trigger.filter)
+                        }
+                    }
+
+                    if (matchingSacrificed.isNotEmpty()) {
+                        triggers.add(
+                            PendingTrigger(
+                                ability = ability,
+                                sourceId = entry.entityId,
+                                sourceName = entry.cardComponent.name,
+                                controllerId = controllerId,
+                                triggerContext = TriggerContext(
+                                    triggeringEntityId = matchingSacrificed.first(),
+                                    triggeringPlayerId = sacrificingPlayerId
+                                )
                             )
                         )
-                    )
+                    }
                 }
             }
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.state.components.battlefield.GrantCantBeBlockedToS
 import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsCantLoseGameFromLifeComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerHexproofComponent
+import com.wingedsheep.engine.state.components.battlefield.GrantsControllerProtectionComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsStationUsingToughnessComponent
 import com.wingedsheep.engine.state.components.battlefield.GrantsControllerShroudComponent
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
@@ -68,6 +69,7 @@ import com.wingedsheep.sdk.scripting.CantBeTargetedByOpponentAbilities
 import com.wingedsheep.sdk.scripting.CantBeSacrificed
 import com.wingedsheep.sdk.scripting.CantReceiveCounters
 import com.wingedsheep.sdk.scripting.GrantHexproofToController
+import com.wingedsheep.sdk.scripting.GrantProtectionToController
 import com.wingedsheep.sdk.scripting.GrantShroudToController
 import com.wingedsheep.sdk.scripting.StationUsingToughness
 import com.wingedsheep.sdk.scripting.AdditionalAttackTriggers
@@ -229,6 +231,12 @@ class StaticAbilityHandler(
         }
         if (allStaticAbilities.any { it is GrantHexproofToController }) {
             result = result.with(GrantsControllerHexproofComponent)
+        }
+        val controllerProtectionScopes = allStaticAbilities
+            .filterIsInstance<GrantProtectionToController>()
+            .map { it.scope }
+        if (controllerProtectionScopes.isNotEmpty()) {
+            result = result.with(GrantsControllerProtectionComponent(controllerProtectionScopes))
         }
 
         // Add tag component for "you can't lose the game"
@@ -848,6 +856,7 @@ class StaticAbilityHandler(
             is GrantCantLoseGame,
             is com.wingedsheep.sdk.scripting.GrantCantLoseGameFromLife,
             is GrantHexproofToController,
+            is GrantProtectionToController,
             is GrantShroudToController,
             is StationUsingToughness,
             is SuppressHexproofForGroup,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerProtectionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/PlayerProtectionRules.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.mechanics.targeting
 
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.GrantsControllerProtectionComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.player.PlayerProtectionComponent
 import com.wingedsheep.sdk.model.EntityId
@@ -30,8 +31,19 @@ object PlayerProtectionRules {
         sourceId: EntityId?,
         casterId: EntityId?
     ): Boolean {
-        val component = state.getEntity(playerId)?.get<PlayerProtectionComponent>() ?: return false
-        return component.scopes.any { scopeMatchesSource(state, playerId, it, sourceId, casterId) }
+        // Player-level protection comes from two sources, unioned:
+        //  1. A one-shot [PlayerProtectionComponent] on the player (e.g. The One Ring).
+        //  2. Continuous statics ([GrantProtectionToController]) on permanents the player
+        //     controls, stamped as [GrantsControllerProtectionComponent] (Absolute Virtue).
+        val ownScopes = state.getEntity(playerId)?.get<PlayerProtectionComponent>()?.scopes.orEmpty()
+        if (ownScopes.any { scopeMatchesSource(state, playerId, it, sourceId, casterId) }) return true
+
+        return state.getBattlefield().any { entityId ->
+            val container = state.getEntity(entityId) ?: return@any false
+            if (container.get<ControllerComponent>()?.playerId != playerId) return@any false
+            container.get<GrantsControllerProtectionComponent>()?.scopes
+                ?.any { scopeMatchesSource(state, playerId, it, sourceId, casterId) } == true
+        }
     }
 
     private fun scopeMatchesSource(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -692,6 +692,21 @@ data object GrantsControllerShroudComponent : Component
 data object GrantsControllerHexproofComponent : Component
 
 /**
+ * Marks a permanent as granting its controller player-level protection from one or more
+ * [com.wingedsheep.sdk.scripting.ProtectionScope]s (Absolute Virtue:
+ * "You have protection from each of your opponents.").
+ *
+ * Stamped from [com.wingedsheep.sdk.scripting.GrantProtectionToController] static abilities and
+ * read by [com.wingedsheep.engine.mechanics.targeting.PlayerProtectionRules], which scans the
+ * battlefield for permanents carrying this component under the queried player's control. When the
+ * permanent leaves the battlefield the component goes with it — no cleanup needed.
+ */
+@Serializable
+data class GrantsControllerProtectionComponent(
+    val scopes: List<com.wingedsheep.sdk.scripting.ProtectionScope>
+) : Component
+
+/**
  * Marks a permanent as granting "can't lose the game" to its controller.
  * Used for Lich's Mastery: "You can't lose the game."
  * When the permanent leaves the battlefield, the component goes with it — no cleanup needed.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbsoluteVirtueScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbsoluteVirtueScenarioTest.kt
@@ -1,0 +1,156 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.targeting.PlayerProtectionRules
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fin.cards.AbsoluteVirtue
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Absolute Virtue (FIN) — {6}{W}{U} Legendary Creature 8/8.
+ *
+ * "This spell can't be countered. / Flying / You have protection from each of your opponents."
+ *
+ * The protection clause is the continuous, static player-level grant
+ * ([com.wingedsheep.sdk.scripting.GrantProtectionToController] with
+ * [com.wingedsheep.sdk.scripting.ProtectionScope.EachOpponent]): while Absolute Virtue is on the
+ * battlefield its controller can't be dealt damage by, nor targeted by, sources their opponents
+ * control. Crucially it's "each opponent", not "everything" — the controller's own sources still
+ * affect them — and it ends the moment the permanent leaves the battlefield.
+ */
+class AbsoluteVirtueScenarioTest : ScenarioTestBase() {
+
+    // "Deal 3 damage to each player." A non-targeted symmetric damage source.
+    private val burnEachPlayer = card("Burn Each Player") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.DealDamage(3, EffectTarget.PlayerRef(Player.Each)) }
+    }
+
+    init {
+        cardRegistry.register(AbsoluteVirtue)
+        cardRegistry.register(burnEachPlayer)
+
+        context("protection from each opponent — damage") {
+
+            test("an opponent's source can't damage the protected controller, but still hits the opponent") {
+                val game = scenario()
+                    .withPlayers("Controller", "Opponent")
+                    .withCardOnBattlefield(1, "Absolute Virtue", summoningSickness = false)
+                    .withCardInHand(2, "Burn Each Player")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val controllerBefore = game.getLifeTotal(1)
+                val opponentBefore = game.getLifeTotal(2)
+
+                game.castSpell(2, "Burn Each Player")
+                game.resolveStack()
+
+                withClue("protected controller takes no damage from the opponent's source") {
+                    game.getLifeTotal(1) shouldBe controllerBefore
+                }
+                withClue("the opponent (source's controller) still takes the full 3") {
+                    game.getLifeTotal(2) shouldBe opponentBefore - 3
+                }
+            }
+
+            test("control: the controller's OWN source still damages them (each opponent, not everything)") {
+                val game = scenario()
+                    .withPlayers("Controller", "Opponent")
+                    .withCardOnBattlefield(1, "Absolute Virtue", summoningSickness = false)
+                    .withCardInHand(1, "Burn Each Player")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val controllerBefore = game.getLifeTotal(1)
+
+                game.castSpell(1, "Burn Each Player")
+                game.resolveStack()
+
+                withClue("protection is only from opponents' sources — the controller's own burn still hits") {
+                    game.getLifeTotal(1) shouldBe controllerBefore - 3
+                }
+            }
+        }
+
+        context("protection from each opponent — combat") {
+
+            test("an opponent's creature can attack the protected controller, but its combat damage is prevented") {
+                val game = scenario()
+                    .withPlayers("Controller", "Opponent")
+                    .withCardOnBattlefield(1, "Absolute Virtue", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val controllerBefore = game.getLifeTotal(1)
+
+                game.declareAttackers(mapOf("Grizzly Bears" to 1)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.COMBAT_DAMAGE)
+                game.resolveStack()
+                if (game.state.pendingDecision != null) {
+                    game.submitDefaultCombatDamage()
+                    game.resolveStack()
+                }
+
+                withClue("protected controller's life is unchanged — the combat damage is prevented") {
+                    game.getLifeTotal(1) shouldBe controllerBefore
+                }
+            }
+        }
+
+        context("protection from each opponent — targeting source-of-truth") {
+
+            test("the controller is protected from an opponent's source but not their own") {
+                val game = scenario()
+                    .withPlayers("Controller", "Opponent")
+                    .withCardOnBattlefield(1, "Absolute Virtue", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val virtueId = game.findPermanent("Absolute Virtue")!!
+                val opponentSource = game.findPermanent("Grizzly Bears")!!
+
+                withClue("opponent-controlled source is blocked against the protected controller") {
+                    PlayerProtectionRules.isProtectedFromSource(
+                        game.state, game.player1Id, opponentSource, game.player2Id
+                    ) shouldBe true
+                }
+                withClue("the controller's own source (Absolute Virtue) is not blocked") {
+                    PlayerProtectionRules.isProtectedFromSource(
+                        game.state, game.player1Id, virtueId, game.player1Id
+                    ) shouldBe false
+                }
+            }
+
+            test("control: with no Absolute Virtue on the battlefield, the controller has no protection") {
+                val game = scenario()
+                    .withPlayers("Controller", "Opponent")
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val opponentSource = game.findPermanent("Grizzly Bears")!!
+
+                withClue("the protection is sourced from the permanent — absent it, none applies") {
+                    PlayerProtectionRules.isProtectedFromSource(
+                        game.state, game.player1Id, opponentSource, game.player2Id
+                    ) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmegaHeartlessEvolutionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OmegaHeartlessEvolutionScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fin.cards.OmegaHeartlessEvolution
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Omega, Heartless Evolution (FIN) — {5}{G}{U} Legendary Artifact Creature — Robot 8/8.
+ *
+ * "Wave Cannon — When Omega enters, for each opponent, tap up to one target nonland permanent that
+ * opponent controls. Put X stun counters on each of those permanents and you gain X life, where X
+ * is the number of nonbasic lands you control."
+ *
+ * Verifies the enter trigger: the chosen opponent permanent is tapped and loaded with X stun
+ * counters, the controller gains X life, and X counts only *nonbasic* lands (basics don't count).
+ */
+class OmegaHeartlessEvolutionScenarioTest : ScenarioTestBase() {
+
+    // A nonbasic land that taps for any color — lets one setup both pay Omega's {5}{G}{U} and hold
+    // a deterministic number of *nonbasic* lands for X.
+    private val prismaticNexus = card("Prismatic Nexus") {
+        typeLine = "Land"
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddAnyColorMana(1)
+            manaAbility = true
+        }
+    }
+
+    private fun TestGame.stunCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    private fun TestGame.isTapped(id: EntityId): Boolean =
+        state.getEntity(id)?.has<TappedComponent>() == true
+
+    init {
+        cardRegistry.register(OmegaHeartlessEvolution)
+        cardRegistry.register(prismaticNexus)
+
+        context("Omega — Wave Cannon enter trigger") {
+
+            test("taps the opponent's permanent, loads X stun counters, and you gain X life (X = your nonbasic lands)") {
+                var builder = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Omega, Heartless Evolution")
+                    .withLifeTotal(1, 20)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // 7 nonbasic lands pay {5}{G}{U} and set X = 7 ...
+                repeat(7) { builder = builder.withCardOnBattlefield(1, "Prismatic Nexus", summoningSickness = false) }
+                // ... plus 2 basic Forests that must NOT count toward X (proving the nonbasic filter).
+                builder = builder.withLandsOnBattlefield(1, "Forest", 2)
+                val game = builder.build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Omega, Heartless Evolution")
+                game.resolveStack()
+                // Wave Cannon's optional target: choose the opponent's Grizzly Bears.
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("the chosen permanent is tapped") {
+                    game.isTapped(bears) shouldBe true
+                }
+                withClue("X = 7 nonbasic lands (the 2 Forests don't count) → 7 stun counters") {
+                    game.stunCounters(bears) shouldBe 7
+                }
+                withClue("you gain X = 7 life (20 → 27)") {
+                    game.getLifeTotal(1) shouldBe 27
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZodiarkUmbralGodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZodiarkUmbralGodScenarioTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.fin.cards.ZodiarkUmbralGod
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Zodiark, Umbral God (FIN) — {B}{B}{B}{B}{B} Legendary Creature — God 5/5, Indestructible.
+ *
+ * Two abilities under test:
+ *  - The enter trigger: "each player sacrifices half the non-God creatures they control of their
+ *    choice, rounded down." Composed from `ForEachPlayerEffect(Player.Each)` + `Effects.Sacrifice`
+ *    with a `Divide(<their non-God creatures>, 2, roundUp = false)` dynamic count. The rounding is
+ *    the interesting part (3 → 1, not 2), and Zodiark (a God) is excluded from the count and the
+ *    sacrifice.
+ *  - The reactive counter trigger: "Whenever a player sacrifices another creature, put a +1/+1
+ *    counter on Zodiark." This exercises the new `PermanentsSacrificedEvent(byAnyPlayer = true)`
+ *    scope — an *opponent's* sacrifice (not just the controller's) must trigger it.
+ */
+class ZodiarkUmbralGodScenarioTest : ScenarioTestBase() {
+
+    // A {0} sorcery whose caster sacrifices one of their own creatures of their choice.
+    private val ritualSacrifice = card("Ritual Sacrifice") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.Sacrifice(
+                GameObjectFilter.Creature,
+                1,
+                EffectTarget.PlayerRef(Player.You)
+            )
+        }
+    }
+
+    private fun TestGame.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // Resolve the stack while auto-answering the decisions these scenarios raise: sacrifice-choice
+    // (SelectCardsDecision → take the minimum required) and any mana-sources auto-pay.
+    private fun TestGame.resolveAll() {
+        var guard = 0
+        while ((state.stack.isNotEmpty() || hasPendingDecision()) && guard++ < 60) {
+            when (val d = getPendingDecision()) {
+                is SelectCardsDecision -> selectCards(d.options.take(d.minSelections))
+                null -> resolveStack()
+                else ->
+                    if (d::class.simpleName?.contains("Mana") == true) submitManaSourcesAutoPay()
+                    else error("Unexpected decision: ${d::class.simpleName}")
+            }
+        }
+    }
+
+    init {
+        cardRegistry.register(ZodiarkUmbralGod)
+        cardRegistry.register(ritualSacrifice)
+
+        context("Zodiark — 'whenever a player sacrifices another creature'") {
+
+            test("an OPPONENT's sacrifice puts a +1/+1 counter on Zodiark (any player, not just you)") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardOnBattlefield(1, "Zodiark, Umbral God", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(2, "Ritual Sacrifice")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val zodiark = game.findPermanent("Zodiark, Umbral God")!!
+                game.plusOneCounters(zodiark) shouldBe 0
+
+                game.castSpell(2, "Ritual Sacrifice")
+                game.resolveAll()
+
+                withClue("the opponent sacrificing their own creature triggers Zodiark's counter") {
+                    game.plusOneCounters(zodiark) shouldBe 1
+                }
+            }
+
+            test("your OWN sacrifice also puts a counter on Zodiark") {
+                val game = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardOnBattlefield(1, "Zodiark, Umbral God", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardInHand(1, "Ritual Sacrifice")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val zodiark = game.findPermanent("Zodiark, Umbral God")!!
+                game.castSpell(1, "Ritual Sacrifice")
+                game.resolveAll()
+
+                game.plusOneCounters(zodiark) shouldBe 1
+            }
+        }
+
+        context("Zodiark — enter trigger: each player sacrifices half their non-God creatures, rounded down") {
+
+            test("rounds down: you (4 creatures) sacrifice 2, opponent (3 creatures) sacrifices 1") {
+                var builder = scenario()
+                    .withPlayers("You", "Opponent")
+                    .withCardInHand(1, "Zodiark, Umbral God")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(4) { builder = builder.withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) }
+                repeat(3) { builder = builder.withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false) }
+                val game = builder.build()
+
+                game.castSpell(1, "Zodiark, Umbral God")
+                game.resolveAll()
+
+                withClue("you had 4 non-God creatures → sacrifice floor(4/2) = 2") {
+                    game.findCardsInGraveyard(1, "Grizzly Bears").size shouldBe 2
+                }
+                withClue("opponent had 3 non-God creatures → sacrifice floor(3/2) = 1 (rounded down)") {
+                    game.findCardsInGraveyard(2, "Grizzly Bears").size shouldBe 1
+                }
+                withClue("Zodiark is a God — excluded from its own edict and still on the battlefield") {
+                    game.findPermanent("Zodiark, Umbral God") shouldNotBe null
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of **Final Fantasy (FIN)** cards, each via the `add-card` flow with a passing scenario test. Two cards needed small, reusable SDK additions; the third is pure composition. Done on a dedicated worktree branch.

## Cards

### Absolute Virtue — `{6}{W}{U}` Legendary Creature 8/8
Can't be countered, flying, and *"You have protection from each of your opponents."*
- New static **`GrantProtectionToController(scope)`** — the continuous, static counterpart of The One Ring's one-shot `GrantPlayerProtection`. Stamped to `GrantsControllerProtectionComponent` and unioned into `PlayerProtectionRules`. Mirrors the existing `GrantHexproofToController` / `GrantShroudToController` pattern; general over any `ProtectionScope`.

### Zodiark, Umbral God — `{B}{B}{B}{B}{B}` Legendary Creature — God 5/5
Indestructible; ETB *"each player sacrifices half the non-God creatures they control of their choice, rounded down"*; *"whenever a player sacrifices another creature, put a +1/+1 counter on Zodiark."*
- The edict is **pure composition** — `ForEachPlayerEffect(Player.Each)` + `Effects.Sacrifice` with a `Divide(<their non-God creatures>, 2, roundUp = false)` dynamic count (the round-down twin of Rush of Dread).
- Adds a **`byAnyPlayer`** flag to `EventPattern.PermanentsSacrificedEvent` so the ANY-binding sacrifice detector fires for *any* player's sacrifice, not just the source controller's (binds `triggeringPlayerId`). Default `false` preserves all existing "whenever you sacrifice…" cards.

### Omega, Heartless Evolution — `{5}{G}{U}` Legendary Artifact Creature 8/8
Wave Cannon ETB: tap up to one target nonland permanent an opponent controls, put X stun counters on it, and gain X life (X = nonbasic lands you control).
- **Pure composition** — optional target (`TargetPermanent(optional = true, NonlandPermanentOpponentControls)`) + `Tap` + `AddDynamicCounters(STUN, X)` + dynamic `GainLife(X)`, X = `Count(You, BATTLEFIELD, NonbasicLand)`. Models "for each opponent … target … that player controls" as a single optional target, following the Blatant Thievery convention.

## Tests
- `AbsoluteVirtueScenarioTest` — damage/combat/targeting protection, incl. the "each opponent, not everything" and "protection ends when it leaves" controls.
- `ZodiarkUmbralGodScenarioTest` — opponent's sacrifice (proves `byAnyPlayer`) and your own each add a counter; ETB rounds down (4→2, 3→1) and never touches the God.
- `OmegaHeartlessEvolutionScenarioTest` — target tapped + 7 stun counters + 7 life, with basics excluded from X (proves the nonbasic filter).

All three scenario tests pass; `CardDefinitionSnapshotTest` (FIN golden re-blessed, additive only) and `CardLintTest` pass. The SDK reference is updated for both new primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)