### PR TITLE
Add five Final Fantasy transform DFCs

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5308,9 +5308,12 @@ restriction matches the spell context.
   hand (exile, graveyard, top of library, command zone, …). Mm'menon, the Right Hand's
   granted artifact mana ability. Generalizes `CastFromExileOnly` by allowing all non-hand
   origins instead of exile alone; rejects ability activations.
-- `ManaRestriction.CardTypeSpellsOrAbilitiesOnly(cardType, allowSpells?, allowAbilities?)` —
+- `ManaRestriction.CardTypeSpellsOrAbilitiesOnly(cardType, allowSpells?, allowAbilities?, negated?)` —
   Steelswarm Operator shape. Use `cardType = CardType.ENCHANTMENT, allowSpells = true` for
-  "spend only to cast an enchantment spell."
+  "spend only to cast an enchantment spell." `negated = true` flips the type test for the
+  "non[type]" wordings — The Emperor of Palamecia's "Spend this mana only to cast a noncreature
+  spell" is `CardTypeSpellsOrAbilitiesOnly(CardType.CREATURE, negated = true)`; only the type
+  membership is negated, the allowSpells/allowAbilities gating is unchanged.
 - `ManaRestriction.AbilityActivationOnly` — only ability activations (any activated ability of
   any source). Satisfied by `SpellPaymentContext.isAbilityActivation`; unlike
   `CardTypeSpellsOrAbilitiesOnly`, the ability's source card type doesn't matter. Compose with

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/ManaRestriction.kt
@@ -226,6 +226,11 @@ sealed interface ManaRestriction {
      *   - `allowSpells=false, allowAbilities=true`  — Steelswarm Operator's second ability
      *   - `allowSpells=true,  allowAbilities=true`  — hypothetical "spells or abilities" mana
      *
+     * [negated] flips the type test: "cast non[cardType] spells [or activate abilities of
+     * non[cardType] sources]" — e.g. The Emperor of Palamecia's "Spend this mana only to cast
+     * a noncreature spell" is `CardTypeSpellsOrAbilitiesOnly(CardType.CREATURE, negated = true)`.
+     * Only the type membership is negated; the allowSpells/allowAbilities gating is unchanged.
+     *
      * Per the printed ruling, "[cardType] source" includes any object with that card type in
      * any zone (battlefield, hand, graveyard, etc.) — the engine evaluates source type from
      * the activating source's [com.wingedsheep.sdk.core.TypeLine] (plus projected types for
