### PR TITLE
Add four Foundations (FDN) cards

### DIFF
--- a/backlog/sets/bloomburrow-commander/cards.md
+++ b/backlog/sets/bloomburrow-commander/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 312 cards
 **Release Date:** August 2, 2024
-**Implemented:** 109 / 312
+**Implemented:** 110 / 312
 | Color      | Total | Done |
 |------------|-------|------|
 | White      | 37    | 0    |
@@ -20,7 +20,7 @@
 - [ ] Academy Manufactor
 - [x] Adarkar Wastes
 - [ ] Aether Channeler
-- [ ] Aetherize
+- [x] Aetherize
 - [ ] Agate Instigator
 - [x] Alchemist's Talent
 - [ ] An Offer You Can't Refuse

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/AetherizeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/AetherizeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aetherize reprint in Bloomburrow Commander (BLC). Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Gatecrash (GTC).
+ */
+val AetherizeReprint = Printing(
+    oracleId = "7c779721-cd1b-4696-9ae9-68ccc284ed2a",
+    name = "Aetherize",
+    setCode = "BLC",
+    collectorNumber = "161",
+    scryfallId = "468aeb4d-d970-4332-8e8b-a3d57cb661a9",
+    artist = "Alexandre Honoré",
+    imageUri = "https://cards.scryfall.io/normal/front/4/6/468aeb4d-d970-4332-8e8b-a3d57cb661a9.jpg?1782690167",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/AetherizeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c15/cards/AetherizeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aetherize reprint in Commander 2015 (C15). Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Gatecrash (GTC).
+ */
+val AetherizeReprint = Printing(
+    oracleId = "7c779721-cd1b-4696-9ae9-68ccc284ed2a",
+    name = "Aetherize",
+    setCode = "C15",
+    collectorNumber = "85",
+    scryfallId = "22c45d43-95dd-48fd-a8e6-cf56ceb59122",
+    artist = "Ryan Barger",
+    imageUri = "https://cards.scryfall.io/normal/front/2/2/22c45d43-95dd-48fd-a8e6-cf56ceb59122.jpg?1782712371",
+    releaseDate = "2015-11-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AdaptiveAutomatonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AdaptiveAutomatonReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Adaptive Automaton reprint in FDN. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2012 (M12); this file contributes only the FDN presentation row.
+ */
+val AdaptiveAutomatonReprint = Printing(
+    oracleId = "53c730c6-2f8c-4af8-b400-b9d573a71e60",
+    name = "Adaptive Automaton",
+    setCode = "FDN",
+    collectorNumber = "723",
+    scryfallId = "e35e614c-51a9-4d5c-b7fa-1a0a87108785",
+    artist = "Igor Kieryluk",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e35e614c-51a9-4d5c-b7fa-1a0a87108785.jpg?1782688640",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AdventuringGearReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AdventuringGearReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Adventuring Gear reprint in FDN. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Zendikar (ZEN); this file contributes only the FDN presentation row.
+ */
+val AdventuringGearReprint = Printing(
+    oracleId = "17042684-7af4-43a6-88c7-885032cfb27c",
+    name = "Adventuring Gear",
+    setCode = "FDN",
+    collectorNumber = "249",
+    scryfallId = "361f9b99-5b5d-40da-b4b9-5ad90f6280ee",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/361f9b99-5b5d-40da-b4b9-5ad90f6280ee.jpg?1782689053",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AetherizeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AetherizeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Aetherize reprint in FDN. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Gatecrash (GTC); this file contributes only the FDN presentation row.
+ */
+val AetherizeReprint = Printing(
+    oracleId = "7c779721-cd1b-4696-9ae9-68ccc284ed2a",
+    name = "Aetherize",
+    setCode = "FDN",
+    collectorNumber = "151",
+    scryfallId = "1e5530fc-0291-4a17-b048-c5d24e6f51d8",
+    artist = "Alexandre Honoré",
+    imageUri = "https://cards.scryfall.io/normal/front/1/e/1e5530fc-0291-4a17-b048-c5d24e6f51d8.jpg?1782689136",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/UnchartedVoyage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/UnchartedVoyage.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Uncharted Voyage
+ * {3}{U}
+ * Instant
+ *
+ * Target creature's owner puts it on their choice of the top or bottom of their library.
+ * Surveil 1.
+ *
+ * A composite of two existing atoms: [Effects.PutOnTopOrBottomOfLibrary] (the same top-or-bottom
+ * bounce Dire Downdraft uses — the owner chooses) followed by [Effects.Surveil]. Surveil 1 always
+ * happens, even if the bounce fizzles (its target left), because it's an untargeted second clause.
+ */
+val UnchartedVoyage = card("Uncharted Voyage") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Target creature's owner puts it on their choice of the top or bottom of their library.\n" +
+        "Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+
+    spell {
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.PutOnTopOrBottomOfLibrary(creature)
+            .then(Effects.Surveil(1))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Julian Kok Joon Wen"
+        flavorText = "As his ship passed the waterlogged wrecks, Markos realized he wasn't the first person to try sailing out of the Underworld."
+        imageUri = "https://cards.scryfall.io/normal/front/e/0/e0846820-e595-4743-8a28-29c57d728677.jpg?1782689218"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/Aetherize.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/gtc/cards/Aetherize.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.gtc.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Aetherize
+ * {3}{U}
+ * Instant
+ *
+ * Return all attacking creatures to their owner's hand.
+ *
+ * A non-targeted mass bounce of every attacking creature (regardless of who controls
+ * them). Modeled with the [Patterns.Group.returnAllToHand] pipeline over the
+ * [GroupFilter.AttackingCreatures] group — each creature goes to its owner's hand.
+ */
+val Aetherize = card("Aetherize") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Return all attacking creatures to their owner's hand."
+
+    spell {
+        effect = Patterns.Group.returnAllToHand(GroupFilter.AttackingCreatures)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "29"
+        artist = "Ryan Barger"
+        flavorText = "\"You can come back once you've learned some manners—and figured out how to reconstitute your physical forms.\""
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/33303859-c6e0-4ebd-bb5f-44be7f5d7459.jpg?1782714145"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AdventuringGearReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/AdventuringGearReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Adventuring Gear reprint in Jumpstart 2022 (J22). Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Zendikar (ZEN).
+ */
+val AdventuringGearReprint = Printing(
+    oracleId = "17042684-7af4-43a6-88c7-885032cfb27c",
+    name = "Adventuring Gear",
+    setCode = "J22",
+    collectorNumber = "751",
+    scryfallId = "d7493ccb-98a1-4032-9e01-5535d29e106b",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/d/7/d7493ccb-98a1-4032-9e01-5535d29e106b.jpg?1782698871",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AdaptiveAutomaton.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m12/cards/AdaptiveAutomaton.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.m12.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GrantChosenSubtype
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Adaptive Automaton
+ * {3}
+ * Artifact Creature — Construct
+ * 2/2
+ *
+ * As this creature enters, choose a creature type.
+ * This creature is the chosen type in addition to its other types.
+ * Other creatures you control of the chosen type get +1/+1.
+ *
+ * The chosen creature type is captured by [EntersWithChoice]. [GrantChosenSubtype] (default
+ * filter: the source itself) makes this creature the chosen type in addition to Construct, and
+ * the lord [ModifyStats] buffs the *other* creatures you control of that chosen type
+ * (`ChosenSubtypeCreatures(excludeSelf = true)`).
+ */
+val AdaptiveAutomaton = card("Adaptive Automaton") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 2
+    toughness = 2
+    oracleText = "As this creature enters, choose a creature type.\n" +
+        "This creature is the chosen type in addition to its other types.\n" +
+        "Other creatures you control of the chosen type get +1/+1."
+
+    replacementEffect(EntersWithChoice(ChoiceType.CREATURE_TYPE))
+
+    // This creature is the chosen type in addition to its other types.
+    staticAbility {
+        ability = GrantChosenSubtype()
+    }
+
+    // Other creatures you control of the chosen type get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter.ChosenSubtypeCreatures(excludeSelf = true).youControl()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "201"
+        artist = "Igor Kieryluk"
+        flavorText = "Such loyalty can only be made."
+        imageUri = "https://cards.scryfall.io/normal/front/7/9/79e42ead-df6e-4181-ae2b-a2abfc3f1d7c.jpg?1782714857"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/AdventuringGear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/AdventuringGear.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Adventuring Gear
+ * {1}
+ * Artifact — Equipment
+ *
+ * Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.
+ * Equip {1}
+ *
+ * The landfall trigger is a one-shot [Effects.ModifyStats] on the [EffectTarget.EquippedCreature]
+ * (default duration: until end of turn). It only does anything while the Equipment is attached —
+ * with no equipped creature the effect has no target and no-ops.
+ */
+val AdventuringGear = card("Adventuring Gear") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    // Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Effects.ModifyStats(2, 2, EffectTarget.EquippedCreature)
+        description = "Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn."
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "195"
+        artist = "Howard Lyon"
+        flavorText = "An explorer's essentials in a wild world."
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3aa395f2-656e-4bf3-bd9b-6240bd3e2774.jpg?1782715612"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -5321,6 +5321,50 @@
     ]
 }
 
+// Uncharted Voyage
+{
+    "name": "Uncharted Voyage",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature's owner puts it on their choice of the top or bottom of their library.\nSurveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "PutOnLibraryPositionOfChoice",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Julian Kok Joon Wen",
+        "flavorText": "As his ship passed the waterlogged wrecks, Markos realized he wasn't the first person to try sailing out of the Underworld.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0846820-e595-4743-8a28-29c57d728677.jpg?1782689218"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Vampire Gourmand
 {
     "name": "Vampire Gourmand",

--- a/mtg-sets/src/test/resources/snapshots/cards/GTC.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/GTC.json
@@ -1,3 +1,44 @@
+// Aetherize
+{
+    "name": "Aetherize",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Return all attacking creatures to their owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature attacking"
+                    },
+                    "storeAs": "returnAllToHand_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "returnAllToHand_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "rarity": "UNCOMMON",
+        "artist": "Ryan Barger",
+        "flavorText": "\"You can come back once you've learned some manners—and figured out how to reconstitute your physical forms.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33303859-c6e0-4ebd-bb5f-44be7f5d7459.jpg?1782714145"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Angelic Edict
 {
     "name": "Angelic Edict",

--- a/mtg-sets/src/test/resources/snapshots/cards/M12.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M12.json
@@ -1,3 +1,44 @@
+// Adaptive Automaton
+{
+    "name": "Adaptive Automaton",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "As this creature enters, choose a creature type.\nThis creature is the chosen type in addition to its other types.\nOther creatures you control of the chosen type get +1/+1.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            "GrantChosenSubtype",
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature ctrl:you",
+                    "excludeSelf": true,
+                    "chosenSubtypeKey": "chosenCreatureType"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "CREATURE_TYPE"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "RARE",
+        "artist": "Igor Kieryluk",
+        "flavorText": "Such loyalty can only be made.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/9/79e42ead-df6e-4181-ae2b-a2abfc3f1d7c.jpg?1782714857"
+    },
+    "colorIdentityOverride": []
+}
+
 // Grand Abolisher
 {
     "name": "Grand Abolisher",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -1,3 +1,75 @@
+// Adventuring Gear
+{
+    "name": "Adventuring Gear",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "land ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "EquippedCreature"
+                },
+                "descriptionOverride": "Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "195",
+        "artist": "Howard Lyon",
+        "flavorText": "An explorer's essentials in a wild world.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3aa395f2-656e-4bf3-bd9b-6240bd3e2774.jpg?1782715612"
+    },
+    "colorIdentityOverride": []
+}
+
 // Burst Lightning
 {
     "name": "Burst Lightning",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdaptiveAutomatonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdaptiveAutomatonScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.m12.cards.AdaptiveAutomaton
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private val projector = StateProjector()
+
+/**
+ * Adaptive Automaton (M12) — {3} 2/2 Artifact Creature — Construct
+ *
+ * "As this creature enters, choose a creature type.
+ *  This creature is the chosen type in addition to its other types.
+ *  Other creatures you control of the chosen type get +1/+1."
+ */
+class AdaptiveAutomatonScenarioTest : FunSpec({
+
+    val goblin = CardDefinition.creature(
+        name = "Test Goblin",
+        manaCost = ManaCost.parse("{1}{R}"),
+        subtypes = setOf(Subtype("Goblin")),
+        power = 1,
+        toughness = 1
+    )
+
+    val bear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AdaptiveAutomaton, goblin, bear))
+        return driver
+    }
+
+    test("the Automaton becomes the chosen type and buffs OTHER creatures of that type you control") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Forest" to 20), skipMulligans = true)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val automaton = driver.putCreatureOnBattlefield(you, "Adaptive Automaton")
+        driver.replaceState(driver.state.updateEntity(automaton) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        val goblinId = driver.putCreatureOnBattlefield(you, "Test Goblin")
+        val bearId = driver.putCreatureOnBattlefield(you, "Test Bear")
+
+        val projected = projector.project(driver.state)
+
+        // The Automaton is now a Goblin in addition to Construct.
+        projected.hasSubtype(automaton, "Goblin") shouldBe true
+        projected.hasSubtype(automaton, "Construct") shouldBe true
+
+        // The other Goblin you control gets +1/+1.
+        projected.getPower(goblinId) shouldBe 2
+        projected.getToughness(goblinId) shouldBe 2
+
+        // "Other" excludes the Automaton itself — it stays a base 2/2.
+        projected.getPower(automaton) shouldBe 2
+        projected.getToughness(automaton) shouldBe 2
+
+        // A non-Goblin is unaffected.
+        projected.getPower(bearId) shouldBe 2
+        projected.getToughness(bearId) shouldBe 2
+    }
+
+    test("opponents' creatures of the chosen type are not buffed (creatures YOU control)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Forest" to 20), skipMulligans = true)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val automaton = driver.putCreatureOnBattlefield(you, "Adaptive Automaton")
+        driver.replaceState(driver.state.updateEntity(automaton) { c ->
+            c.with(CastChoicesComponent(chosen = mapOf(ChoiceSlot.CREATURE_TYPE to ChoiceValue.TextChoice("Goblin"))))
+        })
+
+        val enemyGoblin = driver.putCreatureOnBattlefield(opponent, "Test Goblin")
+
+        val projected = projector.project(driver.state)
+        projected.getPower(enemyGoblin) shouldBe 1
+        projected.getToughness(enemyGoblin) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdventuringGearScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdventuringGearScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Adventuring Gear (ZEN #195) — {1} Artifact — Equipment
+ * "Landfall — Whenever a land you control enters, equipped creature gets +2/+2 until end of turn.
+ *  Equip {1}"
+ *
+ * Exercises the landfall trigger firing the one-shot [com.wingedsheep.sdk.dsl.Effects.ModifyStats]
+ * on [com.wingedsheep.sdk.scripting.targets.EffectTarget.EquippedCreature].
+ */
+class AdventuringGearScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Adventuring Gear — landfall pumps the equipped creature") {
+
+            test("playing a land gives the equipped creature +2/+2 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardAttachedTo(1, "Adventuring Gear", "Grizzly Bears")
+                    .withCardInHand(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.state.getBattlefield(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                val forest = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+                }
+
+                // Base 2/2 before any land drop.
+                game.state.projectedState.getPower(bears) shouldBe 2
+                game.state.projectedState.getToughness(bears) shouldBe 2
+
+                val played = game.execute(PlayLand(game.player1Id, forest))
+                withClue("Playing the land should succeed: ${played.error}") { played.error shouldBe null }
+                game.resolveStack() // resolve the landfall trigger
+
+                withClue("equipped creature is now 4/4 until end of turn") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 4
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherizeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AetherizeScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Aetherize (GTC #29) — {3}{U} Instant
+ * "Return all attacking creatures to their owner's hand."
+ *
+ * Exercises [com.wingedsheep.sdk.dsl.Patterns.Group.returnAllToHand] over the
+ * [com.wingedsheep.sdk.scripting.filters.unified.GroupFilter.AttackingCreatures] group — a
+ * non-targeted mass bounce that only touches creatures currently attacking.
+ */
+class AetherizeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Aetherize — bounce every attacking creature") {
+
+            test("all attacking creatures go to their owners' hands; non-attackers stay") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Aetherize")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = false, summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", tapped = false, summoningSickness = false)
+                    // A creature that does not attack — must be left alone.
+                    .withCardOnBattlefield(1, "Glory Seeker", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Grizzly Bears and Hill Giant attack Player2; Glory Seeker holds back.
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2, "Hill Giant" to 2)).error shouldBe null
+
+                val spellId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Aetherize"
+                }
+                val cast = game.execute(CastSpell(game.player1Id, spellId, emptyList()))
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                fun onBattlefield(name: String) = game.state.getBattlefield(game.player1Id).any { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == name
+                }
+                fun inHand(name: String) = game.state.getHand(game.player1Id).any { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == name
+                }
+
+                withClue("both attackers returned to their owner's hand") {
+                    onBattlefield("Grizzly Bears") shouldBe false
+                    onBattlefield("Hill Giant") shouldBe false
+                    inHand("Grizzly Bears") shouldBe true
+                    inHand("Hill Giant") shouldBe true
+                }
+                withClue("the non-attacking creature is untouched") {
+                    onBattlefield("Glory Seeker") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnchartedVoyageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnchartedVoyageScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Uncharted Voyage (FDN #53) — {3}{U} Instant
+ * "Target creature's owner puts it on their choice of the top or bottom of their library. Surveil 1."
+ *
+ * Composes [com.wingedsheep.sdk.dsl.Effects.PutOnTopOrBottomOfLibrary] (owner picks top/bottom)
+ * with [com.wingedsheep.sdk.dsl.Effects.Surveil] — the same pair as Vanish from Sight, but the
+ * bounce is restricted to a creature.
+ */
+class UnchartedVoyageScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Uncharted Voyage — bounce a creature to its owner's library, then surveil") {
+
+            test("the targeted creature's owner puts it into their library, then the caster surveils") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Uncharted Voyage")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInLibrary(1, "Island") // something for surveil to look at
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spellId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Uncharted Voyage"
+                }
+                val bears = game.state.getBattlefield(game.player2Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+
+                val cast = game.execute(
+                    CastSpell(game.player1Id, spellId, listOf(ChosenTarget.Permanent(bears)))
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // The bounced creature's owner (Player2) chooses top or bottom.
+                withClue("Owner of the bounced creature is prompted for top/bottom") {
+                    (game.getPendingDecision() != null) shouldBe true
+                    game.getPendingDecision()!!.playerId shouldBe game.player2Id
+                }
+                game.submitDecision(OptionChosenResponse(game.getPendingDecision()!!.id, 0)) // top
+                game.resolveStack()
+
+                withClue("Grizzly Bears left the battlefield and is now in Player2's library") {
+                    game.state.getBattlefield(game.player2Id).contains(bears) shouldBe false
+                    game.state.getLibrary(game.player2Id).contains(bears) shouldBe true
+                }
+
+                // Surveil 1 for the caster resolves as a SelectCardsDecision (min 0) — keep the top card.
+                if (game.getPendingDecision() is SelectCardsDecision) {
+                    game.skipSelection()
+                    game.resolveStack()
+                }
+                withClue("the surveil decision is resolved") {
+                    (game.getPendingDecision() is SelectCardsDecision) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of Foundations cards, each composed from existing SDK primitives (no new engine features). Canonical `CardDefinition`s live in each card's earliest real printing; FDN (and other scaffolded sets) get `Printing` rows.

## Cards

| Card | Canonical | Printing rows | Mechanic |
|------|-----------|---------------|----------|
| **Aetherize** | GTC | FDN, C15, BLC | Return all attacking creatures to owners' hands — `Patterns.Group.returnAllToHand(GroupFilter.AttackingCreatures)` |
| **Adventuring Gear** | ZEN | FDN, J22 | Equipment; landfall → equipped creature +2/+2 EOT (`ModifyStats` on `EquippedCreature`) + Equip {1} |
| **Adaptive Automaton** | M12 | FDN | Choose creature type (`GrantChosenSubtype`) + type lord for other creatures you control |
| **Uncharted Voyage** | FDN (original) | — | Bounce target creature to top/bottom of library (`PutOnTopOrBottomOfLibrary`) + Surveil 1 |

Each card has a rules-engine scenario test proving behavior (mass bounce leaves non-attackers alone; landfall pump; CDA type + "other" lord exclusion; owner-choice bounce + surveil). Card snapshots re-blessed for GTC/M12/ZEN/FDN. `just build` is green.

## Dropped (need `add-feature`, not lossy approximations)

Two cards initially attempted were removed because they need genuine engine work beyond `add-card`:

- **Authority of the Consuls** — "creatures your opponents control enter tapped" requires a battlefield-runtime replacement affecting *other* permanents. `EntersTapped` is a self-only replacement (read from the entering card's own script), and making it scan the battlefield would regress every self-tapping card (e.g. The Watcher in the Water uses `EntersTapped()` with an `Any` filter). Needs a distinct "other permanents enter tapped" replacement type + scanner (mirror of `EnterUntappedReplacements`).
- **Heraldic Banner** — the chosen-**color** lord isn't supported in the projection layer: `AffectsFilterResolver` returns `false` for `HasChosenColor`/`SharesChosenColorWithSource`, and only the chosen-**creature-type** lord has a first-class resolver path (`ChosenSubtypeCreatures`). Needs a chosen-color group-filter scope + resolver branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)