### PR TITLE
Add five Final Fantasy cards (Serah, Kuja, Dion, Garland, Balamb Garden)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -524,6 +524,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   (the opposite face — front→back), `FRONT` ("return it front face up" — the eikon Saga's final chapter flips
   back to the legend), or `BACK`. The front face's activated ability is sorcery-speed
   (`timing = TimingRule.SorcerySpeed`); Jecht uses it from a "may" combat-damage trigger instead.
+- `ReturnSelfFromGraveyardTransformed()` — "Return this card from your graveyard to the battlefield
+  transformed" (Garland, Knight of Cornelia). Returns the *source card* from the graveyard to the
+  battlefield with its back face up; pair with `activateFromZone = Zone.GRAVEYARD` on the owning
+  activated ability. No transform triggers fire (the card was never turned over on the battlefield);
+  the back face's ETB triggers fire normally. No-ops if the source left the graveyard before
+  resolution, or if it isn't a double-faced card (a single-faced card instructed to enter transformed
+  doesn't move at all). Raw type `ReturnSelfFromZoneTransformedEffect(fromZone)` generalizes to other
+  source zones.
 - `ReturnCreaturesPutInGraveyardThisTurn(player)` — Patriarch's Bidding shape.
 - `ReturnSameNamedFromGraveyard(target = ContextTarget(0))` — return the target graveyard card and
   **every other card with the same name** in the controller's graveyard to the battlefield **tapped**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -127,6 +127,7 @@ import com.wingedsheep.sdk.scripting.effects.ReturnOneFromLinkedExileEffect
 import com.wingedsheep.sdk.scripting.effects.ExileAndReturnTransformedEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnFace
 import com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect
+import com.wingedsheep.sdk.scripting.effects.ReturnSelfFromZoneTransformedEffect
 import com.wingedsheep.sdk.scripting.effects.ReturnSelfToBattlefieldAttachedEffect
 import com.wingedsheep.sdk.scripting.effects.DrawUpToEffect
 import com.wingedsheep.sdk.scripting.effects.RemoveFromCombatEffect
