### PR TITLE
Show ELO delta on recent games

### DIFF
--- a/docs/accounts-and-persistence.md
+++ b/docs/accounts-and-persistence.md
@@ -143,7 +143,10 @@ Flyway migration `V5__game_replays.sql` adds durable replays:
 A signed-in player's history (`/api/stats/me/history`) `LEFT JOIN`s `game_replays` on `game_id` to
 flag which past games can be watched/shared (`hasReplay`). Stored replays survive server restarts and
 the 100-game in-memory cache; the unguessable `game_id` doubles as the share token via the public
-`/replay/{gameId}` page.
+`/replay/{gameId}` page. For ranked games each history row also carries `selfRating`/`opponentRating`
+(both players' ELO at game time) plus `ratingDelta` (`rating_after − rating_before` from
+`rating_history`), so the recent-games table can show how each game moved your rating (green +N /
+red −N); non-ranked games leave all three null.
 
 Flyway migration `V6__user_uuid.sql` switches the account primary key from a `BIGINT` identity to a
 **UUID** (`gen_random_uuid()` default). It backfills every existing row and re-points each foreign key

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -44,6 +44,11 @@ data class GameHistoryEntry(
     val selfRating: Int?,
     /** The opponent's ELO at the time of a ranked game; null otherwise (or for multi-seat games). */
     val opponentRating: Int?,
+    /**
+     * How this game changed the player's ELO (`rating_after - rating_before`, rounded), when it was a
+     * ranked game; null otherwise. Positive for a gain, negative for a loss.
+     */
+    val ratingDelta: Int?,
     /** Stable game id, used to open/share the replay. */
     val gameId: String,
     /** True when a compact replay was stored for this game and can be watched/shared. */
@@ -370,6 +375,7 @@ class StatsQueryService(
                         won = rs.getBoolean("won"),
                         selfRating = null,
                         opponentRating = null,
+                        ratingDelta = null,
                         gameId = rs.getString("game_id"),
                         hasReplay = rs.getBoolean("has_replay"),
                     ),
@@ -391,8 +397,9 @@ class StatsQueryService(
                 colors = colors,
                 opponents = opps.takeIf { it.isNotEmpty() }?.joinToString(", ") { it.name },
                 opponentList = opps,
-                selfRating = rating?.first,
-                opponentRating = rating?.second,
+                selfRating = rating?.selfRating,
+                opponentRating = rating?.opponentRating,
+                ratingDelta = rating?.delta,
             )
         }
     }
@@ -425,19 +432,23 @@ class StatsQueryService(
         return out
     }
 
+    /** A ranked game's ELO snapshot for the requesting user: pre-game rating, opponent rating, and delta. */
+    private data class GameRating(val selfRating: Int, val opponentRating: Int?, val delta: Int?)
+
     /**
-     * Each player's pre-game ELO and the opponent's ELO for the given ranked games, keyed by game id.
-     * `rating_before` is the rating the player carried into the game and `opponent_rating` is the
-     * opponent's rating at that time — i.e. both players' ELO "at the time the game was played".
-     * Non-ranked games have no row and are simply absent from the map.
+     * Each player's pre-game ELO, the opponent's ELO, and how the game moved the player's rating, for
+     * the given ranked games, keyed by game id. `rating_before` is the rating the player carried into
+     * the game and `opponent_rating` is the opponent's rating at that time — i.e. both players' ELO "at
+     * the time the game was played" — and `delta` (`rating_after - rating_before`) is the change this
+     * game caused. Non-ranked games have no row and are simply absent from the map.
      */
