### PR TITLE
Add five Foundations (FDN) cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CryptFeaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CryptFeaster.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Crypt Feaster
+ * {3}{B}
+ * Creature — Zombie
+ * 3/4
+ *
+ * Menace
+ * Threshold — Whenever this creature attacks, if there are seven or more cards in your
+ * graveyard, this creature gets +2/+0 until end of turn.
+ *
+ * The threshold clause is an intervening-"if" on the attack trigger ([triggerCondition] is
+ * checked both when the trigger would go on the stack and again on resolution), pumping the
+ * source via [Effects.ModifyStats] targeting [EffectTarget.Self].
+ */
+val CryptFeaster = card("Crypt Feaster") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 3
+    toughness = 4
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Threshold — Whenever this creature attacks, if there are seven or more cards in your " +
+        "graveyard, this creature gets +2/+0 until end of turn."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.CardsInGraveyardAtLeast(7)
+        effect = Effects.ModifyStats(power = 2, toughness = 0, target = EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "John Di Giovanni"
+        imageUri = "https://cards.scryfall.io/normal/front/3/b/3b072811-998a-4a71-b59c-6afecc0dc4b6.jpg?1782689215"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DreadwingScavenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DreadwingScavenger.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Dreadwing Scavenger
+ * {1}{U}{B}
+ * Creature — Nightmare Bird
+ * 2/2
+ *
+ * Flying
+ * Whenever this creature enters or attacks, draw a card, then discard a card.
+ * Threshold — This creature gets +1/+1 and has deathtouch as long as there are seven or more
+ * cards in your graveyard.
+ *
+ * "Enters or attacks" is modeled as the established pair of triggered abilities (one on
+ * [Triggers.EntersBattlefield], one on [Triggers.Attacks]), each running the [Patterns.Hand.loot]
+ * draw-then-discard. The threshold buff is two [ConditionalStaticAbility]s gated on
+ * [Conditions.CardsInGraveyardAtLeast] — one stat buff, one keyword grant — so it turns on and
+ * off continuously with the graveyard count.
+ */
+val DreadwingScavenger = card("Dreadwing Scavenger") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Creature — Nightmare Bird"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever this creature enters or attacks, draw a card, then discard a card.\n" +
+        "Threshold — This creature gets +1/+1 and has deathtouch as long as there are seven or " +
+        "more cards in your graveyard."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Hand.loot(draw = 1, discard = 1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Hand.loot(draw = 1, discard = 1)
+    }
+
+    // Threshold: +1/+1
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(1, 1, Filters.Self),
+            condition = Conditions.CardsInGraveyardAtLeast(7)
+        )
+    }
+
+    // Threshold: deathtouch
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.DEATHTOUCH, Filters.Self),
+            condition = Conditions.CardsInGraveyardAtLeast(7)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "118"
+        artist = "Xavier Ribeiro"
+        flavorText = "It scours battlefields for corpses, consuming flesh and souls alike."
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e24d838b-ab48-410a-9a50-dbfea5da089b.jpg?1782689165"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GutlessPlunderer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GutlessPlunderer.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Gutless Plunderer
+ * {2}{B}
+ * Creature — Skeleton Pirate
+ * 2/2
+ *
+ * Deathtouch
+ * Raid — When this creature enters, if you attacked this turn, look at the top three cards of
+ * your library. You may put one of those cards back on top of your library. Put the rest into
+ * your graveyard.
+ *
+ * Raid is the intervening-"if" [Conditions.YouAttackedThisTurn] on the ETB trigger. The effect
+ * is a Gather → Select (up to one) → Move pipeline: gather the top three, the controller may keep
+ * one on top of the library, and the remainder is milled to the graveyard.
+ */
+val GutlessPlunderer = card("Gutless Plunderer") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton Pirate"
+    power = 2
+    toughness = 2
+    oracleText = "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\n" +
+        "Raid — When this creature enters, if you attacked this turn, look at the top three cards " +
+        "of your library. You may put one of those cards back on top of your library. Put the rest " +
+        "into your graveyard."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouAttackedThisTurn
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.TopOfLibrary(DynamicAmount.Fixed(3)),
+                storeAs = "gp_looked",
+                revealed = false
+            ),
+            SelectFromCollectionEffect(
+                from = "gp_looked",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                storeSelected = "gp_kept",
+                storeRemainder = "gp_rest",
+                prompt = "You may put a card back on top of your library",
+                selectedLabel = "Put on top of your library",
+                remainderLabel = "Put into your graveyard"
+            ),
+            MoveCollectionEffect(
+                from = "gp_kept",
+                destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Top)
+            ),
+            MoveCollectionEffect(
+                from = "gp_rest",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Loïc Canavaggia"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/909d7778-c7f8-4fa4-89f2-8b32e86e96e4.jpg?1782689215"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SoulShackledZombie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SoulShackledZombie.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Soul-Shackled Zombie
+ * {3}{B}
+ * Creature — Zombie
+ * 4/2
+ *
+ * When this creature enters, exile up to two target cards from a single graveyard. If at least
+ * one creature card was exiled this way, each opponent loses 2 life and you gain 2 life.
+ *
+ * "From a single graveyard" is the cross-target [TargetObject.sameOwner] constraint (Arashin
+ * Sunshield shape). The chosen cards are gathered ([CardSource.ChosenTargets]) so the post-exile
+ * "if at least one creature card was exiled this way" check is a [ConditionalOnCollectionEffect]
+ * over the exiled pile filtered to creatures — gating the drain on what actually moved, not on
+ * the (possibly-fizzled) targets.
+ */
+val SoulShackledZombie = card("Soul-Shackled Zombie") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 4
+    toughness = 2
+    oracleText = "When this creature enters, exile up to two target cards from a single graveyard. " +
+        "If at least one creature card was exiled this way, each opponent loses 2 life and you " +
+        "gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to two target cards from a single graveyard",
+            TargetObject(
+                count = 2,
+                optional = true,
+                filter = TargetFilter.CardInGraveyard,
+                sameOwner = true
+            )
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.ChosenTargets,
+                storeAs = "ssz_exiled"
+            ),
+            MoveCollectionEffect(
+                from = "ssz_exiled",
+                destination = CardDestination.ToZone(Zone.EXILE)
+            ),
+            ConditionalOnCollectionEffect(
+                collection = "ssz_exiled",
+                filter = GameObjectFilter.Creature,
+                ifNotEmpty = Effects.Composite(
+                    Effects.LoseLife(2, EffectTarget.PlayerRef(Player.EachOpponent)),
+                    Effects.GainLife(2)
+                ),
+                ifEmpty = Effects.Composite(emptyList())
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Diana Franco"
+        flavorText = "The ritual successfully rebound her soul to her body, but not quite in the way she'd planned."
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/deea5690-6eb2-4353-b917-cbbf840e4e71.jpg?1782689206"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VengefulBloodwitch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/VengefulBloodwitch.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Vengeful Bloodwitch
+ * {1}{B}
+ * Creature — Vampire Warlock
+ * 1/1
+ *
+ * Whenever this creature or another creature you control dies, target opponent loses 1 life
+ * and you gain 1 life.
+ *
+ * "This creature or another creature you control" is exactly "a creature you control" (it
+ * includes the source itself), so the trigger is [Triggers.YourCreatureDies] — it fires off
+ * the source's own death via last-known information just as for any other controlled creature.
+ */
+val VengefulBloodwitch = card("Vengeful Bloodwitch") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Warlock"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature or another creature you control dies, target opponent " +
+        "loses 1 life and you gain 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.YourCreatureDies
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.Composite(
+            Effects.LoseLife(1, opponent),
+            Effects.GainLife(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "76"
+        artist = "Jarel Threat"
+        flavorText = "\"You thought I was unarmed? Poor fool—your veins are my arsenal.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd0c12dd-f138-45c0-9614-d83a1d8e8399.jpg?1782689199"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -959,6 +959,62 @@
     ]
 }
 
+// Crypt Feaster
+{
+    "name": "Crypt Feaster",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nThreshold — Whenever this creature attacks, if there are seven or more cards in your graveyard, this creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "John Di Giovanni",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/b/3b072811-998a-4a71-b59c-6afecc0dc4b6.jpg?1782689215"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dauntless Veteran
 {
     "name": "Dauntless Veteran",
@@ -1158,6 +1214,192 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Dreadwing Scavenger
+{
+    "name": "Dreadwing Scavenger",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Creature — Nightmare Bird",
+    "oracleText": "Flying\nWhenever this creature enters or attacks, draw a card, then discard a card.\nThreshold — This creature gets +1/+1 and has deathtouch as long as there are seven or more cards in your graveyard.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 7
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "rarity": "UNCOMMON",
+        "artist": "Xavier Ribeiro",
+        "flavorText": "It scours battlefields for corpses, consuming flesh and souls alike.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e24d838b-ab48-410a-9a50-dbfea5da089b.jpg?1782689165"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 
@@ -1987,6 +2229,102 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Gutless Plunderer
+{
+    "name": "Gutless Plunderer",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Skeleton Pirate",
+    "oracleText": "Deathtouch (Any amount of damage this deals to a creature is enough to destroy it.)\nRaid — When this creature enters, if you attacked this turn, look at the top three cards of your library. You may put one of those cards back on top of your library. Put the rest into your graveyard.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "storeAs": "gp_looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gp_looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "gp_kept",
+                            "storeRemainder": "gp_rest",
+                            "prompt": "You may put a card back on top of your library",
+                            "selectedLabel": "Put on top of your library",
+                            "remainderLabel": "Put into your graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gp_kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Top"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "gp_rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "PLAYER_ATTACKED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Loïc Canavaggia",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/909d7778-c7f8-4fa4-89f2-8b32e86e96e4.jpg?1782689215"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -3811,6 +4149,99 @@
     ]
 }
 
+// Soul-Shackled Zombie
+{
+    "name": "Soul-Shackled Zombie",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature enters, exile up to two target cards from a single graveyard. If at least one creature card was exiled this way, each opponent loses 2 life and you gain 2 life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "ssz_exiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "ssz_exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "ssz_exiled",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "LoseLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "EachOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "GainLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    }
+                                ]
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": []
+                            },
+                            "filter": "creature"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to two target cards from a single graveyard",
+                    "sameOwner": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Diana Franco",
+        "flavorText": "The ritual successfully rebound her soul to her body, but not quite in the way she'd planned.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/deea5690-6eb2-4353-b917-cbbf840e4e71.jpg?1782689206"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Soulstone Sanctuary
 {
     "name": "Soulstone Sanctuary",
@@ -4947,6 +5378,69 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Vengeful Bloodwitch
+{
+    "name": "Vengeful Bloodwitch",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Vampire Warlock",
+    "oracleText": "Whenever this creature or another creature you control dies, target opponent loses 1 life and you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target opponent"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetOpponent",
+                    "id": "target opponent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "rarity": "UNCOMMON",
+        "artist": "Jarel Threat",
+        "flavorText": "\"You thought I was unarmed? Poor fool—your veins are my arsenal.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd0c12dd-f138-45c0-9614-d83a1d8e8399.jpg?1782689199"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptFeasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CryptFeasterScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.CryptFeaster
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Crypt Feaster {3}{B} — Creature — Zombie 3/4
+ *   Menace
+ *   Threshold — Whenever this creature attacks, if there are seven or more cards in your
+ *   graveyard, this creature gets +2/+0 until end of turn.
+ *
+ * Proves the intervening-"if" attack trigger: pumps only when the controller's graveyard has
+ * seven or more cards.
+ */
+class CryptFeasterScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CryptFeaster))
+        return driver
+    }
+
+    fun projectedPower(driver: GameTestDriver, id: EntityId): Int =
+        StateProjector().getProjectedPower(driver.state, id)
+
+    test("attacks with seven cards in graveyard → +2/+0") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val feaster = driver.putCreatureOnBattlefield(you, "Crypt Feaster")
+        driver.removeSummoningSickness(feaster)
+        repeat(7) { driver.putCardInGraveyard(you, "Swamp") }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(feaster), defendingPlayer = opponent).error shouldBe null
+
+        // Resolve the attack trigger.
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) { driver.bothPass(); safety++ }
+
+        projectedPower(driver, feaster) shouldBe 5 // 3 base + 2
+    }
+
+    test("attacks with only six cards in graveyard → no pump") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val feaster = driver.putCreatureOnBattlefield(you, "Crypt Feaster")
+        driver.removeSummoningSickness(feaster)
+        repeat(6) { driver.putCardInGraveyard(you, "Swamp") }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(feaster), defendingPlayer = opponent).error shouldBe null
+
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) { driver.bothPass(); safety++ }
+
+        projectedPower(driver, feaster) shouldBe 3 // unchanged
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadwingScavengerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreadwingScavengerScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.DreadwingScavenger
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dreadwing Scavenger {1}{U}{B} — Creature — Nightmare Bird 2/2
+ *   Flying
+ *   Whenever this creature enters or attacks, draw a card, then discard a card.
+ *   Threshold — This creature gets +1/+1 and has deathtouch as long as there are seven or more
+ *   cards in your graveyard.
+ *
+ * Proves the threshold continuous buff toggles with the graveyard count — a stat boost and a
+ * keyword grant that both switch on at seven cards and off below it.
+ */
+class DreadwingScavengerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DreadwingScavenger))
+        return driver
+    }
+
+    fun power(driver: GameTestDriver, id: EntityId) = StateProjector().getProjectedPower(driver.state, id)
+    fun toughness(driver: GameTestDriver, id: EntityId) = StateProjector().getProjectedToughness(driver.state, id)
+    fun keywords(driver: GameTestDriver, id: EntityId) = StateProjector().getProjectedKeywords(driver.state, id)
+
+    test("below threshold: 2/2 flyer without deathtouch") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Island" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val bird = driver.putCreatureOnBattlefield(you, "Dreadwing Scavenger")
+        repeat(6) { driver.putCardInGraveyard(you, "Swamp") }
+
+        power(driver, bird) shouldBe 2
+        toughness(driver, bird) shouldBe 2
+        keywords(driver, bird).contains(Keyword.FLYING) shouldBe true
+        keywords(driver, bird).contains(Keyword.DEATHTOUCH) shouldBe false
+    }
+
+    test("at threshold: 3/3 with deathtouch") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Island" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val bird = driver.putCreatureOnBattlefield(you, "Dreadwing Scavenger")
+        repeat(7) { driver.putCardInGraveyard(you, "Swamp") }
+
+        power(driver, bird) shouldBe 3
+        toughness(driver, bird) shouldBe 3
+        keywords(driver, bird).contains(Keyword.FLYING) shouldBe true
+        keywords(driver, bird).contains(Keyword.DEATHTOUCH) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GutlessPlundererScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GutlessPlundererScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.GutlessPlunderer
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gutless Plunderer {2}{B} — Creature — Skeleton Pirate 2/2
+ *   Deathtouch
+ *   Raid — When this creature enters, if you attacked this turn, look at the top three cards of
+ *   your library. You may put one of those cards back on top of your library. Put the rest into
+ *   your graveyard.
+ *
+ * Proves the Raid intervening-"if" gates the look-at-top-three pipeline: when the controller
+ * attacked this turn the two unselected cards are milled and one is kept on top; with no attack
+ * the ETB does nothing.
+ */
+class GutlessPlundererScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GutlessPlunderer))
+        return driver
+    }
+
+    test("raid active: keeps one on top and mills the other two") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        // Attack this turn to satisfy Raid.
+        val goblin = driver.putCreatureOnBattlefield(you, "Goblin Guide")
+        driver.removeSummoningSickness(goblin)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(goblin), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // Seed the top three cards of the library.
+        val bottomOfThree = driver.putCardOnTopOfLibrary(you, "Grizzly Bears")
+        val midOfThree = driver.putCardOnTopOfLibrary(you, "Hill Giant")
+        val topOfThree = driver.putCardOnTopOfLibrary(you, "Centaur Courser")
+        val seeded = setOf(bottomOfThree, midOfThree, topOfThree)
+
+        driver.giveMana(you, Color.BLACK, 3)
+        val plunderer = driver.putCardInHand(you, "Gutless Plunderer")
+        driver.castSpell(you, plunderer).error shouldBe null
+
+        val graveyardBefore = driver.getGraveyard(you).size
+
+        var kept: EntityId? = null
+        var safety = 0
+        while (safety < 40) {
+            val pending = driver.state.pendingDecision
+            when {
+                pending is SelectCardsDecision -> {
+                    kept = pending.options.first()
+                    driver.submitCardSelection(pending.playerId, listOf(kept!!))
+                }
+                driver.stackSize > 0 -> driver.bothPass()
+                else -> break
+            }
+            safety++
+        }
+
+        val keptCard = kept
+        (keptCard != null) shouldBe true // a selection decision was presented
+        (keptCard in seeded) shouldBe true
+
+        val graveyard = driver.getGraveyard(you)
+        (graveyard.size - graveyardBefore) shouldBe 2
+        seeded.filter { it != keptCard }.forEach { milled ->
+            graveyard.contains(milled) shouldBe true
+        }
+        graveyard.contains(keptCard) shouldBe false
+    }
+
+    test("no attack this turn: raid ETB does nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+
+        driver.putCardOnTopOfLibrary(you, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(you, "Hill Giant")
+        driver.putCardOnTopOfLibrary(you, "Centaur Courser")
+
+        driver.giveMana(you, Color.BLACK, 3)
+        val plunderer = driver.putCardInHand(you, "Gutless Plunderer")
+        driver.castSpell(you, plunderer).error shouldBe null
+
+        val graveyardBefore = driver.getGraveyard(you).size
+
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 20) {
+            (driver.state.pendingDecision is SelectCardsDecision) shouldBe false
+            driver.bothPass()
+            safety++
+        }
+
+        driver.getGraveyard(you).size shouldBe graveyardBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulShackledZombieScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SoulShackledZombieScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Soul-Shackled Zombie {3}{B} — Creature — Zombie 4/2
+ *   When this creature enters, exile up to two target cards from a single graveyard. If at least
+ *   one creature card was exiled this way, each opponent loses 2 life and you gain 2 life.
+ *
+ * The single-graveyard exile reuses Arashin Sunshield's `TargetObject.sameOwner` path; here we
+ * confirm the conditional drain fires only when a creature card is among the exiled cards.
+ */
+class SoulShackledZombieScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Soul-Shackled Zombie ETB") {
+
+            test("exiling a creature card drains each opponent for 2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Soul-Shackled Zombie")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInGraveyard(2, "Hill Giant") // creature
+                    .withCardInGraveyard(2, "Swamp")      // noncreature
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Soul-Shackled Zombie").error shouldBe null
+                game.resolveStack() // creature enters → ETB trigger asks for targets
+
+                val creatureCard = game.findCardsInGraveyard(2, "Hill Giant").first()
+                val landCard = game.findCardsInGraveyard(2, "Swamp").first()
+                game.selectTargets(listOf(creatureCard, landCard)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Both targeted cards are exiled") {
+                    game.state.getExile(game.player2Id).size shouldBe 2
+                }
+                withClue("A creature was exiled → opponent loses 2, you gain 2") {
+                    game.getLifeTotal(2) shouldBe 18
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+
+            test("exiling only noncreature cards does not drain") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Soul-Shackled Zombie")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInGraveyard(2, "Swamp")
+                    .withCardInGraveyard(2, "Mountain")
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(2, "Swamp")
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Soul-Shackled Zombie").error shouldBe null
+                game.resolveStack()
+
+                val land1 = game.findCardsInGraveyard(2, "Swamp").first()
+                val land2 = game.findCardsInGraveyard(2, "Mountain").first()
+                game.selectTargets(listOf(land1, land2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Both lands are exiled") {
+                    game.state.getExile(game.player2Id).size shouldBe 2
+                }
+                withClue("No creature exiled → no life change") {
+                    game.getLifeTotal(2) shouldBe 20
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulBloodwitchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VengefulBloodwitchScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.VengefulBloodwitch
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Vengeful Bloodwitch {1}{B} — Creature — Vampire Warlock 1/1
+ *   Whenever this creature or another creature you control dies, target opponent loses 1 life
+ *   and you gain 1 life.
+ *
+ * Proves the Blood Artist shape via [com.wingedsheep.sdk.dsl.Triggers.YourCreatureDies]:
+ *  - another creature you control dying drains the chosen opponent,
+ *  - the witch's OWN death also drains (the "this creature or" clause).
+ */
+class VengefulBloodwitchScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(VengefulBloodwitch))
+        return driver
+    }
+
+    fun drainStack(driver: GameTestDriver, opponentToTarget: EntityId) {
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 30) {
+            val pending = driver.state.pendingDecision
+            if (pending != null) {
+                driver.submitTargetSelection(pending.playerId, listOf(opponentToTarget))
+            } else {
+                driver.bothPass()
+            }
+            safety++
+        }
+    }
+
+    test("another creature you control dying drains a target opponent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youLifeBefore = driver.getLifeTotal(you)
+        val oppLifeBefore = driver.getLifeTotal(opponent)
+
+        driver.putCreatureOnBattlefield(you, "Vengeful Bloodwitch")
+        val frail = driver.putCreatureOnBattlefield(you, "Goblin Guide") // 2/1
+
+        driver.giveMana(opponent, Color.RED, 1)
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.passPriority(you)
+        driver.castSpellWithTargets(opponent, bolt, listOf(ChosenTarget.Permanent(frail))).error shouldBe null
+
+        drainStack(driver, opponent)
+
+        driver.getLifeTotal(opponent) shouldBe (oppLifeBefore - 1)
+        driver.getLifeTotal(you) shouldBe (youLifeBefore + 1)
+    }
+
+    test("the witch's own death also drains") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youLifeBefore = driver.getLifeTotal(you)
+        val oppLifeBefore = driver.getLifeTotal(opponent)
+
+        val witch = driver.putCreatureOnBattlefield(you, "Vengeful Bloodwitch")
+
+        driver.giveMana(opponent, Color.RED, 1)
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.passPriority(you)
+        driver.castSpellWithTargets(opponent, bolt, listOf(ChosenTarget.Permanent(witch))).error shouldBe null
+
+        drainStack(driver, opponent)
+
+        driver.getLifeTotal(opponent) shouldBe (oppLifeBefore - 1)
+        driver.getLifeTotal(you) shouldBe (youLifeBefore + 1)
+    }
+})


