### PR TITLE
Record tournament lifecycle (in-progress/abandoned) + Recent tournaments on profiles

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -20,7 +20,10 @@ the rules engine is untouched.
   played, head-to-head vs specific opponents, and a game history, all computed on demand.
 - **Deck contents** of every recorded game are stored card-by-card, so we can compute the most-played
   cards and per-card win rates.
-- **Tournaments** are recorded on completion (settings + final standings).
+- **Tournaments** are recorded across their whole lifecycle: an `IN_PROGRESS` row is written when the
+  bracket goes live, flipped to `COMPLETED` (with final standings) when it finishes, or `ABANDONED` if
+  the lobby is torn down first. This means the admin dashboard and player profiles see running and
+  abandoned tournaments, not only finished ones. The row is keyed by lobby id and upserted in place.
 - **Admin dashboard** — global totals, games-per-day, mode/color distributions, top cards, recorded
   tournaments, and an IP-based geolocation estimate of where players connect from.
 - **Guest play still works** — login is optional. Per-account stats need an account, but guest games
@@ -95,8 +98,8 @@ Flyway migration `V2__match_stats.sql` extends the stats schema:
 | `match_results.game_mode / frame_count / turn_count` | matchmaking mode + activity measures (the recording gate, games-per-day, mode distribution) |
 | `match_participants.colors / set_codes / is_ai / client_ip` | per-seat deck color identity + sets, AI flag (distinguishes AI from guests), and raw client IP (**admin-only**, never sent to clients) |
 | `match_participant_cards` | each seat's deck card-by-card (`card_name`, `copies`) — backs most-played-cards + per-card win rate |