@@ -781,6 +782,15 @@ object Effects {
      * as the activated ability's effect; see CR 702.167a.
      */
     val ReturnSelfFromExileTransformed: Effect = ReturnSelfFromExileTransformedEffect
+
+    /**
+     * Return the source card from your graveyard to the battlefield with its back face up —
+     * "Return this card from your graveyard to the battlefield transformed" (Garland, Knight
+     * of Cornelia). Pair with `activateFromZone = Zone.GRAVEYARD` on the owning ability. No-ops
+     * if the source left the graveyard before resolution or is not a double-faced card.
+     */
+    fun ReturnSelfFromGraveyardTransformed(): Effect =
+        ReturnSelfFromZoneTransformedEffect(Zone.GRAVEYARD)
 
     /**
      * Exile a double-faced permanent, then return it to the battlefield as a new object on the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TransformEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/TransformEffects.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.sdk.scripting.effects
 
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.sdk.scripting.text.TextReplacer
 import kotlinx.serialization.SerialName
@@ -81,4 +82,28 @@ data class ExileAndReturnTransformedEffect(
 data object ReturnSelfFromExileTransformedEffect : Effect {
     override val description: String =
         "Return this card to the battlefield transformed under its owner's control"
+}
+
+/**
+ * Return the source **card** from a non-battlefield zone to the battlefield with its back face
+ * up — "Return this card from your graveyard to the battlefield transformed" (Garland, Knight
+ * of Cornelia). Typically the resolution of an activated ability with
+ * `activateFromZone = fromZone`.
+ *
+ * A double-faced card in a non-battlefield zone has only its front face's characteristics;
+ * entering "transformed" means the new battlefield object has its back face up. As with the
+ * other off-battlefield return-transformed effects (and unlike [TransformEffect]), no transform
+ * triggers fire — the card was never turned over on the battlefield; enters-the-battlefield
+ * triggers of the back face fire normally. Per the official ruling ("If you are instructed to
+ * put a card that isn't a double-faced card onto the battlefield transformed, it will not enter
+ * at all"), the executor no-ops when the source is not a double-faced card, and it also no-ops
+ * if the source has already left [fromZone] by the time the ability resolves.
+ */
+@SerialName("ReturnSelfFromZoneTransformed")
+@Serializable
+data class ReturnSelfFromZoneTransformedEffect(
+    val fromZone: Zone = Zone.GRAVEYARD,
+) : Effect {
+    override val description: String =
+        "Return this card from your ${fromZone.displayName.lowercase()} to the battlefield transformed"
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BalambGardenSeedAcademy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/BalambGardenSeedAcademy.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Balamb Garden, SeeD Academy // Balamb Garden, Airborne — Final Fantasy #272
+ * Land — Town // Legendary Artifact — Vehicle 5/4
+ *
+ * Front — Balamb Garden, SeeD Academy:
+ *   This land enters tapped.
+ *   {T}: Add {G} or {U}.
+ *   {5}{G}{U}, {T}: Transform this land. This ability costs {1} less to activate for each
+ *   other Town you control.
+ *
+ * Back — Balamb Garden, Airborne:
+ *   Flying
+ *   Whenever Balamb Garden attacks, draw a card.
+ *   Crew 1
+ *
+ * The transform activation's discount rides
+ * [com.wingedsheep.sdk.scripting.ActivatedAbility.genericCostReduction] (Qiqirn Merchant's
+ * Town-count pattern) with `excludeSelf = true` for the "each *other* Town" wording. The
+ * transform itself is an on-battlefield [TransformEffect] flip — the land turns over into the
+ * Vehicle in place (unlike the Dominant exile-and-return cycle, no new object is created).
+ */
+private val BalambGardenAirborne = card("Balamb Garden, Airborne") {
+    manaCost = ""
+    colorIdentity = "GU"
+    typeLine = "Legendary Artifact — Vehicle"
+    oracleText = "Flying\n" +
+        "Whenever Balamb Garden attacks, draw a card.\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This " +
+        "Vehicle becomes an artifact creature until end of turn.)"
+    power = 5
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    // Whenever Balamb Garden attacks, draw a card.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.DrawCards(1)
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "272"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/back/0/0/001e9f20-5b15-41cb-bf82-46172decc235.jpg?1782686387"
+    }
+}
+
+private val BalambGardenSeedAcademyFront = card("Balamb Garden, SeeD Academy") {
+    manaCost = ""
+    colorIdentity = "GU"
+    typeLine = "Land — Town"
+    oracleText = "This land enters tapped.\n" +
+        "{T}: Add {G} or {U}.\n" +
+        "{5}{G}{U}, {T}: Transform this land. This ability costs {1} less to activate for " +
+        "each other Town you control."
+
+    // This land enters tapped.
+    replacementEffect(EntersTapped())
+
+    // {T}: Add {G} or {U}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {5}{G}{U}, {T}: Transform this land. This ability costs {1} less to activate for each
+    // other Town you control.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}{G}{U}"), Costs.Tap)
+        effect = TransformEffect(EffectTarget.Self)
+        genericCostReduction = DynamicAmount.AggregateBattlefield(
+            player = Player.You,
+            filter = GameObjectFilter.Land.withSubtype("Town"),
+            excludeSelf = true,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "272"
+        artist = "Jonas De Ro"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/001e9f20-5b15-41cb-bf82-46172decc235.jpg?1782686387"
+
+        ruling(
+            "2025-06-06",
+            "Town is a land type with no special meaning. It doesn't grant the land any " +
+                "intrinsic abilities. Other cards may care about which lands are Towns."
+        )
+    }
+}
+
+val BalambGardenSeedAcademy: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = BalambGardenSeedAcademyFront,
+    backFace = BalambGardenAirborne,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DionBahamutsDominant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/DionBahamutsDominant.kt
@@ -1,0 +1,171 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.ReturnFace
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Dion, Bahamut's Dominant // Bahamut, Warden of Light — Final Fantasy #16
+ * {3}{W} · Legendary Creature — Human Noble Knight 3/3
+ * // Legendary Enchantment Creature — Saga Dragon 5/5
+ *
+ * Front — Dion, Bahamut's Dominant:
+ *   Dragonfire Dive — During your turn, Dion and other Knights you control have flying.
+ *   When Dion enters, create a 2/2 white Knight creature token.
+ *   {4}{W}{W}, {T}: Exile Dion, then return it to the battlefield transformed under its
+ *   owner's control. Activate only as a sorcery.
+ *
+ * Back — Bahamut, Warden of Light (eikon Saga):
+ *   (As this Saga enters and after your draw step, add a lore counter.)
+ *   I, II — Wings of Light — Put a +1/+1 counter on each other creature you control. Those
+ *   creatures gain flying until end of turn.
+ *   III — Gigaflare — Destroy target permanent. Exile Bahamut, then return it to the
+ *   battlefield (front face up).
+ *   Flying
+ *
+ * Dragonfire Dive is two [Conditions.IsYourTurn]-gated statics — one on Dion himself and one
+ * on *other* Knights you control — because per the official ruling Dion keeps flying during
+ * your turn even if he somehow isn't a Knight. Wings of Light iterates the other-creatures
+ * group once (snapshot), giving each a counter and end-of-turn flying, so "those creatures"
+ * is exactly the set that received counters. The Dominant transform loop follows Jill,
+ * Shiva's Dominant.
+ */
+private val BahamutWardenOfLight = card("Bahamut, Warden of Light") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Legendary Enchantment Creature — Saga Dragon"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter.)\n" +
+        "I, II — Wings of Light — Put a +1/+1 counter on each other creature you control. " +
+        "Those creatures gain flying until end of turn.\n" +
+        "III — Gigaflare — Destroy target permanent. Exile Bahamut, then return it to the " +
+        "battlefield (front face up).\n" +
+        "Flying"
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.FLYING)
+
+    // I, II — Wings of Light — Put a +1/+1 counter on each other creature you control.
+    // Those creatures gain flying until end of turn.
+    val wingsOfLight = Effects.ForEachInGroup(
+        GroupFilter.OtherCreaturesYouControl,
+        Effects.Composite(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self),
+        ),
+    )
+    sagaChapter(1) {
+        effect = wingsOfLight
+    }
+    sagaChapter(2) {
+        effect = wingsOfLight
+    }
+
+    // III — Gigaflare — Destroy target permanent. Exile Bahamut, then return it to the
+    // battlefield (front face up).
+    sagaChapter(3) {
+        val t = target("permanent", TargetObject(filter = TargetFilter(GameObjectFilter.Permanent)))
+        effect = Effects.Composite(
+            Effects.Destroy(t),
+            Effects.ExileAndReturnTransformed(EffectTarget.Self, ReturnFace.FRONT),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "16"
+        artist = "Kevin Glint"
+        imageUri = "https://cards.scryfall.io/normal/back/8/c/8c0f9306-2058-476d-a711-bd37a6e15e42.jpg?1782686587"
+
+        ruling(
+            "2025-06-06",
+            "If the target permanent is an illegal target when Bahamut's third chapter ability " +
+                "tries to resolve, it won't resolve and none of its effects will happen. You " +
+                "won't exile Bahamut and return it to the battlefield front face up."
+        )
+    }
+}
+
+private val DionBahamutsDominantFront = card("Dion, Bahamut's Dominant") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Noble Knight"
+    oracleText = "Dragonfire Dive — During your turn, Dion and other Knights you control have " +
+        "flying.\n" +
+        "When Dion enters, create a 2/2 white Knight creature token.\n" +
+        "{4}{W}{W}, {T}: Exile Dion, then return it to the battlefield transformed under its " +
+        "owner's control. Activate only as a sorcery."
+    power = 3
+    toughness = 3
+
+    // Dragonfire Dive — During your turn, Dion has flying (even if he isn't a Knight)...
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(Keyword.FLYING, Filters.Self)
+    }
+    // ...and other Knights you control have flying.
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(
+            Keyword.FLYING,
+            GroupFilter(
+                GameObjectFilter.Creature.withSubtype("Knight").youControl(),
+                excludeSelf = true,
+            ),
+        )
+    }
+
+    // When Dion enters, create a 2/2 white Knight creature token.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Knight"),
+            imageUri = "https://cards.scryfall.io/normal/front/a/7/a7758a0b-9e85-4b4a-bf1c-ffcc6761dbad.jpg?1782725381",
+        )
+    }
+
+    // {4}{W}{W}, {T}: Exile Dion, then return it transformed. Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{W}{W}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.ExileAndReturnTransformed()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "16"
+        artist = "Kevin Glint"
+        imageUri = "https://cards.scryfall.io/normal/front/8/c/8c0f9306-2058-476d-a711-bd37a6e15e42.jpg?1782686587"
+
+        ruling(
+            "2025-06-06",
+            "Dion's first ability will still give it flying during your turn even if Dion " +
+                "somehow isn't a Knight."
+        )
+    }
+}
+
+val DionBahamutsDominant: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = DionBahamutsDominantFront,
+    backFace = BahamutWardenOfLight,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GarlandKnightOfCornelia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/GarlandKnightOfCornelia.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Garland, Knight of Cornelia // Chaos, the Endless — Final Fantasy #221
+ * {B}{R} · Legendary Creature — Human Knight 3/2
+ * // Legendary Creature — Demon 5/5
+ *
+ * Front — Garland, Knight of Cornelia:
+ *   Whenever you cast a noncreature spell, surveil 1.
+ *   {3}{B}{B}{R}{R}: Return this card from your graveyard to the battlefield transformed.
+ *   Activate only as a sorcery.
+ *
+ * Back — Chaos, the Endless:
+ *   Flying
+ *   When Chaos dies, put it on the bottom of its owner's library.
+ *
+ * The graveyard ability is an `activateFromZone = GRAVEYARD` activated ability resolving to
+ * [Effects.ReturnSelfFromGraveyardTransformed] — the card enters as a new object with the
+ * Chaos face up (no transform triggers; a DFC in the graveyard is front-face-up by
+ * definition). Chaos's death trigger is a plain bottom-of-library move: by the time it is in
+ * the graveyard the card has reverted to its front face (Rule 712.8a), and the trigger uses
+ * last-known information to move the card wherever it went.
+ */
+private val ChaosTheEndless = card("Chaos, the Endless") {
+    manaCost = ""
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Demon"
+    oracleText = "Flying\n" +
+        "When Chaos dies, put it on the bottom of its owner's library."
+    power = 5
+    toughness = 5
+
+    keywords(Keyword.FLYING)
+
+    // When Chaos dies, put it on the bottom of its owner's library.
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.PutOnBottomOfLibrary(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Billy Christian"
+        imageUri = "https://cards.scryfall.io/normal/back/d/d/dd463dbe-5f2c-4d4f-86f8-ad8ff407af62.jpg?1782686428"
+    }
+}
+
+private val GarlandKnightOfCorneliaFront = card("Garland, Knight of Cornelia") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human Knight"
+    oracleText = "Whenever you cast a noncreature spell, surveil 1. (Look at the top card of " +
+        "your library. You may put it into your graveyard.)\n" +
+        "{3}{B}{B}{R}{R}: Return this card from your graveyard to the battlefield transformed. " +
+        "Activate only as a sorcery."
+    power = 3
+    toughness = 2
+
+    // Whenever you cast a noncreature spell, surveil 1.
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.Surveil(1)
+    }
+
+    // {3}{B}{B}{R}{R}: Return this card from your graveyard to the battlefield transformed.
+    // Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Mana("{3}{B}{B}{R}{R}")
+        timing = TimingRule.SorcerySpeed
+        activateFromZone = Zone.GRAVEYARD
+        effect = Effects.ReturnSelfFromGraveyardTransformed()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "221"
+        artist = "Billy Christian"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd463dbe-5f2c-4d4f-86f8-ad8ff407af62.jpg?1782686428"
+    }
+}
+
+val GarlandKnightOfCornelia: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = GarlandKnightOfCorneliaFront,
+    backFace = ChaosTheEndless,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/KujaGenomeSorcerer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/KujaGenomeSorcerer.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DoubleDamage
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kuja, Genome Sorcerer // Trance Kuja, Fate Defied — Final Fantasy #232
+ * {2}{B}{R} · Legendary Creature — Human Mutant Wizard 3/4
+ * // Legendary Creature — Avatar Wizard 4/6
+ *
+ * Front — Kuja, Genome Sorcerer:
+ *   At the beginning of your end step, create a tapped 0/1 black Wizard creature token with
+ *   "Whenever you cast a noncreature spell, this token deals 1 damage to each opponent."
+ *   Then if you control four or more Wizards, transform Kuja.
+ *
+ * Back — Trance Kuja, Fate Defied:
+ *   Flare Star — If a Wizard you control would deal damage to a permanent or player, it deals
+ *   double that damage instead.
+ *
+ * The token carries its noncreature-cast trigger via [CreateTokenEffect.triggeredAbilities]
+ * (Sidequest: Raise a Chocobo's pattern). The "Then if" transform check is a
+ * [ConditionalEffect] *after* the token creation in the same resolution, so the freshly
+ * created Wizard counts toward the four. Flare Star is the Gratuitous Violence shape
+ * ([DoubleDamage]) restricted to Wizards you control; per the official ruling the doubled
+ * damage is still dealt by the original source, which the replacement preserves.
+ */
+private val TranceKujaFateDefied = card("Trance Kuja, Fate Defied") {
+    manaCost = ""
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Avatar Wizard"
+    oracleText = "Flare Star — If a Wizard you control would deal damage to a permanent or " +
+        "player, it deals double that damage instead."
+    power = 4
+    toughness = 6
+
+    // Flare Star — If a Wizard you control would deal damage to a permanent or player,
+    // it deals double that damage instead.
+    replacementEffect(
+        DoubleDamage(
+            appliesTo = EventPattern.DamageEvent(
+                source = SourceFilter.Matching(
+                    GameObjectFilter.Creature.withSubtype("Wizard").youControl()
+                ),
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "232"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/back/0/0/008782d2-72b0-4554-b1ce-2db99969a4d8.jpg?1782686418"
+    }
+}
+
+private val KujaGenomeSorcererFront = card("Kuja, Genome Sorcerer") {
+    manaCost = "{2}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Legendary Creature — Human Mutant Wizard"
+    oracleText = "At the beginning of your end step, create a tapped 0/1 black Wizard creature " +
+        "token with \"Whenever you cast a noncreature spell, this token deals 1 damage to each " +
+        "opponent.\" Then if you control four or more Wizards, transform Kuja."
+    power = 3
+    toughness = 4
+
+    // At the beginning of your end step, create a tapped 0/1 black Wizard creature token with
+    // "Whenever you cast a noncreature spell, this token deals 1 damage to each opponent."
+    // Then if you control four or more Wizards, transform Kuja.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.Composite(
+            CreateTokenEffect(
+                power = 0,
+                toughness = 1,
+                colors = setOf(Color.BLACK),
+                creatureTypes = setOf("Wizard"),
+                tapped = true,
+                imageUri = "https://cards.scryfall.io/normal/front/1/8/187fe54c-7d0c-4225-9d46-3affbead897d.jpg?1782725378",
+                triggeredAbilities = listOf(
+                    TriggeredAbility.create(
+                        trigger = Triggers.YouCastNoncreature.event,
+                        binding = TriggerBinding.ANY,
+                        effect = DealDamageEffect(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+                    ),
+                ),
+            ),
+            ConditionalEffect(
+                condition = Conditions.YouControlAtLeast(
+                    4,
+                    GameObjectFilter.Creature.withSubtype("Wizard")
+                ),
+                effect = TransformEffect(EffectTarget.Self),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "232"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/0/0/008782d2-72b0-4554-b1ce-2db99969a4d8.jpg?1782686418"
+
+        ruling(
+            "2025-06-06",
+            "The Wizard token's ability resolves before the spell that caused it to trigger. " +
+                "It resolves even if that spell is countered or otherwise leaves the stack."
+        )
+        ruling(
+            "2025-06-06",
+            "The damage is dealt by the same source as the original source of damage. The " +
+                "doubled damage isn't dealt by Trance Kuja unless it was the original source " +
+                "of damage."
+        )
+    }
+}
+
+val KujaGenomeSorcerer: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = KujaGenomeSorcererFront,
+    backFace = TranceKujaFateDefied,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SerahFarron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SerahFarron.kt
@@ -1,0 +1,134 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostGating
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+import com.wingedsheep.sdk.scripting.conditions.Compare
+import com.wingedsheep.sdk.scripting.conditions.ComparisonOperator
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Serah Farron // Crystallized Serah — Final Fantasy #240
+ * {1}{G}{W} · Legendary Creature — Human Citizen 2/2 // Legendary Artifact
+ *
+ * Front — Serah Farron:
+ *   The first legendary creature spell you cast each turn costs {2} less to cast.
+ *   At the beginning of combat on your turn, if you control two or more other legendary
+ *   creatures, you may transform Serah Farron.
+ *
+ * Back — Crystallized Serah:
+ *   The first legendary creature spell you cast each turn costs {2} less to cast.
+ *   Legendary creatures you control get +2/+2.
+ *
+ * The transform trigger is an intervening-"if" (checked when the trigger would go on the
+ * stack and again on resolution) over the count of *other* legendary creatures you control —
+ * `AggregateBattlefield(excludeSelf = true)` so Serah never counts herself even if her own
+ * types change. The cost reduction is `CostGating.NthOfTypePerTurn(1)` (Eluge-style
+ * first-matching-spell-each-turn gating) and, per the official ruling, only reduces the
+ * generic component of the cost.
+ */
+private val CrystallizedSerah = card("Crystallized Serah") {
+    manaCost = ""
+    colorIdentity = "GW"
+    typeLine = "Legendary Artifact"
+    oracleText = "The first legendary creature spell you cast each turn costs {2} less to cast.\n" +
+        "Legendary creatures you control get +2/+2."
+
+    // The first legendary creature spell you cast each turn costs {2} less to cast.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature.legendary()),
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.NthOfTypePerTurn(1),
+        )
+    }
+
+    // Legendary creatures you control get +2/+2.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 2,
+            toughnessBonus = 2,
+            filter = GroupFilter(GameObjectFilter.Creature.legendary().youControl()),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "240"
+        artist = "Carissa Susilo"
+        imageUri = "https://cards.scryfall.io/normal/back/6/2/62fa74c0-43ae-445c-8039-ca9d00e9709a.jpg?1782686410"
+    }
+}
+
+private val SerahFarronFront = card("Serah Farron") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Citizen"
+    oracleText = "The first legendary creature spell you cast each turn costs {2} less to cast.\n" +
+        "At the beginning of combat on your turn, if you control two or more other legendary " +
+        "creatures, you may transform Serah Farron."
+    power = 2
+    toughness = 2
+
+    // The first legendary creature spell you cast each turn costs {2} less to cast.
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.Creature.legendary()),
+            modification = CostModification.ReduceGeneric(2),
+            gating = CostGating.NthOfTypePerTurn(1),
+        )
+    }
+
+    // At the beginning of combat on your turn, if you control two or more other legendary
+    // creatures, you may transform Serah Farron.
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Compare(
+            DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Creature.legendary(),
+                excludeSelf = true,
+            ),
+            ComparisonOperator.GTE,
+            DynamicAmount.Fixed(2),
+        )
+        effect = MayEffect(effect = TransformEffect(EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "240"
+        artist = "Carissa Susilo"
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62fa74c0-43ae-445c-8039-ca9d00e9709a.jpg?1782686410"
+
+        ruling(
+            "2025-06-06",
+            "The cost reduction applies only to generic mana in the total cost of legendary " +
+                "creature spells you cast."
+        )
+        ruling(
+            "2025-06-06",
+            "Serah Farron's last ability checks at the moment it would trigger to see if you " +
+                "control two or more other legendary creatures. If you don't, the ability won't " +
+                "trigger at all. If it does trigger, the ability will check again as it tries to " +
+                "resolve."
+        )
+    }
+}
+
+val SerahFarron: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = SerahFarronFront,
+    backFace = CrystallizedSerah,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -1132,6 +1132,126 @@
     ]
 }
 
