### PR TITLE
Fix "discard your hand. If you do" to fire on an empty hand

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1213,7 +1213,11 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     enforced corpus-wide by `SuccessCriterionValidationTest`) rejects an Auto criterion on any other
     action — non-zone-move actions (deal damage, gain life, …) must state `SuccessCriterion.Always`,
     `CollectionNonEmpty(name, min)`, or `DamageDealt(recipient)` explicitly instead of silently
-    inheriting a fail-open "it happened". `SuccessCriterion.DamageDealt(recipient = Controller|Any)`
+    inheriting a fail-open "it happened". Auto's zone-grew probe is also **wrong for zone-move
+    actions that succeed vacuously**: "discard your hand" discards zero cards from an empty hand yet
+    still counts as performed (Narset, Jeskai Waymaster ruling 2025-04-04 — "You may choose to
+    discard your hand even if your hand contains zero cards"), so gate it with
+    `SuccessCriterion.Always`, never Auto (Vaultguard Trooper, Narset, Sauron the Dark Lord). `SuccessCriterion.DamageDealt(recipient = Controller|Any)`
     gates on whether the action **actually dealt damage** from the effect's source (a positive-amount
     `DamageDealtEvent` sourced from it) — damage that was fully prevented or replaced (a Circle of
     Protection, a prevention shield, redirection) emits no such event and counts as "didn't happen".

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/VaultguardTrooper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eoe/cards/VaultguardTrooper.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
 import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -42,7 +43,10 @@ val VaultguardTrooper = card("Vaultguard Trooper") {
         effect = MayEffect(
             IfYouDoEffect(
                 action = Patterns.Hand.discardHand(EffectTarget.Controller),
-                ifYouDo = Effects.DrawCards(2)
+                ifYouDo = Effects.DrawCards(2),
+                // Discarding your hand always succeeds, even with zero cards in it — Auto's
+                // "graveyard grew" probe would wrongly skip the draw on an empty hand.
+                successCriterion = SuccessCriterion.Always
             )
         )
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronTheDarkLord.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ltr/cards/SauronTheDarkLord.kt
@@ -10,6 +10,7 @@ import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.TriggerBinding
 import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.events.DamageType
 import com.wingedsheep.sdk.scripting.events.RecipientFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -72,7 +73,10 @@ val SauronTheDarkLord = card("Sauron, the Dark Lord") {
         effect = MayEffect(
             IfYouDoEffect(
                 action = Patterns.Hand.discardHand(EffectTarget.Controller),
-                ifYouDo = Effects.DrawCards(4)
+                ifYouDo = Effects.DrawCards(4),
+                // Discarding your hand always succeeds, even with zero cards in it — Auto's
+                // "graveyard grew" probe would wrongly skip the draw on an empty hand.
+                successCriterion = SuccessCriterion.Always
             )
         )
         description = "You may discard your hand. If you do, draw four cards."

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NarsetJeskaiWaymaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/NarsetJeskaiWaymaster.kt
@@ -7,6 +7,7 @@ import com.wingedsheep.sdk.dsl.Patterns
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
 import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
@@ -39,7 +40,10 @@ val NarsetJeskaiWaymaster = card("Narset, Jeskai Waymaster") {
         effect = MayEffect(
             IfYouDoEffect(
                 action = Patterns.Hand.discardHand(EffectTarget.Controller),
-                ifYouDo = Effects.DrawCards(DynamicAmount.SpellsCastThisTurn(Player.You))
+                ifYouDo = Effects.DrawCards(DynamicAmount.SpellsCastThisTurn(Player.You)),
+                // Discarding your hand always succeeds, even with zero cards in it (official
+                // ruling 2025-04-04) — Auto's "graveyard grew" probe would skip the empty-hand draw.
+                successCriterion = SuccessCriterion.Always
             )
         )
         description = "You may discard your hand. If you do, draw cards equal to the number of spells you've cast this turn."

--- a/mtg-sets/src/test/resources/snapshots/cards/EOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EOE.json
@@ -18790,7 +18790,8 @@
                                         "moveType": "Discard"
                                     }
                                 ]
-                            }
+                            },
+                            "successCriterion": "SuccessCriterion.Always"
                         },
                         "then": {
                             "type": "DrawCards",

--- a/mtg-sets/src/test/resources/snapshots/cards/LTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LTR.json
@@ -15140,7 +15140,8 @@
                                         "moveType": "Discard"
                                     }
                                 ]
-                            }
+                            },
+                            "successCriterion": "SuccessCriterion.Always"
                         },
                         "then": {
                             "type": "DrawCards",

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -10497,7 +10497,8 @@
                                         "moveType": "Discard"
                                     }
                                 ]
