### PR TITLE
Add three Final Fantasy (FIN) cards

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ExdeathVoidWarlock.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ExdeathVoidWarlock.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CharacteristicValue
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Exdeath, Void Warlock // Neo Exdeath, Dimension's End — Final Fantasy #220
+ * {1}{B}{G} · Legendary Creature — Spirit Warlock · 3/3 // Legendary Creature — Spirit Avatar · * /3
+ *
+ * Front — Exdeath, Void Warlock:
+ *   When Exdeath enters, you gain 3 life.
+ *   At the beginning of your end step, if there are six or more permanent cards in your
+ *   graveyard, transform Exdeath.
+ *
+ * Back — Neo Exdeath, Dimension's End:
+ *   Trample
+ *   Neo Exdeath's power is equal to the number of permanent cards in your graveyard.
+ *
+ * The end-step transform is an intervening-"if" (checked both when the trigger would be put on
+ * the stack and again on resolution) counting permanent cards in your graveyard via
+ * [DynamicAmount.Count] over [GameObjectFilter.Permanent]. The back face's power is a
+ * characteristic-defining ability recomputed continuously over the same graveyard count; its
+ * printed toughness is a fixed 3, so only `dynamicPower` is set.
+ */
+private val NeoExdeathDimensionsEnd = card("Neo Exdeath, Dimension's End") {
+    manaCost = ""
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Spirit Avatar"
+    oracleText = "Trample\nNeo Exdeath's power is equal to the number of permanent cards in your graveyard."
+    dynamicPower = CharacteristicValue.dynamic(
+        DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Permanent),
+    )
+    toughness = 3
+
+    keywords(Keyword.TRAMPLE)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Jessica Fong"
+        flavorText = "\"All memories . . . dimensions . . . existence . . . All that is shall be returned to nothing.\""
+        imageUri = "https://cards.scryfall.io/normal/back/1/b/1b4bab87-4000-461d-8b58-d34928fee305.jpg?1782686429"
+    }
+}
+
+private val ExdeathVoidWarlockFrontFace = card("Exdeath, Void Warlock") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Spirit Warlock"
+    oracleText = "When Exdeath enters, you gain 3 life.\n" +
+        "At the beginning of your end step, if there are six or more permanent cards in your graveyard, transform Exdeath."
+    power = 3
+    toughness = 3
+
+    // When Exdeath enters, you gain 3 life.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(3)
+    }
+
+    // At the beginning of your end step, if there are six or more permanent cards in your
+    // graveyard, transform Exdeath.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.Permanent),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(6),
+        )
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Jessica Fong"
+        flavorText = "\"Mwa-hahahaha! Witness what befalls those who stand against me!\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/b/1b4bab87-4000-461d-8b58-d34928fee305.jpg?1782686429"
+    }
+}
+
+val ExdeathVoidWarlock: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = ExdeathVoidWarlockFrontFace,
+    backFace = NeoExdeathDimensionsEnd,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SinSpirasPunishment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SinSpirasPunishment.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.RepeatCondition
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.dsl.Triggers
+
+/**
+ * Sin, Spira's Punishment
+ * {4}{B}{G}{U}
+ * Legendary Creature — Leviathan Avatar
+ * 7/7
+ * Flying
+ * Whenever Sin enters or attacks, exile a permanent card from your graveyard at random, then
+ *   create a tapped token that's a copy of that card. If the exiled card is a land card, repeat
+ *   this process.
+ *
+ * "Enters or attacks" is the Gilgamesh, Master-at-Arms / Frodo, Determined Hero shape: the engine
+ * has no combined enters-or-attacks trigger, so this is two sibling triggered abilities sharing one
+ * [sinExileAndCopyLoop] body.
+ *
+ * The body is a do-while loop ([Effects.RepeatWhile]). Each pass:
+ *   1. gathers the permanent cards in your graveyard (`sinGraveyardPool`),
+ *   2. picks one at random ([PipelineBuilder.chooseRandom]),
+ *   3. moves it to exile, recording it in `sinExiled` ([PipelineBuilder.moveTracked]),
+ *   4. creates a tapped token that's a copy of that exiled card
+ *      ([Effects.CreateTokenCopyOfTarget] over `sinExiled[0]`).
+ * The loop's [RepeatCondition.WhileCondition] re-runs the body while `sinExiled` (this pass's exiled
+ * card) is a land — mirroring The Tale of Tamiyo's "repeat this process" over the pass's own
+ * collection. The RepeatWhile executor evaluates the condition against the body's own pipeline
+ * outputs, so `sinExiled` refers to the card exiled *this* iteration.
+ *
+ * Empty/no-permanent graveyard is handled gracefully: the gather is empty, so the random select and
+ * move are no-ops, the token-copy target resolves to nothing (no token), and the land check is false
+ * (loop ends). Because a later pass re-gathers from the graveyard, an already-exiled card can't be
+ * repicked.
+ *
+ * Per the card's rulings, the token copies only the exiled card's printed characteristics (which
+ * [Effects.CreateTokenCopyOfTarget] reads from the card), {X} in a copied cost is 0, and any
+ * "when this enters" abilities on the copied card trigger for the token as normal.
+ */
+val SinSpirasPunishment = card("Sin, Spira's Punishment") {
+    manaCost = "{4}{B}{G}{U}"
+    colorIdentity = "BGU"
+    typeLine = "Legendary Creature — Leviathan Avatar"
+    power = 7
+    toughness = 7
+    oracleText = "Flying\n" +
+        "Whenever Sin enters or attacks, exile a permanent card from your graveyard at random, then " +
+        "create a tapped token that's a copy of that card. If the exiled card is a land card, repeat " +
+        "this process."
+
+    keywords(Keyword.FLYING)
+
+    // "Whenever Sin enters …"
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = sinExileAndCopyLoop()
+    }
+
+    // "… or attacks"
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = sinExileAndCopyLoop()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "242"
+        artist = "John Tedrick"
+        imageUri = "https://cards.scryfall.io/normal/front/6/5/659be746-bd31-4a70-8cec-7798da78b0b5.jpg?1782686408"
+
+        ruling(
+            "2025-06-06",
+            "If the copied card has {X} in its mana cost, X is 0."
+        )
+        ruling(
+            "2025-06-06",
+            "The token copies exactly what was printed on the original card and nothing else. It " +
+                "doesn't copy any information about the object the card was before it was put into " +
+                "your graveyard."
+        )
+        ruling(
+            "2025-06-06",
+            "If a card copied by the token had any \"when [this permanent] enters\" abilities, the " +
+                "token also has those abilities, and they'll trigger when it's created."
+        )
+    }
+}
+
+/** The shared "exile a random permanent card, copy it tapped, repeat if it was a land" loop. */
+private fun sinExileAndCopyLoop(): Effect = Effects.RepeatWhile(
+    body = Effects.Pipeline {
+        val pool = gather(
+            CardSource.FromZone(
+                zone = Zone.GRAVEYARD,
+                player = Player.You,
+                filter = GameObjectFilter.Permanent
+            ),
+            name = "sinGraveyardPool"
+        )
+        val chosen = chooseRandom(1, from = pool, name = "sinChosen")
+        val exiled = moveTracked(
+            chosen,
+            CardDestination.ToZone(Zone.EXILE, Player.You),
+            name = "sinExiled"
+        )
+        run(
+            Effects.CreateTokenCopyOfTarget(
+                target = EffectTarget.PipelineTarget(exiled.key, 0),
+                tapped = true
+            )
+        )
+    },
+    repeatCondition = RepeatCondition.WhileCondition(
+        Conditions.CollectionContainsMatch("sinExiled", GameObjectFilter.Land)
+    ),
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/VenatHeartOfHydaelyn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/VenatHeartOfHydaelyn.kt
@@ -1,0 +1,123 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Venat, Heart of Hydaelyn // Hydaelyn, the Mothercrystal
+ * {1}{W}{W} — Legendary Creature — Elder Wizard 3/3 // Legendary Creature — God 4/4
+ *
+ * Front — Venat, Heart of Hydaelyn:
+ *   Whenever you cast a legendary spell, draw a card. This ability triggers only once each turn.
+ *   Hero's Sundering — {7}, {T}: Exile target nonland permanent. Transform Venat.
+ *     Activate only as a sorcery.
+ *
+ * Back — Hydaelyn, the Mothercrystal:
+ *   Indestructible
+ *   Blessing of Light — At the beginning of combat on your turn, put a +1/+1 counter on another
+ *     target creature you control. Until your next turn, it gains indestructible. If that creature
+ *     is legendary, draw a card.
+ *
+ * Note: the task brief referred to the back face as "Venat, Sundered Heart"; Scryfall's authoritative
+ * Oracle text names it "Hydaelyn, the Mothercrystal" (Legendary Creature — God, 4/4). Oracle text of
+ * both faces is otherwise as briefed.
+ */
+private val HydaelynTheMothercrystal = card("Hydaelyn, the Mothercrystal") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — God"
+    oracleText = "Indestructible\n" +
+        "Blessing of Light — At the beginning of combat on your turn, put a +1/+1 counter on " +
+        "another target creature you control. Until your next turn, it gains indestructible. " +
+        "If that creature is legendary, draw a card."
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    // Blessing of Light — At the beginning of combat on your turn, put a +1/+1 counter on another
+    // target creature you control. Until your next turn, it gains indestructible. If that creature
+    // is legendary, draw a card.
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val creature = target("creature", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
+        effect = Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, creature),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, creature, Duration.UntilYourNextTurn),
+            ConditionalEffect(
+                // "If that creature is legendary, draw a card." The +1/+1 target is the first (only)
+                // chosen target, so test it via ContextTarget(0) like Blessing of Belzenlok.
+                condition = Conditions.TargetMatchesFilter(GameObjectFilter.Any.legendary()),
+                effect = Effects.DrawCards(1),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "39"
+        artist = "Colin Boyer"
+        flavorText = "\"For the sake of all, I beseech thee: deliver us from this fate!\""
+        imageUri = "https://cards.scryfall.io/normal/back/2/6/2625c00d-0a51-4481-bf36-cf13a2546242.jpg?1782686568"
+    }
+}
+
+private val VenatHeartOfHydaelynFront = card("Venat, Heart of Hydaelyn") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Elder Wizard"
+    oracleText = "Whenever you cast a legendary spell, draw a card. This ability triggers only " +
+        "once each turn.\n" +
+        "Hero's Sundering — {7}, {T}: Exile target nonland permanent. Transform Venat. " +
+        "Activate only as a sorcery."
+    power = 3
+    toughness = 3
+
+    // Whenever you cast a legendary spell, draw a card. This ability triggers only once each turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Any.legendary())
+        oncePerTurn = true
+        effect = Effects.DrawCards(1)
+    }
+
+    // Hero's Sundering — {7}, {T}: Exile target nonland permanent. Transform Venat.
+    // Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{7}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        val victim = target("nonland permanent", TargetPermanent(filter = TargetFilter.NonlandPermanent))
+        effect = Effects.Composite(
+            Effects.Exile(victim),
+            TransformEffect(EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "39"
+        artist = "Colin Boyer"
+        flavorText = "\"Show me your strength of will!\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/6/2625c00d-0a51-4481-bf36-cf13a2546242.jpg?1782686568"
+    }
+}
+
+val VenatHeartOfHydaelyn: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = VenatHeartOfHydaelynFront,
+    backFace = HydaelynTheMothercrystal,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -5329,6 +5329,102 @@
     "colorIdentityOverride": []
 }
 