+// Balamb Garden, SeeD Academy
+{
+    "name": "Balamb Garden, SeeD Academy",
+    "manaCost": "",
+    "typeLine": "Land — Town",
+    "oracleText": "This land enters tapped.\n{T}: Add {G} or {U}.\n{5}{G}{U}, {T}: Transform this land. This ability costs {1} less to activate for each other Town you control.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{G}{U}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "Transform",
+                "genericCostReduction": {
+                    "type": "AggregateBattlefield",
+                    "player": "You",
+                    "filter": "land Town",
+                    "excludeSelf": true
+                }
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "backFace": {
+        "name": "Balamb Garden, Airborne",
+        "manaCost": "",
+        "typeLine": "Legendary Artifact — Vehicle",
+        "oracleText": "Flying\nWhenever Balamb Garden attacks, draw a card.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 4
+        },
+        "keywords": [
+            "FLYING",
+            "CREW"
+        ],
+        "keywordAbilities": [
+            {
+                "type": "Numeric",
+                "keyword": "CREW",
+                "n": 1
+            }
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_4",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "272",
+            "rarity": "RARE",
+            "artist": "Jonas De Ro",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/0/001e9f20-5b15-41cb-bf82-46172decc235.jpg?1782686387"
+        },
+        "colorIdentityOverride": [
+            "GREEN",
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "272",
+        "rarity": "RARE",
+        "artist": "Jonas De Ro",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/001e9f20-5b15-41cb-bf82-46172decc235.jpg?1782686387",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "Town is a land type with no special meaning. It doesn't grant the land any intrinsic abilities. Other cards may care about which lands are Towns."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
+    ]
+}
+
 // Balamb T-Rexaur
 {
     "name": "Balamb T-Rexaur",
@@ -4677,6 +4797,220 @@
     ]
 }
 
