### PR TITLE
Add The Darkness Crystal to Final Fantasy

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2319,6 +2319,14 @@ work for abilities-on-stack (which carry no `CardComponent`).
   ability controller) it never matches — it is only meaningful in target/condition contexts. Used by
   Stolen Uniform's "if it's attached to a creature you control" guard
   (`Conditions.EntityMatches(EffectTarget.TriggeringEntity, GameObjectFilter.Any.attachedTo(GameObjectFilter.Creature.youControl()))`).
+- `ExiledWithSource` (filter builder `exiledWithSource()`) — source-relative: the candidate card is
+  one the effect's source permanent exiled, i.e. its id is recorded in the source's
+  `LinkedExileComponent` (the same linkage set by `RedirectZoneChange(linkToSource = true)`,
+  `RedirectZoneChangeWithEffect(linkToSource = true)`, `MoveToZoneEffect(linkToSource = true)`, and the
+  `FromLinkedExile` pipeline source). Backs "target creature card exiled with ~" reanimation — The
+  Darkness Crystal: `TargetObject(filter = TargetFilter(GameObjectFilter.Creature.exiledWithSource(),
+  zone = Zone.EXILE))`. Resolves against `PredicateContext.sourceId`; inert with no source, and never
+  matches in group-static projection or trigger-gating contexts.
 - `IsWarpExiled` (filter builder `warpExiled()`) — card in exile via warp's
   end-of-turn delayed trigger (CR 702.185b).
 - `WasCastForWarp` (filter builder `castForWarp()`) — battlefield permanent that
