### PR TITLE
Stop auto-passing opponent's end-of-combat step so Desert can be activated

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/priority/AutoPassManager.kt
@@ -527,10 +527,26 @@ class AutoPassManager(
                 }
             }
 
-            // Combat Damage / End Combat - AUTO-PASS
-            Step.COMBAT_DAMAGE, Step.END_COMBAT -> {
-                logger.debug("AUTO-PASS: Opponent's combat damage/end combat")
+            // Combat Damage - AUTO-PASS (no meaningful priority window to hold for here)
+            Step.COMBAT_DAMAGE -> {
+                logger.debug("AUTO-PASS: Opponent's combat damage")
                 true
+            }
+
+            // End Combat - STOP if we have instant-speed responses. This is a real priority
+            // window (CR 511.1) where the defending player can still act — and it's the *only*
+            // window for abilities restricted to it (e.g. Desert's "{T}: deals 1 damage to
+            // target attacking creature. Activate only during the end of combat step."), whose
+            // targets (still-attacking creatures) also vanish once the step ends (CR 511.3).
+            // Mirrors the END step / declare-attackers / first-strike handling above.
+            Step.END_COMBAT -> {
+                if (hasInstantSpeedResponses) {
+                    logger.debug("STOP: Opponent's end combat step (have instant-speed responses)")
+                    false
+                } else {
+                    logger.debug("AUTO-PASS: Opponent's end combat step (no responses)")
+                    true
+                }
             }
 
             // End Step - STOP if we have instant-speed responses
@@ -749,7 +765,8 @@ class AutoPassManager(
             Step.DECLARE_ATTACKERS -> !hasMeaningfulActions // Stop if we have responses
             Step.DECLARE_BLOCKERS -> !hasMeaningfulActions // Stop only if we have blockers/responses
             Step.FIRST_STRIKE_COMBAT_DAMAGE -> !hasMeaningfulActions // Stop if we have responses after first strike
-            Step.COMBAT_DAMAGE, Step.END_COMBAT -> true
+            Step.COMBAT_DAMAGE -> true
+            Step.END_COMBAT -> !hasMeaningfulActions // Stop if we have responses (e.g. Desert's end-of-combat ping)
             Step.END -> !hasMeaningfulActions // Stop if we have responses
             Step.CLEANUP, Step.UNTAP -> true
         }

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/priority/AutoPassManagerTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/priority/AutoPassManagerTest.kt
@@ -294,6 +294,20 @@ class AutoPassManagerTest : FunSpec({
     )
 
     /**
+     * A targeted activated ability restricted to the end-of-combat step (e.g. Desert:
+     * "{T}: This land deals 1 damage to target attacking creature. Activate only during the
+     * end of combat step."). The engine only enumerates it during END_COMBAT with a legal
+     * (still-attacking) target, so its mere presence means the player can act now.
+     */
+    fun endOfCombatPingAction(playerId: EntityId, hasTargets: Boolean = true) = LegalActionInfo(
+        actionType = "ActivateAbility",
+        description = "Deal 1 damage to target attacking creature",
+        action = ActivateAbility(playerId, EntityId.generate(), AbilityId("desert-ping")),
+        requiresTargets = true,
+        validTargets = if (hasTargets) listOf(EntityId.generate()) else emptyList()
+    )
+
+    /**
      * A cast for an alternative cost (Sneak, evoke, flashback, …). The enumerators emit
      * `CastWithAlternativeCost` (and siblings) rather than `CastSpell`; the auto-pass logic must
      * still treat it as a castable spell so it stops in the window where it's legal.
@@ -537,6 +551,47 @@ class AutoPassManagerTest : FunSpec({
             val actions = listOf(
                 passPriorityAction(player2),
                 instantSpellAction(player2)
+            )
+
+            autoPassManager.shouldAutoPass(state, player2, actions) shouldBe true
+        }
+
+        test("STOP during opponent's end combat step with an end-of-combat activated ability (Desert)") {
+            // Desert's ping is only legal during END_COMBAT, and its target (a still-attacking
+            // creature) disappears when the step ends — so the defender must be stopped here or
+            // they can never use it.
+            val state = createMockState(player2, player1, Step.END_COMBAT)
+            val actions = listOf(
+                passPriorityAction(player2),
+                endOfCombatPingAction(player2)
+            )
+
+            autoPassManager.shouldAutoPass(state, player2, actions) shouldBe false
+        }
+
+        test("STOP during opponent's end combat step with an instant-speed response") {
+            val state = createMockState(player2, player1, Step.END_COMBAT)
+            val actions = listOf(
+                passPriorityAction(player2),
+                instantSpellAction(player2)
+            )
+
+            autoPassManager.shouldAutoPass(state, player2, actions) shouldBe false
+        }
+
+        test("Auto-pass during opponent's end combat step with no responses") {
+            val state = createMockState(player2, player1, Step.END_COMBAT)
+            val actions = listOf(passPriorityAction(player2))
+
+            autoPassManager.shouldAutoPass(state, player2, actions) shouldBe true
+        }
+
+        test("Auto-pass during opponent's end combat step when the end-of-combat ability has no legal target") {
+            // No attacking creatures left to target → nothing to stop for.
+            val state = createMockState(player2, player1, Step.END_COMBAT)
+            val actions = listOf(
+                passPriorityAction(player2),
+                endOfCombatPingAction(player2, hasTargets = false)
             )
 
             autoPassManager.shouldAutoPass(state, player2, actions) shouldBe true


### PR DESCRIPTION
## Problem

`Desert` (Arabian Nights) has a second activated ability restricted to the end of combat step:

> `{T}`: This land deals 1 damage to target attacking creature. **Activate only during the end of combat step.**

But you could never actually use it. `AutoPassManager` grouped `END_COMBAT` together with `COMBAT_DAMAGE` and auto-passed it **unconditionally** on the opponent's turn:

```kotlin
Step.COMBAT_DAMAGE, Step.END_COMBAT -> true
```

So the defending player never received priority in the *one* step where the ability is legal — and where its target (a still-attacking creature) still exists. This is the same class of bug as the earlier "auto-pass skipped instant-speed crew" fix: a legal action silently passed because the window it lives in wasn't treated as a stop.

## Fix

The end of combat step **does** have a priority window (CR 511.1), and creatures aren't removed from combat until the step *ends* (CR 511.3). Split `END_COMBAT` out of the `COMBAT_DAMAGE` branch and stop for it when the player has an instant-speed response — mirroring the existing `END` / declare-attackers / first-strike handling:

- **`COMBAT_DAMAGE`** keeps auto-passing (no meaningful window to hold for).
- **`END_COMBAT`** stops if the player has an instant-speed response, otherwise auto-passes.
- **My-turn `END_COMBAT`** is left Arena-aggressive (auto-pass even with instants in hand). Desert only ever targets *attacking* creatures, which on your own turn are yours — the realistic use is defending, on the opponent's turn.

The next-stop-point label logic (`shouldAutoPassOnOpponentTurnForStep`) is updated symmetrically so the Pass button points at end of combat when a response is available.

## Tests

Added to `AutoPassManagerTest` (opponent's-turn end-of-combat had no coverage before):

- STOP with an end-of-combat activated ability (Desert)
- STOP with a generic instant-speed response
- AUTO-PASS with no responses
- AUTO-PASS when the ability has no legal target (no attackers left)

The existing "auto-pass my end combat even with instants (Arena-style)" test still passes. Full `AutoPassManagerTest` class is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)