-                            }
+                            },
+                            "successCriterion": "SuccessCriterion.Always"
                         },
                         "then": {
                             "type": "DrawCards",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NarsetJeskaiWaymasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NarsetJeskaiWaymasterScenarioTest.kt
@@ -76,6 +76,32 @@ class NarsetJeskaiWaymasterScenarioTest : FunSpec({
         driver.getHand(controller).size shouldBe 2
     }
 
+    test("empty hand can still be discarded — the draw fires (ruling 2025-04-04)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(controller, "Narset, Jeskai Waymaster")
+
+        // Cast one spell this turn, then empty the hand entirely.
+        driver.giveMana(controller, Color.RED, 1)
+        val boltCard = driver.putCardInHand(controller, "Test Bolt")
+        driver.submit(CastSpell(playerId = controller, cardId = boltCard))
+        driver.resolveStack()
+        driver.getHand(controller).forEach { driver.moveToGraveyard(it) }
+        driver.getHand(controller).size shouldBe 0
+
+        driver.passPriorityUntil(Step.END)
+        var guard = 0
+        while (driver.state.pendingDecision == null && guard < 20) { driver.bothPass(); guard++ }
+        driver.submitYesNo(controller, true)
+        driver.resolveStack()
+
+        // Discarding zero cards still counts as "if you do" — draw one (one spell cast).
+        driver.getHand(controller).size shouldBe 1
+    }
+
     test("declining the end-step ability keeps the hand and draws nothing") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VaultguardTrooperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VaultguardTrooperScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Vaultguard Trooper (EOE #166).
+ *
+ * "At the beginning of your end step, if you control two or more tapped creatures,
+ *  you may discard your hand. If you do, draw two cards."
+ *
+ * The key case is the empty hand: discarding your hand is an action that always succeeds, even
+ * when it discards zero cards, so answering "yes" with no cards in hand still draws two (same
+ * templating as Narset, Jeskai Waymaster, whose official ruling reads "You may choose to discard
+ * your hand even if your hand contains zero cards.").
+ */
+class VaultguardTrooperScenarioTest : ScenarioTestBase() {
+
+    private fun baseScenario() = run {
+        var builder = scenario()
+            .withPlayers("Player", "Opponent")
+            .withCardOnBattlefield(1, "Vaultguard Trooper", summoningSickness = false)
+            .withCardOnBattlefield(1, "Grizzly Bears", tapped = true)
+            .withCardOnBattlefield(1, "Grizzly Bears", tapped = true)
+            .withActivePlayer(1)
+            .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        // Library fuel for the draws and step advances.
+        repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+        repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+        builder
+    }
+
+    init {
+        context("Vaultguard Trooper end-step trigger") {
+
+            test("empty hand: choosing to discard still draws two cards") {
+                val game = baseScenario().build()
+                game.handSize(1) shouldBe 0
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("The may-discard trigger should prompt even with an empty hand") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("Discarding an empty hand still counts as 'if you do' — draw two") {
+                    game.handSize(1) shouldBe 2
+                }
+                game.graveyardSize(1) shouldBe 0
+            }
+
+            test("nonempty hand: discards everything, then draws two") {
+                val game = baseScenario()
+                    .withCardInHand(1, "Mountain")
+                    .withCardInHand(1, "Mountain")
+                    .withCardInHand(1, "Mountain")
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                game.handSize(1) shouldBe 2
+                withClue("All three discarded cards should be in the graveyard") {
+                    game.graveyardSize(1) shouldBe 3
+                }
+            }
+
+            test("declining keeps the hand and draws nothing") {
+                val game = baseScenario()
+                    .withCardInHand(1, "Mountain")
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe true
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                game.handSize(1) shouldBe 1
+                game.graveyardSize(1) shouldBe 0
+            }
+
+            test("fewer than two tapped creatures: the ability doesn't trigger") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Vaultguard Trooper", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(5) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(5) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                game.hasPendingDecision() shouldBe false
+                game.handSize(1) shouldBe 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Vaultguard Trooper's end-step ability did nothing when your hand was empty: answering "yes" to "you may discard your hand" never drew the two cards.

The `IfYouDoEffect` around `Patterns.Hand.discardHand` used the default `SuccessCriterion.Auto`, whose probe is "did the destination zone (graveyard) grow". Discarding zero cards grows nothing, so Auto scored the action as "didn't happen" and skipped the draw. But by the official rules the whole-hand discard succeeds vacuously — Narset, Jeskai Waymaster's ruling (2025-04-04) states it directly: *"You may choose to discard your hand even if your hand contains zero cards."*

Narset, Jeskai Waymaster and Sauron, the Dark Lord share the exact same `MayEffect(IfYouDoEffect(discardHand, draw))` shape and had the same bug.

## Fix

Gate all three cards with `SuccessCriterion.Always` — the SDK's documented criterion for actions that can't fail. No engine change needed.

## Tests

- New `VaultguardTrooperScenarioTest`: empty-hand discard draws two (the repro), nonempty hand discards all + draws two, declining does nothing, and the intervening-if "two or more tapped creatures" trigger condition.
- Empty-hand regression case added to `NarsetJeskaiWaymasterScenarioTest`.
- EOE/TDM/LTR card snapshots re-blessed (diff is exactly the `successCriterion` field).
- SDK reference updated with the vacuous-success pitfall for `SuccessCriterion.Auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)