@@ -237,6 +242,7 @@ sealed interface ManaRestriction {
         val cardType: CardType,
         val allowSpells: Boolean = true,
         val allowAbilities: Boolean = false,
+        val negated: Boolean = false,
     ) : ManaRestriction {
         init {
             require(allowSpells || allowAbilities) {
@@ -246,9 +252,10 @@ sealed interface ManaRestriction {
 
         override val description: String = buildString {
             append("Spend this mana only to ")
+            val typeName = (if (negated) "non" else "") + cardType.displayName.lowercase()
             val clauses = buildList {
-                if (allowSpells) add("cast ${cardType.displayName.lowercase()} spells")
-                if (allowAbilities) add("activate abilities of ${cardType.displayName.lowercase()} sources")
+                if (allowSpells) add("cast $typeName spells")
+                if (allowAbilities) add("activate abilities of $typeName sources")
             }
             append(clauses.joinToString(" or "))
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestCardCollection.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestCardCollection.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sidequest: Card Collection // Magicked Card — Final Fantasy #73
+ * {3}{U} · Enchantment // Artifact — Vehicle · 4/4
+ *
+ * Front — Sidequest: Card Collection:
+ *   When this enchantment enters, draw three cards, then discard two cards.
+ *   At the beginning of your end step, if eight or more cards are in your graveyard,
+ *   transform this enchantment.
+ *
+ * Back — Magicked Card:
+ *   Flying
+ *   Crew 1
+ *
+ * The end-step transform is an intervening-"if" (checked when the trigger would go on the
+ * stack and again on resolution) over the card count of your graveyard.
+ */
+private val MagickedCard = card("Magicked Card") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Artifact — Vehicle"
+    oracleText = "Flying\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Jurijus Chitrovas"
+        imageUri = "https://cards.scryfall.io/normal/back/8/a/8ac3d2c9-5978-4cfb-a746-c901decff093.jpg?1782686540"
+    }
+}
+
+private val SidequestCardCollectionFront = card("Sidequest: Card Collection") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, draw three cards, then discard two cards.\n" +
+        "At the beginning of your end step, if eight or more cards are in your graveyard, transform this enchantment."
+
+    // When this enchantment enters, draw three cards, then discard two cards.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Effects.DrawCards(3),
+            Effects.Discard(2),
+        )
+    }
+
+    // At the beginning of your end step, if eight or more cards are in your graveyard,
+    // transform this enchantment.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.CardsInGraveyardAtLeast(8)
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "73"
+        artist = "Erikas Perl"
+        flavorText = "The glory of the tourney awaits!"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8ac3d2c9-5978-4cfb-a746-c901decff093.jpg?1782686540"
+
+        ruling(
+            "2025-06-06",
+            "Sidequest: Card Collection's last ability checks at the moment it would trigger to " +
+                "see if you have eight or more cards in your graveyard. If you don't, the ability " +
+                "won't trigger at all. If it does trigger, the ability will check again as it " +
+                "tries to resolve."
+        )
+    }
+}
+
+val SidequestCardCollection: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = SidequestCardCollectionFront,
+    backFace = MagickedCard,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestHuntTheMark.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestHuntTheMark.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.TurnTracker
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sidequest: Hunt the Mark // Yiazmat, Ultimate Mark — Final Fantasy #119
+ * {3}{B}{B} · Enchantment // Legendary Creature — Dragon · 5/6
+ *
+ * Front — Sidequest: Hunt the Mark:
+ *   When this enchantment enters, destroy up to one target creature.
+ *   At the beginning of your end step, if a creature died under an opponent's control this
+ *   turn, create a Treasure token. Then if you control three or more Treasures, transform
+ *   this enchantment.
+ *
+ * Back — Yiazmat, Ultimate Mark:
+ *   {1}{B}, Sacrifice another creature or artifact: Yiazmat gains indestructible until end
+ *   of turn. Tap it.
+ *
+ * The end-step trigger's intervening-"if" reads the opponents' creatures-died-this-turn
+ * tracker ([DynamicAmount.TurnTracking] over [Player.EachOpponent] sums across opponents);
+ * the "Then if" Treasure-count check is a resolution-time [ConditionalEffect], evaluated
+ * after the Treasure is created.
+ */
+private val YiazmatUltimateMark = card("Yiazmat, Ultimate Mark") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Dragon"
+    oracleText = "{1}{B}, Sacrifice another creature or artifact: Yiazmat gains indestructible " +
+        "until end of turn. Tap it."
+    power = 5
+    toughness = 6
+
+    // {1}{B}, Sacrifice another creature or artifact: Yiazmat gains indestructible until end
+    // of turn. Tap it.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}{B}"),
+            Costs.SacrificeAnother(GameObjectFilter.Creature or GameObjectFilter.Artifact),
+        )
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self),
+            Effects.Tap(EffectTarget.Self),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Joshua Raphael"
+        flavorText = "Legend says it is an Anima, guardian to a sacred blade. Though most " +
+            "sacred amongst its kind, its great power drove it to madness, and in the end, it " +
+            "became a threat to its own creator."
+        imageUri = "https://cards.scryfall.io/normal/back/c/3/c3eb2ae5-10de-4c3d-91c8-8734befc80b2.jpg?1782686509"
+    }
+}
+
+private val SidequestHuntTheMarkFront = card("Sidequest: Hunt the Mark") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, destroy up to one target creature.\n" +
+        "At the beginning of your end step, if a creature died under an opponent's control " +
+        "this turn, create a Treasure token. Then if you control three or more Treasures, " +
+        "transform this enchantment."
+
+    // When this enchantment enters, destroy up to one target creature.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target(
+            "creature",
+            TargetObject(optional = true, filter = TargetFilter.Creature),
+        )
+        effect = Effects.Destroy(t)
+    }
+
+    // At the beginning of your end step, if a creature died under an opponent's control this
+    // turn, create a Treasure token. Then if you control three or more Treasures, transform
+    // this enchantment.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.CompareAmounts(
+            DynamicAmount.TurnTracking(Player.EachOpponent, TurnTracker.CREATURES_DIED),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(1),
+        )
+        effect = Effects.Composite(
+            Effects.CreateTreasure(1),
+            ConditionalEffect(
+                condition = Conditions.YouControlAtLeast(3, GameObjectFilter.Artifact.withSubtype("Treasure")),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Nino Is"
+        imageUri = "https://cards.scryfall.io/normal/front/c/3/c3eb2ae5-10de-4c3d-91c8-8734befc80b2.jpg?1782686509"
+
+        ruling(
+            "2025-06-06",
+            "Sidequest: Hunt the Mark's last ability checks at the moment it would trigger to " +
+                "see if a creature died under an opponent's control this turn. If none did, the " +
+                "ability won't trigger at all. Once your end step begins, it's too late to cause " +
+                "creatures your opponents control to die in order to cause the ability to trigger."
+        )
+    }
+}
+
+val SidequestHuntTheMark: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = SidequestHuntTheMarkFront,
+    backFace = YiazmatUltimateMark,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestRaiseAChocobo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestRaiseAChocobo.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sidequest: Raise a Chocobo // Black Chocobo — Final Fantasy #201
+ * {1}{G} · Enchantment // Creature — Bird · 2/2
+ *
+ * Front — Sidequest: Raise a Chocobo:
+ *   When this enchantment enters, create a 2/2 green Bird creature token with "Whenever a
+ *   land you control enters, this token gets +1/+0 until end of turn."
+ *   At the beginning of your first main phase, if you control four or more Birds,
+ *   transform this enchantment.
+ *
+ * Back — Black Chocobo:
+ *   When this permanent transforms into Black Chocobo, search your library for a land card,
+ *   put it onto the battlefield tapped, then shuffle.
+ *   Landfall — Whenever a land you control enters, Birds you control get +1/+0 until end of turn.
+ *
+ * The token (same one Chocobo Racetrack makes) carries a granted landfall trigger via
+ * [CreateTokenEffect.triggeredAbilities]. The first-main transform is an intervening-"if"
+ * over the number of Birds you control.
+ */
+private val BlackChocobo = card("Black Chocobo") {
+    manaCost = ""
+    colorIdentity = "G"
+    typeLine = "Creature — Bird"
+    oracleText = "When this permanent transforms into Black Chocobo, search your library for a " +
+        "land card, put it onto the battlefield tapped, then shuffle.\n" +
+        "Landfall — Whenever a land you control enters, Birds you control get +1/+0 until end of turn."
+    power = 2
+    toughness = 2
+
+    // When this permanent transforms into Black Chocobo, search your library for a land card,
+    // put it onto the battlefield tapped, then shuffle.
+    triggeredAbility {
+        trigger = Triggers.TransformsToBack
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Land,
+            destination = SearchDestination.BATTLEFIELD,
+            entersTapped = true,
+        )
+    }
+
+    // Landfall — Whenever a land you control enters, Birds you control get +1/+0 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.LandYouControlEnters
+        effect = Patterns.Group.modifyStatsForAll(
+            power = 1,
+            toughness = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype("Bird").youControl()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "Sansyu"
+        imageUri = "https://cards.scryfall.io/normal/back/0/c/0cbf911c-a721-4b84-8645-d83a0966be18.jpg?1782686447"
+    }
+}
+
+private val SidequestRaiseAChocoboFront = card("Sidequest: Raise a Chocobo") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment"
+    oracleText = "When this enchantment enters, create a 2/2 green Bird creature token with " +
+        "\"Whenever a land you control enters, this token gets +1/+0 until end of turn.\"\n" +
+        "At the beginning of your first main phase, if you control four or more Birds, transform this enchantment."
+
+    // When this enchantment enters, create a 2/2 green Bird creature token with
+    // "Whenever a land you control enters, this token gets +1/+0 until end of turn."
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.GREEN),
+            creatureTypes = setOf("Bird"),
+            imageUri = "https://cards.scryfall.io/normal/front/1/f/1fbc471d-5948-47fc-b7cc-81cc13a4cd15.jpg?1782725374",
+            triggeredAbilities = listOf(
+                TriggeredAbility.create(
+                    trigger = Triggers.entersBattlefield(
+                        filter = GameObjectFilter.Land.youControl(),
+                        binding = TriggerBinding.ANY,
+                    ).event,
+                    binding = TriggerBinding.ANY,
+                    effect = Effects.ModifyStats(1, 0, EffectTarget.Self),
+                ),
+            ),
+        )
+    }
+
+    // At the beginning of your first main phase, if you control four or more Birds,
+    // transform this enchantment.
+    triggeredAbility {
+        trigger = Triggers.FirstMainPhase
+        triggerCondition = Conditions.YouControlAtLeast(4, GameObjectFilter.Creature.withSubtype("Bird"))
+        effect = TransformEffect(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "201"
+        artist = "Miho Midorikawa"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0cbf911c-a721-4b84-8645-d83a0966be18.jpg?1782686447"
+
+        ruling(
+            "2025-06-06",
+            "Sidequest: Raise a Chocobo's last ability checks at the moment it would trigger to " +
+                "see if you control four or more Birds. If you don't, the ability won't trigger " +
+                "at all. If it does trigger, the ability will check again as it tries to resolve."
+        )
+        ruling(
+            "2025-06-06",
+            "If this card somehow enters the battlefield with its back face up, it didn't " +
+                "transform, so you won't search."
+        )
+    }
+}
+
+val SidequestRaiseAChocobo: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = SidequestRaiseAChocoboFront,
+    backFace = BlackChocobo,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheEmperorOfPalamecia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheEmperorOfPalamecia.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.ManaColorSet
+
+/**
+ * The Emperor of Palamecia // The Lord Master of Hell — Final Fantasy #219
+ * {U}{R} · Legendary Creature — Human Noble Wizard · 2/2 // Legendary Creature — Demon Noble Wizard · 3/3
+ *
+ * Front — The Emperor of Palamecia:
+ *   {T}: Add {U} or {R}. Spend this mana only to cast a noncreature spell.
+ *   Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a
+ *   +1/+1 counter on The Emperor of Palamecia. Then if it has three or more +1/+1 counters
+ *   on it, transform it.
+ *
+ * Back — The Lord Master of Hell:
+ *   Starfall — Whenever The Lord Master of Hell attacks, it deals X damage to each opponent,
+ *   where X is the number of noncreature, nonland cards in your graveyard.
+ *
+ * The restricted mana ability composes [ManaColorSet.Specific] (pick {U} or {R}) with the
+ * negated card-type restriction ("noncreature spells only"). The cast trigger's four-mana
+ * gate reads [ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL] — the mana actually paid
+ * for the *triggering* spell (the Opus idiom); the amount is fixed history, so checking it
+ * at resolution is equivalent to the printed intervening-"if". The "Then if" transform check
+ * runs after the counter lands, counting via [Conditions.SourceCounterCountAtLeast].
+ */
+private val TheLordMasterOfHell = card("The Lord Master of Hell") {
+    manaCost = ""
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Demon Noble Wizard"
+    oracleText = "Starfall — Whenever The Lord Master of Hell attacks, it deals X damage to " +
+        "each opponent, where X is the number of noncreature, nonland cards in your graveyard."
+    power = 3
+    toughness = 3
+
+    // Starfall — Whenever The Lord Master of Hell attacks, it deals X damage to each opponent,
+    // where X is the number of noncreature, nonland cards in your graveyard.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.DealDamage(
+            amount = DynamicAmount.Count(
+                Player.You,
+                Zone.GRAVEYARD,
+                GameObjectFilter.Noncreature and GameObjectFilter.Nonland,
+            ),
+            target = EffectTarget.PlayerRef(Player.EachOpponent),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Heonhwa"
+        flavorText = "\"All the world shall fall by my hand.\""
+        imageUri = "https://cards.scryfall.io/normal/back/3/d/3d75e8fd-6139-4b10-9ce3-195b47d72e0c.jpg?1782686430"
+    }
+}
+
+private val TheEmperorOfPalameciaFront = card("The Emperor of Palamecia") {
+    manaCost = "{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Human Noble Wizard"
+    oracleText = "{T}: Add {U} or {R}. Spend this mana only to cast a noncreature spell.\n" +
+        "Whenever you cast a noncreature spell, if at least four mana was spent to cast it, " +
+        "put a +1/+1 counter on The Emperor of Palamecia. Then if it has three or more +1/+1 " +
+        "counters on it, transform it."
+    power = 2
+    toughness = 2
+
+    // {T}: Add {U} or {R}. Spend this mana only to cast a noncreature spell.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice(
+            colorSet = ManaColorSet.Specific(setOf(Color.BLUE, Color.RED)),
+            restriction = ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                cardType = CardType.CREATURE,
+                negated = true,
+            ),
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add {U} or {R}. Spend this mana only to cast a noncreature spell."
+    }
+
+    // Whenever you cast a noncreature spell, if at least four mana was spent to cast it, put a
+    // +1/+1 counter on The Emperor of Palamecia. Then if it has three or more +1/+1 counters
+    // on it, transform it.
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = ConditionalEffect(
+            condition = Compare(
+                DynamicAmount.ContextProperty(ContextPropertyKey.MANA_SPENT_ON_TRIGGERING_SPELL),
+                ComparisonOperator.GTE,
+                DynamicAmount.Fixed(4),
+            ),
+            effect = Effects.Composite(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                ConditionalEffect(
+                    condition = Conditions.SourceCounterCountAtLeast(Counters.PLUS_ONE_PLUS_ONE, 3),
+                    effect = TransformEffect(EffectTarget.Self),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "219"
+        artist = "Heonhwa"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d75e8fd-6139-4b10-9ce3-195b47d72e0c.jpg?1782686430"
+
+        ruling(
+            "2025-06-06",
+            "The Emperor of Palamecia's last ability resolves before the spell that caused it " +
+                "to trigger. It resolves even if that spell is countered or otherwise leaves the stack."
+        )
+        ruling(
+            "2025-06-06",
+            "The value of X is calculated only once, as The Lord Master of Hell's ability resolves."
+        )
+    }
+}
+
+val TheEmperorOfPalamecia: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = TheEmperorOfPalameciaFront,
+    backFace = TheLordMasterOfHell,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/UltimeciaTimeSorceress.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/UltimeciaTimeSorceress.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ultimecia, Time Sorceress // Ultimecia, Omnipotent — Final Fantasy #247
+ * {3}{U}{B} · Legendary Creature — Human Warlock · 4/5 // Legendary Creature — Nightmare Warlock · 7/7
+ *
+ * Front — Ultimecia, Time Sorceress:
+ *   Whenever Ultimecia enters or attacks, surveil 2.
+ *   At the beginning of your end step, you may pay {4}{U}{U}{B}{B} and exile eight cards
+ *   from your graveyard. If you do, transform Ultimecia.
+ *
+ * Back — Ultimecia, Omnipotent:
+ *   Menace
+ *   Time Compression — When this creature transforms into Ultimecia, Omnipotent, take an
+ *   extra turn after this one.
+ *
+ * "Enters or attacks" is the Gilgamesh/Frodo shape: two sibling triggered abilities. The
+ * end-step pay-and-exile is an [OptionalCostEffect] (Gate.MayPay) whose cost composes a mana
+ * payment with a choose-exactly-8 exile pipeline, wrapped in a [ConditionalEffect] requiring
+ * eight cards in your graveyard — the MayPay affordability pre-pass checks the mana half but
+ * cannot see into the pipeline half, so the condition keeps an unpayable "yes" from being
+ * offered (you can't partially pay a cost).
+ */
+private val UltimeciaOmnipotent = card("Ultimecia, Omnipotent") {
+    manaCost = ""
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Nightmare Warlock"
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "Time Compression — When this creature transforms into Ultimecia, Omnipotent, take an " +
+        "extra turn after this one."
+    power = 7
+    toughness = 7
+
+    keywords(Keyword.MENACE)
+
+    // Time Compression — When this creature transforms into Ultimecia, Omnipotent, take an
+    // extra turn after this one.
+    triggeredAbility {
+        trigger = Triggers.TransformsToBack
+        effect = Effects.TakeExtraTurn()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "247"
+        artist = "Mikio Masuda"
+        flavorText = "\"Time... it will not wait... no matter... how hard you hold on. It escapes you...\""
+        imageUri = "https://cards.scryfall.io/normal/back/2/d/2d6a2b68-5407-464e-a335-7866fd969c30.jpg?1782686404"
+    }
+}
+
+private val UltimeciaTimeSorceressFront = card("Ultimecia, Time Sorceress") {
+    manaCost = "{3}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Human Warlock"
+    oracleText = "Whenever Ultimecia enters or attacks, surveil 2. (Look at the top two cards " +
+        "of your library, then put any number of them into your graveyard and the rest on top " +
+        "of your library in any order.)\n" +
+        "At the beginning of your end step, you may pay {4}{U}{U}{B}{B} and exile eight cards " +
+        "from your graveyard. If you do, transform Ultimecia."
+    power = 4
+    toughness = 5
+
+    // "Whenever Ultimecia enters …"
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Surveil(2)
+    }
+
+    // "… or attacks, surveil 2."
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.Surveil(2)
+    }
+
+    // At the beginning of your end step, you may pay {4}{U}{U}{B}{B} and exile eight cards
+    // from your graveyard. If you do, transform Ultimecia.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = ConditionalEffect(
+            condition = Conditions.CardsInGraveyardAtLeast(8),
+            effect = OptionalCostEffect(
+                cost = Effects.Composite(
+                    PayManaCostEffect(ManaCost.parse("{4}{U}{U}{B}{B}")),
+                    Effects.Pipeline {
+                        val grave = gather(
+                            CardSource.FromZone(Zone.GRAVEYARD, Player.You),
+                            name = "graveyardCards",
+                        )
+                        val toExile = chooseExactly(
+                            8,
+                            from = grave,
+                            prompt = "Choose eight cards from your graveyard to exile",
+                        )
+                        move(toExile, CardDestination.ToZone(Zone.EXILE))
+                    },
+                ),
+                ifPaid = TransformEffect(EffectTarget.Self),
+                descriptionOverride = "Pay {4}{U}{U}{B}{B} and exile eight cards from your " +
+                    "graveyard? If you do, transform Ultimecia.",
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "247"
+        artist = "Mikio Masuda"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2d6a2b68-5407-464e-a335-7866fd969c30.jpg?1782686404"
+    }
+}
+
+val UltimeciaTimeSorceress: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = UltimeciaTimeSorceressFront,
+    backFace = UltimeciaOmnipotent,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -14960,6 +14960,494 @@
     ]
 }
 