+// Exdeath, Void Warlock
+{
+    "name": "Exdeath, Void Warlock",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Legendary Creature — Spirit Warlock",
+    "oracleText": "When Exdeath enters, you gain 3 life.\nAt the beginning of your end step, if there are six or more permanent cards in your graveyard, transform Exdeath.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 6
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Neo Exdeath, Dimension's End",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Spirit Avatar",
+        "oracleText": "Trample\nNeo Exdeath's power is equal to the number of permanent cards in your graveyard.",
+        "creatureStats": {
+            "power": {
+                "type": "Dynamic",
+                "source": {
+                    "type": "Count",
+                    "player": "You",
+                    "zone": "Graveyard",
+                    "filter": "permanent"
+                }
+            },
+            "toughness": 3
+        },
+        "keywords": [
+            "TRAMPLE"
+        ],
+        "metadata": {
+            "collectorNumber": "220",
+            "rarity": "UNCOMMON",
+            "artist": "Jessica Fong",
+            "flavorText": "\"All memories . . . dimensions . . . existence . . . All that is shall be returned to nothing.\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/1/b/1b4bab87-4000-461d-8b58-d34928fee305.jpg?1782686429"
+        },
+        "colorIdentityOverride": [
+            "BLACK",
+            "GREEN"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Jessica Fong",
+        "flavorText": "\"Mwa-hahahaha! Witness what befalls those who stand against me!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/b/1b4bab87-4000-461d-8b58-d34928fee305.jpg?1782686429"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Fang, Fearless l'Cie
 {
     "name": "Fang, Fearless l'Cie",

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -20105,6 +20105,185 @@
     ]
 }
 
+// Venat, Heart of Hydaelyn
+{
+    "name": "Venat, Heart of Hydaelyn",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Legendary Creature — Elder Wizard",
+    "oracleText": "Whenever you cast a legendary spell, draw a card. This ability triggers only once each turn.\nHero's Sundering — {7}, {T}: Exile target nonland permanent. Transform Venat. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsLegendary"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "oncePerTurn": true
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{7}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "nonland permanent"
+                            },
+                            "destination": "Exile"
+                        },
+                        "Transform"
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        },
+                        "id": "nonland permanent"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Hydaelyn, the Mothercrystal",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — God",
+        "oracleText": "Indestructible\nBlessing of Light — At the beginning of combat on your turn, put a +1/+1 counter on another target creature you control. Until your next turn, it gains indestructible. If that creature is legendary, draw a card.",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 4
+        },
+        "keywords": [
+            "INDESTRUCTIBLE"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "BEGIN_COMBAT"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "creature"
+                                }
+                            },
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "creature"
+                                },
+                                "duration": "UntilYourNextTurn"
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "EntityMatches",
+                                        "entity": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsLegendary"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "then": {
+                                    "type": "DrawCards",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "creature"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "39",
+            "rarity": "RARE",
+            "artist": "Colin Boyer",
+            "flavorText": "\"For the sake of all, I beseech thee: deliver us from this fate!\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/2/6/2625c00d-0a51-4481-bf36-cf13a2546242.jpg?1782686568"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "rarity": "RARE",
+        "artist": "Colin Boyer",
+        "flavorText": "\"Show me your strength of will!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/6/2625c00d-0a51-4481-bf36-cf13a2546242.jpg?1782686568"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Vincent Valentine
 {
     "name": "Vincent Valentine",

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -14858,6 +14858,169 @@
     ]
 }
 
