### PR TITLE
Fix 14 oracle-fidelity bugs in LEA/ARN/ATQ + 3 engine bugs found by set audit

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -4393,7 +4393,7 @@ answer it and would silently return `false`.
 - `OpponentControlsMoreCreatures` — an opponent outpaces you.
 - `OpponentControlsMoreLands` — an opponent has more lands.
 - `OpponentHasMoreCardsInHand` — an opponent has more cards in hand than you (compares opponents' hand size to yours). Used by Beza, the Bounding Spring and Joined Researchers.
-- `OpponentControlsLandType(type)` — opponent controls land of a type.
+- `DefendingPlayerControlsLandType(type)` — the defending player controls a land of a type (CantAttackUnless template; defender-relative, not any-opponent).
 - `CompareAmounts(left, operator, right)` — generic numeric comparison of two `DynamicAmount`s with a
   `ComparisonOperator.{LT,LTE,EQ,NEQ,GT,GTE}` (composes the underlying `Compare` condition). The facade
   entry point for any "if amount X (relation) amount Y" intervening-if or static gate. Used by Taii

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -196,11 +196,14 @@ object Conditions {
         )
 
     /**
-     * If opponent controls a land of a specific subtype.
-     * Used for CantAttackUnless (e.g. Deep-Sea Serpent, Slipstream Eel).
+     * If the defending player controls a land of a specific subtype (resolved per
+     * attack declaration via the defender bound into the evaluation context). Used
+     * for CantAttackUnless (e.g. Deep-Sea Serpent, Slipstream Eel, Dandân) — oracle
+     * for these reads "unless defending player controls an Island", so in multiplayer
+     * the check is against the player being attacked, not any opponent.
      */
-    fun OpponentControlsLandType(landType: String): ConditionInterface =
-        Exists(Player.EachOpponent, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype(landType))
+    fun DefendingPlayerControlsLandType(landType: String): ConditionInterface =
+        Exists(Player.DefendingPlayer, Zone.BATTLEFIELD, GameObjectFilter.Land.withSubtype(landType))
 
     /**
      * If an opponent controls a creature.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Dandan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/Dandan.kt
@@ -26,7 +26,7 @@ val Dandan = card("Dandân") {
         "When you control no Islands, sacrifice this creature."
 
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
 
     stateTriggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/IslandFishJasconius.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/IslandFishJasconius.kt
@@ -41,7 +41,7 @@ val IslandFishJasconius = card("Island Fish Jasconius") {
     }
 
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
 
     stateTriggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/MerchantShip.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/arn/cards/MerchantShip.kt
@@ -29,7 +29,7 @@ val MerchantShip = card("Merchant Ship") {
         "When you control no Islands, sacrifice this creature."
 
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
 
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/GolgothianSylex.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/GolgothianSylex.kt
@@ -15,9 +15,10 @@ import com.wingedsheep.sdk.scripting.GameObjectFilter
  *
  * `SacrificeAll` over the set-membership filter: every nontoken permanent whose card was
  * *originally printed* in ATQ (`originallyPrintedInSet("ATQ")`, canonical set code — reprints
- * still match), excluding Golgothian Sylex itself (it is an ATQ artifact, so without the
- * self-exclusion it would sacrifice itself). Each matching permanent is sacrificed by its own
- * controller (CR 701.21), routed to its owner's graveyard; tokens never match the filter.
+ * still match), including Golgothian Sylex itself (its name was originally printed in ATQ and
+ * the oracle text has no self-exclusion, so it sacrifices itself). Each matching permanent is
+ * sacrificed by its own controller (CR 701.17), routed to its owner's graveyard; tokens never
+ * match the filter.
  */
 val GolgothianSylex = card("Golgothian Sylex") {
     manaCost = "{4}"
@@ -28,8 +29,7 @@ val GolgothianSylex = card("Golgothian Sylex") {
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap)
         effect = Effects.SacrificeAll(
-            filter = GameObjectFilter.Permanent.nontoken().originallyPrintedInSet("ATQ"),
-            excludeTriggering = true
+            filter = GameObjectFilter.Permanent.nontoken().originallyPrintedInSet("ATQ")
         )
         description = "{1}, {T}: Each nontoken permanent with a name originally printed in the Antiquities expansion is sacrificed by its controller."
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/HauntingWind.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/HauntingWind.kt
@@ -23,7 +23,9 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *    [EffectTarget.ControllerOfTriggeringEntity].
  *  - the ability half ([Triggers.activatesAbilityWithoutTap]) — keys on the literal "without {T}
  *    in its activation cost" wording (not "isn't a mana ability"), so a non-{T} mana ability also
- *    fires it. "That artifact's controller" is the activating player ([Player.TriggeringPlayer]).
+ *    fires it. "That artifact's controller" is the controller of the activated artifact
+ *    ([EffectTarget.ControllerOfTriggeringEntity]) — not the activating player, which differs
+ *    when a non-controller activates (e.g. Armageddon Clock's any-player ability).
  */
 val HauntingWind = card("Haunting Wind") {
     manaCost = "{3}{B}"
@@ -46,7 +48,7 @@ val HauntingWind = card("Haunting Wind") {
             player = Player.Each,
             sourceFilter = GameObjectFilter.Artifact
         )
-        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+        effect = Effects.DealDamage(1, EffectTarget.ControllerOfTriggeringEntity)
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/Powerleech.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/Powerleech.kt
@@ -17,9 +17,12 @@ import com.wingedsheep.sdk.scripting.references.Player
  *
  * Same "tap / activate an artifact" punisher template as Haunting Wind, but scoped to opponents'
  * artifacts and rewarding the enchantment's controller with life instead of dealing damage:
- *  - tap half: [Triggers.becomesTapped] over `Artifact.opponentControls()`.
- *  - ability half: [Triggers.activatesAbilityWithoutTap] with [Player.EachOpponent] and the same
- *    opponent-controlled artifact filter ("an opponent activates an artifact's ability").
+ *  - tap half: [Triggers.becomesTapped] over `Artifact.opponentControls()` ("an artifact an
+ *    opponent controls becomes tapped").
+ *  - ability half: [Triggers.activatesAbilityWithoutTap] with [Player.EachOpponent] and NO
+ *    controller restriction on the artifact — oracle only requires that "an opponent activates
+ *    an artifact's ability", so an opponent activating an any-player ability of an artifact
+ *    you control (e.g. Armageddon Clock) also triggers it.
  *
  * The reward is [Effects.GainLife] for the controller (default target), so no triggering-entity
  * reference is needed.
@@ -42,7 +45,7 @@ val Powerleech = card("Powerleech") {
     triggeredAbility {
         trigger = Triggers.activatesAbilityWithoutTap(
             player = Player.EachOpponent,
-            sourceFilter = GameObjectFilter.Artifact.opponentControls()
+            sourceFilter = GameObjectFilter.Artifact
         )
         effect = Effects.GainLife(1)
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/UrzasMine.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/UrzasMine.kt
@@ -24,7 +24,7 @@ val UrzasMine = card("Urza's Mine") {
         cost = Costs.Tap
         effect = ConditionalEffect(
             condition = Conditions.All(
-                Conditions.YouControl(GameObjectFilter.Land.named("Urza's Power-Plant")),
+                Conditions.YouControl(GameObjectFilter.Land.named("Urza's Power Plant")),
                 Conditions.YouControl(GameObjectFilter.Land.named("Urza's Tower"))
             ),
             effect = Effects.AddColorlessMana(2),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/UrzasTower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/atq/cards/UrzasTower.kt
@@ -25,7 +25,7 @@ val UrzasTower = card("Urza's Tower") {
         effect = ConditionalEffect(
             condition = Conditions.All(
                 Conditions.YouControl(GameObjectFilter.Land.named("Urza's Mine")),
-                Conditions.YouControl(GameObjectFilter.Land.named("Urza's Power-Plant"))
+                Conditions.YouControl(GameObjectFilter.Land.named("Urza's Power Plant"))
             ),
             effect = Effects.AddColorlessMana(3),
             elseEffect = Effects.AddColorlessMana(1)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianSerpent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianSerpent.kt
@@ -33,7 +33,7 @@ val VodalianSerpent = card("Vodalian Serpent") {
     keywordAbility(KeywordAbility.kicker("{2}"))
 
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
 
     triggeredAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/BlueElementalBlast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/BlueElementalBlast.kt
@@ -4,9 +4,12 @@
 
 package com.wingedsheep.mtg.sets.definitions.lea.cards
 
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 import com.wingedsheep.sdk.scripting.targets.TargetSpell
 
 
@@ -24,8 +27,16 @@ val BlueElementalBlast = card("Blue Elemental Blast") {
     typeLine = "Instant"
     oracleText = "Choose one —\n• Counter target red spell.\n• Destroy target red permanent."
     spell {
-        val t = target("target", TargetSpell())
-        effect = CounterEffect()
+        modal(chooseCount = 1) {
+            mode("Counter target red spell") {
+                val t = target("target", TargetSpell(filter = TargetFilter.SpellOnStack.withColor(Color.RED)))
+                effect = Effects.CounterSpell()
+            }
+            mode("Destroy target red permanent") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.Permanent.withColor(Color.RED)))
+                effect = Effects.Destroy(t)
+            }
+        }
     }
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Deathgrip.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Deathgrip.kt
@@ -4,10 +4,12 @@
 
 package com.wingedsheep.mtg.sets.definitions.lea.cards
 
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetSpell
 
 
@@ -24,7 +26,7 @@ val Deathgrip = card("Deathgrip") {
     oracleText = "{B}{B}: Counter target green spell."
     activatedAbility {
         cost = Costs.Mana("{B}{B}")
-        val t = target("target", TargetSpell())
+        val t = target("target", TargetSpell(filter = TargetFilter.SpellOnStack.withColor(Color.GREEN)))
         effect = CounterEffect()
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Lifeforce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Lifeforce.kt
@@ -4,10 +4,12 @@
 
 package com.wingedsheep.mtg.sets.definitions.lea.cards
 
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetSpell
 
 
@@ -24,7 +26,7 @@ val Lifeforce = card("Lifeforce") {
     oracleText = "{G}{G}: Counter target black spell."
     activatedAbility {
         cost = Costs.Mana("{G}{G}")
-        val t = target("target", TargetSpell())
+        val t = target("target", TargetSpell(filter = TargetFilter.SpellOnStack.withColor(Color.BLACK)))
         effect = CounterEffect()
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/NorthernPaladin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/NorthernPaladin.kt
@@ -4,11 +4,13 @@
 
 package com.wingedsheep.mtg.sets.definitions.lea.cards
 
+import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 
 
@@ -28,7 +30,7 @@ val NorthernPaladin = card("Northern Paladin") {
     toughness = 3
     activatedAbility {
         cost = Costs.Composite(Costs.Mana("{W}{W}"), Costs.Tap)
-        val t = target("target", TargetPermanent())
+        val t = target("target", TargetPermanent(filter = TargetFilter.Permanent.withColor(Color.BLACK)))
         effect = Effects.Move(t, Zone.GRAVEYARD, byDestruction = true)
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/RedElementalBlast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/RedElementalBlast.kt
@@ -4,9 +4,12 @@
 
 package com.wingedsheep.mtg.sets.definitions.lea.cards
 
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
 import com.wingedsheep.sdk.scripting.targets.TargetSpell
 
 
@@ -24,8 +27,16 @@ val RedElementalBlast = card("Red Elemental Blast") {
     typeLine = "Instant"
     oracleText = "Choose one —\n• Counter target blue spell.\n• Destroy target blue permanent."
     spell {
-        val t = target("target", TargetSpell())
-        effect = CounterEffect()
+        modal(chooseCount = 1) {
+            mode("Counter target blue spell") {
+                val t = target("target", TargetSpell(filter = TargetFilter.SpellOnStack.withColor(Color.BLUE)))
+                effect = Effects.CounterSpell()
+            }
+            mode("Destroy target blue permanent") {
+                val t = target("target", TargetPermanent(filter = TargetFilter.Permanent.withColor(Color.BLUE)))
+                effect = Effects.Destroy(t)
+            }
+        }
     }
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Regrowth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Regrowth.kt
@@ -24,7 +24,7 @@ val Regrowth = card("Regrowth") {
     typeLine = "Sorcery"
     oracleText = "Return target card from your graveyard to your hand."
     spell {
-        val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
+        val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard.ownedByYou()))
         effect = Effects.Move(t, Zone.HAND)
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Righteousness.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/Righteousness.kt
@@ -23,7 +23,7 @@ val Righteousness = card("Righteousness") {
     typeLine = "Instant"
     oracleText = "Target blocking creature gets +7/+7 until end of turn."
     spell {
-        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        val t = target("target", TargetCreature(filter = TargetFilter.BlockingCreature))
         effect = Effects.ModifyStats(7, 7, t)
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/SpellBlast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/SpellBlast.kt
@@ -7,6 +7,7 @@ package com.wingedsheep.mtg.sets.definitions.lea.cards
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.CounterEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
 import com.wingedsheep.sdk.scripting.targets.TargetSpell
 
 
@@ -22,7 +23,7 @@ val SpellBlast = card("Spell Blast") {
     typeLine = "Instant"
     oracleText = "Counter target spell with mana value X. (For example, if that spell's mana cost is {3}{U}{U}, X is 5.)"
     spell {
-        val t = target("target", TargetSpell())
+        val t = target("target", TargetSpell(filter = TargetFilter.SpellOnStack.manaValueEqualsX()))
         effect = CounterEffect()
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/ZombieMaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lea/cards/ZombieMaster.kt
@@ -47,7 +47,7 @@ val ZombieMaster = card("Zombie Master") {
                 cost = Costs.Mana("{B}"),
                 effect = RegenerateEffect(EffectTarget.Self)
             ),
-            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE), excludeSelf = true)
+            filter = GroupFilter(GameObjectFilter.Permanent.withSubtype(Subtype.ZOMBIE), excludeSelf = true)
         )
     }
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/SlipstreamEel.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ons/cards/SlipstreamEel.kt
@@ -23,7 +23,7 @@ val SlipstreamEel = card("Slipstream Eel") {
     oracleText = "Slipstream Eel can't attack unless defending player controls an Island.\nCycling {1}{U}"
 
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
 
     keywordAbility(KeywordAbility.cycling("{1}{U}"))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DeepSeaSerpent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/por/cards/DeepSeaSerpent.kt
@@ -25,7 +25,7 @@ val DeepSeaSerpent = card("Deep-Sea Serpent") {
     power = 5
     toughness = 5
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
     metadata {
         rarity = Rarity.UNCOMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/SeaMonster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tmp/cards/SeaMonster.kt
@@ -25,7 +25,7 @@ val SeaMonster = card("Sea Monster") {
     power = 6
     toughness = 6
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/test/resources/snapshots/cards/ARN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ARN.json
@@ -923,7 +923,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "EachOpponent",
+                    "player": "DefendingPlayer",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }
@@ -2032,7 +2032,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "EachOpponent",
+                    "player": "DefendingPlayer",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }
@@ -2771,7 +2771,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "EachOpponent",
+                    "player": "DefendingPlayer",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ATQ.json
@@ -1873,9 +1873,7 @@
                                             "setCode": "ATQ"
                                         }
                                     ]
-                                },
-                                "excludeSelf": true,
-                                "excludeTriggering": true
+                                }
                             },
                             "storeAs": "sacrificeAll_gathered"
                         },
@@ -1992,10 +1990,7 @@
                         "type": "Fixed",
                         "amount": 1
                     },
-                    "target": {
-                        "type": "PlayerRef",
-                        "player": "TriggeringPlayer"
-                    }
+                    "target": "ControllerOfTriggeringEntity"
                 }
             }
         ]
@@ -2853,7 +2848,7 @@
                 "trigger": {
                     "type": "AbilityActivatedEvent",
                     "player": "EachOpponent",
-                    "sourceFilter": "artifact ctrl:opponent",
+                    "sourceFilter": "artifact",
                     "requireNoTapInCost": true
                 },
                 "binding": "ANY",
@@ -4529,7 +4524,7 @@
                                     "type": "Exists",
                                     "player": "You",
                                     "zone": "Battlefield",
-                                    "filter": "land name:Urza's Power-Plant"
+                                    "filter": "land name:Urza's Power Plant"
                                 },
                                 {
                                     "type": "Exists",
@@ -4711,7 +4706,7 @@
                                     "type": "Exists",
                                     "player": "You",
                                     "zone": "Battlefield",
-                                    "filter": "land name:Urza's Power-Plant"
+                                    "filter": "land name:Urza's Power Plant"
                                 }
                             ]
                         }

--- a/mtg-sets/src/test/resources/snapshots/cards/INV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/INV.json
@@ -17319,7 +17319,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "EachOpponent",
+                    "player": "DefendingPlayer",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/LEA.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LEA.json
@@ -288,17 +288,46 @@
     "typeLine": "Instant",
     "oracleText": "Choose one —\n• Counter target red spell.\n• Destroy target red permanent.",
     "script": {
-        "spellEffect": "Counter",
-        "targetRequirements": [
-            {
-                "type": "TargetObject",
-                "filter": {
-                    "baseFilter": {},
-                    "zone": "Stack"
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "red",
+                                "zone": "Stack"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Counter target red spell"
                 },
-                "id": "target"
-            }
-        ]
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent red"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target red permanent"
+                }
+            ]
+        }
     },
     "metadata": {
         "collectorNumber": "49",
@@ -727,7 +756,7 @@
                     {
                         "type": "TargetObject",
                         "filter": {
-                            "baseFilter": {},
+                            "baseFilter": "green",
                             "zone": "Stack"
                         },
                         "id": "target"
@@ -2214,7 +2243,7 @@
                     {
                         "type": "TargetObject",
                         "filter": {
-                            "baseFilter": {},
+                            "baseFilter": "black",
                             "zone": "Stack"
                         },
                         "id": "target"
@@ -2763,7 +2792,7 @@
                     {
                         "type": "TargetObject",
                         "filter": {
-                            "baseFilter": "permanent"
+                            "baseFilter": "permanent black"
                         },
                         "id": "target"
                     }
@@ -3014,17 +3043,46 @@
     "typeLine": "Instant",
     "oracleText": "Choose one —\n• Counter target blue spell.\n• Destroy target blue permanent.",
     "script": {
-        "spellEffect": "Counter",
-        "targetRequirements": [
-            {
-                "type": "TargetObject",
-                "filter": {
-                    "baseFilter": {},
-                    "zone": "Stack"
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": "Counter",
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "blue",
+                                "zone": "Stack"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Counter target blue spell"
                 },
-                "id": "target"
-            }
-        ]
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "permanent blue"
+                            },
+                            "id": "target"
+                        }
+                    ],
+                    "description": "Destroy target blue permanent"
+                }
+            ]
+        }
     },
     "metadata": {
         "collectorNumber": "169",
@@ -3086,7 +3144,7 @@
             {
                 "type": "TargetObject",
                 "filter": {
-                    "baseFilter": {},
+                    "baseFilter": "own:you",
                     "zone": "Graveyard"
                 },
                 "id": "target"
@@ -3168,7 +3226,7 @@
             {
                 "type": "TargetObject",
                 "filter": {
-                    "baseFilter": "creature"
+                    "baseFilter": "creature blocking"
                 },
                 "id": "target"
             }
@@ -3674,7 +3732,11 @@
             {
                 "type": "TargetObject",
                 "filter": {
-                    "baseFilter": {},
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "ManaValueEqualsX"
+                        ]
+                    },
                     "zone": "Stack"
                 },
                 "id": "target"
@@ -4832,7 +4894,7 @@
                     }
                 },
                 "filter": {
-                    "baseFilter": "creature Zombie",
+                    "baseFilter": "permanent Zombie",
                     "excludeSelf": true
                 }
             }