@@ -5628,6 +5636,20 @@ replacementEffect {
   listOf(CardPredicate.IsNontoken), controllerPredicate = ControllerPredicate.And(listOf(OwnedByOpponent,
   Not(ControlledByYou))))))`. The redirect (and link) is honored across every graveyard path: SBA deaths,
   mill/discard/destroy (`ZoneTransitionService`), spell resolution, counters, and fizzles (`StackResolver`).
+- `RedirectZoneChangeWithEffect(newDestination, additionalEffect, selfOnly = false, linkToSource = false,
+  appliesTo)` — like `RedirectZoneChange` but also runs `additionalEffect` when the replacement fires.
+  The additional effect is applied through a small executor whitelist (not the full pipeline) —
+  `TakeExtraTurnEffect` (Ugin's Nexus), `AddCountersEffect` on the redirected card (Darigaaz
+  Reincarnated), and `GainLifeEffect` (fixed amount, gained by the replacement source's controller;
+  emits `LifeChangedEvent` so life-gain triggers fire). `selfOnly = true` restricts it to the source
+  permanent itself; `linkToSource = true` (exile destination only) adds the redirected card to the
+  source's `LinkedExileComponent` exactly like `RedirectZoneChange.linkToSource`. The Darkness Crystal's
+  "If a nontoken creature an opponent controls would die, instead exile it and you gain 2 life" is
+  `RedirectZoneChangeWithEffect(newDestination = Zone.EXILE, additionalEffect = GainLifeEffect(2),
+  linkToSource = true, appliesTo = ZoneChangeEvent(filter = GameObjectFilter.Creature.nontoken().opponentControls(),
+  from = Zone.BATTLEFIELD, to = Zone.GRAVEYARD))` — the linked cards are then retrieved by a
+  `Creature.exiledWithSource()` target (see §7 state predicates). Honored across the same graveyard
+  paths as `RedirectZoneChange`.
 - `ReplacementEffect.IfYouDoBranchEffect(...)` — branch on "if you do" replacement.
 - `OnEnterRunEffect(effect)` — generic "as ~ enters the battlefield, run [effect]". The wrapped effect
   executes via the normal effect-executor pipeline at entry time (so `EffectTarget.Self` resolves to

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -1443,6 +1443,12 @@ data class PreventExtraTurns(
  * @param newDestination The zone to redirect to (e.g., Exile)
  * @param additionalEffect The effect to execute when replacement fires (e.g., TakeExtraTurnEffect)
  * @param selfOnly When true, only applies when the entity being moved IS this permanent
+ * @param linkToSource When true and [newDestination] is [Zone.EXILE], the redirected card is linked
+ *        to this replacement's source permanent via its `LinkedExileComponent`, so the source can
+ *        later reference the cards it exiled (mirrors [RedirectZoneChange.linkToSource]). Enables
+ *        "if a creature an opponent controls would die, instead exile it and ...; {cost}: return a
+ *        creature card exiled with ~" recursion (The Darkness Crystal). Ignored for non-exile
+ *        destinations.
  * @param appliesTo The zone change event this replacement intercepts
  */
 @SerialName("RedirectZoneChangeWithEffect")
@@ -1451,6 +1457,7 @@ data class RedirectZoneChangeWithEffect(
     val newDestination: Zone,
     val additionalEffect: Effect,
     val selfOnly: Boolean = false,
+    val linkToSource: Boolean = false,
     override val appliesTo: EventPattern
 ) : ReplacementEffect {
     override val description: String =

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -792,6 +792,15 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must be a card exiled by the effect's source permanent (recorded in the source's
+     * `LinkedExileComponent`). Source-relative — use when filtering candidates in the exile zone
+     * for "target card exiled with ~" reanimation abilities (The Darkness Crystal).
+     */
+    fun exiledWithSource() = copy(
+        statePredicates = statePredicates + StatePredicate.ExiledWithSource
+    )
+
+    /**
      * Must be a permanent on the battlefield that was cast for its warp cost
      * (CR 702.185) — i.e., the engine wrote a `WarpedComponent` when the
      * warped spell resolved. Use this to gate effects on warp-cast permanents,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -507,6 +507,23 @@ sealed interface StatePredicate {
         override val description: String = "that the source is attached to"
     }
 
+    /**
+     * The candidate card is one this effect's source permanent exiled — i.e. its entity id is
+     * recorded in the source's `LinkedExileComponent` (the same linkage set by
+     * `RedirectZoneChange(linkToSource = true)`, `RedirectZoneChangeWithEffect(linkToSource = true)`,
+     * `MoveToZoneEffect(linkToSource = true)`, and the `FromLinkedExile` pipeline source).
+     * Source-relative: resolves against the source supplied in the evaluation context, and is false
+     * if the source has no linked exile or there is no source context.
+     *
+     * Backs "target creature card exiled with ~" reanimation abilities (The Darkness Crystal), where
+     * the ability retrieves a specific card from among those its own permanent banished.
+     */
+    @SerialName("ExiledWithSource")
+    @Serializable
+    data object ExiledWithSource : Entity {
+        override val description: String = "exiled with this permanent"
+    }
+
     // =============================================================================
     // Composite / Logical Combinators
     // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheDarknessCrystal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheDarknessCrystal.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.RedirectZoneChangeWithEffect
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * The Darkness Crystal
+ * {2}{B}{B}
+ * Legendary Artifact
+ *
+ * Black spells you cast cost {1} less to cast.
+ * If a nontoken creature an opponent controls would die, instead exile it and you gain 2 life.
+ * {4}{B}{B}, {T}: Put target creature card exiled with The Darkness Crystal onto the battlefield
+ * tapped under your control with two additional +1/+1 counters on it.
+ */
+val TheDarknessCrystal = card("The Darkness Crystal") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Artifact"
+    oracleText = "Black spells you cast cost {1} less to cast.\n" +
+        "If a nontoken creature an opponent controls would die, instead exile it and you gain 2 life.\n" +
+        "{4}{B}{B}, {T}: Put target creature card exiled with The Darkness Crystal onto the " +
+        "battlefield tapped under your control with two additional +1/+1 counters on it."
+
+    // Ability 1: Black spells you cast cost {1} less to cast. The ruling clarifies this reduces
+    // only generic mana, so a fixed generic reduction is correct.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Any.withColor(Color.BLACK)),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    // Ability 2: If a nontoken creature an opponent controls would die, instead exile it (linked to
+    // this permanent so ability 3 can retrieve it) and you gain 2 life. The rider gains 2 life per
+    // creature redirected, matching "you'll gain 2 life for each of them".
+    replacementEffect(
+        RedirectZoneChangeWithEffect(
+            newDestination = Zone.EXILE,
+            additionalEffect = GainLifeEffect(2),
+            selfOnly = false,
+            linkToSource = true,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.nontoken().opponentControls(),
+                from = Zone.BATTLEFIELD,
+                to = Zone.GRAVEYARD,
+            ),
+        )
+    )
+
+    // Ability 3: {4}{B}{B}, {T}: Put target creature card exiled with The Darkness Crystal onto the
+    // battlefield tapped under your control with two additional +1/+1 counters on it.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{B}{B}"), Costs.Tap)
+        val t = target(
+            "target creature card exiled with The Darkness Crystal",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.exiledWithSource(),
+                    zone = Zone.EXILE,
+                ),
+            ),
+        )
+        effect = Effects.Move(
+            target = t,
+            destination = Zone.BATTLEFIELD,
+            placement = ZonePlacement.Tapped,
+            controllerOverride = EffectTarget.Controller,
+            fromZone = Zone.EXILE,
+        ).then(AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 2, t))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "96"
+        artist = "Pablo Mendoza"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f93b6ac-54ce-45d0-8549-19307406e6e5.jpg?1782686526"
+        ruling("2025-06-06", "The cost reduction applies only to generic mana in the total cost of black spells you cast.")
+        ruling("2025-06-06", "If a creature token an opponent controls dies, it goes to that player's graveyard as normal before ceasing to exist.")
+        ruling("2025-06-06", "While you control The Darkness Crystal, abilities that trigger whenever a nontoken creature an opponent controls dies won't trigger because that card is exiled instead.")
+        ruling("2025-06-06", "If The Darkness Crystal leaves the battlefield at the same time as one or more nontoken creatures an opponent controls would die, those creature cards will be exiled and you'll gain 2 life for each of them.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -17459,6 +17459,136 @@
     ]
 }
 
+// The Darkness Crystal
+{
+    "name": "The Darkness Crystal",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Black spells you cast cost {1} less to cast.\nIf a nontoken creature an opponent controls would die, instead exile it and you gain 2 life.\n{4}{B}{B}, {T}: Put target creature card exiled with The Darkness Crystal onto the battlefield tapped under your control with two additional +1/+1 counters on it.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{B}{B}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card exiled with The Darkness Crystal"
+                            },
+                            "destination": "Battlefield",
+                            "placement": "Tapped",
+                            "controllerOverride": "Controller",
+                            "fromZone": "Exile"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 2,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature card exiled with The Darkness Crystal"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    "ExiledWithSource"
+                                ]
+                            },
+                            "zone": "Exile"
+                        },
+                        "id": "target creature card exiled with The Darkness Crystal"
+                    }
+                ]
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "black"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "RedirectZoneChangeWithEffect",
+                "newDestination": "Exile",
+                "additionalEffect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                "linkToSource": true,
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature nontoken ctrl:opponent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "rarity": "RARE",
+        "artist": "Pablo Mendoza",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f93b6ac-54ce-45d0-8549-19307406e6e5.jpg?1782686526",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "The cost reduction applies only to generic mana in the total cost of black spells you cast."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "If a creature token an opponent controls dies, it goes to that player's graveyard as normal before ceasing to exist."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "While you control The Darkness Crystal, abilities that trigger whenever a nontoken creature an opponent controls dies won't trigger because that card is exiled instead."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "If The Darkness Crystal leaves the battlefield at the same time as one or more nontoken creatures an opponent controls would die, those creature cards will be exiled and you'll gain 2 life for each of them."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // The Earth Crystal
 {
     "name": "The Earth Crystal",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -465,6 +465,7 @@ class BeginningPhaseManager(
         StatePredicate.IsWarpExiled,
         StatePredicate.NotTargetedByAbilityFromSameNamedSource,
         StatePredicate.IsAttachedToBySource,
+        StatePredicate.ExiledWithSource,
         StatePredicate.WasCastForWarp -> true
         is StatePredicate.AttachedToCardType -> true
         is StatePredicate.AttachedTo -> true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1662,6 +1662,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsWarpExiled,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.NotTargetedByAbilityFromSameNamedSource,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttachedToBySource,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.ExiledWithSource,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastForWarp,
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedToCardType -> true
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedTo -> true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1098,6 +1098,16 @@ class PredicateEvaluator {
                 attachedTo == entityId
             }
 
+            // Source-relative: the candidate card was exiled by the effect's source permanent, i.e.
+            // its id is recorded in the source's LinkedExileComponent. Backs "target card exiled
+            // with ~" reanimation (The Darkness Crystal). Inert with no source context.
+            StatePredicate.ExiledWithSource -> {
+                val sourceId = context?.sourceId ?: return false
+                state.getEntity(sourceId)
+                    ?.get<com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent>()
+                    ?.exiledIds?.contains(entityId) == true
+            }
+
             // Saddled marker — set by BecomeSaddledExecutor when a Saddle ability resolves
             // (CR 702.171b). Cleared at end-of-turn cleanup or when the permanent leaves play.
             StatePredicate.IsSaddled -> container.has<SaddledComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -545,11 +545,15 @@ object ZoneMovementUtils {
                         if (event.from != null && event.from != fromZone) continue
                         if (!effect.selfOnly && !matchesZoneChangeFilter(state, entityId, container, event.filter, sourceControllerId)) continue
 
-                        // Match found — redirect AND return additional effect
+                        // Match found — redirect AND return additional effect. When the replacement
+                        // links its exiled cards to the source (The Darkness Crystal), carry the
+                        // source id so the mover attaches the card to its LinkedExileComponent.
+                        val linkSource = if (effect.linkToSource && effect.newDestination == Zone.EXILE) permanentId else null
                         return ZoneChangeRedirectResult(
                             effect.newDestination,
                             effect.additionalEffect,
-                            sourceControllerId
+                            sourceControllerId,
+                            linkSourceId = linkSource
                         )
                     }
                     else -> continue
@@ -640,7 +644,12 @@ object ZoneMovementUtils {
 
     /**
      * Apply the additional effect from a RedirectZoneChangeWithEffect replacement.
-     * Supports TakeExtraTurnEffect (Ugin's Nexus) and AddCountersEffect (Darigaaz Reincarnated).
+     * Supports TakeExtraTurnEffect (Ugin's Nexus), AddCountersEffect (Darigaaz Reincarnated),
+     * and GainLifeEffect (The Darkness Crystal — "instead exile it and you gain 2 life").
+     *
+     * Returns the updated state plus any events the effect emitted (e.g. LifeGainedEvent, so
+     * "whenever you gain life" triggers see the rider). Callers must fold the events into their
+     * own event stream.
      *
      * @param entityId The entity that was redirected (for effects that target it, like adding counters)
      */
@@ -649,18 +658,19 @@ object ZoneMovementUtils {
         effect: com.wingedsheep.sdk.scripting.effects.Effect,
         controllerId: EntityId?,
         entityId: EntityId? = null
-    ): GameState {
+    ): Pair<GameState, List<EngineGameEvent>> {
         if (effect is com.wingedsheep.sdk.scripting.effects.TakeExtraTurnEffect) {
             // Check if extra turns are prevented by any permanent on the battlefield
-            if (ReplacementEffectUtils.isExtraTurnPrevented(state)) return state
+            if (ReplacementEffectUtils.isExtraTurnPrevented(state)) return state to emptyList()
 
-            val cid = controllerId ?: return state
-            return state.getOpponents(cid).fold(state) { acc, opponentId ->
+            val cid = controllerId ?: return state to emptyList()
+            val newState = state.getOpponents(cid).fold(state) { acc, opponentId ->
                 acc.updateEntity(opponentId) { container ->
                     val existing = container.get<SkipNextTurnComponent>()?.turns ?: 0
                     container.with(SkipNextTurnComponent(existing + 1))
                 }
             }
+            return newState to emptyList()
         }
         if (effect is com.wingedsheep.sdk.scripting.effects.AddCountersEffect && entityId != null) {
             val counterType = try {
@@ -675,11 +685,21 @@ object ZoneMovementUtils {
                 com.wingedsheep.sdk.core.CounterType.PLUS_ONE_PLUS_ONE
             }
             val current = state.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
-            return state.updateEntity(entityId) { container ->
+            val newState = state.updateEntity(entityId) { container ->
                 container.with(current.withAdded(counterType, effect.count))
             }
+            return newState to emptyList()
         }
-        return state
+        if (effect is com.wingedsheep.sdk.scripting.effects.GainLifeEffect) {
+            // The rider's controller (the replacement's source controller) gains the life. Only a
+            // fixed amount is meaningful here — there is no full effect context at replacement time.
+            val cid = controllerId ?: return state to emptyList()
+            val amount = (effect.amount as? com.wingedsheep.sdk.scripting.values.DynamicAmount.Fixed)?.amount
+                ?: return state to emptyList()
+            val (newState, event) = DamageUtils.gainLife(state, cid, amount)
+            return newState to listOfNotNull(event)
+        }
+        return state to emptyList()
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneTransitionService.kt
@@ -586,9 +586,11 @@ object ZoneTransitionService {
 
         // 9. Apply redirect additional effects if any
         if (redirectResult.additionalEffect != null) {
-            newState = ZoneMovementUtils.applyReplacementAdditionalEffect(
+            val (updatedState, extraEvents) = ZoneMovementUtils.applyReplacementAdditionalEffect(
                 newState, redirectResult.additionalEffect, redirectResult.effectControllerId, entityId
             )
+            newState = updatedState
+            events.addAll(extraEvents)
         }
 
         return ZoneTransitionResult(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -399,6 +399,10 @@ internal class AffectsFilterResolver {
         // permanent, absent in group-static projection. Only meaningful in target/gather-filter
         // contexts via PredicateEvaluator. Never match here.
         StatePredicate.IsAttachedToBySource -> false
+        // Source-relative exile linkage (LinkedExileComponent on the effect source). Only
+        // meaningful in target/gather-filter contexts via PredicateEvaluator; never match in
+        // group-static projection.
+        StatePredicate.ExiledWithSource -> false
         StatePredicate.EnteredThisTurn -> container.has<EnteredThisTurnComponent>()
         StatePredicate.WasDealtDamageThisTurn -> container.has<WasDealtDamageThisTurnComponent>()
         StatePredicate.HasDealtDamage -> container.has<HasDealtDamageComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaZoneMovementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/SbaZoneMovementHelper.kt
@@ -132,11 +132,14 @@ object SbaZoneMovementHelper {
             newState = ZoneMovementUtils.linkExiledToSource(newState, entityId, redirectResult.linkSourceId)
         }
 
-        // Apply additional replacement effect (e.g., Ugin's Nexus extra turn, Darigaaz egg counters)
+        // Apply additional replacement effect (e.g., Ugin's Nexus extra turn, Darigaaz egg
+        // counters, The Darkness Crystal's "you gain 2 life").
         if (redirectResult.additionalEffect != null) {
-            newState = ZoneMovementUtils.applyReplacementAdditionalEffect(
+            val (updatedState, extraEvents) = ZoneMovementUtils.applyReplacementAdditionalEffect(
                 newState, redirectResult.additionalEffect, redirectResult.effectControllerId, entityId
             )
+            newState = updatedState
+            events.addAll(extraEvents)
         }
 
         return ExecutionResult.success(newState, events)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1672,9 +1672,11 @@ class StackResolver(
                 }
 
                 pausedRedirect.additionalEffect?.let { extra ->
-                    pausedState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.applyReplacementAdditionalEffect(
+                    val (updatedState, extraEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.applyReplacementAdditionalEffect(
                         pausedState, extra, pausedRedirect.effectControllerId, spellId
                     )
+                    pausedState = updatedState
+                    pausedCounterEvents.addAll(extraEvents)
                 }
 
                 // Include the zone change event along with effect events
@@ -1824,9 +1826,11 @@ class StackResolver(
         }
 
         redirect.additionalEffect?.let { extra ->
-            newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.applyReplacementAdditionalEffect(
+            val (updatedState, extraEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.applyReplacementAdditionalEffect(
                 newState, extra, redirect.effectControllerId, spellId
             )
+            newState = updatedState
+            events.addAll(extraEvents)
         }
 
         events.add(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/targeting/TargetValidator.kt
@@ -759,7 +759,7 @@ class TargetValidator {
             Zone.GRAVEYARD -> validateGraveyardTarget(state, target, filter, casterId, sourceId, xValue, targetPlayerId)
             Zone.BATTLEFIELD -> validatePermanentTarget(state, target, filter, casterId, sourceId, xValue)
             Zone.STACK -> validateSpellTarget(state, target, filter, casterId, xValue, sourceId)
-            else -> validateCardInZoneTarget(state, target, filter, casterId, xValue)
+            else -> validateCardInZoneTarget(state, target, filter, casterId, xValue, sourceId)
         }
     }
 
@@ -812,7 +812,8 @@ class TargetValidator {
         target: ChosenTarget,
         filter: TargetFilter,
         casterId: EntityId,
-        xValue: Int? = null
+        xValue: Int? = null,
+        sourceId: EntityId? = null
     ): String? {
         if (target !is ChosenTarget.Card) {
             return "Target must be a card"
@@ -829,7 +830,9 @@ class TargetValidator {
             return "Target not found in ${filter.zone.displayName}"
         }
 
-        val predicateContext = PredicateContext(controllerId = casterId, ownerId = target.ownerId, xValue = xValue)
+        // sourceId lets source-relative predicates evaluate (e.g. ExiledWithSource — "target card
+        // exiled with ~"). Mirrors the graveyard/spell validation paths.
+        val predicateContext = PredicateContext(controllerId = casterId, ownerId = target.ownerId, xValue = xValue, sourceId = sourceId)
         val matches = predicateEvaluator.matches(state, state.projectedState, target.cardId, filter.baseFilter, predicateContext)
         if (!matches) {
             return "Target does not match filter: ${filter.description}"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheDarknessCrystalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheDarknessCrystalScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for The Darkness Crystal (FIN #96):
+ *   {2}{B}{B} Legendary Artifact
+ *   - Black spells you cast cost {1} less to cast.  (existing ModifySpellCost primitive)
+ *   - If a nontoken creature an opponent controls would die, instead exile it and you gain 2 life.
+ *   - {4}{B}{B}, {T}: Put target creature card exiled with The Darkness Crystal onto the
+ *     battlefield tapped under your control with two additional +1/+1 counters on it.
+ *
+ * Exercises the new engine capabilities: RedirectZoneChangeWithEffect(linkToSource) + the GainLife
+ * replacement rider, and the ExiledWithSource target predicate driving the linked-exile reanimation
+ * (entering tapped, under your control, with two +1/+1 counters).
+ */
+class TheDarknessCrystalScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("The Darkness Crystal") {
+
+            test("an opponent's dying creature is exiled+linked, you gain 2 life, then it can be reanimated tapped with two +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Darkness Crystal", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears") // opponent's 2/2
+                    .withLandsOnBattlefield(1, "Mountain", 1)   // pays {R} for the Bolt
+                    .withLandsOnBattlefield(1, "Swamp", 6)      // pays {4}{B}{B} for the reanimation
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crystal = game.findPermanent("The Darkness Crystal")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val opponentId = game.player2Id
+
+                // Kill the opponent's 2/2 with Lightning Bolt (3 damage).
+                game.castSpell(1, "Lightning Bolt", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("The dying creature is redirected out of the graveyard into exile") {
+                    game.state.getGraveyard(opponentId) shouldNotContain bears
+                    game.state.getExile(opponentId) shouldContain bears
+                }
+                withClue("It is linked to The Darkness Crystal so ability 3 can retrieve it") {
+                    (game.state.getEntity(crystal)?.get<LinkedExileComponent>()?.exiledIds ?: emptyList()) shouldContain bears
+                }
+                withClue("You gain 2 life from the replacement rider (20 -> 22)") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+
+                // Reanimate the exiled creature with the {4}{B}{B}, {T} ability.
+                val abilityId = cardRegistry.getCard("The Darkness Crystal")!!.script.activatedAbilities[0].id
+                val activate = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = crystal,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Card(bears, opponentId, Zone.EXILE)),
+                    )
+                )
+                withClue("Activating the reanimation ability should succeed: ${activate.error}") {
+                    activate.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("The creature returns to the battlefield under your control") {
+                    game.findPermanent("Grizzly Bears") shouldBe bears
+                    game.state.getEntity(bears)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+                }
+                withClue("It enters tapped") {
+                    (game.state.getEntity(bears)?.has<TappedComponent>() ?: false) shouldBe true
+                }
+                withClue("It enters with two additional +1/+1 counters") {
+                    game.state.getEntity(bears)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+            }
+
+            test("your own creature dying is unaffected (only an opponent's nontoken creature is exiled)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "The Darkness Crystal", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // your own 2/2
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crystal = game.findPermanent("The Darkness Crystal")!!
+                val mine = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Lightning Bolt", targetId = mine).error shouldBe null
+                game.resolveStack()
+
+                withClue("Your own creature dies to the graveyard normally, is not exiled or linked") {
+                    game.state.getGraveyard(game.player1Id) shouldContain mine
+                    (game.state.getEntity(crystal)?.get<LinkedExileComponent>()?.exiledIds ?: emptyList()) shouldNotContain mine
+                }
+                withClue("No life is gained for your own creature dying") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements **The Darkness Crystal** (FIN #96, `{2}{B}{B}` Legendary Artifact, rare) — its earliest real printing, so the canonical `CardDefinition` lives in the `fin/cards` package.

## Card
- **Black spells you cast cost {1} less** — `ModifySpellCost(YouCast(black), ReduceGeneric(1))` (existing primitive; per the Scryfall ruling this reduces generic mana only).
- **If a nontoken creature an opponent controls would die, exile it and gain 2 life** — `RedirectZoneChangeWithEffect` redirecting the death to exile (linked to the Crystal) with a gain-2-life rider.
- **`{4}{B}{B}, {T}`: reanimate a creature card exiled with it** — returns it tapped, under your control, with two +1/+1 counters.

## New SDK primitives
- **`RedirectZoneChangeWithEffect.linkToSource`** — links redirected cards into the source's `LinkedExileComponent` (mirrors the existing `RedirectZoneChange.linkToSource`). The additional-effect executor now also handles `GainLifeEffect` and returns its `LifeChangedEvent`, threaded through all four call sites (SBA death, `ZoneTransitionService`, two `StackResolver` paths) so "whenever you gain life" triggers fire.
- **`StatePredicate.ExiledWithSource`** + filter builder **`GameObjectFilter.exiledWithSource()`** — source-relative predicate matching a card recorded in the effect source's linked exile ("target card exiled with ~"). Wired into `PredicateEvaluator` and the other exhaustive `when` sites; also fixed `TargetValidator.validateCardInZoneTarget` to thread `sourceId` so exile-zone source-relative targets validate.
- Updated `docs/card-sdk-language-reference.md` (§7 state predicates + replacement effects).

## Tests
- New `TheDarknessCrystalScenarioTest` (2 tests): full lifecycle (opponent's creature dies → exiled + linked + 2 life → reanimated tapped with 2 counters under your control) and the negative case (your own creature dying is unaffected).
- Re-blessed `FIN.json` snapshot golden — diff contains only the new card.
- `just test-rules` and `just build` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)