+// Sin, Spira's Punishment
+{
+    "name": "Sin, Spira's Punishment",
+    "manaCost": "{4}{B}{G}{U}",
+    "typeLine": "Legendary Creature — Leviathan Avatar",
+    "oracleText": "Flying\nWhenever Sin enters or attacks, exile a permanent card from your graveyard at random, then create a tapped token that's a copy of that card. If the exiled card is a land card, repeat this process.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 7
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "RepeatWhile",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Graveyard",
+                                    "filter": "permanent"
+                                },
+                                "storeAs": "sinGraveyardPool"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "sinGraveyardPool",
+                                "selection": {
+                                    "type": "Random",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "sinChosen"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "sinChosen",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "storeMovedAs": "sinExiled"
+                            },
+                            {
+                                "type": "CreateTokenCopyOfTarget",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "sinExiled"
+                                },
+                                "tapped": true
+                            }
+                        ]
+                    },
+                    "repeatCondition": {
+                        "type": "WhileCondition",
+                        "condition": {
+                            "type": "CollectionContainsMatch",
+                            "collection": "sinExiled",
+                            "filter": "land"
+                        }
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "RepeatWhile",
+                    "body": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Graveyard",
+                                    "filter": "permanent"
+                                },
+                                "storeAs": "sinGraveyardPool"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "sinGraveyardPool",
+                                "selection": {
+                                    "type": "Random",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "sinChosen"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "sinChosen",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile"
+                                },
+                                "storeMovedAs": "sinExiled"
+                            },
+                            {
+                                "type": "CreateTokenCopyOfTarget",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "sinExiled"
+                                },
+                                "tapped": true
+                            }
+                        ]
+                    },
+                    "repeatCondition": {
+                        "type": "WhileCondition",
+                        "condition": {
+                            "type": "CollectionContainsMatch",
+                            "collection": "sinExiled",
+                            "filter": "land"
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "242",
+        "rarity": "RARE",
+        "artist": "John Tedrick",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/5/659be746-bd31-4a70-8cec-7798da78b0b5.jpg?1782686408",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "If the copied card has {X} in its mana cost, X is 0."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "The token copies exactly what was printed on the original card and nothing else. It doesn't copy any information about the object the card was before it was put into your graveyard."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "If a card copied by the token had any \"when [this permanent] enters\" abilities, the token also has those abilities, and they'll trigger when it's created."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Slash of Light
 {
     "name": "Slash of Light",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExdeathVoidWarlockScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExdeathVoidWarlockScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Exdeath, Void Warlock // Neo Exdeath, Dimension's End (FIN #220) — {1}{B}{G} Legendary
+ * Creature — Spirit Warlock 3/3.
+ *
+ *  Front:
+ *    "When Exdeath enters, you gain 3 life.
+ *     At the beginning of your end step, if there are six or more permanent cards in your
+ *     graveyard, transform Exdeath."
+ *  Back — Neo Exdeath, Dimension's End (Spirit Avatar, * /3):
+ *    "Trample
+ *     Neo Exdeath's power is equal to the number of permanent cards in your graveyard."
+ *
+ * Verifies the ETB life gain, the intervening-"if" end-step transform (only at ≥6 permanent
+ * cards in the graveyard — nonpermanent cards don't count), and the back face's
+ * characteristic-defining power tracking the number of permanent cards in the graveyard.
+ */
+class ExdeathVoidWarlockScenarioTest : ScenarioTestBase() {
+
+    private val FRONT = "Exdeath, Void Warlock"
+    private val BACK = "Neo Exdeath, Dimension's End"
+
+    private fun com.wingedsheep.engine.support.ScenarioTestBase.TestGame.faceNameOf(id: com.wingedsheep.sdk.model.EntityId): String? =
+        state.getEntity(id)?.get<CardComponent>()?.name
+
+    init {
+        context("Exdeath, Void Warlock") {
+
+            test("ETB — you gain 3 life when Exdeath enters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withLandsOnBattlefield(1, "Swamp", 2) // pays the {1}{B}
+                    .withLandsOnBattlefield(1, "Forest", 1) // pays the {G}
+                    .withCardInHand(1, FRONT)
+                    .build()
+
+                withClue("starting life is 20") { game.getLifeTotal(1) shouldBe 20 }
+
+                game.castSpell(1, FRONT).error shouldBe null
+                game.resolveStack()
+
+                withClue("Exdeath's ETB gains you 3 life") { game.getLifeTotal(1) shouldBe 23 }
+            }
+
+            test("end step does NOT transform with fewer than six permanent cards in graveyard") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, FRONT, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Five permanent cards + one instant = six graveyard cards but only FIVE permanents.
+                repeat(5) { builder = builder.withCardInGraveyard(1, "Grizzly Bears") }
+                builder = builder.withCardInGraveyard(1, "Lightning Bolt")
+                val game = builder.build()
+
+                val exdeath = game.findPermanent(FRONT)!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("only 5 permanent cards in graveyard → the intervening-if fails, no transform") {
+                    game.faceNameOf(exdeath) shouldBe FRONT
+                }
+            }
+
+            test("end step DOES transform at six permanent cards; back face is Neo Exdeath") {
+                // Cast Exdeath so it enters as a proper double-faced permanent (its transform
+                // needs the DoubleFacedComponent that only a real cast / zone-entry wires up).
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInHand(1, FRONT)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(6) { builder = builder.withCardInGraveyard(1, "Grizzly Bears") }
+                val game = builder.build()
+
+                game.castSpell(1, FRONT).error shouldBe null
+                game.resolveStack()
+                val exdeath = game.findPermanent(FRONT)!!
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("six permanent cards in graveyard → transform into Neo Exdeath") {
+                    game.faceNameOf(exdeath) shouldBe BACK
+                }
+                withClue("after transform, Neo Exdeath's power equals 6 permanent cards, toughness 3") {
+                    game.state.projectedState.getPower(exdeath) shouldBe 6
+                    game.state.projectedState.getToughness(exdeath) shouldBe 3
+                }
+                withClue("Neo Exdeath has trample") {
+                    game.state.projectedState.hasKeyword(exdeath, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+
+            test("Neo Exdeath's power tracks the number of permanent cards in your graveyard") {
+                // Back face placed directly: four permanent cards + one nonpermanent (instant).
+                var fourBuilder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, BACK, summoningSickness = false)
+                repeat(4) { fourBuilder = fourBuilder.withCardInGraveyard(1, "Grizzly Bears") }
+                fourBuilder = fourBuilder.withCardInGraveyard(1, "Lightning Bolt") // does not count
+                val fourGame = fourBuilder.build()
+
+                val neoFour = fourGame.findPermanent(BACK)!!
+                withClue("4 permanent cards (the instant is excluded) → power 4, toughness 3") {
+                    fourGame.state.projectedState.getPower(neoFour) shouldBe 4
+                    fourGame.state.projectedState.getToughness(neoFour) shouldBe 3
+                }
+
+                // A larger graveyard → the CDA recomputes to the new count.
+                var sevenBuilder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, BACK, summoningSickness = false)
+                repeat(7) { sevenBuilder = sevenBuilder.withCardInGraveyard(1, "Grizzly Bears") }
+                val sevenGame = sevenBuilder.build()
+
+                val neoSeven = sevenGame.findPermanent(BACK)!!
+                withClue("7 permanent cards → power updates to 7") {
+                    sevenGame.state.projectedState.getPower(neoSeven) shouldBe 7
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SinSpirasPunishmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SinSpirasPunishmentScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SinSpirasPunishment
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Sin, Spira's Punishment (FIN #242).
+ *
+ * Sin, Spira's Punishment {4}{B}{G}{U} Legendary Creature — Leviathan Avatar 7/7, Flying.
+ * Whenever Sin enters or attacks, exile a permanent card from your graveyard at random, then
+ * create a tapped token that's a copy of that card. If the exiled card is a land card, repeat
+ * this process.
+ *
+ * The random exile has no player choice, so the outcome is made deterministic by graveyard
+ * composition:
+ *  - an all-land graveyard makes the loop repeat until the graveyard runs out of permanent cards,
+ *    proving the land-repeat loop exiles additional cards and creates additional tapped tokens;
+ *  - a single nonland permanent stops the loop after one exile/copy.
+ * Both the "enters" and "attacks" halves ("enters or attacks" = two sibling triggers) are covered.
+ */
+class SinSpirasPunishmentScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + SinSpirasPunishment)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun payForSin(driver: GameTestDriver, you: EntityId) {
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveMana(you, Color.GREEN, 1)
+        driver.giveMana(you, Color.BLUE, 1)
+        driver.giveColorlessMana(you, 4)
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (driver.stackSize > 0 && guard++ < 20) driver.bothPass()
+    }
+
+    fun tokensControlledBy(state: GameState, player: EntityId): List<EntityId> =
+        state.getBattlefield().filter {
+            val e = state.getEntity(it) ?: return@filter false
+            e.has<TokenComponent>() && e.get<ControllerComponent>()?.playerId == player
+        }
+
+    test("enters: an all-land graveyard repeats until empty, creating a tapped copy of each land") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        // Only permanent cards in the graveyard are two lands — the loop repeats until both are gone.
+        val forest = driver.putCardInGraveyard(you, "Forest")
+        val island = driver.putCardInGraveyard(you, "Island")
+
+        val sinCard = driver.putCardInHand(you, "Sin, Spira's Punishment")
+        payForSin(driver, you)
+
+        driver.castSpell(you, sinCard)
+        resolveStack(driver) // resolve Sin onto the battlefield + its enters trigger to completion
+
+        driver.isPaused shouldBe false
+
+        // Both lands were exiled (order-independent because every exiled card was a land).
+        val exile = driver.state.getZone(ZoneKey(you, Zone.EXILE))
+        exile shouldContain forest
+        exile shouldContain island
+
+        // The graveyard no longer holds either land.
+        val graveyard = driver.state.getZone(ZoneKey(you, Zone.GRAVEYARD))
+        (graveyard.contains(forest) || graveyard.contains(island)) shouldBe false
+
+        // Two tapped token copies — one Forest, one Island — were created.
+        val tokens = tokensControlledBy(driver.state, you)
+        tokens.size shouldBe 2
+        tokens.forEach { driver.state.getEntity(it)!!.has<TappedComponent>() shouldBe true }
+        tokens.forEach { driver.state.getEntity(it)!!.get<CardComponent>()!!.typeLine.isLand shouldBe true }
+        tokens.map { driver.state.getEntity(it)!!.get<CardComponent>()!!.name }
+            .shouldContainExactlyInAnyOrder("Forest", "Island")
+    }
+
+    test("enters: a nonland permanent stops the loop after one exile and one tapped copy") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+
+        val bears = driver.putCardInGraveyard(you, "Grizzly Bears")
+
+        val sinCard = driver.putCardInHand(you, "Sin, Spira's Punishment")
+        payForSin(driver, you)
+
+        driver.castSpell(you, sinCard)
+        resolveStack(driver)
+
+        driver.isPaused shouldBe false
+
+        // The lone nonland permanent was exiled; the loop did not repeat.
+        driver.state.getZone(ZoneKey(you, Zone.EXILE)) shouldContain bears
+
+        val tokens = tokensControlledBy(driver.state, you)
+        tokens.size shouldBe 1
+        val token = driver.state.getEntity(tokens.single())!!
+        token.has<TappedComponent>() shouldBe true
+        token.get<CardComponent>()!!.name shouldBe "Grizzly Bears"
+        token.get<CardComponent>()!!.typeLine.isCreature shouldBe true
+    }
+
+    test("attacks: attacking triggers the same exile-and-copy loop") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        // Direct-to-battlefield bypasses the enters trigger, so only the attacks half is exercised.
+        val sin = driver.putCreatureOnBattlefield(you, "Sin, Spira's Punishment")
+        driver.removeSummoningSickness(sin)
+
+        val island = driver.putCardInGraveyard(you, "Island")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(sin), opponent)
+        resolveStack(driver) // resolve the attack trigger to completion
+
+        driver.isPaused shouldBe false
+
+        driver.state.getZone(ZoneKey(you, Zone.EXILE)) shouldContain island
+
+        val tokens = tokensControlledBy(driver.state, you)
+        tokens.size shouldBe 1
+        val token = driver.state.getEntity(tokens.single())!!
+        token.has<TappedComponent>() shouldBe true
+        token.get<CardComponent>()!!.name shouldBe "Island"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VenatHeartOfHydaelynScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VenatHeartOfHydaelynScenarioTest.kt
@@ -1,0 +1,184 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.VenatHeartOfHydaelyn
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.TimingRule
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Venat, Heart of Hydaelyn // Hydaelyn, the Mothercrystal (FIN).
+ *
+ * Front:
+ *   - "Whenever you cast a legendary spell, draw a card. This ability triggers only once each turn."
+ *   - "Hero's Sundering — {7}, {T}: Exile target nonland permanent. Transform Venat. Activate only as a sorcery."
+ * Back (Hydaelyn, the Mothercrystal — 4/4 God):
+ *   - Indestructible
+ *   - "Blessing of Light — At the beginning of combat on your turn, put a +1/+1 counter on another
+ *     target creature you control. Until your next turn, it gains indestructible. If that creature is
+ *     legendary, draw a card."
+ */
+class VenatHeartOfHydaelynScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // Minimal legendary / vanilla spells to drive the front trigger deterministically.
+    val legendOne = card("Test Legend One") {
+        manaCost = "{1}"
+        typeLine = "Legendary Creature — Human"
+        power = 1; toughness = 1
+    }
+    val legendTwo = card("Test Legend Two") {
+        manaCost = "{1}"
+        typeLine = "Legendary Creature — Human"
+        power = 1; toughness = 1
+    }
+    val vanilla = card("Test Vanilla") {
+        manaCost = "{1}"
+        typeLine = "Creature — Human"
+        power = 1; toughness = 1
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(VenatHeartOfHydaelyn)
+        driver.registerCard(legendOne)
+        driver.registerCard(legendTwo)
+        driver.registerCard(vanilla)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("front: casting a legendary spell draws a card, but only once each turn") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(me, "Venat, Heart of Hydaelyn")
+
+        // First legendary spell this turn -> the draw offsets the card leaving hand (net 0).
+        driver.putCardInHand(me, "Test Legend One").let { spell ->
+            driver.giveColorlessMana(me, 1)
+            val before = driver.getHandSize(me)
+            driver.castSpell(me, spell)
+            resolveStack(driver)
+            driver.getHandSize(me) shouldBe before // -1 cast, +1 draw
+        }
+
+        // Second legendary spell the SAME turn -> "triggers only once each turn": no draw (net -1).
+        driver.putCardInHand(me, "Test Legend Two").let { spell ->
+            driver.giveColorlessMana(me, 1)
+            val before = driver.getHandSize(me)
+            driver.castSpell(me, spell)
+            resolveStack(driver)
+            driver.getHandSize(me) shouldBe before - 1 // -1 cast, no draw
+        }
+    }
+
+    test("front: casting a NON-legendary spell does not draw") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putPermanentOnBattlefield(me, "Venat, Heart of Hydaelyn")
+
+        val spell = driver.putCardInHand(me, "Test Vanilla")
+        driver.giveColorlessMana(me, 1)
+        val before = driver.getHandSize(me)
+        driver.castSpell(me, spell)
+        resolveStack(driver)
+        driver.getHandSize(me) shouldBe before - 1 // -1 cast, no draw
+    }
+
+    test("Hero's Sundering is sorcery-speed") {
+        VenatHeartOfHydaelyn.activatedAbilities.first().timing shouldBe TimingRule.SorcerySpeed
+    }
+
+    test("Hero's Sundering: {7},{T} exiles target nonland permanent and transforms Venat") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val venat = driver.putPermanentOnBattlefield(me, "Venat, Heart of Hydaelyn")
+        driver.removeSummoningSickness(venat) // for the {T} cost
+        val victim = driver.putCreatureOnBattlefield(opp, "Test Vanilla")
+        driver.giveColorlessMana(me, 7)
+
+        val abilityId = VenatHeartOfHydaelyn.activatedAbilities.first().id
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = venat,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+            )
+        )
+        driver.bothPass()
+        resolveStack(driver)
+
+        // Target exiled (gone from the battlefield).
+        driver.findPermanent(opp, "Test Vanilla") shouldBe null
+        // Venat transformed in place to its back face — same entity, now Hydaelyn (4/4, indestructible).
+        val container = driver.state.getEntity(venat)!!
+        container.get<CardComponent>()!!.name shouldBe "Hydaelyn, the Mothercrystal"
+        val projected = projector.project(driver.state)
+        projected.getPower(venat) shouldBe 4
+        projected.getToughness(venat) shouldBe 4
+        projected.hasKeyword(venat, Keyword.INDESTRUCTIBLE) shouldBe true
+    }
+
+    test("Blessing of Light: legendary target gets +1/+1, indestructible, and draws a card") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(me, "Hydaelyn, the Mothercrystal")
+        val ally = driver.putCreatureOnBattlefield(me, "Test Legend One") // another legendary creature
+        val before = driver.getHandSize(me)
+
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
+        // Only legal target is the legendary ally; resolve the trigger (auto-target if needed).
+        var guard = 0
+        while (guard++ < 12 && (driver.isPaused || driver.state.stack.isNotEmpty())) {
+            if (driver.isPaused) driver.submitTargetSelection(me, listOf(ally)) else driver.bothPass()
+        }
+
+        driver.state.getEntity(ally)!!.get<CountersComponent>()!!
+            .getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+        projector.project(driver.state).hasKeyword(ally, Keyword.INDESTRUCTIBLE) shouldBe true
+        driver.getHandSize(me) shouldBe before + 1 // legendary -> draw a card
+    }
+
+    test("Blessing of Light: non-legendary target gets +1/+1 and indestructible but no draw") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        driver.putPermanentOnBattlefield(me, "Hydaelyn, the Mothercrystal")
+        val ally = driver.putCreatureOnBattlefield(me, "Test Vanilla") // non-legendary
+        val before = driver.getHandSize(me)
+
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
+        var guard = 0
+        while (guard++ < 12 && (driver.isPaused || driver.state.stack.isNotEmpty())) {
+            if (driver.isPaused) driver.submitTargetSelection(me, listOf(ally)) else driver.bothPass()
+        }
+
+        driver.state.getEntity(ally)!!.get<CountersComponent>()!!
+            .getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+        projector.project(driver.state).hasKeyword(ally, Keyword.INDESTRUCTIBLE) shouldBe true
+        driver.getHandSize(me) shouldBe before // non-legendary -> no draw
+    }
+})