+// Sidequest: Card Collection
+{
+    "name": "Sidequest: Card Collection",
+    "manaCost": "{3}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, draw three cards, then discard two cards.\nAt the beginning of your end step, if eight or more cards are in your graveyard, transform this enchantment.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 3
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 2 cards to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Magicked Card",
+        "manaCost": "",
+        "typeLine": "Artifact — Vehicle",
+        "oracleText": "Flying\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 4
+        },
+        "keywords": [
+            "FLYING",
+            "CREW"
+        ],
+        "keywordAbilities": [
+            {
+                "type": "Numeric",
+                "keyword": "CREW",
+                "n": 1
+            }
+        ],
+        "metadata": {
+            "collectorNumber": "73",
+            "rarity": "UNCOMMON",
+            "artist": "Jurijus Chitrovas",
+            "imageUri": "https://cards.scryfall.io/normal/back/8/a/8ac3d2c9-5978-4cfb-a746-c901decff093.jpg?1782686540"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "rarity": "UNCOMMON",
+        "artist": "Erikas Perl",
+        "flavorText": "The glory of the tourney awaits!",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8ac3d2c9-5978-4cfb-a746-c901decff093.jpg?1782686540",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "Sidequest: Card Collection's last ability checks at the moment it would trigger to see if you have eight or more cards in your graveyard. If you don't, the ability won't trigger at all. If it does trigger, the ability will check again as it tries to resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Sidequest: Hunt the Mark
+{
+    "name": "Sidequest: Hunt the Mark",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, destroy up to one target creature.\nAt the beginning of your end step, if a creature died under an opponent's control this turn, create a Treasure token. Then if you control three or more Treasures, transform this enchantment.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "creature"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "artifact Treasure"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    }
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "EachOpponent",
+                        "tracker": "CREATURES_DIED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Yiazmat, Ultimate Mark",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Dragon",
+        "oracleText": "{1}{B}, Sacrifice another creature or artifact: Yiazmat gains indestructible until end of turn. Tap it.",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 6
+        },
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{1}{B}"
+                                }
+                            },
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomSacrifice",
+                                    "filter": "creature|artifact",
+                                    "excludeSelf": true
+                                }
+                            }
+                        ]
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GrantKeyword",
+                                "keyword": "INDESTRUCTIBLE",
+                                "target": "Self"
+                            },
+                            {
+                                "type": "TapUntap",
+                                "target": "Self"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "119",
+            "rarity": "UNCOMMON",
+            "artist": "Joshua Raphael",
+            "flavorText": "Legend says it is an Anima, guardian to a sacred blade. Though most sacred amongst its kind, its great power drove it to madness, and in the end, it became a threat to its own creator.",
+            "imageUri": "https://cards.scryfall.io/normal/back/c/3/c3eb2ae5-10de-4c3d-91c8-8734befc80b2.jpg?1782686509"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "UNCOMMON",
+        "artist": "Nino Is",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/3/c3eb2ae5-10de-4c3d-91c8-8734befc80b2.jpg?1782686509",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "Sidequest: Hunt the Mark's last ability checks at the moment it would trigger to see if a creature died under an opponent's control this turn. If none did, the ability won't trigger at all. Once your end step begins, it's too late to cause creatures your opponents control to die in order to cause the ability to trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Sidequest: Raise a Chocobo
+{
+    "name": "Sidequest: Raise a Chocobo",
+    "manaCost": "{1}{G}",
+    "typeLine": "Enchantment",
+    "oracleText": "When this enchantment enters, create a 2/2 green Bird creature token with \"Whenever a land you control enters, this token gets +1/+0 until end of turn.\"\nAt the beginning of your first main phase, if you control four or more Birds, transform this enchantment.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "GREEN"
+                    ],
+                    "creatureTypes": [
+                        "Bird"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/1/f/1fbc471d-5948-47fc-b7cc-81cc13a4cd15.jpg?1782725374",
+                    "triggeredAbilities": [
+                        {
+                            "id": "ability_2",
+                            "trigger": {
+                                "type": "ZoneChangeEvent",
+                                "filter": "land ctrl:you",
+                                "to": "Battlefield"
+                            },
+                            "binding": "ANY",
+                            "effect": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "target": "Self"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "PRECOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": "Transform",
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Bird"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Black Chocobo",
+        "manaCost": "",
+        "typeLine": "Creature — Bird",
+        "oracleText": "When this permanent transforms into Black Chocobo, search your library for a land card, put it onto the battlefield tapped, then shuffle.\nLandfall — Whenever a land you control enters, Birds you control get +1/+0 until end of turn.",
+        "creatureStats": {
+            "power": 2,
+            "toughness": 2
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_4",
+                    "trigger": {
+                        "type": "TransformEvent",
+                        "intoBackFace": true
+                    },
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "land"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    }
+                },
+                {
+                    "id": "ability_5",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "filter": "land ctrl:you",
+                        "to": "Battlefield"
+                    },
+                    "binding": "OTHER",
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature Bird ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "201",
+            "rarity": "UNCOMMON",
+            "artist": "Sansyu",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/c/0cbf911c-a721-4b84-8645-d83a0966be18.jpg?1782686447"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "rarity": "UNCOMMON",
+        "artist": "Miho Midorikawa",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0cbf911c-a721-4b84-8645-d83a0966be18.jpg?1782686447",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "Sidequest: Raise a Chocobo's last ability checks at the moment it would trigger to see if you control four or more Birds. If you don't, the ability won't trigger at all. If it does trigger, the ability will check again as it tries to resolve."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "If this card somehow enters the battlefield with its back face up, it didn't transform, so you won't search."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Sin, Spira's Punishment
 {
     "name": "Sin, Spira's Punishment",
@@ -17932,6 +18420,175 @@
     ]
 }
 
+// The Emperor of Palamecia
+{
+    "name": "The Emperor of Palamecia",
+    "manaCost": "{U}{R}",
+    "typeLine": "Legendary Creature — Human Noble Wizard",
+    "oracleText": "{T}: Add {U} or {R}. Spend this mana only to cast a noncreature spell.\nWhenever you cast a noncreature spell, if at least four mana was spent to cast it, put a +1/+1 counter on The Emperor of Palamecia. Then if it has three or more +1/+1 counters on it, transform it.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "ContextProperty",
+                                "key": "MANA_SPENT_ON_TRIGGERING_SPELL"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 4
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "Compare",
+                                        "left": {
+                                            "type": "EntityProperty",
+                                            "entity": "Source",
+                                            "numericProperty": {
+                                                "type": "CounterCount",
+                                                "counterType": {
+                                                    "type": "Named",
+                                                    "name": "+1/+1"
+                                                }
+                                            }
+                                        },
+                                        "operator": "GTE",
+                                        "right": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        }
+                                    }
+                                },
+                                "then": "Transform"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "colorSet": {
+                        "type": "ManaColorSet.Specific",
+                        "colors": [
+                            "BLUE",
+                            "RED"
+                        ]
+                    },
+                    "restriction": {
+                        "type": "CardTypeSpellsOrAbilitiesOnly",
+                        "cardType": "CREATURE",
+                        "negated": true
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add {U} or {R}. Spend this mana only to cast a noncreature spell."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "The Lord Master of Hell",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Demon Noble Wizard",
+        "oracleText": "Starfall — Whenever The Lord Master of Hell attacks, it deals X damage to each opponent, where X is the number of noncreature, nonland cards in your graveyard.",
+        "creatureStats": {
+            "power": 3,
+            "toughness": 3
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "filter": "noncreature nonland"
+                        },
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "EachOpponent"
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "219",
+            "rarity": "UNCOMMON",
+            "artist": "Heonhwa",
+            "flavorText": "\"All the world shall fall by my hand.\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/3/d/3d75e8fd-6139-4b10-9ce3-195b47d72e0c.jpg?1782686430"
+        },
+        "colorIdentityOverride": [
+            "BLUE",
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "219",
+        "rarity": "UNCOMMON",
+        "artist": "Heonhwa",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d75e8fd-6139-4b10-9ce3-195b47d72e0c.jpg?1782686430",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "The Emperor of Palamecia's last ability resolves before the spell that caused it to trigger. It resolves even if that spell is countered or otherwise leaves the stack."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "The value of X is calculated only once, as The Lord Master of Hell's ability resolves."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // The Final Days
 {
     "name": "The Final Days",
@@ -19688,6 +20345,165 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Ultimecia, Time Sorceress
+{
+    "name": "Ultimecia, Time Sorceress",
+    "manaCost": "{3}{U}{B}",
+    "typeLine": "Legendary Creature — Human Warlock",
+    "oracleText": "Whenever Ultimecia enters or attacks, surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.)\nAt the beginning of your end step, you may pay {4}{U}{U}{B}{B} and exile eight cards from your graveyard. If you do, transform Ultimecia.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Surveil",
+                    "count": 2
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Surveil",
+                    "count": 2
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Compare",
+                            "left": {
+                                "type": "Count",
+                                "player": "You",
+                                "zone": "Graveyard"
+                            },
+                            "operator": "GTE",
+                            "right": {
+                                "type": "Fixed",
+                                "amount": 8
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.MayPay",
+                            "cost": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "PayManaCost",
+                                        "cost": "{4}{U}{U}{B}{B}"
+                                    },
+                                    {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "FromZone",
+                                                    "zone": "Graveyard"
+                                                },
+                                                "storeAs": "graveyardCards"
+                                            },
+                                            {
+                                                "type": "SelectFromCollection",
+                                                "from": "graveyardCards",
+                                                "selection": {
+                                                    "type": "ChooseExactly",
+                                                    "count": {
+                                                        "type": "Fixed",
+                                                        "amount": 8
+                                                    }
+                                                },
+                                                "storeSelected": "selected1",
+                                                "prompt": "Choose eight cards from your graveyard to exile"
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "selected1",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Exile"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "then": "Transform",
+                        "descriptionOverride": "Pay {4}{U}{U}{B}{B} and exile eight cards from your graveyard? If you do, transform Ultimecia."
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Ultimecia, Omnipotent",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Nightmare Warlock",
+        "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nTime Compression — When this creature transforms into Ultimecia, Omnipotent, take an extra turn after this one.",
+        "creatureStats": {
+            "power": 7,
+            "toughness": 7
+        },
+        "keywords": [
+            "MENACE"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_4",
+                    "trigger": {
+                        "type": "TransformEvent",
+                        "intoBackFace": true
+                    },
+                    "effect": "TakeExtraTurn"
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "247",
+            "rarity": "UNCOMMON",
+            "artist": "Mikio Masuda",
+            "flavorText": "\"Time... it will not wait... no matter... how hard you hold on. It escapes you...\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/2/d/2d6a2b68-5407-464e-a335-7866fd969c30.jpg?1782686404"
+        },
+        "colorIdentityOverride": [
+            "BLUE",
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "247",
+        "rarity": "UNCOMMON",
+        "artist": "Mikio Masuda",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2d6a2b68-5407-464e-a335-7866fd969c30.jpg?1782686404"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
@@ -86,8 +86,8 @@ fun ManaRestriction.isSatisfiedBy(context: SpellPaymentContext): Boolean = when 
         !context.isAbilityActivation &&
             subtypes.any { sub -> context.subtypes.any { it.equals(sub, ignoreCase = true) } }
     is ManaRestriction.CardTypeSpellsOrAbilitiesOnly ->
-        if (context.isAbilityActivation) allowAbilities && cardType in context.abilitySourceCardTypes
-        else allowSpells && cardType in context.cardTypes
+        if (context.isAbilityActivation) allowAbilities && (cardType in context.abilitySourceCardTypes) != negated
+        else allowSpells && (cardType in context.cardTypes) != negated
 }
 
 @Serializable

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NoncreatureManaRestrictionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NoncreatureManaRestrictionTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Tests for the negated card-type mana restriction —
+ * [ManaRestriction.CardTypeSpellsOrAbilitiesOnly] with `negated = true`
+ * ("Spend this mana only to cast a noncreature spell", The Emperor of Palamecia).
+ */
+class NoncreatureManaRestrictionTest : FunSpec({
+
+    val noncreatureOnly = ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+        cardType = CardType.CREATURE,
+        negated = true,
+    )
+
+    val testInstant = card("Test Noncreature Instant") {
+        manaCost = "{U}"
+        typeLine = "Instant"
+        oracleText = "Draw a card."
+        spell {
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    val testCreature = card("Test Plain Creature") {
+        manaCost = "{U}"
+        typeLine = "Creature — Human"
+        power = 1
+        toughness = 1
+    }
+
+    fun createDriver(extraCards: List<CardDefinition> = emptyList()): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + extraCards)
+        return driver
+    }
+
+    test("negated restriction renders a non-prefixed description") {
+        noncreatureOnly.description shouldContain "noncreature"
+    }
+
+    test("noncreature-only mana CAN pay for an instant") {
+        val driver = createDriver(listOf(testInstant))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20), skipMulligans = true)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.giveRestrictedMana(activePlayer, Color.BLUE, 1, noncreatureOnly)
+
+        val instantId = driver.putCardInHand(activePlayer, "Test Noncreature Instant")
+        val castResult = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = instantId,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        castResult.isSuccess shouldBe true
+
+        val pool = driver.state.getEntity(activePlayer)?.get<ManaPoolComponent>()
+        pool!!.restrictedMana.size shouldBe 0
+    }
+
+    test("noncreature-only mana CANNOT pay for a creature spell") {
+        val driver = createDriver(listOf(testCreature))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20), skipMulligans = true)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.giveRestrictedMana(activePlayer, Color.BLUE, 1, noncreatureOnly)
+
+        val creatureId = driver.putCardInHand(activePlayer, "Test Plain Creature")
+        val castResult = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = creatureId,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        castResult.isSuccess shouldBe false
+    }
+
+    test("non-negated restriction is unchanged: creature-type-only mana pays creature spells") {
+        val creatureOnly = ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+            cardType = CardType.CREATURE,
+            negated = false,
+        )
+        val driver = createDriver(listOf(testCreature))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20), skipMulligans = true)
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.giveRestrictedMana(activePlayer, Color.BLUE, 1, creatureOnly)
+
+        val creatureId = driver.putCardInHand(activePlayer, "Test Plain Creature")
+        val castResult = driver.submit(
+            CastSpell(
+                playerId = activePlayer,
+                cardId = creatureId,
+                paymentStrategy = PaymentStrategy.FromPool,
+            )
+        )
+        castResult.isSuccess shouldBe true
+    }
+})


