### PR TITLE
Nudge guests to create an account at name entry

### DIFF
--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -396,6 +396,30 @@
   font-size: var(--font-md);
 }
 
+.accountNudge {
+  margin: var(--space-1) 0 0;
+  max-width: 340px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+  line-height: 1.45;
+}
+
+.accountNudgeButton {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-accent);
+  font-size: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.accountNudgeButton:hover {
+  filter: brightness(1.15);
+}
+
 .textInput {
   background-color: var(--bg-surface-5);
   color: var(--text-primary);

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -20,6 +20,7 @@ import { buildJoinUrl } from '@/utils/joinLink'
 import { labelForFormat } from '@/utils/deckLegality'
 import { useAuthStore } from '@/store/authStore'
 import { AuthWidget } from '@/components/auth/AuthWidget'
+import { LoginModal } from '@/components/auth/LoginModal'
 import { DeckMigrationPrompt } from '@/components/auth/DeckMigrationPrompt'
 import styles from './GameUI.module.css'
 
@@ -126,6 +127,7 @@ function ConnectionOverlay({
   const [playerName, setPlayerName] = useState(() => localStorage.getItem('argentum-player-name') || '')
 
   const [nameConfirmed, setNameConfirmed] = useState(() => !!localStorage.getItem('argentum-player-name'))
+  const [loginOpen, setLoginOpen] = useState(false)
   const [showReplays, setShowReplays] = useState(false)
   const [publicLobbies, setPublicLobbies] = useState<PublicLobbyEntry[]>([])
   const [publicLobbiesError, setPublicLobbiesError] = useState<string | null>(null)
@@ -338,6 +340,20 @@ function ConnectionOverlay({
               >
                 Continue
               </button>
+              {accountsEnabled && authStatus !== 'authenticated' && (
+                <p className={styles.accountNudge}>
+                  Playing as a guest.{' '}
+                  <button
+                    type="button"
+                    onClick={() => setLoginOpen(true)}
+                    className={styles.accountNudgeButton}
+                  >
+                    Create a free account
+                  </button>{' '}
+                  — one magic link, no password — to save decks across devices, track your stats, and
+                  rewatch your games.
+                </p>
+              )}
             </div>
           )}
 
@@ -509,6 +525,7 @@ function ConnectionOverlay({
           Fan-made project. Not affiliated with, endorsed, or sponsored by Wizards of the Coast. Magic: The Gathering is © Wizards of the Coast LLC.
         </span>
       </div>
+      <LoginModal open={loginOpen} onClose={() => setLoginOpen(false)} />
     </div>
   )
 }


### PR DESCRIPTION
## What

On the landing **Enter your name** step, surface a short, obvious prompt telling guests they can create a free account with a magic link — and why they'd want to. Previously the only account affordance near name entry was a small top-right **Log in** button with no explanation of the benefits.

The new one-liner sits under the **Continue** button:

> Playing as a guest. **Create a free account** — one magic link, no password — to save decks across devices, track your stats, and rewatch your games.

"Create a free account" opens the existing magic-link `LoginModal` (same one the top-right **Log in** button uses).

![Account nudge at name entry](https://raw.githubusercontent.com/wingedsheep/argentum-engine/account-nudge-name-entry-screenshots/nudge-landing.png)

## How

- Reuses existing auth plumbing — `LoginModal` + `authStore` — no server, store, or API changes. Presentation only.
- Gated on `accountsEnabled && authStatus !== 'authenticated'`, so it only appears when sign-in can actually work and disappears once the user is signed in. On a no-accounts deployment nothing new shows.
- Scope: **main landing only** (the `/join/:lobbyId` and tournament-link name-entry pages are intentionally left unchanged).

## Files

- `web-client/src/components/ui/GameUI.tsx` — import `LoginModal`, `loginOpen` state, the nudge JSX, one `LoginModal` instance.
- `web-client/src/components/ui/GameUI.module.css` — `.accountNudge` / `.accountNudgeButton` styles (existing design tokens).

## Verification

- `npm run typecheck` passes.
- Manually verified in the running dev app: the nudge renders under **Continue**, and clicking **Create a free account** opens the "Sign in" magic-link modal.

_The screenshot is hosted on a throwaway `account-nudge-name-entry-screenshots` branch (not part of this diff)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)