### PR DESCRIPTION
Implements a handful of unimplemented Final Fantasy (FIN) cards, each authored via the `add-card` skill (Scryfall lookup, oracle errata, auto-registration, scenario test, snapshot golden).

## Cards added

- **Sin, Spira's Punishment** — Legendary Creature — Leviathan Avatar. Flying; "enters or attacks" (two sibling triggers sharing one body) exiles a permanent card from your graveyard at random, creates a tapped copy token, and repeats while the exiled card is a land — modeled with `Effects.RepeatWhile` over a Gather → Random(1) → Move(EXILE) → `CreateTokenCopyOfTarget(tapped)` pipeline.
- **Venat, Heart of Hydaelyn // Hydaelyn, the Mothercrystal** — transforming DFC. Front: cast-a-legendary-spell draw (once each turn); `{7},{T}` sorcery-speed exile a nonland permanent + transform. Back: indestructible; begin-combat +1/+1 counter + indestructible-until-your-next-turn on another target creature, drawing a card if it's legendary.
- **Exdeath, Void Warlock // Neo Exdeath, Dimension's End** — transforming DFC. Front: ETB gain 3 life; your-end-step intervening-if transform when 6+ permanent cards are in your graveyard. Back: trample and a characteristic-defining power equal to the number of permanent cards in your graveyard.

All three are **pure composition of existing SDK primitives** — no engine/SDK changes, no `docs/card-sdk-language-reference.md` update needed.

## Verification

- Per-card scenario tests pass: `SinSpirasPunishmentScenarioTest`, `VenatHeartOfHydaelynScenarioTest`, `ExdeathVoidWarlockScenarioTest`.
- `CardDefinitionSnapshotTest` re-blessed (FIN.json) and `CardLintTest` pass across the whole corpus; `:mtg-sets` compiles.
- `check-card-printing` confirms FIN is the canonical printing for each face.

## Notes on scope

Several other candidate FIN cards were screened and deliberately **excluded** because they genuinely require new engine primitives (`add-feature` territory, out of scope for an `add-card` batch): The Masamune & Cloud, Midgar Mercenary (source/emblem-scoped trigger doubling + granted continuous "must be blocked"), Lightning, Army of One (captured-player-scoped granted double-damage replacement), Firion, Wild Rose Warrior (static ability on a `CreateTokenCopyOfTarget` copy), Ancient Adamantoise (damage-not-removed-at-cleanup), and Balthier and Fran (reverse "crewed by this source" condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)