### PR TITLE
Nudge signed-out players to create an account on the menu screen

### DIFF
--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -473,6 +473,19 @@ function ConnectionOverlay({
                   Game Replays
                 </button>
               </div>
+
+              {accountsEnabled && authStatus !== 'authenticated' && (
+                <p className={styles.accountNudge}>
+                  <button
+                    type="button"
+                    onClick={() => setLoginOpen(true)}
+                    className={styles.accountNudgeButton}
+                  >
+                    Create a free account
+                  </button>{' '}
+                  to save your decks and track your stats — one magic link, no password.
+                </p>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## What

Follow-up to #1162. That PR nudges guests at the **Enter your name** step — but **returning users already have a stored name, so they skip that step entirely** and never see it. This adds a small matching nudge at the bottom of the post-name-entry **menu screen**, so signed-out players still get the prompt:

> **Create a free account** to save your decks and track your stats — one magic link, no password.

"Create a free account" opens the same magic-link `LoginModal`.

![Account nudge on the menu screen](https://raw.githubusercontent.com/wingedsheep/argentum-engine/account-nudge-menu-screen-screenshots/nudge-menu.png)

_(The "WebSocket connection error" banner in the screenshot is only an artifact of force-rendering the menu without a backend for the capture — it does not appear in the normal connected flow.)_

## How

- Reuses the exact machinery added in #1162 — same `accountsEnabled && authStatus !== 'authenticated'` gate, same `.accountNudge` / `.accountNudgeButton` styles, and the same `LoginModal` instance. Presentation only; no server/store/API changes.
- Placed under the secondary-buttons row in the `status === 'connected' && !sessionId` menu block.

## Files

- `web-client/src/components/ui/GameUI.tsx` — one gated nudge paragraph (+13 lines).

## Stacking

- **Based on `worktree-account-nudge-name-entry` (#1162), not `main`**, because it reuses the `loginOpen` state and `LoginModal` instance introduced there. Merge #1162 first, or GitHub will retarget this to `main` automatically once #1162 lands.

## Verification

- `npm run typecheck` passes.
- Manually verified the nudge renders at the bottom of the menu and opens the sign-in modal.

_Screenshot hosted on a throwaway `account-nudge-menu-screen-screenshots` branch (not part of this diff)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)