-    private fun ratingsForGames(gameIds: List<String>, userId: UUID): Map<String, Pair<Int, Int?>> {
+    private fun ratingsForGames(gameIds: List<String>, userId: UUID): Map<String, GameRating> {
         if (gameIds.isEmpty()) return emptyMap()
         val placeholders = gameIds.joinToString(",") { "?" }
-        val out = HashMap<String, Pair<Int, Int?>>()
+        val out = HashMap<String, GameRating>()
         jdbc.query(
             """
-            SELECT game_id, rating_before, opponent_rating
+            SELECT game_id, rating_before, opponent_rating, delta
             FROM rating_history
             WHERE user_id = ? AND game_id IN ($placeholders)
             """.trimIndent(),
@@ -446,7 +457,9 @@ class StatsQueryService(
                 val self = Math.round(rs.getDouble("rating_before")).toInt()
                 val oppRaw = rs.getObject("opponent_rating")
                 val opp = if (oppRaw == null) null else Math.round((oppRaw as Number).toDouble()).toInt()
-                out[gameId] = self to opp
+                val deltaRaw = rs.getObject("delta")
+                val delta = if (deltaRaw == null) null else Math.round((deltaRaw as Number).toDouble()).toInt()
+                out[gameId] = GameRating(self, opp, delta)
             },
             *buildList<Any> { add(userId); addAll(gameIds) }.toTypedArray(),
         )

--- a/web-client/src/api/account.ts
+++ b/web-client/src/api/account.ts
@@ -237,6 +237,11 @@ export interface GameHistoryEntry {
   readonly selfRating: number | null
   /** The opponent's ELO at the time of a ranked game; null otherwise. */
   readonly opponentRating: number | null
+  /**
+   * How this game moved the player's ELO (rating after − before), for ranked games; null otherwise.
+   * Positive for a gain, negative for a loss.
+   */
+  readonly ratingDelta: number | null
   readonly gameId: string
   /** True when a compact replay was stored for this game and can be watched/shared. */
   readonly hasReplay: boolean

--- a/web-client/src/components/profile/gameHistoryCells.tsx
+++ b/web-client/src/components/profile/gameHistoryCells.tsx
@@ -41,12 +41,21 @@ export function OpponentCell({ entry }: { entry: GameHistoryEntry }) {
   )
 }
 
-/** Both players' ELO at the time of a ranked game (you → opponent); a dash for non-ranked games. */
+/**
+ * Both players' ELO at the time of a ranked game (you → opponent), plus how the game moved your
+ * rating (green +N for a gain, red −N for a loss); a dash for non-ranked games.
+ */
 export function EloCell({ entry }: { entry: GameHistoryEntry }) {
   if (entry.selfRating == null) return <span style={styles.dim}>—</span>
+  const delta = entry.ratingDelta
   return (
     <span style={styles.elo}>
       <span style={styles.eloSelf}>{entry.selfRating}</span>
+      {delta != null && delta !== 0 && (
+        <span style={delta > 0 ? styles.eloDeltaUp : styles.eloDeltaDown}>
+          {delta > 0 ? `+${delta}` : `−${Math.abs(delta)}`}
+        </span>
+      )}
       {entry.opponentRating != null && (
         <>
           <span style={styles.eloVs}> vs </span>
@@ -65,6 +74,8 @@ const styles: Record<string, React.CSSProperties> = {
   dim: { color: '#666' },
   elo: { fontVariantNumeric: 'tabular-nums' },
   eloSelf: { color: '#cdd' },
+  eloDeltaUp: { color: '#5fd08a', marginLeft: 4, fontWeight: 600 },
+  eloDeltaDown: { color: '#e2686b', marginLeft: 4, fontWeight: 600 },
   eloVs: { color: '#666' },
   eloOpp: { color: '#9aa0b5' },
 }


### PR DESCRIPTION
## What

On the recent-games tables (signed-in profile + public profile), ranked games already show **your ELO vs the opponent's ELO**. This adds how the game *moved your rating*: a green **+N** for a gain or a red **−N** for a loss, right after your rating.

The Elo cell now reads, e.g.:

```
1234 +12 vs 1200      (green +12 — you won ground)
1188 −8  vs 1200      (red −8 — you lost ground)
1234     vs 1200      (delta 0 or unavailable → nothing extra)
—                     (non-ranked game, unchanged)
```

## Why it was easy

The delta was **already computed and stored** in `rating_history.delta` (`rating_after − rating_before`, written by `RankedResultSink`). It just wasn't fetched or exposed. This change wires it through the DTO layer — no new computation, no migration.

## Changes

- **Server** (`StatsQueryService`): `ratingsForGames` now also `SELECT delta`; introduced a small `GameRating(selfRating, opponentRating, delta)` holder (replacing the `Pair`), and `GameHistoryEntry` gains a nullable `ratingDelta: Int?`.
- **Client** (`api/account.ts`): `GameHistoryEntry.ratingDelta: number | null`.
- **Client** (`gameHistoryCells.tsx`): `EloCell` renders the signed, colour-coded delta (green gain / red loss); omitted when null or exactly 0. Used by both `ProfilePage` and the public-profile `StatsDashboard`, so it shows in both.
- **Docs** (`accounts-and-persistence.md`): note the new field on the history endpoint.

Non-ranked games have no `rating_history` row, so all three rating fields stay null and the cell renders the same dash as before.

## Verification

- `:game-server:compileKotlin` — BUILD SUCCESSFUL.
- Client typecheck clean for the touched files (`account.ts`, `gameHistoryCells.tsx`); pre-existing `GeoMap.tsx` d3-geo/topojson missing-dep errors are unrelated to this change.

## Screenshot

Not included: rendering the real profile page needs a running Postgres seeded with played **ranked** games plus an authenticated session, which is disproportionate setup for a two-token cell addition. The exact rendered format is shown above; the colour styles are `#5fd08a` (gain) / `#e2686b` (loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)