### PR TITLE
Add five Foundations (FDN) cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/BlanchwoodArmorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/10e/cards/BlanchwoodArmorReprint.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.`10e`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blanchwood Armor reprint in 10E. Canonical CardDefinition lives in Urza's Saga (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.usg.cards.BlanchwoodArmor`.
+ */
+val BlanchwoodArmor10eReprint = Printing(
+    oracleId = "80ea56ad-e741-4a85-b4e8-ce62e7d593d5",
+    name = "Blanchwood Armor",
+    setCode = "10E",
+    collectorNumber = "253",
+    scryfallId = "dd07ac98-f705-485e-8336-86f7cafd9055",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/d/d/dd07ac98-f705-485e-8336-86f7cafd9055.jpg?1782716485",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.UNCOMMON,
+)
+
+val BlanchwoodArmor10eReprintB = Printing(
+    oracleId = "80ea56ad-e741-4a85-b4e8-ce62e7d593d5",
+    name = "Blanchwood Armor",
+    setCode = "10E",
+    collectorNumber = "253★",
+    scryfallId = "21b462ff-a130-4c0f-97e9-b096511d7abb",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/2/1/21b462ff-a130-4c0f-97e9-b096511d7abb.jpg?1782716484",
+    releaseDate = "2007-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/BlanchwoodArmorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/BlanchwoodArmorReprint.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.`8ed`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blanchwood Armor reprint in 8ED. Canonical CardDefinition lives in Urza's Saga (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.usg.cards.BlanchwoodArmor`.
+ */
+val BlanchwoodArmor8edReprint = Printing(
+    oracleId = "80ea56ad-e741-4a85-b4e8-ce62e7d593d5",
+    name = "Blanchwood Armor",
+    setCode = "8ED",
+    collectorNumber = "234",
+    scryfallId = "36a9d7b8-c77e-48f3-89ce-1d5a6dc735e7",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/36a9d7b8-c77e-48f3-89ce-1d5a6dc735e7.jpg?1782718688",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.UNCOMMON,
+)
+
+val BlanchwoodArmor8edReprintB = Printing(
+    oracleId = "80ea56ad-e741-4a85-b4e8-ce62e7d593d5",
+    name = "Blanchwood Armor",
+    setCode = "8ED",
+    collectorNumber = "234★",
+    scryfallId = "c975c324-c96b-461e-9098-d278c01d4a6d",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/c/9/c975c324-c96b-461e-9098-d278c01d4a6d.jpg?1782718687",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/BlanchwoodArmorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/BlanchwoodArmorReprint.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blanchwood Armor reprint in BRO. Canonical CardDefinition lives in Urza's Saga (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.usg.cards.BlanchwoodArmor`.
+ */
+val BlanchwoodArmorBroReprint = Printing(
+    oracleId = "80ea56ad-e741-4a85-b4e8-ce62e7d593d5",
+    name = "Blanchwood Armor",
+    setCode = "BRO",
+    collectorNumber = "171",
+    scryfallId = "e41c0a68-53be-4905-8ed3-79b4782dfd6e",
+    artist = "Manuel Castañón",
+    imageUri = "https://cards.scryfall.io/normal/front/e/4/e41c0a68-53be-4905-8ed3-79b4782dfd6e.jpg?1782699748",
+    releaseDate = "2022-11-18",
+    rarity = Rarity.UNCOMMON,
+)
+
+val BlanchwoodArmorBroReprintB = Printing(
+    oracleId = "80ea56ad-e741-4a85-b4e8-ce62e7d593d5",
+    name = "Blanchwood Armor",
+    setCode = "BRO",
+    collectorNumber = "384",
+    scryfallId = "9755c1da-f1ed-4328-b85f-e905b7468504",
+    artist = "Manuel Castañón",
+    imageUri = "https://cards.scryfall.io/normal/front/9/7/9755c1da-f1ed-4328-b85f-e905b7468504.jpg?1782699604",
+    releaseDate = "2022-11-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AngelOfVitalityReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AngelOfVitalityReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Angel of Vitality reprint in FDN. Canonical CardDefinition lives in Core Set 2020 (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.m20.cards.AngelOfVitality`.
+ */
+val AngelOfVitalityReprint = Printing(
+    oracleId = "635fe908-6f58-4c9e-ac55-0775a7c6f278",
+    name = "Angel of Vitality",
+    setCode = "FDN",
+    collectorNumber = "706",
+    scryfallId = "c279947e-168f-4af5-902b-aba724f52b8a",
+    artist = "Johannes Voss",
+    imageUri = "https://cards.scryfall.io/normal/front/c/2/c279947e-168f-4af5-902b-aba724f52b8a.jpg?1782688653",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BlanchwoodArmorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BlanchwoodArmorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blanchwood Armor reprint in FDN. Canonical CardDefinition lives in Urza's Saga (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.usg.cards.BlanchwoodArmor`.
+ */
+val BlanchwoodArmorReprint = Printing(
+    oracleId = "80ea56ad-e741-4a85-b4e8-ce62e7d593d5",
+    name = "Blanchwood Armor",
+    setCode = "FDN",
+    collectorNumber = "213",
+    scryfallId = "1fd7ec1a-dafa-42ca-bc25-f6848fb03f60",
+    artist = "Manuel Castañón",
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1fd7ec1a-dafa-42ca-bc25-f6848fb03f60.jpg?1782689084",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CatCollector.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CatCollector.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cat Collector
+ * {2}{W}
+ * Creature — Human Citizen
+ * 3/2
+ * When this creature enters, create a Food token. (It's an artifact with
+ * "{2}, {T}, Sacrifice this token: You gain 3 life.")
+ * Whenever you gain life for the first time during each of your turns, create a
+ * 1/1 white Cat creature token.
+ */
+val CatCollector = card("Cat Collector") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Citizen"
+    oracleText = "When this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nWhenever you gain life for the first time during each of your turns, create a 1/1 white Cat creature token."
+    power = 3
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateFood()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLifeFirstTimeEachTurn
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Cat"),
+            imageUri = "https://cards.scryfall.io/normal/front/2/8/2885d54c-9fb2-4f01-8937-54f8ac1ce5bc.jpg"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "4"
+        artist = "Chris Seaman"
+        flavorText = "\"Why so many? Because they need a home, just like I once did.\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/526fe356-bff1-4211-9e88-bf913ac76b1d.jpg"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FrenziedGoblinReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FrenziedGoblinReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frenzied Goblin reprint in FDN. Canonical CardDefinition lives in Ravnica: City of Guilds
+ * (its earliest real printing), `com.wingedsheep.mtg.sets.definitions.rav.cards.FrenziedGoblin`.
+ */
+val FrenziedGoblinReprint = Printing(
+    oracleId = "6ac470a1-c2be-4971-a5ca-10bb189ebe4d",
+    name = "Frenzied Goblin",
+    setCode = "FDN",
+    collectorNumber = "199",
+    scryfallId = "d5592573-2889-40b1-b1d5-c2802482549a",
+    artist = "Randy Vargas",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d5592573-2889-40b1-b1d5-c2802482549a.jpg?1782689095",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SlumberingCerberus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SlumberingCerberus.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Slumbering Cerberus
+ * {1}{R}
+ * Creature — Dog
+ * 4/2
+ * This creature doesn't untap during your untap step.
+ * Morbid — At the beginning of each end step, if a creature died this turn, untap this creature.
+ */
+val SlumberingCerberus = card("Slumbering Cerberus") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dog"
+    power = 4
+    toughness = 2
+    oracleText = "This creature doesn't untap during your untap step.\n" +
+        "Morbid — At the beginning of each end step, if a creature died this turn, untap this creature."
+
+    // "This creature doesn't untap during your untap step."
+    flags(AbilityFlag.DOESNT_UNTAP)
+
+    // "Morbid — At the beginning of each end step, if a creature died this turn, untap this creature."
+    // The intervening-if (Rule 603.4) is checked when the trigger would fire AND again on resolution.
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        triggerCondition = Conditions.CreatureDiedThisTurn
+        effect = Effects.Untap(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "94"
+        artist = "Kari Christensen"
+        flavorText = "The plan seemed to be going perfectly, until Mino realized the third head was no longer snoring."
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d06faa8-201d-45db-b398-ad56f7b01848.jpg?1782689185"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FrenziedGoblinReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/FrenziedGoblinReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frenzied Goblin reprint in J22. Canonical CardDefinition lives in Ravnica: City of Guilds
+ * (its earliest real printing), `com.wingedsheep.mtg.sets.definitions.rav.cards.FrenziedGoblin`.
+ */
+val FrenziedGoblinJ22Reprint = Printing(
+    oracleId = "6ac470a1-c2be-4971-a5ca-10bb189ebe4d",
+    name = "Frenzied Goblin",
+    setCode = "J22",
+    collectorNumber = "536",
+    scryfallId = "2e68ddf0-5cf6-4024-ab71-827f28a0b0ee",
+    artist = "Randy Vargas",
+    imageUri = "https://cards.scryfall.io/normal/front/2/e/2e68ddf0-5cf6-4024-ab71-827f28a0b0ee.jpg?1782699009",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/FrenziedGoblinReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/FrenziedGoblinReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Frenzied Goblin reprint in M15. Canonical CardDefinition lives in Ravnica: City of Guilds
+ * (its earliest real printing), `com.wingedsheep.mtg.sets.definitions.rav.cards.FrenziedGoblin`.
+ */
+val FrenziedGoblinM15Reprint = Printing(
+    oracleId = "6ac470a1-c2be-4971-a5ca-10bb189ebe4d",
+    name = "Frenzied Goblin",
+    setCode = "M15",
+    collectorNumber = "142",
+    scryfallId = "7ddfe382-3a80-45f3-a022-54739c4b69a6",
+    artist = "Carl Critchlow",
+    imageUri = "https://cards.scryfall.io/normal/front/7/d/7ddfe382-3a80-45f3-a022-54739c4b69a6.jpg?1782713201",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/BlanchwoodArmorReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/BlanchwoodArmorReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blanchwood Armor reprint in M19. Canonical CardDefinition lives in Urza's Saga (its
+ * earliest real printing), `com.wingedsheep.mtg.sets.definitions.usg.cards.BlanchwoodArmor`.
+ */
+val BlanchwoodArmorM19Reprint = Printing(
+    oracleId = "80ea56ad-e741-4a85-b4e8-ce62e7d593d5",
+    name = "Blanchwood Armor",
+    setCode = "M19",
+    collectorNumber = "169",
+    scryfallId = "1b01d243-9f68-47c7-980b-1418e5f2f3e9",
+    artist = "Paolo Parente",
+    imageUri = "https://cards.scryfall.io/normal/front/1/b/1b01d243-9f68-47c7-980b-1418e5f2f3e9.jpg?1782709525",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/AngelOfVitality.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/AngelOfVitality.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.ModifyLifeGain
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Angel of Vitality (M20 #4)
+ * {2}{W}  Creature — Angel  2/2
+ *
+ * Flying
+ * If you would gain life, you gain that much life plus 1 instead.
+ * This creature gets +2/+2 as long as you have 25 or more life.
+ */
+val AngelOfVitality = card("Angel of Vitality") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText = "Flying\n" +
+        "If you would gain life, you gain that much life plus 1 instead.\n" +
+        "This creature gets +2/+2 as long as you have 25 or more life."
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    replacementEffect(
+        ModifyLifeGain(
+            multiplier = 1,
+            modifier = 1,
+            appliesTo = EventPattern.LifeGainEvent(player = Player.You)
+        )
+    )
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(
+                powerBonus = 2,
+                toughnessBonus = 2,
+                filter = GroupFilter.source()
+            ),
+            condition = Compare(
+                left = DynamicAmount.LifeTotal(Player.You),
+                operator = ComparisonOperator.GTE,
+                right = DynamicAmount.Fixed(25)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "4"
+        artist = "Johannes Voss"
+        imageUri = "https://cards.scryfall.io/normal/front/e/2/e2f39777-b80a-4618-9310-a9e5b91bb2a2.jpg?1782708391"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FrenziedGoblin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rav/cards/FrenziedGoblin.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.rav.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Frenzied Goblin
+ * {R}
+ * Creature — Goblin Berserker
+ * 1/1
+ * Whenever this creature attacks, you may pay {R}. If you do, target creature can't block this turn.
+ */
+val FrenziedGoblin = card("Frenzied Goblin") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Berserker"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever this creature attacks, you may pay {R}. If you do, target creature can't block this turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target("creature", TargetCreature())
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{R}"),
+            effect = Effects.CantBlock(creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Carl Critchlow"
+        flavorText = "The upside to not thinking about the consequences is that you'll always surprise those who do."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d307d8c7-b9b5-4f8f-933d-f1c64cbbf92f.jpg?1782717468"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/BlanchwoodArmor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/BlanchwoodArmor.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.usg.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Blanchwood Armor
+ * {2}{G}
+ * Enchantment — Aura
+ * Enchant creature
+ * Enchanted creature gets +1/+1 for each Forest you control.
+ */
+val BlanchwoodArmor = card("Blanchwood Armor") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +1/+1 for each Forest you control."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Land.withSubtype(Subtype.FOREST)
+            ).count(),
+            toughnessBonus = DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Land.withSubtype(Subtype.FOREST)
+            ).count()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Paolo Parente"
+        imageUri = "https://cards.scryfall.io/normal/front/9/b/9b5f3776-74f4-4626-833b-e1b0921d3cbc.jpg?1782720658"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -652,6 +652,63 @@
     ]
 }
 
+// Cat Collector
+{
+    "name": "Cat Collector",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Citizen",
+    "oracleText": "When this creature enters, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nWhenever you gain life for the first time during each of your turns, create a 1/1 white Cat creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "LifeGainEvent",
+                    "firstTimeEachTurn": true
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Cat"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/2/8/2885d54c-9fb2-4f01-8937-54f8ac1ce5bc.jpg"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Seaman",
+        "flavorText": "\"Why so many? Because they need a home, just like I once did.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/526fe356-bff1-4211-9e88-bf913ac76b1d.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Celestial Armor
 {
     "name": "Celestial Armor",
@@ -4146,6 +4203,50 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Slumbering Cerberus
+{
+    "name": "Slumbering Cerberus",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Dog",
+    "oracleText": "This creature doesn't untap during your untap step.\nMorbid — At the beginning of each end step, if a creature died this turn, untap this creature.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "flags": [
+        "DOESNT_UNTAP"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": "Self",
+                    "tap": false
+                },
+                "triggerCondition": "CreatureDiedThisTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "rarity": "UNCOMMON",
+        "artist": "Kari Christensen",
+        "flavorText": "The plan seemed to be going perfectly, until Mino realized the third head was no longer snoring.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d06faa8-201d-45db-b398-ad56f7b01848.jpg?1782689185"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -1,3 +1,62 @@
+// Angel of Vitality
+{
+    "name": "Angel of Vitality",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "Flying\nIf you would gain life, you gain that much life plus 1 instead.\nThis creature gets +2/+2 as long as you have 25 or more life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "LifeTotal",
+                        "player": "You"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 25
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "ModifyLifeGain",
+                "multiplier": 1,
+                "modifier": 1
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "4",
+        "rarity": "UNCOMMON",
+        "artist": "Johannes Voss",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/2/e2f39777-b80a-4618-9310-a9e5b91bb2a2.jpg?1782708391"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Empyrean Eagle
 {
     "name": "Empyrean Eagle",

--- a/mtg-sets/src/test/resources/snapshots/cards/RAV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RAV.json
@@ -1540,6 +1540,60 @@
     ]
 }
 
+// Frenzied Goblin
+{
+    "name": "Frenzied Goblin",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Goblin Berserker",
+    "oracleText": "Whenever this creature attacks, you may pay {R}. If you do, target creature can't block this turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{R}"
+                        }
+                    },
+                    "then": {
+                        "type": "CantBlockTargetCreatures",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "creature"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Carl Critchlow",
+        "flavorText": "The upside to not thinking about the consequences is that you'll always surprise those who do.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d307d8c7-b9b5-4f8f-933d-f1c64cbbf92f.jpg?1782717468"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Glass Golem
 {
     "name": "Glass Golem",

--- a/mtg-sets/src/test/resources/snapshots/cards/USG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/USG.json
@@ -505,6 +505,50 @@
     ]
 }
 
+// Blanchwood Armor
+{
+    "name": "Blanchwood Armor",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +1/+1 for each Forest you control.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land Forest"
+                },
+                "toughnessBonus": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land Forest"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Paolo Parente",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/b/9b5f3776-74f4-4626-833b-e1b0921d3cbc.jpg?1782720658"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Blanchwood Treefolk
 {
     "name": "Blanchwood Treefolk",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AngelOfVitalityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AngelOfVitalityScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Angel of Vitality (M20 #4).
+ *
+ * "{2}{W} Creature — Angel 2/2
+ *  Flying
+ *  If you would gain life, you gain that much life plus 1 instead.
+ *  This creature gets +2/+2 as long as you have 25 or more life."
+ */
+class AngelOfVitalityScenarioTest : ScenarioTestBase() {
+
+    // A minimal sorcery that gives the caster 3 life. Used to drive the +1 life rider.
+    private val gainThreeLife = card("Test Gain Three") {
+        manaCost = "{W}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(3) }
+    }
+
+    private val stateProjector = StateProjector()
+
+    init {
+        cardRegistry.register(gainThreeLife)
+
+        context("Angel of Vitality") {
+
+            test("gaining 3 life actually gains 4 while Angel of Vitality is on the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Angel of Vitality")
+                    .withCardInHand(1, "Test Gain Three")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Test Gain Three")
+                withClue("Casting the test spell should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Gaining 3 life with Angel of Vitality should net 4") {
+                    game.getLifeTotal(1) shouldBe 24
+                }
+            }
+
+            test("Angel of Vitality is a 4/4 at 25 or more life and a 2/2 below 25") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Angel of Vitality", summoningSickness = false)
+                    .withLifeTotal(1, 25)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val angelId = game.findPermanent("Angel of Vitality")!!
+                val projectedHigh = stateProjector.project(game.state)
+                withClue("At life=25 the +2/+2 bonus should be active (4/4)") {
+                    projectedHigh.getPower(angelId) shouldBe 4
+                    projectedHigh.getToughness(angelId) shouldBe 4
+                }
+
+                withClue("Angel of Vitality should have flying") {
+                    projectedHigh.hasKeyword(angelId, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("Angel of Vitality is a 2/2 while below 25 life") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Angel of Vitality", summoningSickness = false)
+                    .withLifeTotal(1, 24)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val angelId = game.findPermanent("Angel of Vitality")!!
+                val projected = stateProjector.project(game.state)
+                withClue("At life=24 the bonus should be inactive (2/2)") {
+                    projected.getPower(angelId) shouldBe 2
+                    projected.getToughness(angelId) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlanchwoodArmorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BlanchwoodArmorScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Blanchwood Armor — {2}{G} Aura.
+ * "Enchanted creature gets +1/+1 for each Forest you control."
+ *
+ * Proves the buff scales dynamically with the number of Forests controlled: a 2/2
+ * enchanted creature with 3 Forests becomes 5/5, and playing a 4th Forest makes it 6/6.
+ */
+class BlanchwoodArmorScenarioTest : ScenarioTestBase() {
+
+    private val stateProjector = StateProjector()
+
+    init {
+        test("enchanted creature gets +1/+1 per Forest and scales when a Forest enters") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Blanchwood Armor")
+                .withCardInHand(1, "Forest")
+                .withLandsOnBattlefield(1, "Forest", 3)
+                .withCardOnBattlefield(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val bears = game.findPermanent("Grizzly Bears")!!
+
+            // Cast Blanchwood Armor on Grizzly Bears (2/2). 3 Forests provide {2}{G}.
+            val castResult = game.castSpell(1, "Blanchwood Armor", bears)
+            withClue("Blanchwood Armor should cast successfully: ${castResult.error}") {
+                castResult.error shouldBe null
+            }
+            game.resolveStack()
+
+            withClue("Blanchwood Armor should be on the battlefield (attached)") {
+                game.findPermanent("Blanchwood Armor").shouldNotBeNull()
+            }
+
+            // 2/2 base + (3 Forests) = 5/5
+            withClue("Grizzly Bears power with 3 Forests (2 + 3)") {
+                stateProjector.getProjectedPower(game.state, bears) shouldBe 5
+            }
+            withClue("Grizzly Bears toughness with 3 Forests (2 + 3)") {
+                stateProjector.getProjectedToughness(game.state, bears) shouldBe 5
+            }
+
+            // Play a 4th Forest from hand.
+            val forestInHand = game.findCardsInHand(1, "Forest").first()
+            val playResult = game.execute(PlayLand(game.player1Id, forestInHand))
+            withClue("Playing a 4th Forest should succeed: ${playResult.error}") {
+                playResult.error shouldBe null
+            }
+
+            // 2/2 base + (4 Forests) = 6/6 — the buff scales dynamically.
+            withClue("Grizzly Bears power with 4 Forests (2 + 4)") {
+                stateProjector.getProjectedPower(game.state, bears) shouldBe 6
+            }
+            withClue("Grizzly Bears toughness with 4 Forests (2 + 4)") {
+                stateProjector.getProjectedToughness(game.state, bears) shouldBe 6
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CatCollectorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CatCollectorScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Cat Collector (Foundations).
+ *
+ * {2}{W} Creature — Human Citizen 3/2
+ * - When this creature enters, create a Food token.
+ * - Whenever you gain life for the first time during each of your turns, create a
+ *   1/1 white Cat creature token.
+ *
+ * Exercises the [com.wingedsheep.sdk.dsl.Effects.CreateFood] ETB and the
+ * `YouGainLifeFirstTimeEachTurn` trigger — the latter fires only on the first life gain per turn.
+ */
+class CatCollectorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cat Collector") {
+
+            test("ETB creates a Food token") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Cat Collector")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Cat Collector")
+                game.resolveStack()
+
+                withClue("Cat Collector should be on the battlefield") {
+                    game.isOnBattlefield("Cat Collector") shouldBe true
+                }
+                withClue("ETB creates exactly one Food token") {
+                    game.findPermanents("Food").size shouldBe 1
+                }
+                withClue("No Cat token exists before any life is gained") {
+                    game.findPermanents("Cat Token").size shouldBe 0
+                }
+            }
+
+            test("first life gain each turn creates a Cat token; a second gain the same turn does not") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Cat Collector", summoningSickness = false)
+                    .withCardInHand(1, "Venerable Monk")
+                    .withCardInHand(1, "Venerable Monk")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Venerable Monk's ETB gains 2 life — the first life gain this turn.
+                game.castSpell(1, "Venerable Monk")
+                game.resolveStack()
+
+                withClue("First life gain this turn creates one 1/1 white Cat token") {
+                    game.findPermanents("Cat Token").size shouldBe 1
+                }
+
+                // A second life gain the same turn no longer satisfies "for the first time each turn".
+                game.castSpell(1, "Venerable Monk")
+                game.resolveStack()
+
+                withClue("A second same-turn life gain must not create another Cat token") {
+                    game.findPermanents("Cat Token").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrenziedGoblinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrenziedGoblinScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Frenzied Goblin ({R} 1/1 Creature — Goblin Berserker) — Ravnica: City of Guilds.
+ *
+ * "Whenever this creature attacks, you may pay {R}. If you do, target creature can't block
+ *  this turn."
+ *
+ * Modelled with `MayPayManaEffect` (the Lightning Rift / "Words of ..." shape): after the trigger
+ * goes on the stack, the engine offers the optional {R} payment first, then — only if paid — asks
+ * for the mana sources and the creature target (the deliberate pay → select-mana → choose-target
+ * order, so the player isn't asked to pick a target before deciding whether to pay). Paying applies
+ * the can't-block restriction to the target; declining leaves it able to block.
+ */
+class FrenziedGoblinScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+    }
+
+    test("paying {R} makes the target creature unable to block this turn") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val goblin = d.putCreatureOnBattlefield(you, "Frenzied Goblin")
+        d.removeSummoningSickness(goblin)
+        d.putLandOnBattlefield(you, "Mountain") // taps for the optional {R}
+        val blocker = d.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(you, listOf(goblin), opponent)
+
+        // Advance priority until each decision surfaces, answering in the engine's order:
+        // pay {R} (yes) → auto-pay mana sources → choose the creature target.
+        var targeted = false
+        var guard = 0
+        while (!targeted && guard++ < 40) {
+            when (d.pendingDecision) {
+                is YesNoDecision -> d.submitYesNo(you, true)
+                is SelectManaSourcesDecision -> d.submitManaAutoPayOrDecline(you, true)
+                is ChooseTargetsDecision -> {
+                    d.submitTargetSelection(you, listOf(blocker)); targeted = true
+                }
+                else -> d.bothPass()
+            }
+        }
+        targeted shouldBe true
+
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.state.projectedState.cantBlock(blocker) shouldBe true
+    }
+
+    test("declining the {R} payment leaves the creature able to block") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val goblin = d.putCreatureOnBattlefield(you, "Frenzied Goblin")
+        d.removeSummoningSickness(goblin)
+        d.putLandOnBattlefield(you, "Mountain")
+        val blocker = d.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(you, listOf(goblin), opponent)
+
+        // The pay-{R} choice is genuinely offered (mana is available) — but decline it. Declining is
+        // legal, so no target is chosen and the "if you do" restriction never applies.
+        var answered = false
+        var guard = 0
+        while (!answered && guard++ < 40) {
+            when (d.pendingDecision) {
+                is YesNoDecision -> {
+                    d.submitYesNo(you, false); answered = true
+                }
+                else -> d.bothPass()
+            }
+        }
+        answered shouldBe true
+
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.state.projectedState.cantBlock(blocker) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlumberingCerberusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SlumberingCerberusScenarioTest.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Slumbering Cerberus (FDN #94) — {1}{R} 4/2 Creature — Dog
+ *
+ * "This creature doesn't untap during your untap step.
+ *  Morbid — At the beginning of each end step, if a creature died this turn, untap this creature."
+ *
+ * Verifies:
+ *  (a) it stays tapped through its controller's untap step (the DOESNT_UNTAP static);
+ *  (b) at an end step, if a creature died this turn, its Morbid trigger untaps it;
+ *  (c) at an end step with no creature having died, the Morbid intervening-if fails and it stays tapped.
+ */
+class SlumberingCerberusScenarioTest : ScenarioTestBase() {
+
+    private fun isTapped(game: TestGame, id: EntityId): Boolean =
+        game.state.getEntity(id)?.has<TappedComponent>() == true
+
+    init {
+        context("Slumbering Cerberus") {
+
+            test("does not untap during its controller's untap step") {
+                // Cerberus (player 1) starts tapped. We are on player 2's turn, so passing priority
+                // crosses into player 1's next turn — through player 1's untap step — before we stop.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Slumbering Cerberus", tapped = true)
+                    .withCardOnBattlefield(1, "Mountain", tapped = true) // control: DOES untap
+                    .withActivePlayer(2)
+                    .inPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+                    .build()
+
+                val cerberus = game.findPermanent("Slumbering Cerberus")!!
+                val mountain = game.findPermanent("Mountain")!!
+
+                // Advance into player 1's turn, stopping at their upkeep (past the untap step).
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+
+                withClue("The control Mountain should have untapped during player 1's untap step") {
+                    isTapped(game, mountain) shouldBe false
+                }
+                withClue("Slumbering Cerberus must NOT untap during its controller's untap step") {
+                    isTapped(game, cerberus) shouldBe true
+                }
+            }
+
+            test("Morbid untaps it at end step when a creature died this turn") {
+                // Player 1's turn. Cerberus is tapped; a spare creature will die this turn.
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Slumbering Cerberus", tapped = true)
+                    .withCardOnBattlefield(1, "Savannah Lions") // 1/1 victim
+                    .withCardOnBattlefield(1, "Mountain") // untapped, for the Bolt
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cerberus = game.findPermanent("Slumbering Cerberus")!!
+                val lions = game.findPermanent("Savannah Lions")!!
+
+                // Kill the Lions so "a creature died this turn" becomes true.
+                val cast = game.castSpell(1, "Lightning Bolt", lions)
+                withClue("Casting Lightning Bolt should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Savannah Lions should have died to Lightning Bolt") {
+                    game.isOnBattlefield("Savannah Lions") shouldBe false
+                }
+                withClue("Cerberus is still tapped before the end step") {
+                    isTapped(game, cerberus) shouldBe true
+                }
+
+                // Advance to the end step; the Morbid trigger queues, then drain it.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Morbid: a creature died this turn, so Cerberus untaps at the end step") {
+                    isTapped(game, cerberus) shouldBe false
+                }
+            }
+
+            test("Morbid does not untap it at end step when no creature died") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Slumbering Cerberus", tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cerberus = game.findPermanent("Slumbering Cerberus")!!
+
+                // Advance straight to the end step; no creature has died this turn.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("No creature died this turn, so the Morbid intervening-if fails — Cerberus stays tapped") {
+                    isTapped(game, cerberus) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of Foundations cards via the `add-card` flow. Every card composes from existing SDK facades — **no new engine primitives were added**.

## Cards

| Card | Canonical set | In FDN as | Mechanic |
|------|---------------|-----------|----------|
| **Cat Collector** | FDN (original) | canonical | ETB Food token + a 1/1 white Cat on your first life gain each turn |
| **Slumbering Cerberus** | FDN (original) | canonical | Doesn't untap during your untap step; Morbid untap at each end step |
| **Angel of Vitality** | M20 | reprint row | Flying; life-gain +1 replacement; +2/+2 while you have 25+ life |
| **Frenzied Goblin** | RAV | reprint row | Attack trigger, may pay {R}, target creature can't block this turn |
| **Blanchwood Armor** | USG | reprint row | Aura; enchanted creature gets +1/+1 for each Forest you control |

## Notes

- **Reprint placement** follows the project rule (canonical `CardDefinition` in the earliest real printing; later sets get `Printing` rows). Added the missing rows for the other already-scaffolded sets that printed Blanchwood Armor (8ED, 10E, M19, BRO) and Frenzied Goblin (M15, J22) so `just check-card-printing` passes clean for both.
- **Authority of the Consuls** was originally in the batch but is **blocked** on a missing SDK primitive: a runtime "creatures your opponents control enter tapped" static replacement (the engine has `EntersUntapped` as a runtime replacement but no tapped equivalent; `EntersTapped` is self/entry-time only). That is `add-feature` territory, so it was swapped for **Slumbering Cerberus** rather than shipping a lossy approximation.

## Testing

- Blessed the FDN / M20 / RAV / USG card-snapshot goldens; diff is confined to the five new cards.
- `:mtg-sets:test` green (CardDefinitionSnapshotTest + CardLintTest over the whole corpus).
- One scenario test per card in `rules-engine` — all green, including Frenzied Goblin's pay/decline branches (which exercise the `MayPayManaEffect` pay → auto-pay → choose-target order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)