+// Dion, Bahamut's Dominant
+{
+    "name": "Dion, Bahamut's Dominant",
+    "manaCost": "{3}{W}",
+    "typeLine": "Legendary Creature — Human Noble Knight",
+    "oracleText": "Dragonfire Dive — During your turn, Dion and other Knights you control have flying.\nWhen Dion enters, create a 2/2 white Knight creature token.\n{4}{W}{W}, {T}: Exile Dion, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Knight"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/a/7/a7758a0b-9e85-4b4a-bf1c-ffcc6761dbad.jpg?1782725381"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{W}{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "ExileAndReturnTransformed",
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "creature Knight ctrl:you",
+                        "excludeSelf": true
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Bahamut, Warden of Light",
+        "manaCost": "",
+        "typeLine": "Legendary Enchantment Creature — Saga Dragon",
+        "oracleText": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II — Wings of Light — Put a +1/+1 counter on each other creature you control. Those creatures gain flying until end of turn.\nIII — Gigaflare — Destroy target permanent. Exile Bahamut, then return it to the battlefield (front face up).\nFlying",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 5
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "sagaChapters": [
+                {
+                    "chapter": 1,
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you",
+                                "excludeSelf": true
+                            }
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "AddCounters",
+                                    "counterType": "+1/+1",
+                                    "count": 1,
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "FLYING",
+                                    "target": "Self"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "chapter": 2,
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you",
+                                "excludeSelf": true
+                            }
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "AddCounters",
+                                    "counterType": "+1/+1",
+                                    "count": 1,
+                                    "target": "Self"
+                                },
+                                {
+                                    "type": "GrantKeyword",
+                                    "keyword": "FLYING",
+                                    "target": "Self"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "chapter": 3,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "permanent"
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            {
+                                "type": "ExileAndReturnTransformed",
+                                "returnAs": "FRONT"
+                            }
+                        ]
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "permanent"
+                        },
+                        "id": "permanent"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "16",
+            "rarity": "RARE",
+            "artist": "Kevin Glint",
+            "imageUri": "https://cards.scryfall.io/normal/back/8/c/8c0f9306-2058-476d-a711-bd37a6e15e42.jpg?1782686587",
+            "rulings": [
+                {
+                    "date": "2025-06-06",
+                    "text": "If the target permanent is an illegal target when Bahamut's third chapter ability tries to resolve, it won't resolve and none of its effects will happen. You won't exile Bahamut and return it to the battlefield front face up."
+                }
+            ]
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "RARE",
+        "artist": "Kevin Glint",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/c/8c0f9306-2058-476d-a711-bd37a6e15e42.jpg?1782686587",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "Dion's first ability will still give it flying during your turn even if Dion somehow isn't a Knight."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Dragoon's Lance
 {
     "name": "Dragoon's Lance",
@@ -6050,6 +6384,104 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Garland, Knight of Cornelia
+{
+    "name": "Garland, Knight of Cornelia",
+    "manaCost": "{B}{R}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "Whenever you cast a noncreature spell, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\n{3}{B}{B}{R}{R}: Return this card from your graveyard to the battlefield transformed. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{B}{B}{R}{R}"
+                    }
+                },
+                "effect": "ReturnSelfFromZoneTransformed",
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Chaos, the Endless",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Demon",
+        "oracleText": "Flying\nWhen Chaos dies, put it on the bottom of its owner's library.",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 5
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "from": "Battlefield",
+                        "to": "Graveyard"
+                    },
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Library",
+                        "placement": "Bottom"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "221",
+            "rarity": "UNCOMMON",
+            "artist": "Billy Christian",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/d/dd463dbe-5f2c-4d4f-86f8-ad8ff407af62.jpg?1782686428"
+        },
+        "colorIdentityOverride": [
+            "BLACK",
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "UNCOMMON",
+        "artist": "Billy Christian",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd463dbe-5f2c-4d4f-86f8-ad8ff407af62.jpg?1782686428"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -8717,6 +9149,147 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Kuja, Genome Sorcerer
+{
+    "name": "Kuja, Genome Sorcerer",
+    "manaCost": "{2}{B}{R}",
+    "typeLine": "Legendary Creature — Human Mutant Wizard",
+    "oracleText": "At the beginning of your end step, create a tapped 0/1 black Wizard creature token with \"Whenever you cast a noncreature spell, this token deals 1 damage to each opponent.\" Then if you control four or more Wizards, transform Kuja.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "CreateToken",
+                            "power": 0,
+                            "toughness": 1,
+                            "colors": [
+                                "BLACK"
+                            ],
+                            "creatureTypes": [
+                                "Wizard"
+                            ],
+                            "imageUri": "https://cards.scryfall.io/normal/front/1/8/187fe54c-7d0c-4225-9d46-3affbead897d.jpg?1782725378",
+                            "tapped": true,
+                            "triggeredAbilities": [
+                                {
+                                    "id": "ability_2",
+                                    "trigger": {
+                                        "type": "SpellCastEvent",
+                                        "spellFilter": {
+                                            "cardPredicates": [
+                                                "IsNoncreature"
+                                            ]
+                                        }
+                                    },
+                                    "binding": "ANY",
+                                    "effect": {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "EachOpponent"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "Compare",
+                                    "left": {
+                                        "type": "AggregateBattlefield",
+                                        "player": "You",
+                                        "filter": "creature Wizard"
+                                    },
+                                    "operator": "GTE",
+                                    "right": {
+                                        "type": "Fixed",
+                                        "amount": 4
+                                    }
+                                }
+                            },
+                            "then": "Transform"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Trance Kuja, Fate Defied",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Avatar Wizard",
+        "oracleText": "Flare Star — If a Wizard you control would deal damage to a permanent or player, it deals double that damage instead.",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 6
+        },
+        "script": {
+            "replacementEffects": [
+                {
+                    "type": "DoubleDamage",
+                    "appliesTo": {
+                        "type": "DamageEvent",
+                        "source": {
+                            "type": "SourceMatching",
+                            "filter": "creature Wizard ctrl:you"
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "232",
+            "rarity": "RARE",
+            "artist": "Joshua Raphael",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/0/008782d2-72b0-4554-b1ce-2db99969a4d8.jpg?1782686418"
+        },
+        "colorIdentityOverride": [
+            "BLACK",
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "232",
+        "rarity": "RARE",
+        "artist": "Joshua Raphael",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/0/008782d2-72b0-4554-b1ce-2db99969a4d8.jpg?1782686418",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "The Wizard token's ability resolves before the spell that caused it to trigger. It resolves even if that spell is countered or otherwise leaves the stack."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "The damage is dealt by the same source as the original source of damage. The doubled damage isn't dealt by Trance Kuja unless it was the original source of damage."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
     ]
 }
 
@@ -14643,6 +15216,150 @@
     "colorIdentityOverride": [
         "BLUE",
         "BLACK"
+    ]
+}
+
+// Serah Farron
+{
+    "name": "Serah Farron",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Legendary Creature — Human Citizen",
+    "oracleText": "The first legendary creature spell you cast each turn costs {2} less to cast.\nAt the beginning of combat on your turn, if you control two or more other legendary creatures, you may transform Serah Farron.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Transform"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "IsLegendary"
+                            ]
+                        },
+                        "excludeSelf": true
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsLegendary"
+                        ]
+                    }
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 2
+                },
+                "gating": {
+                    "type": "NthOfTypePerTurn",
+                    "n": 1
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Crystallized Serah",
+        "manaCost": "",
+        "typeLine": "Legendary Artifact",
+        "oracleText": "The first legendary creature spell you cast each turn costs {2} less to cast.\nLegendary creatures you control get +2/+2.",
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "ModifySpellCost",
+                    "target": {
+                        "type": "YouCast",
+                        "filter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "IsLegendary"
+                            ]
+                        }
+                    },
+                    "modification": {
+                        "type": "ReduceGeneric",
+                        "amount": 2
+                    },
+                    "gating": {
+                        "type": "NthOfTypePerTurn",
+                        "n": 1
+                    }
+                },
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": {
+                            "cardPredicates": [
+                                "IsCreature",
+                                "IsLegendary"
+                            ],
+                            "controllerPredicate": "ControlledByYou"
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "240",
+            "rarity": "RARE",
+            "artist": "Carissa Susilo",
+            "imageUri": "https://cards.scryfall.io/normal/back/6/2/62fa74c0-43ae-445c-8039-ca9d00e9709a.jpg?1782686410"
+        },
+        "colorIdentityOverride": [
+            "GREEN",
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "240",
+        "rarity": "RARE",
+        "artist": "Carissa Susilo",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62fa74c0-43ae-445c-8039-ca9d00e9709a.jpg?1782686410",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "The cost reduction applies only to generic mana in the total cost of legendary creature spells you cast."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "Serah Farron's last ability checks at the moment it would trigger to see if you control two or more other legendary creatures. If you don't, the ability won't trigger at all. If it does trigger, the ability will check again as it tries to resolve."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -85,6 +85,7 @@ import com.wingedsheep.engine.handlers.effects.permanent.types.SetGroupCreatureS
 import com.wingedsheep.engine.handlers.effects.permanent.types.SetLandTypeExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.ExileAndReturnTransformedExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.ReturnSelfFromExileTransformedExecutor
+import com.wingedsheep.engine.handlers.effects.permanent.types.ReturnSelfFromZoneTransformedExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TransformEffectExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TurnFaceDownExecutor
 import com.wingedsheep.engine.handlers.effects.permanent.types.TurnFaceUpExecutor
@@ -165,6 +166,7 @@ class PermanentExecutors(
         SetGroupCreatureSubtypesExecutor(),
         TransformEffectExecutor(cardRegistry),
         ReturnSelfFromExileTransformedExecutor(cardRegistry),
+        ReturnSelfFromZoneTransformedExecutor(cardRegistry),
         ExileAndReturnTransformedExecutor(cardRegistry),
         TurnFaceDownExecutor(),
         TurnFaceUpExecutor(cardRegistry),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromZoneTransformedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/types/ReturnSelfFromZoneTransformedExecutor.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.handlers.effects.permanent.types
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.sdk.scripting.effects.ReturnSelfFromZoneTransformedEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ReturnSelfFromZoneTransformedEffect] — "Return this card from your graveyard
+ * to the battlefield transformed" (Garland, Knight of Cornelia).
+ *
+ * Guards, in order:
+ *  1. The source must still be in the effect's [ReturnSelfFromZoneTransformedEffect.fromZone]
+ *     when the ability resolves (it may have been exiled or reanimated in response) — else no-op.
+ *  2. The source must be a double-faced card. A single-faced card instructed to enter the
+ *     battlefield transformed doesn't move at all (official FIN ruling), so this is a no-op,
+ *     not an error.
+ *
+ * The face flip + zone move is the shared [returnDfcFaceFromExile] helper (its name predates
+ * this executor — it flips-then-moves from whatever zone the entity is currently in), always
+ * to the back face: a card in a non-battlefield zone is front-face-up by definition, so
+ * "transformed" can only mean the back face.
+ */
+class ReturnSelfFromZoneTransformedExecutor(
+    private val cardRegistry: CardRegistry
+) : EffectExecutor<ReturnSelfFromZoneTransformedEffect> {
+
+    override val effectType: KClass<ReturnSelfFromZoneTransformedEffect> =
+        ReturnSelfFromZoneTransformedEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ReturnSelfFromZoneTransformedEffect,
+        context: EffectContext
+    ): EffectResult {
+        val sourceId = context.sourceId
+            ?: return EffectResult.error(state, "ReturnSelfFromZoneTransformed has no source")
+        val container = state.getEntity(sourceId)
+            ?: return EffectResult.success(state)
+
+        // Fizzle quietly if the card already left the expected zone.
+        val currentZone = state.zones.entries.firstOrNull { sourceId in it.value }?.key
+            ?: return EffectResult.success(state)
+        if (currentZone.zoneType != effect.fromZone) {
+            return EffectResult.success(state)
+        }
+
+        // A non-DFC instructed to enter transformed stays where it is. DFC-ness comes from the
+        // card definition, not the component: DoubleFacedComponent is only stamped when a DFC
+        // spell resolves onto the battlefield, so a card that was discarded or milled straight
+        // into the graveyard doesn't carry one yet.
+        val cardComponent = container.get<com.wingedsheep.engine.state.components.identity.CardComponent>()
+            ?: return EffectResult.success(state)
+        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
+        val backFace = cardDef?.backFace
+            ?: return EffectResult.success(state)
+
+        var workingState = state
+        if (container.get<DoubleFacedComponent>() == null) {
+            workingState = state.updateEntity(sourceId) { c ->
+                c.with(
+                    DoubleFacedComponent(
+                        frontCardDefinitionId = cardDef.name,
+                        backCardDefinitionId = backFace.name,
+                        currentFace = DoubleFacedComponent.Face.FRONT
+                    )
+                )
+            }
+        }
+
+        val transition = returnDfcFaceFromExile(
+            workingState, cardRegistry, sourceId, DoubleFacedComponent.Face.BACK
+        )
+        return EffectResult.success(transition.state, transition.events)
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GarlandKnightOfCorneliaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GarlandKnightOfCorneliaScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.GarlandKnightOfCornelia
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.TimingRule
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Garland, Knight of Cornelia // Chaos, the Endless (FIN):
+ * "{3}{B}{B}{R}{R}: Return this card from your graveyard to the battlefield transformed.
+ * Activate only as a sorcery."
+ *
+ * Exercises the new [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromZoneTransformedEffect]:
+ * a graveyard-activated ability whose resolution puts the card onto the battlefield with its
+ * back face (Chaos) up. The card in the test goes to the graveyard *without ever being on the
+ * battlefield* (as if discarded/milled), covering the path where no DoubleFacedComponent has
+ * been stamped yet. Also closes the loop: Chaos dying puts the card (reverted to its front
+ * face, Rule 712.8a) on the bottom of its owner's library.
+ */
+class GarlandKnightOfCorneliaScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GarlandKnightOfCornelia))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun returnFromGraveyard(driver: GameTestDriver, active: com.wingedsheep.sdk.model.EntityId): com.wingedsheep.sdk.model.EntityId {
+        val garland = driver.putCardInGraveyard(active, "Garland, Knight of Cornelia")
+        driver.giveMana(active, Color.BLACK, 2)
+        driver.giveMana(active, Color.RED, 2)
+        driver.giveColorlessMana(active, 3)
+        val abilityId = GarlandKnightOfCornelia.activatedAbilities.first().id
+        driver.submit(ActivateAbility(playerId = active, sourceId = garland, abilityId = abilityId))
+            .isSuccess shouldBe true
+        driver.bothPass()
+        resolveStack(driver)
+        return garland
+    }
+
+    test("the graveyard ability is sorcery-speed and activates from the graveyard") {
+        val ability = GarlandKnightOfCornelia.activatedAbilities.first()
+        ability.timing shouldBe TimingRule.SorcerySpeed
+        ability.activateFromZone shouldBe Zone.GRAVEYARD
+    }
+
+    test("activating from the graveyard returns the card to the battlefield as Chaos, the Endless") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+
+        val garland = returnFromGraveyard(driver, active)
+
+        // Same entity, now on the battlefield with the back face up: Chaos, a 5/5 flying Demon.
+        driver.findPermanent(active, "Chaos, the Endless") shouldBe garland
+        driver.state.getZone(active, Zone.GRAVEYARD).isEmpty() shouldBe true
+        val projected = projector.project(driver.state)
+        projected.getPower(garland) shouldBe 5
+        projected.getToughness(garland) shouldBe 5
+        projected.hasKeyword(garland, Keyword.FLYING) shouldBe true
+    }
+
+    test("when Chaos dies it goes to the bottom of its owner's library as Garland (front face)") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+
+        val garland = returnFromGraveyard(driver, active)
+        driver.findPermanent(active, "Chaos, the Endless") shouldBe garland
+
+        // Kill the 5/5 with two of our own 3-damage bolts in the same turn; the death trigger
+        // puts the card on the bottom of its owner's library instead of leaving it in the
+        // graveyard.
+        repeat(2) {
+            val bolt = driver.putCardInHand(active, "Lightning Bolt")
+            driver.giveMana(active, Color.RED, 1)
+            driver.castSpell(active, bolt, targets = listOf(garland)).isSuccess shouldBe true
+            driver.bothPass()
+            resolveStack(driver)
+        }
+
+        driver.findPermanent(active, "Chaos, the Endless") shouldBe null
+        driver.state.getZone(active, Zone.GRAVEYARD).contains(garland) shouldBe false
+        val library = driver.state.getZone(active, Zone.LIBRARY)
+        library.last() shouldBe garland
+        // Off the battlefield the card reverts to its front face (Rule 712.8a).
+        driver.state.getEntity(garland)!!.get<CardComponent>()!!.name shouldBe
+            "Garland, Knight of Cornelia"
+    }
+
+})


