### PR TITLE
Fix 9 Bloomburrow oracle-fidelity bugs found in a set-wide audit

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3059,9 +3059,12 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
   Triggering permanent is `EffectTarget.TriggeringEntity`. Stalwart Successor shape.
 - `CountersPlacedOnThis` — "whenever you put one or more counters on ~" (any kind, SELF-bound).
   Aragorn, Company Leader.
-- `OneOrMorePermanentsEnter(filter?)` — batched ETB trigger; fires at most once per event batch
-  (CR 603.3b). The `filter`'s controller predicate scopes which players' permanents count: no
-  predicate means "you control" (default), `.opponentControls()` scopes to your opponents. The
+- `OneOrMorePermanentsEnter(filter?, excludeSource?)` — batched ETB trigger; fires at most once per
+  event batch (CR 603.3b). The `filter`'s controller predicate scopes which players' permanents
+  count: no predicate means "you control" (default), `.opponentControls()` scopes to your opponents.
+  `excludeSource = true` models "one or more **other** … you control enter" — the source's own entry
+  never counts toward the batch (Valley Questcaller); leave it false for wordings that include the
+  source ("Satoru and/or one or more other creatures…"). The
   matching members of the batch are exposed to the payoff as the pipeline collection
   `PipelineState.TRIGGER_CAPTURED_COLLECTION` — iterate them with
   `ForEachInCollectionEffect(PipelineState.TRIGGER_CAPTURED_COLLECTION, body)` where the body uses

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1696,9 +1696,16 @@ object Triggers {
      *
      * Example: "Whenever one or more noncreature, nonland permanents you control enter"
      * → OneOrMorePermanentsEnter(GameObjectFilter.Noncreature and GameObjectFilter.Nonland)
+     *
+     * [excludeSource] models "one or more OTHER … you control enter" (Valley Questcaller):
+     * the source's own entry never counts toward the batch. Leave false for wordings that
+     * include the source ("Satoru and/or one or more other creatures…").
      */
-    fun OneOrMorePermanentsEnter(filter: GameObjectFilter = GameObjectFilter.Any): TriggerSpec = TriggerSpec(
-        event = PermanentsEnteredEvent(filter = filter),
+    fun OneOrMorePermanentsEnter(
+        filter: GameObjectFilter = GameObjectFilter.Any,
+        excludeSource: Boolean = false
+    ): TriggerSpec = TriggerSpec(
+        event = PermanentsEnteredEvent(filter = filter, excludeSource = excludeSource),
         binding = TriggerBinding.ANY
     )
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -1863,10 +1863,18 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     @SerialName("PermanentsEnteredEvent")
     @Serializable
     data class PermanentsEnteredEvent(
-        val filter: GameObjectFilter = GameObjectFilter.Any
+        val filter: GameObjectFilter = GameObjectFilter.Any,
+        /**
+         * "One or more OTHER …" — the trigger's own source never counts toward the batch,
+         * so the ability doesn't fire off its source's own entry (Valley Questcaller).
+         * Contrast Satoru, the Infiltrator ("Satoru and/or one or more other creatures"),
+         * which deliberately counts itself and leaves this false.
+         */
+        val excludeSource: Boolean = false
     ) : EventPattern {
         override val description: String = buildString {
             append("one or more ")
+            if (excludeSource) append("other ")
             append(describeObjectForEvent(filter))
             append(" you control enter the battlefield")
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/AgateBladeAssassin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/AgateBladeAssassin.kt
@@ -29,7 +29,7 @@ val AgateBladeAssassin = card("Agate-Blade Assassin") {
         trigger = Triggers.Attacks
         effect = Effects.Composite(
             listOf(
-                LoseLifeEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                LoseLifeEffect(1, EffectTarget.PlayerRef(Player.DefendingPlayer)),
                 GainLifeEffect(1, EffectTarget.Controller)
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CarrotCake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CarrotCake.kt
@@ -15,10 +15,6 @@ import com.wingedsheep.sdk.model.Rarity
  * When this artifact enters and when you sacrifice it, create a 1/1 white
  * Rabbit creature token and scry 1.
  * {2}, {T}, Sacrifice this artifact: You gain 3 life.
- *
- * Note: "When you sacrifice it" is approximated using the Dies trigger
- * (battlefield → graveyard with SELF binding). This covers sacrifice cases
- * and also destroy, which is slightly broader than oracle text specifies.
  */
 val CarrotCake = card("Carrot Cake") {
     manaCost = "{1}{W}"
@@ -40,9 +36,10 @@ val CarrotCake = card("Carrot Cake") {
         effect = createRabbitAndScry
     }
 
-    // When you sacrifice it — same effect (create Rabbit token + scry 1)
+    // When you sacrifice it — same effect (create Rabbit token + scry 1).
+    // Sacrifice only: destruction or other battlefield→graveyard moves must not trigger this.
     triggeredAbility {
-        trigger = Triggers.Dies
+        trigger = Triggers.Sacrificed
         effect = createRabbitAndScry
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/FinneasAceArcher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/FinneasAceArcher.kt
@@ -45,7 +45,9 @@ val FinneasAceArcher = card("Finneas, Ace Archer") {
 
         // Put a +1/+1 counter on each other creature you control that's a token or a Rabbit
         // Then if creatures you control have total power 10 or greater, draw a card
-        val tokenOrRabbitFilter = GameObjectFilter.Token or GameObjectFilter.Creature.withSubtype("Rabbit")
+        // "each other CREATURE … that's a token or a Rabbit" — noncreature tokens
+        // (Food, Treasure, …) don't get counters
+        val tokenOrRabbitFilter = GameObjectFilter.Creature.token() or GameObjectFilter.Creature.withSubtype("Rabbit")
         val otherTokenOrRabbitYouControl = GroupFilter(
             baseFilter = tokenOrRabbitFilter.youControl(),
             excludeSelf = true

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MabelsMettle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MabelsMettle.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
 
 /**
  * Mabel's Mettle {1}{W}
@@ -21,7 +22,8 @@ val MabelsMettle = card("Mabel's Mettle") {
 
     spell {
         val primary = target("target creature", Targets.Creature)
-        val secondary = target("up to one other target creature", TargetCreature(optional = true))
+        // "other target creature" — must differ from the first target (CR 601.2c)
+        val secondary = target("up to one other target creature", TargetOther(TargetCreature(optional = true)))
         effect = Effects.ModifyStats(2, 2, primary)
             .then(Effects.ModifyStats(1, 1, secondary))
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/SkyskipperDuo.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/SkyskipperDuo.kt
@@ -40,7 +40,8 @@ val SkyskipperDuo = card("Skyskipper Duo") {
         val creature = target(
             "other creature you control",
             TargetCreature(
-                filter = TargetFilter(GameObjectFilter.Creature.youControl()),
+                // "one OTHER target creature you control" — Skyskipper Duo can't blink itself
+                filter = TargetFilter(GameObjectFilter.Creature.youControl()).other(),
                 optional = true
             )
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StormchasersTalent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StormchasersTalent.kt
@@ -3,11 +3,11 @@ package com.wingedsheep.mtg.sets.definitions.blb.cards
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
 
 /**
  * Stormchaser's Talent {U}
@@ -43,11 +43,14 @@ val StormchasersTalent = card("Stormchaser's Talent") {
         )
     }
 
-    // Level 2: When this becomes level 2, return target instant or sorcery from graveyard to hand
+    // Level 2: When this becomes level 2, return target instant or sorcery from YOUR graveyard to hand
     classLevel(2, "{3}{U}") {
         triggeredAbility {
             trigger = Triggers.EntersBattlefield
-            val card = target("instant or sorcery card in a graveyard", Targets.InstantOrSorceryInGraveyard)
+            val card = target(
+                "instant or sorcery card in your graveyard",
+                TargetObject(filter = TargetFilter.InstantOrSorceryInYourGraveyard)
+            )
             effect = Effects.ReturnToHand(card)
         }
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ValleyQuestcaller.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ValleyQuestcaller.kt
@@ -1,15 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.blb.cards
 
 import com.wingedsheep.sdk.core.Subtype
-import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.EventPattern.ZoneChangeEvent
 import com.wingedsheep.sdk.scripting.ModifyStats
-import com.wingedsheep.sdk.scripting.TriggerBinding
-import com.wingedsheep.sdk.scripting.TriggerSpec
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 
 /**
@@ -35,15 +32,11 @@ val ValleyQuestcaller = card("Valley Questcaller") {
     )
     val valleyCreatureFilter = GameObjectFilter.Creature.youControl().withAnyOfSubtypes(valleySubtypes)
 
-    // Triggered: whenever one or more other matching creatures ETB under your control, scry 1
+    // Triggered: whenever one or more other matching creatures ETB under your control, scry 1.
+    // Batched (CR 603.3b): simultaneous entries yield a single scry, and Questcaller's own
+    // entry doesn't count ("other") — but it does trigger off others entering alongside it.
     triggeredAbility {
-        trigger = TriggerSpec(
-            event = ZoneChangeEvent(
-                filter = valleyCreatureFilter,
-                to = Zone.BATTLEFIELD
-            ),
-            binding = TriggerBinding.OTHER
-        )
+        trigger = Triggers.OneOrMorePermanentsEnter(valleyCreatureFilter, excludeSource = true)
         effect = Patterns.Library.scry(1)
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/VrenTheRelentless.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/VrenTheRelentless.kt
@@ -2,13 +2,14 @@ package com.wingedsheep.mtg.sets.definitions.blb.cards
 
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.core.Color
-import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Subtype
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
 import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
 import com.wingedsheep.sdk.scripting.RedirectZoneChange
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
@@ -39,8 +40,9 @@ val VrenTheRelentless = card("Vren, the Relentless") {
         "\"This creature gets +1/+1 for each other Rat you control,\" where X is the number " +
         "of creatures that were exiled under your opponents' control this turn."
 
-    // Ward {2} — keyword display only; ward mechanic not yet enforced by engine
-    keywords(Keyword.WARD)
+    // Ward {2} — enforced: spells/abilities an opponent controls that target Vren are
+    // countered unless that player pays {2}
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
 
     // Replacement effect: if a creature an opponent controls would die, exile it instead
     replacementEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WarSqueak.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WarSqueak.kt
@@ -30,11 +30,10 @@ val WarSqueak = card("War Squeak") {
     auraTarget = Targets.Creature
 
     // When this Aura enters, target creature an opponent controls can't block this turn.
-    // Using CantAttackOrBlock as closest available effect (slightly stronger than card text)
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
         target = Targets.CreatureOpponentControls
-        effect = Effects.CantAttackOrBlock(EffectTarget.ContextTarget(0))
+        effect = Effects.CantBlock(EffectTarget.ContextTarget(0))
     }
 
     // Enchanted creature gets +1/+1

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -103,7 +103,7 @@
                             },
                             "target": {
                                 "type": "PlayerRef",
-                                "player": "EachOpponent"
+                                "player": "DefendingPlayer"
                             }
                         },
                         {
@@ -2960,11 +2960,7 @@
             },
             {
                 "id": "ability_2",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "from": "Battlefield",
-                    "to": "Graveyard"
-                },
+                "trigger": "PermanentsSacrificedEvent",
                 "effect": {
                     "type": "Composite",
                     "effects": [
@@ -6455,7 +6451,13 @@
                                             {
                                                 "type": "Or",
                                                 "predicates": [
-                                                    "IsToken",
+                                                    {
+                                                        "type": "And",
+                                                        "predicates": [
+                                                            "IsCreature",
+                                                            "IsToken"
+                                                        ]
+                                                    },
                                                     {
                                                         "type": "And",
                                                         "predicates": [
@@ -11326,10 +11328,13 @@
                 "id": "target creature"
             },
             {
-                "type": "TargetObject",
-                "optional": true,
-                "filter": {
-                    "baseFilter": "creature"
+                "type": "TargetOther",
+                "baseRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
                 },
                 "id": "up to one other target creature"
             }
@@ -17044,7 +17049,8 @@
                     "type": "TargetObject",
                     "optional": true,
                     "filter": {
-                        "baseFilter": "creature ctrl:you"
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
                     },
                     "id": "other creature you control"
                 }
@@ -18348,17 +18354,17 @@
                             "type": "MoveToZone",
                             "target": {
                                 "type": "BoundVariable",
-                                "name": "instant or sorcery card in a graveyard"
+                                "name": "instant or sorcery card in your graveyard"
                             },
                             "destination": "Hand"
                         },
                         "targetRequirement": {
                             "type": "TargetObject",
                             "filter": {
-                                "baseFilter": "instant|sorcery",
+                                "baseFilter": "instant|sorcery own:you",
                                 "zone": "Graveyard"
                             },
-                            "id": "instant or sorcery card in a graveyard"
+                            "id": "instant or sorcery card in your graveyard"
                         }
                     }
                 ]
@@ -20576,7 +20582,7 @@
             {
                 "id": "ability_1",
                 "trigger": {
-                    "type": "ZoneChangeEvent",
+                    "type": "PermanentsEnteredEvent",
                     "filter": {
                         "cardPredicates": [
                             "IsCreature",
@@ -20592,9 +20598,9 @@
                         ],
                         "controllerPredicate": "ControlledByYou"
                     },
-                    "to": "Battlefield"
+                    "excludeSource": true
                 },
-                "binding": "OTHER",
+                "binding": "ANY",
                 "effect": {
                     "type": "Scry",
                     "count": 1
@@ -21064,6 +21070,15 @@
     "keywords": [
         "WARD"
     ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
     "script": {
         "triggeredAbilities": [
             {
@@ -21234,23 +21249,11 @@
                     "to": "Battlefield"
                 },
                 "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "CantAttack",
-                            "target": {
-                                "type": "ContextTarget",
-                                "index": 0
-                            }
-                        },
-                        {
-                            "type": "CantBlockTargetCreatures",
-                            "target": {
-                                "type": "ContextTarget",
-                                "index": 0
-                            }
-                        }
-                    ]
+                    "type": "CantBlockTargetCreatures",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
                 },
                 "targetRequirement": {
                     "type": "TargetObject",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -2284,6 +2284,8 @@ class TriggerDetector(
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNonartifact -> !info.cardComponent.typeLine.isArtifact
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent -> info.cardComponent.typeLine.isPermanent
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype -> info.cardComponent.typeLine.hasSubtype(predicate.subtype)
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasAnyOfSubtypes ->
+                        predicate.subtypes.any { info.cardComponent.typeLine.hasSubtype(it) }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact -> info.cardComponent.typeLine.isArtifact
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsEnchantment -> info.cardComponent.typeLine.isEnchantment
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsToken -> info.isToken
@@ -2322,9 +2324,12 @@ class TriggerDetector(
 
                 // The permanents in this batch matching both the card filter and the controller
                 // scope — these "caused" the trigger and are exposed to the payoff (CR 603.3b
-                // groups them into a single batch trigger).
+                // groups them into a single batch trigger). "One or more OTHER …" wordings
+                // (excludeSource) never count the trigger's own source entering.
                 val matching = enters.filter { info ->
-                    controllerMatches(info.controllerId) && matchesCardPredicates(info, trigger.filter)
+                    (!trigger.excludeSource || info.entityId != entry.entityId) &&
+                        controllerMatches(info.controllerId) &&
+                        matchesCardPredicates(info, trigger.filter)
                 }
 
                 if (matching.isNotEmpty()) {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/AgateBladeAssassinMultiplayerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/AgateBladeAssassinMultiplayerTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutorRegistry
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.mtg.sets.definitions.blb.cards.AgateBladeAssassin
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Agate-Blade Assassin (BLB): "Whenever this creature attacks, DEFENDING PLAYER loses
+ * 1 life and you gain 1 life."
+ *
+ * Regression guard: the life loss used to be Player.EachOpponent, which in multiplayer
+ * drained every opponent instead of only the player being attacked (CR 802.2a).
+ */
+class AgateBladeAssassinMultiplayerTest : FunSpec({
+
+    fun initFourPlayerGame(registry: CardRegistry): Pair<GameState, List<EntityId>> {
+        val deck = Deck(cards = List(40) { "Agate-Blade Assassin" })
+        val result = GameInitializer(registry).initializeGame(
+            GameConfig(
+                players = (1..4).map { PlayerConfig("Player $it", deck, 20) },
+                skipMulligans = true,
+                startingPlayerIndex = 0
+            )
+        )
+        return result.state to result.playerIds
+    }
+
+    test("attack trigger drains only the defending player, not every opponent") {
+        val registry = CardRegistry()
+        registry.register(AgateBladeAssassin)
+        val (initial, players) = initFourPlayerGame(registry)
+
+        // Materialize the assassin for player 0, declared attacking player 2.
+        val assassinId = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = AgateBladeAssassin.name,
+                name = AgateBladeAssassin.name,
+                manaCost = AgateBladeAssassin.manaCost,
+                typeLine = AgateBladeAssassin.typeLine,
+                ownerId = players[0]
+            ),
+            ControllerComponent(players[0]),
+            AttackingComponent(defenderId = players[2])
+        )
+        val state = initial
+            .withEntity(assassinId, container)
+            .addToZone(ZoneKey(players[0], Zone.BATTLEFIELD), assassinId)
+
+        // Execute the card's actual attack-trigger effect.
+        val triggerEffect = AgateBladeAssassin.triggeredAbilities.first().effect
+        val context = EffectContext(sourceId = assassinId, controllerId = players[0])
+        val result = EffectExecutorRegistry(cardRegistry = registry).execute(state, triggerEffect, context)
+
+        fun life(s: GameState, p: EntityId) = s.getEntity(p)?.get<LifeTotalComponent>()?.life
+
+        life(result.state, players[0]) shouldBe 21 // "you gain 1 life"
+        life(result.state, players[1]) shouldBe 20 // not attacked — untouched
+        life(result.state, players[2]) shouldBe 19 // defending player loses 1
+        life(result.state, players[3]) shouldBe 20 // not attacked — untouched
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloomburrowTargetingFixesTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloomburrowTargetingFixesTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.MabelsMettle
+import com.wingedsheep.mtg.sets.definitions.blb.cards.SkyskipperDuo
+import com.wingedsheep.mtg.sets.definitions.blb.cards.StormchasersTalent
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Targeting regression guards for three BLB oracle-text fixes:
+ *
+ * - Skyskipper Duo: "exile up to one OTHER target creature you control" — it must not
+ *   be able to blink itself.
+ * - Stormchaser's Talent level 2: "return target instant or sorcery card FROM YOUR
+ *   GRAVEYARD" — opponents' graveyards are off-limits.
+ * - Mabel's Mettle: "Up to one OTHER target creature gets +1/+1" — the second target
+ *   must differ from the first (no stacking +3/+3 on one creature).
+ */
+class BloomburrowTargetingFixesTest : FunSpec({
+
+    // Triggered-ability targets are chosen when the trigger is put on the stack, so the
+    // ChooseTargetsDecision can surface before or after a priority pass — pass until it shows.
+    fun GameTestDriver.passUntilDecision(max: Int = 4) {
+        repeat(max) {
+            if (pendingDecision != null || state.priorityPlayerId == null) return
+            bothPass()
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SkyskipperDuo, StormchasersTalent, MabelsMettle))
+        return driver
+    }
+
+    test("Skyskipper Duo's ETB blink cannot target itself") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lions = driver.putCreatureOnBattlefield(active, "Savannah Lions")
+
+        driver.giveMana(active, Color.BLUE, 5)
+        val duo = driver.putCardInHand(active, "Skyskipper Duo")
+        driver.castSpell(active, duo)
+        driver.passUntilDecision() // resolve the creature spell; the ETB trigger asks for a target
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        val skyskipper = driver.findPermanent(active, "Skyskipper Duo")!!
+        val legal = decision.legalTargets[0].orEmpty()
+        legal shouldContain lions
+        legal shouldNotContain skyskipper
+    }
+
+    test("Stormchaser's Talent level 2 can only return cards from YOUR graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mine = driver.putCardInGraveyard(active, "Lightning Bolt")
+        val theirs = driver.putCardInGraveyard(opponent, "Lightning Bolt")
+
+        // Materialize the Class already at level 2 — the "becomes level 2" trigger fires.
+        driver.giveMana(active, Color.BLUE, 4)
+        val talent = driver.putCardInHand(active, "Stormchaser's Talent")
+        driver.castSpell(active, talent)
+        driver.bothPass() // resolve the enchantment; its ETB token trigger goes on the stack
+        if (driver.state.stack.isNotEmpty()) driver.bothPass() // resolve the level-1 token trigger
+
+        val classId = driver.findPermanent(active, "Stormchaser's Talent")!!
+        driver.giveMana(active, Color.BLUE, 4)
+        driver.submitSuccess(
+            com.wingedsheep.engine.core.ActivateAbility(
+                playerId = active,
+                sourceId = classId,
+                abilityId = com.wingedsheep.sdk.scripting.AbilityId.classLevelUp(2)
+            )
+        )
+        driver.passUntilDecision() // resolve the level-up → the becomes-level-2 trigger targets
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        val legal = decision.legalTargets[0].orEmpty()
+        legal shouldContain mine
+        legal shouldNotContain theirs
+    }
+
+    test("Mabel's Mettle cannot choose the same creature for both targets") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lions = driver.putCreatureOnBattlefield(active, "Savannah Lions")
+        val bear = driver.putCreatureOnBattlefield(active, "Centaur Courser")
+
+        // Same creature for both target slots must be rejected outright.
+        driver.giveMana(active, Color.WHITE, 2)
+        val mettle = driver.putCardInHand(active, "Mabel's Mettle")
+        val sameTwice = driver.castSpellWithTargets(
+            active, mettle,
+            listOf(ChosenTarget.Permanent(lions), ChosenTarget.Permanent(lions))
+        )
+        sameTwice.isSuccess shouldBe false
+
+        // Two different creatures is legal.
+        val differing = driver.castSpellWithTargets(
+            active, mettle,
+            listOf(ChosenTarget.Permanent(lions), ChosenTarget.Permanent(bear))
+        )
+        differing.isSuccess shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CarrotCakeSacrificeTriggerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CarrotCakeSacrificeTriggerTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.CarrotCake
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Carrot Cake (BLB): "When this artifact enters AND WHEN YOU SACRIFICE IT, create a
+ * 1/1 white Rabbit creature token and scry 1."
+ *
+ * Regression guard: the second trigger is sacrifice-only (Triggers.Sacrificed). It used
+ * to be modeled as Triggers.Dies, which wrongly fired on any battlefield→graveyard
+ * transition — an opponent destroying the Food handed its controller a free Rabbit + scry.
+ */
+class CarrotCakeSacrificeTriggerTest : FunSpec({
+
+    val testShatter: CardDefinition = card("Test Shatter") {
+        manaCost = "{R}"
+        typeLine = "Instant"
+        spell {
+            val artifact = target("target artifact", Targets.Artifact)
+            effect = Effects.Destroy(artifact)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CarrotCake, testShatter))
+        return driver
+    }
+
+    test("sacrificing Carrot Cake to its own ability creates a Rabbit and scrys 1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val cake = driver.putPermanentOnBattlefield(active, "Carrot Cake")
+        driver.giveColorlessMana(active, 2)
+
+        val gainLifeAbility = CarrotCake.activatedAbilities.first().id
+        driver.submitSuccess(ActivateAbility(playerId = active, sourceId = cake, abilityId = gainLifeAbility))
+
+        val lifeBefore = driver.getLifeTotal(active)
+
+        // Sacrificing as a cost puts the "when you sacrifice it" trigger on the stack above
+        // the gain-3-life ability. Resolve both; the trigger's scry 1 pauses for a selection.
+        var sawScry = false
+        repeat(8) {
+            val decision = driver.pendingDecision
+            if (decision != null) {
+                // Scry 1 pauses twice: the SelectCardsDecision (keep/bottom) and the
+                // follow-up ReorderLibraryDecision. Auto-resolve both.
+                if (decision is SelectCardsDecision && decision.playerId == active) sawScry = true
+                driver.autoResolveDecision()
+            } else if (driver.state.priorityPlayerId != null) {
+                driver.bothPass()
+            }
+        }
+
+        sawScry shouldBe true
+        driver.findPermanent(active, "Rabbit Token") shouldNotBe null
+        driver.getLifeTotal(active) shouldBe lifeBefore + 3
+        driver.state.getZone(active, Zone.GRAVEYARD).contains(cake) shouldBe true
+    }
+
+    test("an opponent destroying Carrot Cake does NOT create a Rabbit or scry") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // The opponent controls Carrot Cake; the active player destroys it.
+        val cake = driver.putPermanentOnBattlefield(opponent, "Carrot Cake")
+
+        driver.giveMana(active, com.wingedsheep.sdk.core.Color.RED, 1)
+        val shatter = driver.putCardInHand(active, "Test Shatter")
+        driver.castSpellWithTargets(active, shatter, listOf(ChosenTarget.Permanent(cake)))
+
+        repeat(4) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        // Carrot Cake was destroyed (died, not sacrificed) — no Rabbit, no scry decision.
+        driver.state.getZone(opponent, Zone.GRAVEYARD).contains(cake) shouldBe true
+        driver.findPermanent(opponent, "Rabbit Token") shouldBe null
+        driver.pendingDecision shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinneasAceArcherTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FinneasAceArcherTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.FinneasAceArcher
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Finneas, Ace Archer (BLB): "Whenever Finneas attacks, put a +1/+1 counter on each
+ * other CREATURE you control that's a token or a Rabbit."
+ *
+ * Regression guard: the token branch of the filter used to match any token — a Food
+ * (noncreature artifact token) wrongly received +1/+1 counters. Only creature tokens
+ * and Rabbits qualify.
+ */
+class FinneasAceArcherTest : FunSpec({
+
+    val testProvisions: CardDefinition = card("Test Provisions") {
+        manaCost = "{G}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.CreateFood(1)
+                .then(
+                    Effects.CreateToken(
+                        power = 2,
+                        toughness = 2,
+                        colors = setOf(Color.GREEN),
+                        creatureTypes = setOf("Bear")
+                    )
+                )
+        }
+    }
+
+    val testRabbit: CardDefinition = CardDefinition.creature(
+        name = "Test Rabbit",
+        manaCost = ManaCost.parse("{W}"),
+        subtypes = setOf(Subtype("Rabbit")),
+        power = 1,
+        toughness = 1
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + com.wingedsheep.mtg.sets.tokens.PredefinedTokens.allTokens +
+                listOf(FinneasAceArcher, testProvisions, testRabbit)
+        )
+        return driver
+    }
+
+    fun GameTestDriver.plusCounters(id: com.wingedsheep.sdk.model.EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("attack trigger puts counters on creature tokens and Rabbits, NOT on Food tokens") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        var active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        active = driver.activePlayer!!
+
+        val finneas = driver.putCreatureOnBattlefield(active, "Finneas, Ace Archer")
+        driver.removeSummoningSickness(finneas)
+        val rabbit = driver.putCreatureOnBattlefield(active, "Test Rabbit")
+        val nonRabbitNontoken = driver.putCreatureOnBattlefield(active, "Savannah Lions")
+
+        // Create a Food token and a Bear creature token via a real spell so both are tokens.
+        driver.giveMana(active, Color.GREEN, 1)
+        val provisions = driver.putCardInHand(active, "Test Provisions")
+        driver.castSpell(active, provisions)
+        driver.bothPass()
+
+        val food = driver.findPermanent(active, "Food")
+        food.shouldNotBeNull()
+        val bearToken = driver.findPermanent(active, "Bear Token")
+        bearToken.shouldNotBeNull()
+
+        // Attack with Finneas → the counter trigger resolves.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        var safety = 0
+        while (driver.activePlayer != active && safety < 50) {
+            driver.bothPass()
+            driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+            safety++
+        }
+        driver.declareAttackers(active, listOf(finneas), driver.getOpponent(active))
+        driver.bothPass()
+
+        // Creature token and Rabbit get a counter; Food token, non-Rabbit nontoken
+        // creature, and Finneas itself ("each OTHER creature") do not.
+        driver.plusCounters(bearToken) shouldBe 1
+        driver.plusCounters(rabbit) shouldBe 1
+        driver.plusCounters(food) shouldBe 0
+        driver.plusCounters(nonRabbitNontoken) shouldBe 0
+        driver.plusCounters(finneas) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValleyQuestcallerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValleyQuestcallerTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.ValleyQuestcaller
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Valley Questcaller (BLB): "Whenever ONE OR MORE other Rabbits, Bats, Birds, and/or
+ * Mice you control enter, scry 1."
+ *
+ * Regression guards:
+ * - Batched (CR 603.3b): two Rabbits entering simultaneously yield ONE scry, not two.
+ *   The old per-object ZoneChangeEvent trigger scried once per creature.
+ * - "Other": Questcaller (itself a Rabbit) must not scry off its own entry.
+ */
+class ValleyQuestcallerTest : FunSpec({
+
+    val twoRabbits: CardDefinition = card("Test Rabbit Pair") {
+        manaCost = "{W}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.CreateToken(
+                count = 2,
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Rabbit")
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ValleyQuestcaller, twoRabbits))
+        return driver
+    }
+
+    /** Count how many scry selections occur while resolving everything on the stack. */
+    fun GameTestDriver.resolveAllCountingScrys(player: com.wingedsheep.sdk.model.EntityId): Int {
+        var scrys = 0
+        repeat(10) {
+            val decision = pendingDecision
+            if (decision is SelectCardsDecision && decision.playerId == player) {
+                scrys++
+                autoResolveDecision()
+            } else if (state.priorityPlayerId != null && (state.stack.isNotEmpty() || state.pendingDecision != null)) {
+                bothPass()
+            }
+        }
+        return scrys
+    }
+
+    test("two Rabbits entering simultaneously cause exactly ONE scry") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(active, "Valley Questcaller")
+
+        driver.giveMana(active, Color.WHITE, 1)
+        val spell = driver.putCardInHand(active, "Test Rabbit Pair")
+        driver.castSpell(active, spell)
+        driver.bothPass() // resolve the sorcery → both tokens enter at once → one batched trigger
+
+        val scrys = driver.resolveAllCountingScrys(active)
+        scrys shouldBe 1
+    }
+
+    test("Questcaller entering alone does not trigger its own scry") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.giveMana(active, Color.WHITE, 2)
+        val questcaller = driver.putCardInHand(active, "Valley Questcaller")
+        driver.castSpell(active, questcaller)
+        driver.bothPass() // resolve the creature spell — it is itself a Rabbit, but "other"
+
+        val scrys = driver.resolveAllCountingScrys(active)
+        scrys shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VrenWardTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VrenWardTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ManaSourcesSelectedResponse
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.VrenTheRelentless
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Vren, the Relentless (BLB): "Ward {2}".
+ *
+ * Regression guard: Vren used to carry only the bare WARD keyword (display-only, no
+ * cost), so opponents could target it for free. It must be KeywordAbility.Ward with a
+ * {2} mana cost: a spell an opponent casts targeting Vren is countered unless they pay.
+ */
+class VrenWardTest : FunSpec({
+
+    val testExile: CardDefinition = card("Test Exile Instant") {
+        manaCost = "{B}"
+        typeLine = "Instant"
+        spell {
+            val creature = target("target creature to exile", Targets.Creature)
+            effect = Effects.Exile(creature)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(VrenTheRelentless, testExile))
+        return driver
+    }
+
+    test("targeting Vren without mana to pay ward counters the spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val vren = driver.putCreatureOnBattlefield(opponent, "Vren, the Relentless")
+
+        // Exactly enough mana for the spell itself — nothing left for ward.
+        driver.giveMana(active, Color.BLACK, 1)
+        val spell = driver.putCardInHand(active, "Test Exile Instant")
+        driver.castSpellWithTargets(active, spell, listOf(ChosenTarget.Permanent(vren)))
+
+        repeat(4) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        // Ward could not be paid → the spell is countered; Vren survives.
+        driver.findPermanent(opponent, "Vren, the Relentless") shouldNotBe null
+        driver.state.getZone(opponent, Zone.EXILE).contains(vren) shouldBe false
+    }
+
+    test("paying {2} for ward lets the spell resolve") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val vren = driver.putCreatureOnBattlefield(opponent, "Vren, the Relentless")
+
+        // Two untapped lands to pay ward with, plus floating mana for the spell.
+        driver.putLandOnBattlefield(active, "Swamp")
+        driver.putLandOnBattlefield(active, "Swamp")
+        driver.giveMana(active, Color.BLACK, 1)
+        val spell = driver.putCardInHand(active, "Test Exile Instant")
+        driver.castSpellWithTargets(active, spell, listOf(ChosenTarget.Permanent(vren)))
+
+        // Ward trigger resolves → the caster is prompted to pay {2}.
+        driver.bothPass()
+        val decision = driver.pendingDecision
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        decision.playerId shouldBe active
+
+        driver.submitDecision(active, ManaSourcesSelectedResponse(decision.id, autoPay = true))
+
+        repeat(4) { if (driver.state.priorityPlayerId != null) driver.bothPass() }
+
+        // Ward was paid — the exile spell resolves. Vren's own replacement effect only
+        // covers dying (battlefield→graveyard), so it is exiled.
+        driver.findPermanent(opponent, "Vren, the Relentless") shouldBe null
+        driver.state.getZone(opponent, Zone.EXILE).contains(vren) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WarSqueakTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WarSqueakTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.WarSqueak
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * War Squeak (BLB): "When this Aura enters, target creature an opponent controls
+ * CAN'T BLOCK this turn."
+ *
+ * Regression guard: this used to be modeled as CantAttackOrBlock, which also stopped
+ * the opponent's creature from attacking. The card only restricts blocking.
+ */
+class WarSqueakTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(WarSqueak))
+        return driver
+    }
+
+    test("the targeted creature can't block but is NOT restricted from attacking") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val myCreature = driver.putCreatureOnBattlefield(active, "Savannah Lions")
+        val theirCreature = driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+
+        driver.giveMana(active, Color.RED, 1)
+        val aura = driver.putCardInHand(active, "War Squeak")
+        driver.castSpellWithTargets(active, aura, listOf(ChosenTarget.Permanent(myCreature)))
+        repeat(4) {
+            if (driver.pendingDecision == null && driver.state.priorityPlayerId != null) driver.bothPass()
+        }
+
+        // The ETB trigger asks for a target creature an opponent controls.
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(active, listOf(theirCreature))
+        driver.bothPass()
+
+        val projected = projector.project(driver.state)
+        projected.cantBlock(theirCreature) shouldBe true
+        // Oracle text only says "can't block" — attacking must stay legal.
+        projected.cantAttack(theirCreature) shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

A full audit of all 277 BLB card implementations against their embedded oracle text (plus the engine paths for offspring, gift, forage, expend, and valiant) surfaced 9 real bugs. Each is fixed here with regression test coverage (12 tests across 7 new test classes).

## Card fixes

| Card | Bug | Fix |
|------|-----|-----|
| Carrot Cake | "when you sacrifice it" used `Triggers.Dies` — destruction wrongly granted a Rabbit + scry | `Triggers.Sacrificed` |
| Vren, the Relentless | Ward {2} was a bare display keyword with no cost — no protection at all | `KeywordAbility.Ward(WardCost.Mana("{2}"))` |
| War Squeak | "can't block this turn" also prevented attacking | `Effects.CantBlock` only |
| Skyskipper Duo | could blink **itself** ("one *other* target creature you control") | target filter `.other()` |
| Stormchaser's Talent (L2) | returned instants/sorceries from **any** graveyard | restricted to your graveyard |
| Mabel's Mettle | same creature could take both pumps (+3/+3) | second target is `TargetOther` |
| Finneas, Ace Archer | +1/+1 counters landed on **noncreature** tokens (Food, Treasure) | token branch is creature-tokens-only |
| Valley Questcaller | "one or more other … enter, scry 1" scried once **per creature**, and never modeled "other" | batched `OneOrMorePermanentsEnter(filter, excludeSource = true)` |
| Agate-Blade Assassin | "defending player loses 1 life" drained **every** opponent in multiplayer | `Player.DefendingPlayer` (CR 802.2a) |

## Engine/SDK support (for the Questcaller fix)

- `PermanentsEnteredEvent` gains `excludeSource` — "one or more **other** … you control enter" never counts the source's own entry. Satoru-style wordings ("Satoru and/or one or more other creatures…") keep it `false`.
- The batched-enters matcher in `TriggerDetector` learns `CardPredicate.HasAnyOfSubtypes` (previously fell through to match-everything for that predicate).
- SDK language reference updated; BLB card snapshot re-blessed (diff is exactly the 9 intended changes).

## Verified correct during the audit

Offspring (1/1 token copy, kicker-gated), forage (exactly 3 cards / 1 Food, both modes), expend (spell mana only, once per turn, per-turn reset), valiant (own spells only, first-time-per-turn latch per controller).

## Known-open approximations (not fixed here, tracked for follow-up)

- Gift recipient is `Player.AnOpponent` (first opponent) instead of a cast-time choice — correct in 2-player, wrong in multiplayer (deliberate simplification from #1146).
- Early Winter mode 2 targets the enchantment directly; oracle targets the opponent who then picks.
- Thought-Stalker Warlock's "if they lost life" condition checks any opponent, not the chosen target (multiplayer-only).
- Alania's "first Otter spell other than Alania" doesn't exclude Alania from the tracker.
- Seasoned Warrenguard re-checks its token condition at resolution, contrary to the printed ruling.
- Cross-set lead: other sets' uses of `Targets.InstantOrSorceryInGraveyard` may have the same "your graveyard" bug Stormchaser's Talent had.

## Test plan

- 7 new test classes (12 tests) covering every fix, including a 4-player test for the DefendingPlayer fix and batch/own-entry tests for Questcaller.
- Full `:rules-engine:test` and `:mtg-sets:test` suites pass (card lint + re-blessed snapshot included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)