-| `tournaments` | finished tournaments + settings (format, mode, set codes, player count, rounds, winner) |
-| `tournament_participants` | a seat in a tournament with final placement + W/L/D |
+| `tournaments` | tournaments + settings (format, mode, set codes, player count, rounds, winner) and a `status` (`IN_PROGRESS` / `COMPLETED` / `ABANDONED`); `ended_at` is null while in progress |
+| `tournament_participants` | a seat in a tournament with placement (0 until it finishes) + W/L/D |
 
 Flyway migration `V3__admin_role.sql` adds `users.is_admin` (boolean, default false) — the per-account
 admin flag (see **Admin access** below).

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -32,6 +32,7 @@ class ConnectionHandler(
     private val sender: MessageSender,
     private val aiGameManager: AiGameManager,
     private val boosterGenerator: BoosterGenerator,
+    private val tournamentResultSink: com.wingedsheep.gameserver.stats.TournamentResultSink,
     // Present only when accounts are enabled; resolved lazily so this handler stays usable without it.
     private val authSupport: ObjectProvider<AuthSupport>,
     private val magicLinkService: ObjectProvider<MagicLinkService>,
@@ -443,6 +444,7 @@ class ConnectionHandler(
                     LobbyState.WAITING_FOR_PLAYERS, LobbyState.DRAFTING, LobbyState.DECK_BUILDING -> {
                         lobby.removePlayer(identity.playerId)
                         if (lobby.playerCount == 0) {
+                            tournamentResultSink.recordAbandoned(lobbyId)
                             lobbyRepository.removeLobby(lobbyId)
                             lobbyRepository.removeTournament(lobbyId)
                         } else {

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -52,7 +52,8 @@ class LobbyHandler(
     private val spectatingHandler: SpectatingHandler,
     private val tournamentMatchHandler: TournamentMatchHandler,
     private val freeForAllHandler: FreeForAllHandler,
-    private val deckValidator: DeckValidator
+    private val deckValidator: DeckValidator,
+    private val tournamentResultSink: com.wingedsheep.gameserver.stats.TournamentResultSink
 ) {
     private val logger = LoggerFactory.getLogger(LobbyHandler::class.java)
 
@@ -1779,6 +1780,7 @@ class LobbyHandler(
         logger.info("Player ${identity.playerName} left lobby $lobbyId (cannot rejoin)")
 
         if (lobby.playerCount == 0) {
+            tournamentResultSink.recordAbandoned(lobbyId)
             lobbyRepository.removeLobby(lobbyId)
             logger.info("Lobby $lobbyId removed (empty)")
         } else {
@@ -1808,6 +1810,7 @@ class LobbyHandler(
         logger.info("Player ${identity.playerName} auto-left lobby $lobbyId")
 
         if (lobby.playerCount == 0) {
+            tournamentResultSink.recordAbandoned(lobbyId)
             lobbyRepository.removeLobby(lobbyId)
             logger.info("Lobby $lobbyId removed (empty)")
         } else {
@@ -1865,6 +1868,7 @@ class LobbyHandler(
         }
 
         // Remove the lobby
+        tournamentResultSink.recordAbandoned(lobbyId)
         lobbyRepository.removeLobby(lobbyId)
     }
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -598,6 +598,7 @@ class TournamentMatchHandler(
 
             val tournament = TournamentManager(lobby.lobbyId, players, lobby.gamesPerMatch)
             ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
+            recordTournamentStarted(lobby)
 
             tournament
         }
@@ -705,6 +706,7 @@ class TournamentMatchHandler(
 
         val tournament = TournamentManager(lobby.lobbyId, players, lobby.gamesPerMatch)
         ctx.lobbyRepository.saveTournament(lobby.lobbyId, tournament)
+        recordTournamentStarted(lobby)
 
         val connectedIds = lobby.players.values
             .filter { it.identity.isConnected }
@@ -906,15 +908,14 @@ class TournamentMatchHandler(
         }
 
         // Record the finished tournament for durable stats. No-op unless accounts are enabled, and
-        // only when at least one seat is a human (AI-only / LLM tournaments use a separate path).
+        // only when at least one seat is a human (AI-only / LLM tournaments use a separate path). This
+        // upserts the in-progress row recorded when the bracket went live, flipping it to COMPLETED.
         run {
             val standings = tournament.getRankedStandings()
-            val name = lobby.setNames.joinToString(" / ") + " " +
-                lobby.format.name.lowercase().replaceFirstChar { it.uppercase() }
-            tournamentResultSink.record(
+            tournamentResultSink.recordCompleted(
                 com.wingedsheep.gameserver.stats.RecordedTournament(
                     lobbyId = lobbyId,
-                    name = name,
+                    name = tournamentDisplayName(lobby),
                     format = lobby.format.name,
                     gameMode = lobby.gameMode.name,
                     setCodes = lobby.setCodes.joinToString(","),
@@ -939,6 +940,46 @@ class TournamentMatchHandler(
                 )
             )
         }
+    }
+
+    /** Human-readable tournament name, e.g. "Bloomburrow / Duskmourn Sealed". */
+    private fun tournamentDisplayName(lobby: TournamentLobby): String =
+        lobby.setNames.joinToString(" / ") + " " +
+            lobby.format.name.lowercase().replaceFirstChar { it.uppercase() }
+
+    /**
+     * Record that a tournament has gone live, so it shows in the admin dashboard and player profiles
+     * while it is still being played. Idempotent per lobby (the sink skips if a row already exists) and
+     * a no-op unless accounts are enabled with at least one human seat. Placements are recorded as 0
+     * (unknown) until [completeTournament] fills in the final standings.
+     */
+    private fun recordTournamentStarted(lobby: TournamentLobby) {
+        tournamentResultSink.recordStarted(
+            com.wingedsheep.gameserver.stats.RecordedTournament(
+                lobbyId = lobby.lobbyId,
+                name = tournamentDisplayName(lobby),
+                format = lobby.format.name,
+                gameMode = lobby.gameMode.name,
+                setCodes = lobby.setCodes.joinToString(","),
+                playerCount = lobby.playerCount,
+                rounds = 0,
+                gamesPerMatch = lobby.gamesPerMatch,
+                winnerName = null,
+                startedAt = java.time.Instant.now(),
+                endedAt = null,
+                participants = lobby.players.values.map { ps ->
+                    com.wingedsheep.gameserver.stats.RecordedTournamentParticipant(
+                        userId = ps.identity.userId,
+                        playerName = ps.identity.playerName,
+                        isAi = ps.identity.isAi,
+                        placement = 0,
+                        wins = 0,
+                        losses = 0,
+                        draws = 0,
+                    )
+                },
+            )
+        )
     }
 
     /**

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Repositories.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Repositories.kt
@@ -32,7 +32,10 @@ interface MatchResultRepository : CrudRepository<MatchResultRow, Long> {
     fun countWinsForUser(@Param("userId") userId: UUID): Long
 }
 
-interface TournamentRepository : CrudRepository<TournamentRow, Long>
+interface TournamentRepository : CrudRepository<TournamentRow, Long> {
+    /** The most recent row recorded for a lobby, if any — the upsert key for the lifecycle sink. */
+    fun findFirstByLobbyIdOrderByIdDesc(lobbyId: String): TournamentRow?
+}
 
 /**
  * Friendships and pending friend requests. A friendship is symmetric once accepted, so most lookups

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Rows.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/persistence/Rows.kt
@@ -144,8 +144,12 @@ data class TournamentRow(
     val rounds: Int = 0,
     val gamesPerMatch: Int = 0,
     val winnerName: String? = null,
+    /** Lifecycle status: IN_PROGRESS while the bracket is live, COMPLETED when it finishes, or ABANDONED
+     *  if the lobby is torn down before completing. See [com.wingedsheep.gameserver.stats.TournamentStatus]. */
+    val status: String = "COMPLETED",
     val startedAt: Instant? = null,
-    val endedAt: Instant = Instant.now(),
+    /** Null while [status] is IN_PROGRESS; set when the tournament completes or is abandoned. */
+    val endedAt: Instant? = null,
     @MappedCollection(idColumn = "tournament_id")
     val participants: Set<TournamentParticipantRow> = emptySet(),
 )

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/ZombieSessionSweeper.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/session/ZombieSessionSweeper.kt
@@ -15,7 +15,8 @@ class ZombieSessionSweeper(
     private val gameRepository: GameRepository,
     private val lobbyRepository: LobbyRepository,
     private val gamePlayHandler: GamePlayHandler,
-    private val lobbySharedContext: LobbySharedContext
+    private val lobbySharedContext: LobbySharedContext,
+    private val tournamentResultSink: com.wingedsheep.gameserver.stats.TournamentResultSink
 ) {
     private val logger = LoggerFactory.getLogger(ZombieSessionSweeper::class.java)
 
@@ -51,6 +52,8 @@ class ZombieSessionSweeper(
         }
         for (lobby in empty) {
             logger.info("Sweeping lobby: ${lobby.lobbyId} (state=${lobby.state}, players=${lobby.playerCount})")
+            // No-op unless this was a still-live tournament with an in-progress stats row.
+            tournamentResultSink.recordAbandoned(lobby.lobbyId)
             lobbyRepository.removeLobby(lobby.lobbyId)
             lobbyRepository.removeTournament(lobby.lobbyId)
         }

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -122,12 +122,16 @@ data class CardWinRate(val cardName: String, val decks: Long, val wins: Long, va
 /** One tournament in a user's tournament history. [id] opens the full tournament detail. */
 data class UserTournamentEntry(
     val id: Long,
+    /** Completion time, or the start time while the tournament is still in progress. */
     val endedAt: String,
     val name: String?,
     val format: String?,
     val gameMode: String?,
+    /** Final placement (1 = winner); 0 while the tournament is still in progress. */
     val placement: Int,
     val playerCount: Int,
+    /** IN_PROGRESS / COMPLETED / ABANDONED — see [TournamentStatus]. */
+    val status: String,
 )
 
 /** One player's final standing in a tournament. */
@@ -171,7 +175,10 @@ data class TournamentDetail(
     val setCodes: String?,
     val playerCount: Int,
     val winnerName: String?,
+    /** Completion time, or the start time while the tournament is still in progress. */
     val endedAt: String,
+    /** IN_PROGRESS / COMPLETED / ABANDONED — see [TournamentStatus]. */
+    val status: String,
     val standings: List<TournamentStanding>,
     val games: List<TournamentGame>,
 )
@@ -193,12 +200,15 @@ data class AdminUserStat(
 /** A recorded tournament for the admin list. The [id] opens the shared tournament detail view. */
 data class TournamentSummary(
     val id: Long,
+    /** Completion time, or the start time while the tournament is still in progress. */
     val endedAt: String,
     val name: String?,
     val format: String?,
     val gameMode: String?,
     val playerCount: Int,
     val winnerName: String?,
+    /** IN_PROGRESS / COMPLETED / ABANDONED — see [TournamentStatus]. */
+    val status: String,
 )
 
 /** One seat in a recorded game, for the admin global game list. */
@@ -671,15 +681,16 @@ class StatsQueryService(
     private fun imageUriFor(name: String): String? =
         lookupCard(name)?.let { printingRegistry.defaultPrinting(it.name)?.imageUri ?: it.metadata.imageUri }
 
-    /** The user's tournament finishes, newest first. */
+    /** The user's tournaments, newest first — including any in-progress or abandoned ones. */
     fun tournamentHistory(userId: UUID, limit: Int): List<UserTournamentEntry> = jdbc.query(
         """
-        SELECT t.id AS id, t.ended_at AS ended_at, t.name AS name, t.format AS format,
-               t.game_mode AS game_mode, tp.placement AS placement, t.player_count AS player_count
+        SELECT t.id AS id, COALESCE(t.ended_at, t.started_at, now()) AS ended_at, t.name AS name,
+               t.format AS format, t.game_mode AS game_mode, tp.placement AS placement,
+               t.player_count AS player_count, t.status AS status
         FROM tournament_participants tp
         JOIN tournaments t ON t.id = tp.tournament_id
         WHERE tp.user_id = ?
-        ORDER BY t.ended_at DESC
+        ORDER BY COALESCE(t.ended_at, t.started_at, now()) DESC
         LIMIT ?
         """.trimIndent(),
         { rs, _ ->
@@ -691,6 +702,7 @@ class StatsQueryService(
                 gameMode = rs.getString("game_mode"),
                 placement = rs.getInt("placement"),
                 playerCount = rs.getInt("player_count"),
+                status = rs.getString("status"),
             )
         },
         userId, limit,
@@ -705,7 +717,8 @@ class StatsQueryService(
     fun tournamentDetail(id: Long): TournamentDetail? {
         val header = jdbc.query(
             """
-            SELECT id, lobby_id, name, format, game_mode, set_codes, player_count, winner_name, ended_at
+            SELECT id, lobby_id, name, format, game_mode, set_codes, player_count, winner_name,
+                   COALESCE(ended_at, started_at, now()) AS ended_at, status
             FROM tournaments WHERE id = ?
             """.trimIndent(),
             { rs, _ ->
@@ -718,6 +731,7 @@ class StatsQueryService(
                     playerCount = rs.getInt("player_count"),
                     winnerName = rs.getString("winner_name"),
                     endedAt = rs.getTimestamp("ended_at").toInstant().toString(),
+                    status = rs.getString("status"),
                     standings = emptyList(),
                     games = emptyList(),
                 ) to rs.getString("lobby_id")
@@ -937,12 +951,13 @@ class StatsQueryService(
         minDecks,
     ).filterNot { lookupCard(it.cardName)?.typeLine?.isBasicLand == true }.take(limit)
 
-    /** Recorded tournaments, newest first. */
+    /** Recorded tournaments, newest first — including in-progress and abandoned ones. */
     fun recentTournaments(limit: Int): List<TournamentSummary> = jdbc.query(
         """
-        SELECT id, ended_at, name, format, game_mode, player_count, winner_name
+        SELECT id, COALESCE(ended_at, started_at, now()) AS ended_at, name, format, game_mode,
+               player_count, winner_name, status
         FROM tournaments
-        ORDER BY ended_at DESC
+        ORDER BY COALESCE(ended_at, started_at, now()) DESC
         LIMIT ?
         """.trimIndent(),
         { rs, _ ->
@@ -954,6 +969,7 @@ class StatsQueryService(
                 gameMode = rs.getString("game_mode"),
                 playerCount = rs.getInt("player_count"),
                 winnerName = rs.getString("winner_name"),
+                status = rs.getString("status"),
             )
         },
         limit,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/TournamentResultSink.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/TournamentResultSink.kt
@@ -9,7 +9,10 @@ import org.springframework.stereotype.Component
 import java.time.Instant
 import java.util.UUID
 
-/** A finished tournament ready to be recorded for stats. */
+/** Lifecycle state of a recorded tournament. Mirrors the `status` column on the `tournaments` table. */
+enum class TournamentStatus { IN_PROGRESS, COMPLETED, ABANDONED }
+
+/** A tournament ready to be recorded for stats — at start (partial) or on completion (final). */
 data class RecordedTournament(
     val lobbyId: String,
     val name: String?,
@@ -21,7 +24,8 @@ data class RecordedTournament(
     val gamesPerMatch: Int,
     val winnerName: String?,
     val startedAt: Instant?,
-    val endedAt: Instant,
+    /** Null while the tournament is still in progress; set when it completes. */
+    val endedAt: Instant?,
     val participants: List<RecordedTournamentParticipant>,
 )
 
@@ -37,54 +41,94 @@ data class RecordedTournamentParticipant(
 )
 
 /**
- * Records finished tournaments for durable stats. The completion path calls this unconditionally;
- * which implementation is wired depends on whether accounts are enabled, mirroring [MatchResultSink].
+ * Records tournaments for durable stats across their whole lifecycle, so the admin dashboard and
+ * player profiles see in-progress and abandoned tournaments, not only finished ones. All three calls
+ * are safe no-ops when accounts are disabled (mirroring [MatchResultSink]); the JDBC implementation is
+ * keyed on lobby id so start/complete/abandon upsert a single row.
  */
 interface TournamentResultSink {
-    fun record(tournament: RecordedTournament)
+    /** Record that a tournament has gone live. Idempotent per lobby; skipped when no seat is human. */
+    fun recordStarted(tournament: RecordedTournament)
+
+    /** Record a tournament's final result, flipping it to COMPLETED. Upserts the in-progress row. */
+    fun recordCompleted(tournament: RecordedTournament)
+
+    /** Mark a torn-down tournament as ABANDONED. No-op unless an in-progress row exists for the lobby. */
+    fun recordAbandoned(lobbyId: String)
 }
 
 /** Default: accounts disabled — tournaments are not persisted. */
 @Component
 @ConditionalOnProperty(name = ["accounts.enabled"], havingValue = "false", matchIfMissing = true)
 class NoOpTournamentResultSink : TournamentResultSink {
-    override fun record(tournament: RecordedTournament) = Unit
+    override fun recordStarted(tournament: RecordedTournament) = Unit
+    override fun recordCompleted(tournament: RecordedTournament) = Unit
+    override fun recordAbandoned(lobbyId: String) = Unit
 }
 
-/** Accounts enabled: persist the tournament, but only when at least one seat is a human. */
+/** Accounts enabled: persist the tournament lifecycle, but only when at least one seat is a human. */
 @Component
 @ConditionalOnProperty(name = ["accounts.enabled"], havingValue = "true")
 class JdbcTournamentResultSink(private val tournaments: TournamentRepository) : TournamentResultSink {
     private val logger = LoggerFactory.getLogger(JdbcTournamentResultSink::class.java)
 
-    override fun record(tournament: RecordedTournament) {
+    override fun recordStarted(tournament: RecordedTournament) {
         if (tournament.participants.none { !it.isAi }) return
+        // Idempotent: startTournament and the eager-creation path may both fire for one lobby.
+        if (tournaments.findFirstByLobbyIdOrderByIdDesc(tournament.lobbyId) != null) return
+        tournaments.save(tournament.toRow(TournamentStatus.IN_PROGRESS))
+        logger.debug("Recorded tournament {} as in progress ({} seats)", tournament.lobbyId, tournament.participants.size)
+    }
+
+    override fun recordCompleted(tournament: RecordedTournament) {
+        if (tournament.participants.none { !it.isAi }) return
+        val existing = tournaments.findFirstByLobbyIdOrderByIdDesc(tournament.lobbyId)
         tournaments.save(
-            TournamentRow(
-                lobbyId = tournament.lobbyId,
-                name = tournament.name,
-                format = tournament.format,
-                gameMode = tournament.gameMode,
-                setCodes = tournament.setCodes,
-                playerCount = tournament.playerCount,
-                rounds = tournament.rounds,
-                gamesPerMatch = tournament.gamesPerMatch,
-                winnerName = tournament.winnerName,
-                startedAt = tournament.startedAt,
-                endedAt = tournament.endedAt,
-                participants = tournament.participants.map {
-                    TournamentParticipantRow(
-                        userId = it.userId,
-                        playerName = it.playerName,
-                        isAi = it.isAi,
-                        placement = it.placement,
-                        wins = it.wins,
-                        losses = it.losses,
-                        draws = it.draws,
-                    )
-                }.toSet(),
+            tournament.toRow(
+                status = TournamentStatus.COMPLETED,
+                id = existing?.id,
+                // Keep the start time captured when the bracket went live.
+                startedAt = tournament.startedAt ?: existing?.startedAt,
             )
         )
-        logger.debug("Recorded tournament {} for stats ({} seats)", tournament.lobbyId, tournament.participants.size)
+        logger.debug("Recorded tournament {} as completed ({} seats)", tournament.lobbyId, tournament.participants.size)
     }
+
+    override fun recordAbandoned(lobbyId: String) {
+        val existing = tournaments.findFirstByLobbyIdOrderByIdDesc(lobbyId) ?: return
+        if (existing.status != TournamentStatus.IN_PROGRESS.name) return
+        tournaments.save(existing.copy(status = TournamentStatus.ABANDONED.name, endedAt = Instant.now()))
+        logger.debug("Recorded tournament {} as abandoned", lobbyId)
+    }
+
+    private fun RecordedTournament.toRow(
+        status: TournamentStatus,
+        id: Long? = null,
+        startedAt: Instant? = this.startedAt,
+    ) = TournamentRow(
+        id = id,
+        lobbyId = lobbyId,
+        name = name,
+        format = format,
+        gameMode = gameMode,
+        setCodes = setCodes,
+        playerCount = playerCount,
+        rounds = rounds,
+        gamesPerMatch = gamesPerMatch,
+        winnerName = winnerName,
+        status = status.name,
+        startedAt = startedAt,
+        endedAt = endedAt,
+        participants = participants.map {
+            TournamentParticipantRow(
+                userId = it.userId,
+                playerName = it.playerName,
+                isAi = it.isAi,
+                placement = it.placement,
+                wins = it.wins,
+                losses = it.losses,
+                draws = it.draws,
+            )
+        }.toSet(),
+    )
 }

--- a/game-server/src/main/resources/db/migration/V9__tournament_status.sql
+++ b/game-server/src/main/resources/db/migration/V9__tournament_status.sql
@@ -1,0 +1,14 @@
+-- Tournaments used to be written to this table only when they finished, so abandoned or still-running
+-- tournaments never appeared in the admin dashboard or player profiles. They are now recorded from the
+-- moment the bracket goes live and updated as they progress, so a status column distinguishes the three
+-- lifecycle states. Every pre-existing row was, by definition, only ever written on completion, so the
+-- default backfills them as COMPLETED. IN_PROGRESS rows carry a started_at and a null ended_at until
+-- they finish (COMPLETED) or the lobby is torn down early (ABANDONED).
+ALTER TABLE tournaments ADD COLUMN status TEXT NOT NULL DEFAULT 'COMPLETED';
+
+-- ended_at is now null while a tournament is in progress; readers coalesce it with started_at for
+-- ordering and display. Drop the now() default too, so an in-progress insert genuinely stores null.
+ALTER TABLE tournaments ALTER COLUMN ended_at DROP NOT NULL;
+ALTER TABLE tournaments ALTER COLUMN ended_at DROP DEFAULT;
+
+CREATE INDEX idx_tournaments_status ON tournaments (status);

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/persistence/FlywayMigrationTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/persistence/FlywayMigrationTest.kt
@@ -285,4 +285,45 @@ class FlywayMigrationTest : FunSpec({
             postgres.stop()
         }
     }
+
+    test("V9 adds tournament status and allows null ended_at for in-progress rows").config(enabled = dockerAvailable) {
+        val postgres = PostgreSQLContainer<Nothing>(DockerImageName.parse("postgres:16-alpine"))
+        postgres.start()
+        try {
+            migrateAll(postgres)
+
+            DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { conn ->
+                conn.createStatement().use { st ->
+                    // An insert that omits status backfills status=COMPLETED (the column default).
+                    st.execute(
+                        "INSERT INTO tournaments(id, lobby_id, name, player_count, ended_at) " +
+                            "VALUES (300, 'done', 'Finished', 4, now())"
+                    )
+                    st.executeQuery("SELECT status FROM tournaments WHERE id = 300").use { rs ->
+                        rs.next(); rs.getString(1) shouldBe "COMPLETED"
+                    }
+
+                    // An in-progress tournament: null ended_at, explicit status and started_at.
+                    st.execute(
+                        "INSERT INTO tournaments(id, lobby_id, name, player_count, status, started_at, ended_at) " +
+                            "VALUES (301, 'live', 'Running', 4, 'IN_PROGRESS', now(), NULL)"
+                    )
+                    st.executeQuery("SELECT status, ended_at FROM tournaments WHERE id = 301").use { rs ->
+                        rs.next(); rs.getString(1) shouldBe "IN_PROGRESS"; rs.getTimestamp(2) shouldBe null
+                    }
+
+                    // Ordering by COALESCE(ended_at, started_at) surfaces both, newest first.
+                    st.executeQuery(
+                        "SELECT id FROM tournaments ORDER BY COALESCE(ended_at, started_at, now()) DESC"
+                    ).use { rs ->
+                        rs.next(); val first = rs.getLong(1)
+                        rs.next(); val second = rs.getLong(1)
+                        setOf(first, second) shouldBe setOf(300L, 301L)
+                    }
+                }
+            }
+        } finally {
+            postgres.stop()
+        }
+    }
 })

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/stats/MatchResultSinkTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/stats/MatchResultSinkTest.kt
@@ -67,18 +67,67 @@ class MatchResultSinkTest : FunSpec({
         verify(exactly = 1) { repo.save(any()) }
     }
 
-    test("tournaments with at least one human seat are recorded; AI-only are skipped") {
+    test("recordStarted persists an in-progress row for a human seat but skips AI-only") {
         val repo = mockk<TournamentRepository>(relaxed = true)
+        every { repo.findFirstByLobbyIdOrderByIdDesc(any()) } returns null
         val saved = slot<TournamentRow>()
         every { repo.save(capture(saved)) } answers { saved.captured }
         val sink = JdbcTournamentResultSink(repo)
 
-        sink.record(tournament(RecordedTournamentParticipant(null, "Bot", isAi = true, placement = 1, wins = 3, losses = 0, draws = 0)))
+        sink.recordStarted(tournament(RecordedTournamentParticipant(null, "Bot", isAi = true, placement = 0, wins = 0, losses = 0, draws = 0)))
         verify(exactly = 0) { repo.save(any()) }
 
-        sink.record(tournament(RecordedTournamentParticipant(SOME_USER, "Carol", isAi = false, placement = 1, wins = 3, losses = 0, draws = 0)))
+        sink.recordStarted(tournament(RecordedTournamentParticipant(SOME_USER, "Carol", isAi = false, placement = 0, wins = 0, losses = 0, draws = 0)))
         verify(exactly = 1) { repo.save(any()) }
+        saved.captured.status shouldBe TournamentStatus.IN_PROGRESS.name
+    }
+
+    test("recordStarted is idempotent — a second start for the same lobby does not insert again") {
+        val repo = mockk<TournamentRepository>(relaxed = true)
+        every { repo.findFirstByLobbyIdOrderByIdDesc(any()) } returns
+            TournamentRow(id = 1, lobbyId = "l", status = "IN_PROGRESS")
+        JdbcTournamentResultSink(repo).recordStarted(
+            tournament(RecordedTournamentParticipant(SOME_USER, "Carol", isAi = false, placement = 0, wins = 0, losses = 0, draws = 0))
+        )
+        verify(exactly = 0) { repo.save(any()) }
+    }
+
+    test("recordCompleted upserts the in-progress row, preserving its id and start time") {
+        val repo = mockk<TournamentRepository>(relaxed = true)
+        val startedAt = Instant.now()
+        every { repo.findFirstByLobbyIdOrderByIdDesc("l") } returns
+            TournamentRow(id = 7, lobbyId = "l", status = "IN_PROGRESS", startedAt = startedAt)
+        val saved = slot<TournamentRow>()
+        every { repo.save(capture(saved)) } answers { saved.captured }
+
+        JdbcTournamentResultSink(repo).recordCompleted(
+            tournament(RecordedTournamentParticipant(SOME_USER, "Carol", isAi = false, placement = 1, wins = 3, losses = 0, draws = 0))
+        )
+        saved.captured.id shouldBe 7
+        saved.captured.status shouldBe TournamentStatus.COMPLETED.name
+        saved.captured.startedAt shouldBe startedAt
         saved.captured.winnerName shouldBe "Carol"
+    }
+
+    test("recordAbandoned flips only in-progress rows to ABANDONED") {
+        val repo = mockk<TournamentRepository>(relaxed = true)
+        val saved = slot<TournamentRow>()
+        every { repo.save(capture(saved)) } answers { saved.captured }
+
+        // No row recorded yet → nothing to abandon.
+        every { repo.findFirstByLobbyIdOrderByIdDesc("l") } returns null
+        JdbcTournamentResultSink(repo).recordAbandoned("l")
+        verify(exactly = 0) { repo.save(any()) }
+
+        // Already completed → left untouched.
+        every { repo.findFirstByLobbyIdOrderByIdDesc("l") } returns TournamentRow(id = 1, lobbyId = "l", status = "COMPLETED")
+        JdbcTournamentResultSink(repo).recordAbandoned("l")
+        verify(exactly = 0) { repo.save(any()) }
+
+        // In progress → marked abandoned.
+        every { repo.findFirstByLobbyIdOrderByIdDesc("l") } returns TournamentRow(id = 1, lobbyId = "l", status = "IN_PROGRESS")
+        JdbcTournamentResultSink(repo).recordAbandoned("l")
+        saved.captured.status shouldBe TournamentStatus.ABANDONED.name
     }
 })
 

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -250,15 +250,21 @@ export interface CardStat {
   readonly imageUri: string | null
 }
 
+/** Tournament lifecycle status, mirroring the server's `TournamentStatus`. */
+export type TournamentStatus = 'IN_PROGRESS' | 'COMPLETED' | 'ABANDONED'
+
 export interface UserTournamentEntry {
   /** Opens the full tournament detail (standings + games). */
   readonly id: number
+  /** Completion time, or the start time while still in progress. */
   readonly endedAt: string
   readonly name: string | null
   readonly format: string | null
   readonly gameMode: string | null
+  /** Final placement (1 = winner); 0 while the tournament is still in progress. */
   readonly placement: number
   readonly playerCount: number
+  readonly status: TournamentStatus
 }
 
 /** One player's final standing in a tournament. */
@@ -298,6 +304,7 @@ export interface TournamentDetail {
   readonly playerCount: number
   readonly winnerName: string | null
   readonly endedAt: string
+  readonly status: TournamentStatus
   readonly standings: TournamentStanding[]
   readonly games: TournamentGame[]
 }

--- a/web-client/src/api/adminStats.ts
+++ b/web-client/src/api/adminStats.ts
@@ -41,15 +41,20 @@ export interface CardWinRate {
   readonly winRate: number
 }
 
+/** Tournament lifecycle status, mirroring the server's `TournamentStatus`. */
+export type TournamentStatus = 'IN_PROGRESS' | 'COMPLETED' | 'ABANDONED'
+
 export interface TournamentSummary {
   /** Opens the full tournament detail (standings + games). */
   readonly id: number
+  /** Completion time, or the start time while still in progress. */
   readonly endedAt: string
   readonly name: string | null
   readonly format: string | null
   readonly gameMode: string | null
   readonly playerCount: number
   readonly winnerName: string | null
+  readonly status: TournamentStatus
 }
 
 /** Coarse connection origin for a seat, resolved from its IP server-side (raw IP never sent). */

--- a/web-client/src/components/admin/AdminDashboard.tsx
+++ b/web-client/src/components/admin/AdminDashboard.tsx
@@ -38,6 +38,7 @@ import {
 import type { AdminAuth } from '@/api/adminAuth'
 import type { StatBucket } from '@/api/account'
 import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
+import { TournamentStatusBadge } from '@/components/tournament/TournamentStatusBadge'
 import { colorLabel } from './statFormat'
 import { GeoMap } from './GeoMap'
 import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle, chartTooltipStyle } from './adminUi'
@@ -161,12 +162,15 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
         {tournaments.length === 0 ? (
           <p style={cellStyle.muted}>No tournaments recorded yet.</p>
         ) : (
-          <Table head={['Date', 'Name', 'Mode', 'Players', 'Winner']}>
+          <Table head={['Date', 'Name', 'Mode', 'Status', 'Players', 'Winner']}>
             {tournaments.map((t) => (
               <tr key={t.id} style={styles.clickableRow} onClick={() => setOpenTournament(t.id)}>
                 <td style={cellStyle.td}>{t.endedAt.slice(0, 10)}</td>
                 <td style={cellStyle.td}>{t.name ?? '—'}</td>
                 <td style={cellStyle.td}>{t.gameMode ?? '—'}</td>
+                <td style={cellStyle.td}>
+                  <TournamentStatusBadge status={t.status} />
+                </td>
                 <td style={cellStyle.tdNum}>{t.playerCount}</td>
                 <td style={cellStyle.td}>{t.winnerName ?? '—'}</td>
               </tr>

--- a/web-client/src/components/profile/StatsDashboard.tsx
+++ b/web-client/src/components/profile/StatsDashboard.tsx
@@ -39,6 +39,7 @@ import { formatDateTime } from '@/utils/datetime'
 import { HoverCardPreview } from '@/components/ui/HoverCardPreview'
 import { EloCell, GameModeCell, OpponentCell } from '@/components/profile/gameHistoryCells'
 import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
+import { TournamentStatusBadge } from '@/components/tournament/TournamentStatusBadge'
 
 export interface StatsDashboardData {
   stats: AccountStats | null
@@ -247,7 +248,9 @@ export function StatsDashboard(props: StatsDashboardData) {
         {tournaments.length > 0 && (
           <Panel title="Tournaments">
             <p style={styles.subtle}>Open a tournament to see its final standings and every game’s replay.</p>
-            <SimpleTable head={['Date', 'Tournament', { label: 'Mode' }, { label: 'Place', numeric: true }]}>
+            <SimpleTable
+              head={['Date', 'Tournament', { label: 'Mode' }, { label: 'Status' }, { label: 'Place', numeric: true }]}
+            >
               {tournaments.map((t, i) => (
                 <tr
                   key={`${t.id}-${i}`}
@@ -259,9 +262,10 @@ export function StatsDashboard(props: StatsDashboardData) {
                   <td style={styles.td}>
                     <GameModeCell gameMode={t.gameMode} format={t.format} />
                   </td>
-                  <td style={styles.tdNum}>
-                    {t.placement}/{t.playerCount}
+                  <td style={styles.td}>
+                    <TournamentStatusBadge status={t.status} />
                   </td>
+                  <td style={styles.tdNum}>{t.status === 'COMPLETED' ? `${t.placement}/${t.playerCount}` : '—'}</td>
                 </tr>
               ))}
             </SimpleTable>

--- a/web-client/src/components/profile/TournamentDetailModal.tsx
+++ b/web-client/src/components/profile/TournamentDetailModal.tsx
@@ -8,6 +8,7 @@ import type React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { type TournamentDetail, fetchTournamentDetail } from '@/api/account'
 import { gameModeLabel } from '@/components/admin/statFormat'
+import { TournamentStatusBadge } from '@/components/tournament/TournamentStatusBadge'
 
 export function TournamentDetailModal({
   tournamentId,
@@ -46,7 +47,10 @@ export function TournamentDetailModal({
     <div style={styles.backdrop} onClick={onClose} role="presentation">
       <div style={styles.modal} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal>
         <div style={styles.header}>
-          <h2 style={styles.title}>{title}</h2>
+          <span style={styles.titleRow}>
+            <h2 style={styles.title}>{title}</h2>
+            {detail && detail.status !== 'COMPLETED' && <TournamentStatusBadge status={detail.status} />}
+          </span>
           <button type="button" style={styles.close} onClick={onClose} aria-label="Close">
             ✕
           </button>
@@ -66,7 +70,7 @@ export function TournamentDetailModal({
           <p style={styles.muted}>Loading…</p>
         ) : (
           <>
-            <h3 style={styles.section}>Final standings</h3>
+            <h3 style={styles.section}>{detail.status === 'COMPLETED' ? 'Final standings' : 'Standings so far'}</h3>
             <div style={styles.tableWrap}>
               <table style={styles.table}>
                 <thead>
@@ -191,6 +195,7 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '20px 22px',
   },
   header: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 },
+  titleRow: { display: 'inline-flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' },
   title: { margin: 0, color: '#fff', fontSize: 20 },
   close: { background: 'none', border: 'none', color: '#999', cursor: 'pointer', fontSize: 18 },
   muted: { margin: '4px 0 0', color: '#888', fontSize: 13 },

--- a/web-client/src/components/tournament/TournamentStatusBadge.tsx
+++ b/web-client/src/components/tournament/TournamentStatusBadge.tsx
@@ -1,0 +1,43 @@
+/**
+ * A small colored pill for a tournament's lifecycle status (in progress / completed / abandoned).
+ * Shared by the admin dashboard's Tournaments table, the profile Recent tournaments table, and the
+ * tournament detail modal. Accepts a plain string so callers don't have to share a status type.
+ */
+import type React from 'react'
+
+const STYLES: Record<string, { label: string; color: string; bg: string; border: string }> = {
+  IN_PROGRESS: { label: 'In progress', color: '#7fd1ff', bg: 'rgba(88,166,255,0.14)', border: '#3d6fa855' },
+  COMPLETED: { label: 'Completed', color: '#5bd16e', bg: 'rgba(91,209,110,0.12)', border: '#3a8a4a55' },
+  ABANDONED: { label: 'Abandoned', color: '#e0a15b', bg: 'rgba(224,161,91,0.12)', border: '#8a6a3a55' },
+}
+
+export function TournamentStatusBadge({ status }: { status: string }) {
+  const s = STYLES[status] ?? {
+    label: status,
+    color: '#aaa',
+    bg: 'rgba(160,160,160,0.12)',
+    border: '#55555555',
+  }
+  return (
+    <span
+      style={{
+        ...badge,
+        color: s.color,
+        backgroundColor: s.bg,
+        border: `1px solid ${s.border}`,
+      }}
+    >
+      {s.label}
+    </span>
+  )
+}
+
+const badge: React.CSSProperties = {
+  display: 'inline-block',
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: 0.3,
+  borderRadius: 999,
+  padding: '2px 8px',
+  whiteSpace: 'nowrap',
+}

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -12,12 +12,16 @@ import {
   type AccountStats,
   type DeckSummary,
   type GameHistoryEntry,
+  type UserTournamentEntry,
   fetchHistoryPage,
   fetchStats,
+  fetchTournamentHistory,
   listDecks,
 } from '@/api/account'
 import { LoginModal } from '@/components/auth/LoginModal'
 import { DeckViewModal } from '@/components/profile/DeckViewModal'
+import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
+import { TournamentStatusBadge } from '@/components/tournament/TournamentStatusBadge'
 import { EloCell, GameModeCell, OpponentCell } from '@/components/profile/gameHistoryCells'
 import { colorForIdentity, colorLabel } from '@/components/admin/statFormat'
 import { formatDateTime } from '@/utils/datetime'
@@ -39,6 +43,8 @@ export function ProfilePage() {
   const [history, setHistory] = useState<GameHistoryEntry[]>([])
   const [historyTotal, setHistoryTotal] = useState(0)
   const [page, setPage] = useState(0)
+  const [tournaments, setTournaments] = useState<UserTournamentEntry[]>([])
+  const [openTournament, setOpenTournament] = useState<number | null>(null)
   const [loginOpen, setLoginOpen] = useState(false)
 
   const [editingName, setEditingName] = useState(false)
@@ -67,6 +73,7 @@ export function ProfilePage() {
     if (status !== 'authenticated') return
     void fetchStats().then(setStats).catch(() => setStats(null))
     void listDecks().then(setDecks).catch(() => setDecks([]))
+    void fetchTournamentHistory(25).then(setTournaments).catch(() => setTournaments([]))
   }, [status])
 
   useEffect(() => {
@@ -293,6 +300,43 @@ export function ProfilePage() {
               )}
             </div>
           )}
+          {tournaments.length > 0 && (
+            <div style={styles.sectionBlock}>
+              <div style={styles.recentHead}>
+                <h2 style={{ ...styles.section, margin: 0 }}>Recent tournaments</h2>
+                <span style={styles.muted}>Open one for its standings and every game’s replay</span>
+              </div>
+              <SimpleTable
+                head={[
+                  'Date',
+                  'Tournament',
+                  'Mode',
+                  'Status',
+                  { label: 'Place', numeric: true },
+                ]}
+              >
+                {tournaments.map((t, i) => (
+                  <tr
+                    key={`${t.id}-${i}`}
+                    style={styles.clickableRow}
+                    onClick={() => setOpenTournament(t.id)}
+                  >
+                    <td style={styles.td}>{formatDateTime(t.endedAt)}</td>
+                    <td style={styles.tdLink}>{t.name?.trim() || 'Tournament'}</td>
+                    <td style={styles.td}>
+                      <GameModeCell gameMode={t.gameMode} format={t.format} />
+                    </td>
+                    <td style={styles.td}>
+                      <TournamentStatusBadge status={t.status} />
+                    </td>
+                    <td style={styles.tdNum}>
+                      {t.status === 'COMPLETED' ? `${t.placement}/${t.playerCount}` : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </SimpleTable>
+            </div>
+          )}
         </div>
 
         {deckModal && (
@@ -301,6 +345,9 @@ export function ProfilePage() {
             opponentLabel={deckModal.opponent}
             onClose={() => setDeckModal(null)}
           />
+        )}
+        {openTournament != null && (
+          <TournamentDetailModal tournamentId={openTournament} onClose={() => setOpenTournament(null)} />
         )}
       </div>
     )
@@ -449,7 +496,9 @@ const styles: Record<string, React.CSSProperties> = {
   th: { textAlign: 'left', color: '#888', fontWeight: 600, padding: '6px 8px', borderBottom: '1px solid #2a2a3e' },
   thNum: { textAlign: 'right', color: '#888', fontWeight: 600, padding: '6px 8px', borderBottom: '1px solid #2a2a3e' },
   td: { textAlign: 'left', color: '#ccc', padding: '6px 8px', borderBottom: '1px solid #1f1f2e' },
+  tdLink: { textAlign: 'left', color: '#8b9bff', padding: '6px 8px', borderBottom: '1px solid #1f1f2e' },
   tdNum: { textAlign: 'right', color: '#ccc', padding: '6px 8px', borderBottom: '1px solid #1f1f2e' },
+  clickableRow: { cursor: 'pointer' },
   colorsCell: { display: 'inline-flex', alignItems: 'center', gap: 6 },
   colorDot: { width: 9, height: 9, borderRadius: 999, display: 'inline-block' },
   pager: { display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 14, marginTop: 12 },


### PR DESCRIPTION
## Why

The admin dashboard's **Recent tournaments** list only ever showed *finished* tournaments — a tournament was written to the DB only inside `completeTournament()`. Anything abandoned or still running never appeared. This PR records the whole tournament lifecycle, and adds a Recent tournaments section to the signed-in profile page.

Both behaviours were confirmed against the code before building, and the approach (persist-from-start with a status column) was chosen with the user.

## What changed

### Backend — lifecycle recording
- **Migration `V9__tournament_status.sql`**: adds a `status` column (`IN_PROGRESS` / `COMPLETED` / `ABANDONED`) to `tournaments`, defaulting existing rows to `COMPLETED`, and makes `ended_at` nullable (null while in progress; the now() default is dropped).
- **`TournamentResultSink`** is now `recordStarted` / `recordCompleted` / `recordAbandoned`, upserting **a single row keyed by lobby id**:
  - `recordStarted` — when the bracket goes live (`ensureTournamentCreated` + `startTournament`), idempotent, skipped for AI-only tournaments.
  - `recordCompleted` — flips the in-progress row to `COMPLETED` with final standings, preserving the original id + start time.
  - `recordAbandoned` — marks a torn-down lobby `ABANDONED`; a **no-op unless an in-progress row exists**, so it's safe to call from every `removeLobby` teardown path (leave, auto-leave, host-stop, disconnect cleanup, zombie sweep).
- Stats queries **coalesce `ended_at` with `started_at`** for ordering/display and surface `status` in the admin, profile, and detail DTOs.

### Frontend
- **Admin dashboard**: new **Status** column with a colored badge.
- **Signed-in `/profile`**: new **Recent tournaments** section (it previously showed only recent games), reusing `GET /api/stats/me/tournaments`; rows open the existing tournament detail modal.
- **Tournament detail modal**: status badge in the header + "Standings so far" (vs "Final standings") while a tournament is live.
- Shared **`StatsDashboard`** tournaments table (used by `/stats` and public profiles) now renders a status badge and shows `—` instead of a misleading `0/N` placement for non-completed tournaments.
- New reusable `TournamentStatusBadge` component.

## Tests
- `MatchResultSinkTest` rewritten for the three lifecycle methods (start/complete/abandon, idempotency, upsert-preserves-id, abandon-guards-on-in-progress). ✅
- `FlywayMigrationTest` gains a V9 case (status default, nullable `ended_at`, coalesced ordering) — Docker-gated, runs in CI.
- Full `game-server` suite green; `web-client` typecheck clean.

## Notes
- FFA / premade-waiting lobbies `return` before `ensureTournamentCreated`, so they don't create spurious in-progress rows — only bracket tournaments (which reach `completeTournament` or a teardown) are recorded.
- No card-SDK surface changed, so `card-sdk-language-reference.md` is untouched; `accounts-and-persistence.md` is updated.
- No screenshots: the UI needs a Postgres with `accounts.enabled` plus seeded in-progress/abandoned tournaments to look meaningful. Happy to capture a seeded run if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)