### PR DESCRIPTION
Implements a handful of cards **original to Foundations (FDN)** via the `add-card` flow. Each is composed entirely from existing SDK primitives — no new engine mechanics, effects, keywords, or SDK-reference changes.

## Cards
| Card | Cost | Mechanics reused |
|------|------|------------------|
| **Vengeful Bloodwitch** | {1}{B} | `Triggers.YourCreatureDies` drain (Blood Artist shape; covers the witch's own death) |
| **Crypt Feaster** | {3}{B} | Menace + intervening-`if` attack trigger (`CardsInGraveyardAtLeast(7)`) → `ModifyStats(+2/+0)` |
| **Dreadwing Scavenger** | {1}{U}{B} | Flying + enters/attacks `Patterns.Hand.loot` + threshold `ConditionalStaticAbility` (+1/+1 and deathtouch) |
| **Gutless Plunderer** | {2}{B} | Deathtouch + Raid (`YouAttackedThisTurn`) look-at-top-three → keep one on top, mill the rest |
| **Soul-Shackled Zombie** | {3}{B} | Single-graveyard exile (`TargetObject.sameOwner`, Arashin Sunshield shape) + `ConditionalOnCollectionEffect` drain when a creature card was exiled |

## Testing
- 5 new rules-engine scenario tests (10 cases), all passing — including edge cases: self-death drain, below-threshold no-pump, no-attack no-raid, and no-creature-exiled no-drain.
- FDN card snapshot golden re-blessed; diff adds only these five cards (no other card trees changed).
- `:mtg-sets:test` (snapshot + `CardLintTest` + `FacadeBoundaryTest`) and full `build` green.
- Image URIs verified with HEAD requests (HTTP 200); metadata pulled from Scryfall per-printing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)