--- a/mtg-sets/src/test/resources/snapshots/cards/ONS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ONS.json
@@ -14208,7 +14208,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "EachOpponent",
+                    "player": "DefendingPlayer",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/POR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/POR.json
@@ -1398,7 +1398,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "EachOpponent",
+                    "player": "DefendingPlayer",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }

--- a/mtg-sets/src/test/resources/snapshots/cards/TMP.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TMP.json
@@ -2157,7 +2157,7 @@
                 "type": "CantAttackUnless",
                 "condition": {
                     "type": "Exists",
-                    "player": "EachOpponent",
+                    "player": "DefendingPlayer",
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/StaticAbilities.kt
@@ -608,7 +608,7 @@ internal fun EmitCtx.staticAbilityExpr(ruleName: String, ruleNode: JsonObject): 
         "CantAttackUnlessDefendingPlayer" -> {  // Deep-Sea Serpent: defender must control an Island
             val subs = subtypes(ruleNode)
             if (subs.isEmpty()) return null
-            return call("CantAttackUnless", arg(call("Conditions.OpponentControlsLandType", arg("\"${subs[0]}\""))))
+            return call("CantAttackUnless", arg(call("Conditions.DefendingPlayerControlsLandType", arg("\"${subs[0]}\""))))
         }
         "MustBlockAttacker" -> return call("MustBlock")
         // "This creature must be blocked if able" (Fear of Being Hunted) — the unconditional

--- a/mtgish-tooling/src/test/resources/fixtures/10e.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/10e.emitted.golden.txt
@@ -10371,7 +10371,7 @@ val SeaMonster = card("Sea Monster") {
     power = 6
     toughness = 6
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
     metadata {
         rarity = Rarity.COMMON

--- a/mtgish-tooling/src/test/resources/fixtures/ons.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/ons.emitted.golden.txt
@@ -10865,7 +10865,7 @@ val SlipstreamEel = card("Slipstream Eel") {
     power = 6
     toughness = 6
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
     keywordAbility(KeywordAbility.cycling("{1}{U}"))
     metadata {

--- a/mtgish-tooling/src/test/resources/fixtures/por.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/por.emitted.golden.txt
@@ -1685,7 +1685,7 @@ val DeepSeaSerpent = card("Deep-Sea Serpent") {
     power = 5
     toughness = 5
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
     metadata {
         rarity = Rarity.UNCOMMON

--- a/mtgish-tooling/src/test/resources/fixtures/tmp.emitted.golden.txt
+++ b/mtgish-tooling/src/test/resources/fixtures/tmp.emitted.golden.txt
@@ -9726,7 +9726,7 @@ val SeaMonster = card("Sea Monster") {
     power = 6
     toughness = 6
     staticAbility {
-        ability = CantAttackUnless(Conditions.OpponentControlsLandType("Island"))
+        ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
     metadata {
         rarity = Rarity.COMMON

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -274,7 +274,12 @@ data class TriggerContext(
                     triggeringPlayerId = event.chooserId
                 )
                 is AbilityActivatedEvent -> TriggerContext(
-                    triggeringEntityId = event.abilityEntityId,
+                    // The permanent whose ability was activated — NOT the ability's stack entity
+                    // (a bare container with no ControllerComponent/CardComponent, so "that
+                    // artifact's controller" reads via EffectTarget.ControllerOfTriggeringEntity
+                    // would silently resolve to null; Haunting Wind / Artifact Possession).
+                    // TriggerMatcher keys its matching off event.sourceId/abilityEntityId directly.
+                    triggeringEntityId = event.sourceId,
                     triggeringPlayerId = event.controllerId
                 )
                 is AbilityTriggeredEvent -> TriggerContext(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -274,12 +274,13 @@ data class TriggerContext(
                     triggeringPlayerId = event.chooserId
                 )
                 is AbilityActivatedEvent -> TriggerContext(
-                    // The permanent whose ability was activated — NOT the ability's stack entity
-                    // (a bare container with no ControllerComponent/CardComponent, so "that
-                    // artifact's controller" reads via EffectTarget.ControllerOfTriggeringEntity
-                    // would silently resolve to null; Haunting Wind / Artifact Possession).
-                    // TriggerMatcher keys its matching off event.sourceId/abilityEntityId directly.
-                    triggeringEntityId = event.sourceId,
+                    // The ability's stack entity — copy effects target it (Ertha Jo's
+                    // CopyTargetSpellOrAbility(TriggeringEntity)). "That artifact's controller"
+                    // reads resolve THROUGH it: ControllerOfTriggeringEntity falls through the
+                    // ActivatedAbilityOnStackComponent to the source permanent's controller.
+                    // A non-{T} mana ability never reaches the stack (abilityEntityId == null),
+                    // so fall back to the source permanent directly (Haunting Wind).
+                    triggeringEntityId = event.abilityEntityId ?: event.sourceId,
                     triggeringPlayerId = event.controllerId
                 )
                 is AbilityTriggeredEvent -> TriggerContext(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -662,6 +662,15 @@ class ConditionEvaluator(
             is Player.ChosenOpponent -> listOfNotNull(
                 ctx.sourceId?.let { state.getEntity(it)?.chosenOpponent() }
             )
+            // Defender-relative conditions (CantAttackUnless "defending player controls…"):
+            // the defender is bound into the EffectContext by the attack legality check, or
+            // read from the source's attack assignment once combat is underway. No defender
+            // in scope -> empty (the condition fails rather than leaking to other players).
+            is Player.DefendingPlayer -> listOfNotNull(
+                (ctx as? Resolution)?.effectContext?.let {
+                    com.wingedsheep.engine.handlers.effects.TargetResolutionUtils.resolveDefendingPlayer(it, state)
+                }
+            )
             else -> controllerId?.let { listOf(it) } ?: emptyList()
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/EffectContext.kt
@@ -196,6 +196,15 @@ data class EffectContext(
     val triggeringPlayerId: EntityId? = null,
     /** The spell or ability that targeted a permanent (for ward triggers) */
     val targetingSourceEntityId: EntityId? = null,
+    /**
+     * The defending player for a per-defender combat legality check (CR 508.1 attack
+     * declaration). Bound by [com.wingedsheep.engine.mechanics.combat.rules.CantAttackUnlessDefenderRule]
+     * so `Player.DefendingPlayer` conditions ("can't attack unless defending player controls
+     * an Island") evaluate against the player actually being attacked — the source has no
+     * `AttackingComponent` yet at declaration time, so the attack-time resolution path can't
+     * supply it.
+     */
+    val defendingPlayerId: EntityId? = null,
     /** Power of the triggering entity the moment it left the battlefield (dies/leaves triggers) */
     val triggerLastKnownPower: Int? = null,
     /** Toughness of the triggering entity the moment it left the battlefield (dies/leaves triggers) */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -99,13 +99,16 @@ object TargetResolutionUtils {
             ?: context.targets.firstOrNull()?.toEntityId()
 
     /**
-     * The defending player for the ability's source, per CR 802.2a: read from the
-     * source's attack assignment (a creature attacking a planeswalker defends against
-     * that planeswalker's controller). When the source has already left combat (e.g.
-     * it died dealing combat damage), the trigger event's player is last-known
-     * information for "deals combat damage to a player" triggers.
+     * The defending player for the ability's source, per CR 802.2a: an explicitly bound
+     * defender (attack-declaration legality checks bind [EffectContext.defendingPlayerId]
+     * before the attacker has an `AttackingComponent`), else read from the source's attack
+     * assignment (a creature attacking a planeswalker defends against that planeswalker's
+     * controller). When the source has already left combat (e.g. it died dealing combat
+     * damage), the trigger event's player is last-known information for "deals combat
+     * damage to a player" triggers.
      */
     fun resolveDefendingPlayer(context: EffectContext, state: GameState): EntityId? {
+        context.defendingPlayerId?.let { return it }
         val defenderId = context.sourceId
             ?.let { state.getEntity(it)?.get<AttackingComponent>()?.defenderId }
         if (defenderId != null) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/TargetResolutionUtils.kt
@@ -68,8 +68,17 @@ object TargetResolutionUtils {
         if (effectTarget is EffectTarget.ControllerOfTriggeringEntity) {
             val triggerId = context.triggeringEntityId ?: return null
             val entity = state.getEntity(triggerId) ?: return null
-            return entity.get<ControllerComponent>()?.playerId
-                ?: entity.get<CardComponent>()?.ownerId
+            entity.get<ControllerComponent>()?.playerId?.let { return it }
+            // An activated ability's stack entity is a bare container with no
+            // ControllerComponent. "That artifact's controller" (Haunting Wind, Artifact
+            // Possession) means the controller of the ability's SOURCE permanent — fall
+            // through to it, or to the ability's own controller as last-known information
+            // if the source has left the battlefield.
+            entity.get<com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent>()?.let { ability ->
+                return state.getEntity(ability.sourceId)?.get<ControllerComponent>()?.playerId
+                    ?: ability.controllerId
+            }
+            return entity.get<CardComponent>()?.ownerId
         }
         if (effectTarget is EffectTarget.AttachedToTriggeringPermanent) {
             // The triggering entity is the attachment (Aura/Equipment) that became attached; the

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/AttackRestrictionRules.kt
@@ -171,6 +171,7 @@ class CantAttackUnlessDefenderRule : AttackDefenderRule {
         val effectContext = EffectContext(
             sourceId = ctx.attackerId,
             controllerId = ctx.attackingPlayer,
+            defendingPlayerId = defendingPlayer,
         )
         if (!conditionEvaluator.evaluate(ctx.state, restriction.condition, effectContext)) {
             return "${cardComponent.name} ${restriction.description}"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/PermanentSbaModule.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/PermanentSbaModule.kt
@@ -15,7 +15,7 @@ class PermanentSbaModule(
         PlaneswalkerLoyaltyCheck(),
         LegendRuleCheck(decisionHandler),
         CounterAnnihilationCheck(),
-        UnattachedAurasCheck(),
+        UnattachedAurasCheck(cardRegistry),
         SagaSacrificeCheck(cardRegistry),
         CommanderZoneChoiceCheck(decisionHandler),
     )

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -2,13 +2,18 @@ package com.wingedsheep.engine.mechanics.sba.permanent
 
 import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.cleanupReverseAttachmentLink
+import com.wingedsheep.engine.mechanics.layers.ProjectedState
 import com.wingedsheep.engine.mechanics.sba.SbaOrder
 import com.wingedsheep.engine.mechanics.sba.SbaZoneMovementHelper
 import com.wingedsheep.engine.mechanics.sba.StateBasedActionCheck
+import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import com.wingedsheep.engine.state.components.battlefield.AttachmentHostLeftComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.GrantProtection
 
 /**
  * 704.5m - An Aura attached to an illegal object/player or not attached goes to graveyard.
@@ -23,8 +28,17 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
  *              into a 0/0 Robot artifact creature by Tezzeret, Cruel Captain's emblem.
  * 704.5p - A battle or creature attached to an object or player becomes unattached but
  *          remains on the battlefield.
+ *
+ * Protection (CR 702.16c/d): a permanent with protection from a quality can't be enchanted by
+ * Auras (put into their owners' graveyards as a state-based action) or equipped by Equipment
+ * (becomes unattached, stays on the battlefield) that have the stated quality. This covers
+ * protection gained *after* the attachment landed — targeting-time protection is enforced by
+ * `TargetValidator`. An attachment whose own printed ability grants that very protection to
+ * its host is exempt ("This effect doesn't remove this Aura", the Ward cycle).
  */
-class UnattachedAurasCheck : StateBasedActionCheck {
+class UnattachedAurasCheck(
+    private val cardRegistry: CardRegistry
+) : StateBasedActionCheck {
     override val name = "704.5m/n/p Unattached Auras"
     override val order = SbaOrder.UNATTACHED_AURAS
 
@@ -128,10 +142,59 @@ class UnattachedAurasCheck : StateBasedActionCheck {
                     newState = newState.updateEntity(entityId) { c ->
                         c.without<AttachedToComponent>()
                     }
+                } else if (
+                    hostProtectedFromAttachmentColor(projected, entityId, cardComponent, attachedTo.targetId)
+                ) {
+                    // CR 702.16c/d: the host has protection from one of this attachment's colors
+                    // (gained after the attachment landed — e.g. White Ward's pro-white sends an
+                    // already-attached Holy Strength to the graveyard). Aura -> owner's graveyard
+                    // (704.5m); Equipment -> unattaches, stays on the battlefield (704.5n).
+                    if (isAura) {
+                        val result = SbaZoneMovementHelper.putPermanentInGraveyard(
+                            newState, entityId, cardComponent,
+                            lastKnownAttachedTo = attachedTo.targetId
+                        )
+                        newState = result.newState
+                        events.addAll(result.events)
+                    } else {
+                        newState = cleanupReverseAttachmentLink(newState, entityId)
+                        newState = newState.updateEntity(entityId) { c ->
+                            c.without<AttachedToComponent>()
+                        }
+                    }
                 }
             }
         }
 
         return ExecutionResult.success(newState, events)
+    }
+
+    /**
+     * True when the attached permanent's host has protection from one of the attachment's
+     * (projected) colors, CR 702.16c/d. An attachment whose own printed [GrantProtection]
+     * grants that color's protection is exempt — the Ward cycle's "This effect doesn't remove
+     * this Aura". (Approximation: the exemption is per-color rather than per-effect, so two
+     * same-color Wards on one host both survive where strict rules would remove each via the
+     * other's effect — an untracked-provenance corner case.)
+     */
+    private fun hostProtectedFromAttachmentColor(
+        projected: ProjectedState,
+        attachmentId: EntityId,
+        attachmentCard: CardComponent,
+        hostId: EntityId
+    ): Boolean {
+        val colors = projected.getColors(attachmentId)
+        if (colors.isEmpty()) return false
+        val selfGrantedColors: Set<Color> = cardRegistry.getCard(attachmentCard.cardDefinitionId)
+            ?.staticAbilities
+            ?.filterIsInstance<GrantProtection>()
+            ?.map { it.color }
+            ?.toSet()
+            ?: emptySet()
+        return Color.entries.any { color ->
+            color.name in colors &&
+                color !in selfGrantedColors &&
+                projected.hasKeyword(hostId, "PROTECTION_FROM_${color.name}")
+        }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/sba/permanent/UnattachedAurasCheck.kt
@@ -185,12 +185,21 @@ class UnattachedAurasCheck(
     ): Boolean {
         val colors = projected.getColors(attachmentId)
         if (colors.isEmpty()) return false
-        val selfGrantedColors: Set<Color> = cardRegistry.getCard(attachmentCard.cardDefinitionId)
+        val statics = cardRegistry.getCard(attachmentCard.cardDefinitionId)
             ?.staticAbilities
-            ?.filterIsInstance<GrantProtection>()
-            ?.map { it.color }
-            ?.toSet()
-            ?: emptySet()
+            .orEmpty()
+        // Dynamic protection grants (chosen color, colors of controlled permanents) can cover
+        // any color at any time — exempt the attachment from protection-removal entirely
+        // (Pledge of Loyalty's "This effect doesn't remove Pledge of Loyalty").
+        if (statics.any {
+                it is com.wingedsheep.sdk.scripting.GrantProtectionFromControlledColors ||
+                    it is com.wingedsheep.sdk.scripting.GrantProtectionFromChosenColorToGroup
+            }
+        ) return false
+        val selfGrantedColors: Set<Color> = statics
+            .filterIsInstance<GrantProtection>()
+            .map { it.color }
+            .toSet()
         return Color.entries.any { color ->
             color.name in colors &&
                 color !in selfGrantedColors &&

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/DefendingPlayerAttackRestrictionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/DefendingPlayerAttackRestrictionTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.ActionProcessor
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.CantAttackUnless
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * "This creature can't attack unless defending player controls an Island" (Dandân, Island Fish
+ * Jasconius, Merchant Ship, Sea Monster, …) must be evaluated against the player actually being
+ * attacked, not any opponent (CR 508.1 attack legality; the condition is
+ * [Conditions.DefendingPlayerControlsLandType] → `Exists(Player.DefendingPlayer, …)`).
+ *
+ * Regression net for the audit finding that `CantAttackUnlessDefenderRule` computed the
+ * defending player and then never used it — the old `Exists(Player.EachOpponent, …)` shape let
+ * these creatures attack an Island-less player in multiplayer as long as *some* opponent
+ * controlled an Island.
+ */
+class DefendingPlayerAttackRestrictionTest : FunSpec({
+
+    val serpent = card("Test Serpent") {
+        manaCost = "{U}{U}"
+        typeLine = "Creature — Serpent"
+        power = 4
+        toughness = 1
+        staticAbility {
+            ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
+        }
+    }
+    val island = CardDefinition.basicLand("Island", Subtype("Island"))
+    val bear = CardDefinition.creature(
+        name = "Filler Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun registry() = CardRegistry().also {
+        it.register(serpent); it.register(island); it.register(bear)
+    }
+
+    fun GameState.withPermanent(def: CardDefinition, owner: EntityId): Pair<GameState, EntityId> {
+        val id = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = def.name,
+                name = def.name,
+                manaCost = def.manaCost,
+                typeLine = def.typeLine,
+                baseStats = def.creatureStats,
+                ownerId = owner
+            ),
+            OwnerComponent(owner),
+            ControllerComponent(owner)
+        )
+        return withEntity(id, container).addToZone(ZoneKey(owner, Zone.BATTLEFIELD), id) to id
+    }
+
+    /** Three players: A (active) with the serpent; B controls an Island; C controls none. */
+    fun setup(): Triple<GameState, List<EntityId>, EntityId> {
+        val deck = Deck(cards = List(40) { "Filler Bear" })
+        val init = GameInitializer(registry()).initializeGame(
+            GameConfig(
+                players = (1..3).map { PlayerConfig("Player $it", deck, 20) },
+                skipMulligans = true,
+                startingPlayerIndex = 0
+            )
+        )
+        val players = init.playerIds
+        var state = init.state
+        val (s1, serpentId) = state.withPermanent(serpent, players[0])
+        val (s2, _) = s1.withPermanent(island, players[1])
+        state = s2.copy(phase = Phase.COMBAT, step = Step.DECLARE_ATTACKERS)
+            .withPriority(players[0])
+        return Triple(state, players, serpentId)
+    }
+
+    test("cannot attack the defender who controls no Island, even though another opponent does") {
+        val (state, players, serpentId) = setup()
+        val result = ActionProcessor(registry())
+            .process(state, DeclareAttackers(players[0], mapOf(serpentId to players[2]))).result
+        result.error shouldNotBe null
+    }
+
+    test("can attack the defender who controls an Island") {
+        val (state, players, serpentId) = setup()
+        val result = ActionProcessor(registry())
+            .process(state, DeclareAttackers(players[0], mapOf(serpentId to players[1]))).result
+        result.error shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GolgothianSylexScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GolgothianSylexScenarioTest.kt
@@ -14,7 +14,8 @@ import io.kotest.matchers.shouldBe
  * Proves the `OriginallyPrintedInSet("ATQ")` set-membership filter + `SacrificeAll`:
  *  - ATQ-printed nontoken permanents (both players') are sacrificed,
  *  - non-ATQ permanents survive,
- *  - Golgothian Sylex itself survives (the "except for ~" self-exclusion),
+ *  - Golgothian Sylex sacrifices itself too (its name was originally printed in ATQ and
+ *    the oracle text has no self-exclusion),
  *  - a token (even of an ATQ permanent's name) survives, since tokens have no original set.
  */
 class GolgothianSylexScenarioTest : ScenarioTestBase() {
@@ -25,7 +26,7 @@ class GolgothianSylexScenarioTest : ScenarioTestBase() {
 
     init {
         context("Golgothian Sylex set-membership mass sacrifice") {
-            test("sacrifices only ATQ-printed nontoken permanents, sparing non-ATQ and itself") {
+            test("sacrifices all ATQ-printed nontoken permanents, including itself, sparing non-ATQ") {
                 val game = scenario()
                     .withPlayers("Player1", "Player2")
                     .withCardOnBattlefield(1, "Golgothian Sylex", tapped = false, summoningSickness = false)
@@ -57,8 +58,9 @@ class GolgothianSylexScenarioTest : ScenarioTestBase() {
                 withClue("Grizzly Bears (non-ATQ) should survive") {
                     game.isOnBattlefield("Grizzly Bears") shouldBe true
                 }
-                withClue("Golgothian Sylex spares itself") {
-                    game.isOnBattlefield("Golgothian Sylex") shouldBe true
+                withClue("Golgothian Sylex sacrifices itself (its name is ATQ-printed; no self-exclusion in oracle)") {
+                    game.isOnBattlefield("Golgothian Sylex") shouldBe false
+                    game.isInGraveyard(1, "Golgothian Sylex") shouldBe true
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeaOracleFidelityFixesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeaOracleFidelityFixesScenarioTest.kt
@@ -1,0 +1,344 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression net for the Alpha (LEA) oracle-fidelity bugs found in the set audit: a family of
+ * mtgish-generated cards silently dropped a targeting constraint (color / blocking / ownership /
+ * mana value X) or a whole modal mode, making each card strictly stronger than printed.
+ *
+ *  - Blue Elemental Blast: "Choose one — Counter target RED spell / Destroy target RED permanent"
+ *    (was: counter ANY spell, no destroy mode at all). Red Elemental Blast is the exact mirror.
+ *  - Deathgrip: "{B}{B}: Counter target GREEN spell" (was: any spell).
+ *  - Northern Paladin: "{W}{W}, {T}: Destroy target BLACK permanent" (was: any permanent).
+ *  - Righteousness: "Target BLOCKING creature gets +7/+7" (was: any creature).
+ *  - Spell Blast: "Counter target spell WITH MANA VALUE X" (was: any spell, X ignored).
+ *  - Regrowth: "Return target card from YOUR graveyard" (was: any graveyard).
+ */
+class LeaOracleFidelityFixesScenarioTest : ScenarioTestBase() {
+
+    private val deathgripAbilityId by lazy {
+        cardRegistry.getCard("Deathgrip")!!.activatedAbilities[0].id
+    }
+    private val paladinAbilityId by lazy {
+        cardRegistry.getCard("Northern Paladin")!!.activatedAbilities[0].id
+    }
+
+    init {
+        context("Blue Elemental Blast — modal, red-only") {
+            test("counter mode counters a red spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Blue Elemental Blast")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.passPriority() // P2 passes so P1 can respond
+
+                val boltId = game.state.stack.first()
+                val handId = game.state.getHand(game.player1Id).first()
+                val result = game.execute(
+                    CastSpell(
+                        game.player1Id, handId,
+                        targets = listOf(ChosenTarget.Spell(boltId)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Spell(boltId)))
+                    )
+                )
+                withClue("Countering a red spell should be legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Lightning Bolt should be countered") {
+                    game.isInGraveyard(2, "Lightning Bolt") shouldBe true
+                }
+            }
+
+            test("counter mode cannot target a non-red spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Blue Elemental Blast")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+
+                val bearsId = game.state.stack.first()
+                val handId = game.state.getHand(game.player1Id).first()
+                val result = game.execute(
+                    CastSpell(
+                        game.player1Id, handId,
+                        targets = listOf(ChosenTarget.Spell(bearsId)),
+                        chosenModes = listOf(0),
+                        modeTargetsOrdered = listOf(listOf(ChosenTarget.Spell(bearsId)))
+                    )
+                )
+                withClue("A green spell must not be a legal target for the counter mode") {
+                    result.error shouldNotBe null
+                }
+            }
+
+            test("destroy mode destroys a red permanent but cannot target a non-red one") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Blue Elemental Blast")
+                    .withCardInHand(1, "Blue Elemental Blast")
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardOnBattlefield(2, "Gray Ogre")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("A green permanent must not be a legal target for the destroy mode") {
+                    game.castSpellWithMode(1, "Blue Elemental Blast", 1, bears).error shouldNotBe null
+                }
+
+                val ogre = game.findPermanent("Gray Ogre")!!
+                val result = game.castSpellWithMode(1, "Blue Elemental Blast", 1, ogre)
+                withClue("Destroying a red permanent should be legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Gray Ogre (red) should be destroyed") {
+                    game.isOnBattlefield("Gray Ogre") shouldBe false
+                    game.isInGraveyard(2, "Gray Ogre") shouldBe true
+                }
+            }
+        }
+
+        context("Deathgrip — counters only green spells") {
+            test("counters a green spell, rejects a red spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Deathgrip")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val deathgrip = game.findPermanent("Deathgrip")!!
+
+                // Red spell on the stack: not a legal target.
+                game.castSpellTargetingPlayer(2, "Lightning Bolt", 1).error shouldBe null
+                game.passPriority()
+                val boltId = game.state.stack.first()
+                withClue("A red spell must not be targetable by Deathgrip") {
+                    game.execute(
+                        ActivateAbility(
+                            game.player1Id, deathgrip, deathgripAbilityId,
+                            targets = listOf(ChosenTarget.Spell(boltId))
+                        )
+                    ).error shouldNotBe null
+                }
+                game.resolveStack() // bolt resolves
+
+                // Green spell on the stack: countered.
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+                val bearsId = game.state.stack.first()
+                val result = game.execute(
+                    ActivateAbility(
+                        game.player1Id, deathgrip, deathgripAbilityId,
+                        targets = listOf(ChosenTarget.Spell(bearsId))
+                    )
+                )
+                withClue("Countering a green spell should be legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Grizzly Bears should be countered") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+
+        context("Northern Paladin — destroys only black permanents") {
+            test("destroys a black creature, rejects a non-black one") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Northern Paladin", tapped = false, summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withCardOnBattlefield(2, "Scathe Zombies")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val paladin = game.findPermanent("Northern Paladin")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("A green permanent must not be a legal target") {
+                    game.execute(
+                        ActivateAbility(
+                            game.player1Id, paladin, paladinAbilityId,
+                            targets = listOf(ChosenTarget.Permanent(bears))
+                        )
+                    ).error shouldNotBe null
+                }
+
+                val zombies = game.findPermanent("Scathe Zombies")!!
+                val result = game.execute(
+                    ActivateAbility(
+                        game.player1Id, paladin, paladinAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(zombies))
+                    )
+                )
+                withClue("Destroying a black permanent should be legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Scathe Zombies (black) should be destroyed") {
+                    game.isOnBattlefield("Scathe Zombies") shouldBe false
+                }
+            }
+        }
+
+        context("Righteousness — target blocking creature only") {
+            test("cannot target a creature that isn't blocking") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Righteousness")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("A non-blocking creature must not be a legal target") {
+                    game.castSpell(1, "Righteousness", bears).error shouldNotBe null
+                }
+            }
+
+            test("gives a blocking creature +7/+7") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gray Ogre", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardInHand(2, "Righteousness")
+                    .withLandsOnBattlefield(2, "Plains", 1)
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(2, "Plains")
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                game.declareAttackers(mapOf("Gray Ogre" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                game.declareBlockers(mapOf("Grizzly Bears" to listOf("Gray Ogre"))).error shouldBe null
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.castSpell(2, "Righteousness", bears)
+                withClue("A blocking creature should be a legal target: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Blocker should be 9/9 (+7/+7 on a 2/2)") {
+                    game.state.projectedState.getPower(bears) shouldBe 9
+                }
+            }
+        }
+
+        context("Spell Blast — counters only a spell with mana value X") {
+            test("X must equal the target spell's mana value") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Spell Blast")
+                    .withCardInHand(1, "Spell Blast")
+                    .withLandsOnBattlefield(1, "Island", 8)
+                    .withCardInHand(2, "Grizzly Bears") // mana value 2
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+
+                val bearsId = game.state.stack.first()
+                fun spellBlastInHand() = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Spell Blast"
+                }
+
+                withClue("X=1 must not legally counter a mana value 2 spell") {
+                    game.execute(
+                        CastSpell(
+                            game.player1Id, spellBlastInHand(),
+                            targets = listOf(ChosenTarget.Spell(bearsId)),
+                            xValue = 1
+                        )
+                    ).error shouldNotBe null
+                }
+
+                val result = game.execute(
+                    CastSpell(
+                        game.player1Id, spellBlastInHand(),
+                        targets = listOf(ChosenTarget.Spell(bearsId)),
+                        xValue = 2
+                    )
+                )
+                withClue("X=2 should legally counter a mana value 2 spell: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Grizzly Bears should be countered") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+
+        context("Regrowth — your graveyard only") {
+            test("cannot target a card in an opponent's graveyard; returns your own") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Regrowth")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withCardInGraveyard(1, "Giant Growth")
+                    .withCardInGraveyard(2, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("An opponent's graveyard card must not be a legal target") {
+                    game.castSpellTargetingGraveyardCard(1, "Regrowth", 2, "Lightning Bolt")
+                        .error shouldNotBe null
+                }
+
+                val handBefore = game.handSize(1)
+                val result = game.castSpellTargetingGraveyardCard(1, "Regrowth", 1, "Giant Growth")
+                withClue("Your own graveyard card should be a legal target: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+                withClue("Giant Growth returns to hand (Regrowth cast -1, Giant Growth +1)") {
+                    game.handSize(1) shouldBe handBefore
+                    game.isInGraveyard(1, "Giant Growth") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProtectionAuraStateBasedActionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ProtectionAuraStateBasedActionTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * CR 702.16c: a permanent with protection can't be enchanted by Auras that have the stated
+ * quality — such Auras are put into their owners' graveyards as a state-based action. This
+ * covers protection gained AFTER the Aura attached (targeting-time protection is a separate,
+ * already-enforced check).
+ *
+ * The classic Alpha case: a creature wearing Holy Strength (a white Aura) gains protection
+ * from white via White Ward → Holy Strength falls off into the graveyard; White Ward itself
+ * stays ("This effect doesn't remove this Aura"), and off-color Auras are untouched.
+ */
+class ProtectionAuraStateBasedActionTest : ScenarioTestBase() {
+
+    init {
+        context("protection gained after attachment removes same-color auras") {
+            test("White Ward's pro-white sends an attached white aura to the graveyard, keeps itself and off-color auras") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Holy Strength", "Grizzly Bears")   // white aura
+                    .withCardAttachedTo(1, "Unholy Strength", "Grizzly Bears") // black aura
+                    .withCardInHand(1, "White Ward")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val result = game.castSpell(1, "White Ward", bears)
+                withClue("Casting White Ward on the (not yet protected) creature should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Holy Strength (white) becomes an illegal attachment and goes to the graveyard") {
+                    game.isOnBattlefield("Holy Strength") shouldBe false
+                    game.isInGraveyard(1, "Holy Strength") shouldBe true
+                }
+                withClue("White Ward itself stays attached — its own effect doesn't remove it") {
+                    game.isOnBattlefield("White Ward") shouldBe true
+                }
+                withClue("Unholy Strength (black) is unaffected by protection from white") {
+                    game.isOnBattlefield("Unholy Strength") shouldBe true
+                }
+                withClue("The enchanted creature is unharmed") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UrzaTronScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UrzaTronScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Urza's Mine / Power Plant / Tower (ATQ) — the "if you control an Urza's X and an Urza's Y,
+ * add more" bonus. Regression net for the audit finding that Mine and Tower checked for a land
+ * *named* "Urza's Power-Plant" (hyphenated, the subtype spelling) while the card is named
+ * "Urza's Power Plant" — an exact-name mismatch that made assembled Tron never produce bonus
+ * mana from those two lands.
+ */
+class UrzaTronScenarioTest : ScenarioTestBase() {
+
+    private fun abilityId(cardName: String) =
+        cardRegistry.getCard(cardName)!!.activatedAbilities[0].id
+
+    private fun colorlessMana(game: TestGame): Int =
+        game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.colorless ?: 0
+
+    private fun tronScenario(vararg lands: String): TestGame {
+        val builder = scenario()
+            .withPlayers("Player1", "Player2")
+            .withActivePlayer(1)
+        for (land in lands) builder.withCardOnBattlefield(1, land, tapped = false)
+        return builder.inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN).build()
+    }
+
+    init {
+        context("assembled Tron produces bonus mana") {
+            test("Urza's Tower adds {C}{C}{C} with Mine and Power Plant on the battlefield") {
+                val game = tronScenario("Urza's Tower", "Urza's Mine", "Urza's Power Plant")
+                val tower = game.findPermanent("Urza's Tower")!!
+                val result = game.execute(ActivateAbility(game.player1Id, tower, abilityId("Urza's Tower")))
+                withClue("Tapping Urza's Tower should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Full Tron: Tower adds three colorless") {
+                    colorlessMana(game) shouldBe 3
+                }
+            }
+
+            test("Urza's Mine adds {C}{C} with Power Plant and Tower on the battlefield") {
+                val game = tronScenario("Urza's Tower", "Urza's Mine", "Urza's Power Plant")
+                val mine = game.findPermanent("Urza's Mine")!!
+                val result = game.execute(ActivateAbility(game.player1Id, mine, abilityId("Urza's Mine")))
+                withClue("Tapping Urza's Mine should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Full Tron: Mine adds two colorless") {
+                    colorlessMana(game) shouldBe 2
+                }
+            }
+        }
+
+        context("incomplete Tron produces one mana") {
+            test("Urza's Tower adds only {C} when Power Plant is missing") {
+                val game = tronScenario("Urza's Tower", "Urza's Mine")
+                val tower = game.findPermanent("Urza's Tower")!!
+                game.execute(ActivateAbility(game.player1Id, tower, abilityId("Urza's Tower"))).error shouldBe null
+                withClue("Tower without Power Plant adds one colorless") {
+                    colorlessMana(game) shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A full audit of every implemented Alpha (146), Arabian Nights (74), and Antiquities (84) card against current Scryfall oracle text, plus the engine features those sets exercise. It found one dominant bug class — **mtgish-generated cards promoted into `cards/` packages without scenario tests had silently dropped a targeting constraint (color / blocking / ownership / mana-value-X) or a whole modal mode** — plus three engine-level bugs.

## Card fixes

| Card | Oracle says | Implementation did |
|------|-------------|--------------------|
| Blue/Red Elemental Blast | Choose one — counter target red/blue spell; destroy target red/blue permanent | Countered **any** spell; destroy mode missing entirely |
| Deathgrip | Counter target **green** spell | Any spell |
| Lifeforce | Counter target **black** spell | Any spell |
| Northern Paladin | Destroy target **black** permanent | Any permanent (incl. lands) |
| Righteousness | Target **blocking** creature +7/+7 | Any creature |
| Spell Blast | Counter target spell **with mana value X** | Any spell, X ignored |
| Regrowth | Return card from **your** graveyard | Any graveyard |
| Zombie Master | Other **Zombies** have "{B}: Regenerate" | Zombie creatures only |
| Golgothian Sylex | Each ATQ-named nontoken permanent is sacrificed | Excluded itself (invented clause; its test asserted the bug) |
| Urza's Mine / Tower | Bonus if you control an Urza's Power-Plant | Checked a land **named** "Urza's Power-Plant" (hyphen = subtype spelling); card is named "Urza's Power Plant" → Tron **never** gave bonus mana |
| Haunting Wind | Damage to **that artifact's controller** | Damaged the activating player |
| Powerleech | An opponent activates **an artifact's** ability | Required the artifact to be opponent-controlled |

## Engine fixes

- **Protection-based attachment legality (CR 702.16c/d)**: `UnattachedAurasCheck` now puts same-color Auras into the graveyard / unattaches Equipment when the host has protection from one of the attachment's colors — covering protection gained *after* attachment (e.g. White Ward's pro-white removes an already-attached Holy Strength). An attachment whose own `GrantProtection` grants that color is exempt (the Ward cycle's "This effect doesn't remove this Aura"). Guardian Beast's `CANT_BE_ENCHANTED` intentionally stays targeting-only (its oracle keeps existing Auras).
- **Defending-player attack restrictions**: `CantAttackUnlessDefenderRule` computed the defending player and never used it, and the condition was `Exists(Player.EachOpponent, …)` — so Dandân / Island Fish Jasconius / Merchant Ship (and Sea Monster / Deep-Sea Serpent / Slipstream Eel / Vodalian Serpent) could attack an Island-less defender in multiplayer if *any* opponent had an Island. Added `EffectContext.defendingPlayerId` + `Player.DefendingPlayer` support in `Exists` evaluation, and renamed `Conditions.OpponentControlsLandType` → `DefendingPlayerControlsLandType` (7 card call sites, mtgish emitter, goldens re-blessed).
- **`AbilityActivatedEvent` trigger context**: `triggeringEntityId` pointed at the bare ability stack entity (no `ControllerComponent`), so `EffectTarget.ControllerOfTriggeringEntity` silently resolved to null — "that artifact's controller" fizzled for Haunting Wind and Artifact Possession. Now points at the activated permanent; matching still keys off `event.sourceId`/`abilityEntityId` in `TriggerMatcher`.

## Tests

- `LeaOracleFidelityFixesScenarioTest` — 9 tests: each fixed LEA card proves both the accept and reject leg of its restored constraint.
- `UrzaTronScenarioTest` — full Tron gives {C}{C}{C}/{C}{C}, broken Tron gives {C}.
- `ProtectionAuraStateBasedActionTest` — White Ward removes Holy Strength, keeps itself and Unholy Strength.
- `DefendingPlayerAttackRestrictionTest` — 3-player game: can't attack the Island-less defender even though another opponent has one.
- `GolgothianSylexScenarioTest` — assertion inverted to match oracle (Sylex sacrifices itself).
- Card snapshots (7 sets) and emitter goldens (4 sets, pure rename) re-blessed; SDK reference doc updated.

## Reported but intentionally not changed (documented approximations / out of scope)

Clockwork Avian's mandatory-max "up to X"; Candelabra's `dynamicMaxCount` min-count; Erg Raiders' entered-this-turn proxy; Aladdin's Lamp X=0; Cuombajj Witches' multiplayer chooser; Oubliette phase-in via trigger; Nafs Asp pay timing; Goblin Goon's `ControlMoreCreatures` still has the any-opponent shape (same class as the Dandân fix, LGN out of audit scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)