### PR DESCRIPTION
Implements five missing FIN cards — four transform DFCs and a land DFC — taking the set from 272/300 to 277/300 draft cards.

## Cards

| Card | Key mechanics |
|------|---------------|
| **Serah Farron // Crystallized Serah** | First-legendary-creature-spell-each-turn {2} discount (`CostGating.NthOfTypePerTurn(1)`); begin-combat intervening-if "may transform" counting *other* legendary creatures (`AggregateBattlefield(excludeSelf = true)`, so Serah never counts herself even if her types change); back-face +2/+2 legendary lord. |
| **Kuja, Genome Sorcerer // Trance Kuja, Fate Defied** | End-step tapped 0/1 Wizard token carrying a granted "you cast a noncreature spell → 1 damage to each opponent" trigger (Raise-a-Chocobo pattern); "Then if you control four or more Wizards" as a same-resolution `ConditionalEffect` so the fresh token counts; back face is the Gratuitous Violence `DoubleDamage` shape filtered to Wizards you control. |
| **Dion, Bahamut's Dominant // Bahamut, Warden of Light** | Dragonfire Dive as two `IsYourTurn`-gated flying statics (self + other Knights — per the official ruling Dion keeps flying even if he somehow isn't a Knight); ETB 2/2 Knight token; Dominant exile-and-return-transformed loop (Jill/Clive template) with Wings of Light (per-creature counter + end-of-turn flying over one group snapshot) and Gigaflare (destroy target, return front face up). |
| **Garland, Knight of Cornelia // Chaos, the Endless** | Noncreature-cast surveil 1; `activateFromZone = GRAVEYARD` sorcery-speed "return this card from your graveyard to the battlefield transformed"; Chaos dies → bottom of its owner's library (reverting to the front face, Rule 712.8a). |
| **Balamb Garden, SeeD Academy // Balamb Garden, Airborne** | Town land, enters tapped, {T}: add {G}/{U}; transform activation discounted {1} per *other* Town via `genericCostReduction`; back is a flying crew-1 Vehicle with an attack draw trigger. |