### PR DESCRIPTION
## Summary

Implements five missing FIN cards (all nonmodal double-faced), taking the set from 267/300 to 272/300:

| Card | Front | Back |
|---|---|---|
| **Sidequest: Card Collection // Magicked Card** (#73) | ETB draw 3/discard 2; end-step transform at 8+ cards in graveyard (intervening-if) | 4/4 Vehicle, flying, crew 1 |
| **Sidequest: Raise a Chocobo // Black Chocobo** (#201) | ETB 2/2 Bird token carrying a granted landfall pump trigger; first-main transform at 4+ Birds | Fetches a tapped land on transform; landfall pumps your Birds |
| **Sidequest: Hunt the Mark // Yiazmat, Ultimate Mark** (#119) | ETB destroy up to one target creature; end-step Treasure + transform at 3+ Treasures, gated on a creature dying under an opponent's control this turn | {1}{B}, sac another creature or artifact: indestructible, tap it |
| **Ultimecia, Time Sorceress // Ultimecia, Omnipotent** (#247) | Enters-or-attacks surveil 2; end-step "you may pay {4}{U}{U}{B}{B} and exile eight cards from your graveyard → transform" | Menace; extra turn on transforming |
| **The Emperor of Palamecia // The Lord Master of Hell** (#219) | {T}: Add {U} or {R}, noncreature spells only; 4+-mana noncreature casts add +1/+1 counters, transforms at 3 | Attack trigger: X damage to each opponent, X = noncreature/nonland cards in your graveyard |