## SDK/engine change

New `ReturnSelfFromZoneTransformedEffect` (+ `Effects.ReturnSelfFromGraveyardTransformed()` facade, executor, SDK-reference entry): returns the source card from a non-battlefield zone to the battlefield with its back face up, reusing the shared `returnDfcFaceFromExile` face-flip helper.

- DFC-ness is derived from the **card definition**, not `DoubleFacedComponent` — a card discarded or milled straight to the graveyard never had the component stamped (it's only attached when a DFC spell resolves onto the battlefield).
- A non-DFC source no-ops (official ruling: a single-faced card instructed to enter transformed doesn't move at all).
- Fizzles quietly if the card left the zone before the ability resolves.
- No transform triggers fire — the card enters as a new object; back-face ETB triggers fire normally.

## Cards deliberately *not* picked

Scoped out after probing SDK support — each needs a real engine feature, not card authoring: Kefka (cross-player pipeline-collection accumulation for "card types among cards discarded this way"), Lightning (floating scoped damage-doubling replacement), Emet-Selch (unrestricted play-from-graveyard static), Joshua/Terra (total-MV-budget multi-targeting / lore-counter choice on copy tokens), Ragnarok + Vanille (meld).

## Testing

- `GarlandKnightOfCorneliaScenarioTest` — graveyard activation returns the card as Chaos (5/5 flying, back face) including the never-on-battlefield path; Chaos death puts the card on the bottom of the library as Garland; sorcery-speed + graveyard-zone pins.
- `just test-rules` and `:mtg-sets:test` green (card lint, facade boundary, executor coverage).
- FIN snapshot golden re-blessed; verified the diff is pure insertion of the five new card trees (every removed line reappears — no existing card moved).
- All ten card-face image URLs HEAD-verified 200; `just check-card-printing` confirms FIN is the canonical earliest printing for all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)