Everything composes existing primitives (transform DFC factories, `Gate.MayPay` composite costs, `TurnTracking(Player.EachOpponent, CREATURES_DIED)`, `Effects.Pipeline`, granted token triggers), except one small SDK addition:

## SDK/engine change

`ManaRestriction.CardTypeSpellsOrAbilitiesOnly` gains a `negated: Boolean = false` flag for the "Spend this mana only to cast a non[type] spell" wordings (Emperor's noncreature restriction; covers future nonartifact/nonland variants). Only the type-membership test is negated — the `allowSpells`/`allowAbilities` gating is unchanged. Honored in `ManaPool.isSatisfiedBy`, documented in `card-sdk-language-reference.md`, and covered by `NoncreatureManaRestrictionTest` (pay-eligible, pay-ineligible, and non-negated regression paths).

No mtgish bridge/emitter entry: FIN cards aren't in the mtgish IR (name-join misses), and the restricted two-color mana shape isn't rendered by the emitter.

## Modeling notes

- "Enters or attacks" is the established two-sibling-trigger shape (Gilgamesh/Frodo).
- Ultimecia's pay-and-exile-8 cost is `Gate.MayPay` over `Composite(PayManaCostEffect, choose-exactly-8 exile pipeline)`, wrapped in a `CardsInGraveyardAtLeast(8)` condition — the MayPay affordability pre-pass checks the mana half but can't see into a pipeline cost, so the condition prevents offering an unpayable "yes" (you can't partially pay a cost).
- Emperor's four-mana gate reads `MANA_SPENT_ON_TRIGGERING_SPELL` at resolution (the Opus idiom); the amount is fixed history so this is equivalent to the printed intervening-if.
- Mechanically significant Scryfall rulings (intervening-if double-checks, enters-transformed ≠ transforms, X-computed-once) are recorded in `metadata { ruling(...) }`.

## Testing

- `:rules-engine:test` full suite green (including the new `NoncreatureManaRestrictionTest`)
- `:mtg-sets:test` green — card lint, facade boundary, and re-blessed FIN snapshot golden (verified semantically: only the five new card trees added, zero existing trees changed)
- `just check-card-printing` OK for all five (FIN is the earliest real printing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)