### PR TITLE
Fix the 6 open findings from the BLB oracle-fidelity audit

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1402,6 +1402,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   (replacement at entry + this effect each upkeep), whose P/T is a
   `SetBasePowerToughnessDynamicStatic(power = CastChoice(CHOSEN_NUMBER), toughness = Subtract(Fixed(7),
   CastChoice(CHOSEN_NUMBER)))` CDA — power = last chosen number, toughness = 7 − it.
+- `Effects.ChooseOpponent(prompt)` — the controller picks an opponent, **stored durably on the
+  source entity** under `ChoiceSlot.OPPONENT` (a `ChoiceValue.EntityChoice` in its
+  `CastChoicesComponent`) and read back through `Player.ChosenOpponent`. Forced (promptless) with a
+  single opponent, so 2-player games see no extra decision. The source may be a spell on the stack
+  (the choice lives on the spell entity for its resolution) or a permanent (recorded durably).
+  `Patterns.Mechanic.giftSpell` prefixes its gift mode with this automatically — gift recipients
+  address `Player.ChosenOpponent`. The *as-enters* analogue is `EntersWithChoice(ChoiceType.OPPONENT)`,
+  which writes the same slot (Jihad, The Rack).
 - `GrantHexproofFromChosenColorEffect(target)` — hexproof from chosen color.
 - `GrantProtectionFromChosenColorEffect(target)` — protection from chosen color. Must run inside `ChooseColorThen`; wrap in `ForEachInGroup` for the group case (Akroma's Blessing: "Creatures you control gain protection from the chosen color").
 - `Effects.GrantProtectionFromChosenCardType(target, duration)` — "gains protection from the card type of your choice" (Pippin, Guard of the Citadel). The card-type analogue of `GrantProtectionFromChosenColor`, but **self-contained**: its executor owns the choice — it presents a `ChooseOptionDecision` over the fixed protectable card-type set (Artifact, Creature, Enchantment, Instant, Land, Planeswalker, Sorcery, Battle) and, on response, grants a floating `PROTECTION_FROM_CARDTYPE_<TYPE>` keyword for `duration`. The targeting validator, `StackResolver` spell-targeting, `DamageUtils`, the combat-damage pipeline/manager, and a `ProtectionFromCardTypeRule` block-evasion rule all match the protected keyword against the source's projected card types. (The "can't be enchanted/equipped by that type" clause is reminder text and unenforced at attach time, mirroring color/subtype protection.)
@@ -4556,6 +4564,10 @@ answer it and would silently return `false`.
 - `APlayerLifeAtMost(n)` — *some* player in the game has ≤N life (existential over `state.turnOrder`; distinct from `LifeAtMost`, which is `Player.You`). Used by enters-tapped-unless lands like Razortrap Gorge.
 - `YouLostLife` — you lost life this turn.
 - `OpponentLostLife` — an opponent lost life this turn.
+- `PlayerLostLifeThisTurn(player)` — a specific player lost life this turn. Use when the wording
+  binds the check to a particular player rather than "an opponent" — Thought-Stalker Warlock's
+  "choose target opponent. If THEY lost life this turn, …" is
+  `PlayerLostLifeThisTurn(Player.ContextPlayer(0))` (the chosen target, not any opponent).
 - `YouGainedLifeThisTurn` — you gained ≥1 life this turn (intervening-if / static gate; backed by the
   `LIFE_GAINED` turn tracker). Used by Ulna Alley Shopkeep's Infusion buff.
 - `YouGainedLifeThisTurnAtLeast(n)` — you gained ≥`n` life this turn. The threshold form of

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1152,6 +1152,15 @@ object Conditions {
         trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_LOST, player = Player.EachOpponent)
 
     /**
+     * If [player] lost life this turn (from any source). Use when the wording binds the
+     * check to a specific player rather than "an opponent" — e.g. Thought-Stalker Warlock:
+     * "choose target opponent. If THEY lost life this turn, …" →
+     * `PlayerLostLifeThisTurn(Player.ContextPlayer(0))`.
+     */
+    fun PlayerLostLifeThisTurn(player: Player): ConditionInterface =
+        trackerAtLeast(com.wingedsheep.sdk.scripting.values.TurnTracker.LIFE_LOST, player = player)
+
+    /**
      * If an opponent was dealt combat damage by a legendary creature this turn.
      * Used for cards like Blitzball: "Activate only if an opponent was dealt combat damage by a
      * legendary creature this turn."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -2234,6 +2234,16 @@ object Effects {
     )
 
     /**
+     * The controller chooses an opponent, stored durably on the source entity under
+     * [com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT] and read back through
+     * [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent]. Forced (no prompt)
+     * with a single opponent, so 2-player games see no extra decision. Powers the gift
+     * mechanic's "promise AN OPPONENT a gift" recipient choice.
+     */
+    fun ChooseOpponent(prompt: String = "Choose an opponent"): Effect =
+        com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect(prompt)
+
+    /**
      * Grant Toxic N to a target until end of turn.
      *
      * Composes [GrantKeywordEffect] with the `TOXIC_<n>` string keyword — the same projected

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MechanicPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/MechanicPatterns.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.scripting.effects.CreatePredefinedTokenEffect
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.Chooser
 import com.wingedsheep.sdk.scripting.effects.ChooseActionEffect
+import com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect
 import com.wingedsheep.sdk.scripting.effects.CollectionFilter
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
@@ -273,6 +274,12 @@ object MechanicPatterns {
      * [com.wingedsheep.sdk.dsl.Effects.GiftGiven]). The flag `countsAsModalSpell = false`
      * keeps "Whenever you cast a modal spell" triggers from misreading Gift as modal.
      *
+     * The gift branch is prefixed with a
+     * [com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect]: the promising
+     * player picks WHICH opponent receives the gift (forced, promptless with a single
+     * opponent), and the gift effect addresses the recipient through
+     * [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent].
+     *
      * Standard usage:
      * ```kotlin
      * spell {
@@ -283,9 +290,17 @@ object MechanicPatterns {
      *     )
      * }
      * ```
+     * where `opponentDraws` targets `Player.ChosenOpponent`.
      */
     fun giftSpell(noGiftMode: Mode, giftMode: Mode): ModalEffect =
-        ModalEffect.chooseOne(noGiftMode, giftMode, countsAsModalSpell = false)
+        ModalEffect.chooseOne(
+            noGiftMode,
+            giftMode.copy(
+                effect = ChooseOpponentForSourceEffect(prompt = "Choose an opponent to receive the gift")
+                    .then(giftMode.effect)
+            ),
+            countsAsModalSpell = false
+        )
 
     // =========================================================================
     // Incubate Pattern (CR 701.53)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -742,3 +742,24 @@ data class ChooseNumberForSourceEffect(
 ) : Effect {
     override val description: String = "choose a number between $minValue and $maxValue"
 }
+
+/**
+ * The controller chooses an opponent; the choice is written durably onto the source entity's
+ * cast-choices bag under [com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT], where downstream
+ * effects read it back through [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent].
+ *
+ * With a single opponent the choice is forced and resolves without a prompt, so two-player
+ * games see no extra decision. The source may be a spell on the stack (gift instants and
+ * sorceries — the choice lives on the spell entity for the rest of its resolution) or a
+ * permanent (gift ETB triggers — the choice is recorded durably on the permanent).
+ *
+ * Used by the gift mechanic ([com.wingedsheep.sdk.dsl.MechanicPatterns.giftSpell]): "promise
+ * an opponent a gift" — the promising player picks which opponent receives it.
+ */
+@SerialName("ChooseOpponentForSource")
+@Serializable
+data class ChooseOpponentForSourceEffect(
+    val prompt: String = "Choose an opponent"
+) : Effect {
+    override val description: String = "choose an opponent"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -288,6 +288,9 @@ object CardLinter {
         // Both are what HasChosenColor / GrantChosenColor-style readers consume.
         "ChooseColorThen" to "COLOR",
         "ChooseColorForTarget" to "COLOR",
+        // Resolution-time opponent choice: writes ChoiceSlot.OPPONENT on the source entity,
+        // read back by Player.ChosenOpponent (gift recipient).
+        "ChooseOpponentForSource" to "OPPONENT",
     )
 
     /** [com.wingedsheep.sdk.scripting.ReplacementEffect] `EntersWithChoice.choiceType` → slot. */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/AlaniaDivergentStorm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/AlaniaDivergentStorm.kt
@@ -35,7 +35,13 @@ val AlaniaDivergentStorm = card("Alania, Divergent Storm") {
         triggerCondition = Conditions.Any(
             Conditions.YouCastFirstSpellOfTypeThisTurn(GameObjectFilter.Instant),
             Conditions.YouCastFirstSpellOfTypeThisTurn(GameObjectFilter.Sorcery),
-            Conditions.YouCastFirstSpellOfTypeThisTurn(GameObjectFilter.Any.withSubtype(com.wingedsheep.sdk.core.Subtype("Otter")))
+            // "the first Otter spell OTHER THAN ALANIA you've cast this turn" — Alania herself
+            // neither triggers this branch nor counts toward the first-Otter-spell tracking
+            Conditions.YouCastFirstSpellOfTypeThisTurn(
+                GameObjectFilter.Any
+                    .withSubtype(com.wingedsheep.sdk.core.Subtype("Otter"))
+                    .notNamed("Alania, Divergent Storm")
+            )
         )
         val opponent = target("opponent", Targets.Opponent)
         effect = ReflexiveTriggerEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/BloomingBlast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/BloomingBlast.kt
@@ -41,7 +41,7 @@ val BloomingBlast = card("Blooming Blast") {
             ),
             // Mode 2: Gift a Treasure — opponent creates Treasure, 2 damage to creature, 3 damage to controller
             Mode.withTarget(
-                CreatePredefinedTokenEffect("Treasure", 1, EffectTarget.PlayerRef(Player.AnOpponent))
+                CreatePredefinedTokenEffect("Treasure", 1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(Effects.DealDamage(2, EffectTarget.ContextTarget(0)))
                     .then(Effects.DealDamage(3, EffectTarget.TargetController))
                     .then(Effects.GiftGiven()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CoilingRebirth.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CoilingRebirth.kt
@@ -47,7 +47,7 @@ val CoilingRebirth = card("Coiling Rebirth") {
             ),
             // Mode 2: Gift a card — opponent draws, return creature, then if nonlegendary create 1/1 copy
             Mode(
-                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
+                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(returnEffect)
                     .then(
                         ConditionalEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ConsumedByGreed.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ConsumedByGreed.kt
@@ -47,7 +47,7 @@ val ConsumedByGreed = card("Consumed by Greed") {
             Mode(
                 effect = Effects.Composite(
                     listOf(
-                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
+                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent)),
                         sacrificeEffect,
                         Effects.ReturnToHand(EffectTarget.ContextTarget(1)),
                         Effects.GiftGiven()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CrumbAndGetIt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CrumbAndGetIt.kt
@@ -43,7 +43,7 @@ val CrumbAndGetIt = card("Crumb and Get It") {
             ),
             // Mode 2: Gift a Food — opponent creates Food, +2/+2 and indestructible until end of turn
             Mode.withTarget(
-                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.AnOpponent))
+                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(baseEffect)
                     .then(Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.ContextTarget(0)))
                     .then(Effects.GiftGiven()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DawnsTruce.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DawnsTruce.kt
@@ -44,7 +44,7 @@ val DawnsTruce = card("Dawn's Truce") {
             ),
             // Mode 2: Gift a card — opponent draws, hexproof + indestructible until end of turn
             Mode.noTarget(
-                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
+                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(hexproofEffects)
                     .then(Patterns.Group.grantKeywordToAll(Keyword.INDESTRUCTIBLE, Filters.Group.permanentsYouControl))
                     .then(Effects.GiftGiven()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DewdropCure.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/DewdropCure.kt
@@ -49,7 +49,7 @@ val DewdropCure = card("Dewdrop Cure") {
             ),
             // Mode 2: Gift a card — opponent draws, return up to 3 creature cards with MV ≤ 2
             Mode(
-                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
+                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(returnEffect)
                     .then(Effects.GiftGiven()),
                 targetRequirements = listOf(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/EarlyWinter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/EarlyWinter.kt
@@ -1,11 +1,14 @@
 package com.wingedsheep.mtg.sets.definitions.blb.cards
 
+import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
-import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.references.Player
 
 /**
  * Early Winter
@@ -15,9 +18,6 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  * Choose one —
  * - Exile target creature.
  * - Target opponent exiles an enchantment they control.
- *
- * Mode 2 is approximated by targeting an enchantment an opponent controls
- * and exiling it (caster chooses rather than opponent choosing).
  */
 val EarlyWinter = card("Early Winter") {
     manaCost = "{4}{B}"
@@ -31,11 +31,24 @@ val EarlyWinter = card("Early Winter") {
                 val t = target("target creature to exile", Targets.Creature)
                 effect = Effects.Exile(t)
             }
-            mode("Exile target enchantment an opponent controls") {
-                val t = target("target enchantment to exile", TargetObject(
-                    filter = TargetFilter.Enchantment.opponentControls()
-                ))
-                effect = Effects.Exile(t)
+            mode("Target opponent exiles an enchantment they control") {
+                // The opponent is the target; THEY pick which of their enchantments to
+                // exile (so hexproof on the enchantment is irrelevant, and the mode is
+                // legal even if they control none).
+                target("target opponent", Targets.Opponent)
+                effect = Effects.Pipeline {
+                    val enchantments = gather(
+                        CardSource.FromZone(Zone.BATTLEFIELD, Player.ContextPlayer(0), GameObjectFilter.Enchantment),
+                        name = "theirEnchantments"
+                    )
+                    val chosen = chooseExactly(
+                        1, from = enchantments,
+                        chooser = Chooser.TargetPlayer,
+                        prompt = "Choose an enchantment to exile",
+                        name = "chosenEnchantment"
+                    )
+                    exile(chosen, owner = Player.ContextPlayer(0))
+                }
             }
         }
     }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/IntoTheFloodMaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/IntoTheFloodMaw.kt
@@ -48,7 +48,7 @@ val IntoTheFloodMaw = card("Into the Flood Maw") {
                     toughness = 1,
                     colors = setOf(Color.BLUE),
                     creatureTypes = setOf("Fish"),
-                    controller = EffectTarget.PlayerRef(Player.AnOpponent),
+                    controller = EffectTarget.PlayerRef(Player.ChosenOpponent),
                     tapped = true,
                     imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                 ).then(Effects.ReturnToHand(EffectTarget.ContextTarget(0)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Kitnap.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Kitnap.kt
@@ -48,7 +48,7 @@ val Kitnap = card("Kitnap") {
             ),
             // Mode 2: Gift a card — opponent draws a card, tap enchanted creature (no stun counters)
             Mode.noTarget(
-                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
+                DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(Effects.Tap(EffectTarget.EnchantedCreature))
                     .then(Effects.GiftGiven()),
                 "Promise a gift — an opponent draws a card, tap enchanted creature"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LongRiversPull.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LongRiversPull.kt
@@ -35,7 +35,7 @@ val LongRiversPull = card("Long River's Pull") {
             // Mode 1: Gift promised — opponent draws a card, then counter target spell
             Mode.withTarget(
                 effect = Effects.Composite(listOf(
-                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
+                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent)),
                     Effects.CounterSpell(),
                     Effects.GiftGiven()
                 )),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LongstalkBrawl.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/LongstalkBrawl.kt
@@ -52,7 +52,7 @@ val LongstalkBrawl = card("Longstalk Brawl") {
                     colors = setOf(Color.BLUE),
                     creatureTypes = setOf("Fish"),
                     tapped = true,
-                    controller = EffectTarget.PlayerRef(Player.AnOpponent),
+                    controller = EffectTarget.PlayerRef(Player.ChosenOpponent),
                     imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                 )
                     .then(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MindSpiral.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/MindSpiral.kt
@@ -54,7 +54,7 @@ val MindSpiral = card("Mind Spiral") {
                             toughness = 1,
                             colors = setOf(Color.BLUE),
                             creatureTypes = setOf("Fish"),
-                            controller = EffectTarget.PlayerRef(Player.AnOpponent),
+                            controller = EffectTarget.PlayerRef(Player.ChosenOpponent),
                             tapped = true,
                             imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                         ),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/NocturnalHunger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/NocturnalHunger.kt
@@ -40,7 +40,7 @@ val NocturnalHunger = card("Nocturnal Hunger") {
             ),
             // Mode 2: Gift a Food — opponent creates Food token, then destroy target creature
             Mode.withTarget(
-                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.AnOpponent))
+                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(destroyEffect)
                     .then(Effects.GiftGiven()),
                 Targets.Creature,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/PartingGust.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/PartingGust.kt
@@ -64,7 +64,7 @@ val PartingGust = card("Parting Gust") {
                     toughness = 1,
                     colors = setOf(Color.BLUE),
                     creatureTypes = setOf("Fish"),
-                    controller = EffectTarget.PlayerRef(Player.AnOpponent),
+                    controller = EffectTarget.PlayerRef(Player.ChosenOpponent),
                     tapped = true,
                     imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                 ).then(Effects.Exile(EffectTarget.ContextTarget(0)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/PeerlessRecycling.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/PeerlessRecycling.kt
@@ -43,7 +43,7 @@ val PeerlessRecycling = card("Peerless Recycling") {
             // Mode 1: Gift — opponent draws a card, return 2 target permanent cards to hand
             Mode(
                 effect = Effects.Composite(listOf(
-                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
+                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent)),
                     Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
                     Effects.ReturnToHand(EffectTarget.ContextTarget(1)),
                     Effects.GiftGiven()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/SazacapsBrew.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/SazacapsBrew.kt
@@ -59,7 +59,7 @@ val SazacapsBrew = card("Sazacap's Brew") {
                             colors = setOf(Color.BLUE),
                             creatureTypes = setOf("Fish"),
                             tapped = true,
-                            controller = EffectTarget.PlayerRef(Player.AnOpponent),
+                            controller = EffectTarget.PlayerRef(Player.ChosenOpponent),
                             imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                         ),
                         DrawCardsEffect(2, EffectTarget.ContextTarget(0)),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Scrapshooter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/Scrapshooter.kt
@@ -46,7 +46,7 @@ val Scrapshooter = card("Scrapshooter") {
             ),
             // Mode 2: Gift a card — opponent draws, destroy target artifact or enchantment
             Mode(
-                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent))
+                effect = DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(Effects.Destroy(EffectTarget.ContextTarget(0)))
                     .then(Effects.GiftGiven()),
                 targetRequirements = listOf(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/SeasonedWarrenguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/SeasonedWarrenguard.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.conditions.Exists
-import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
 import com.wingedsheep.sdk.scripting.references.Player
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
@@ -31,11 +30,11 @@ val SeasonedWarrenguard = card("Seasoned Warrenguard") {
 
     triggeredAbility {
         trigger = Triggers.Attacks
+        // "attacks WHILE you control a token" — checked only when the trigger fires
+        // (attack declaration). Per the printed ruling, losing the token before the
+        // ability resolves must not stop the pump, so there is no resolution-time check.
         triggerCondition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Token)
-        effect = ConditionalEffect(
-            condition = Exists(Player.You, Zone.BATTLEFIELD, GameObjectFilter.Token),
-            effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
-        )
+        effect = Effects.ModifyStats(2, 0, EffectTarget.Self)
     }
 
     metadata {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarfallInvocation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarfallInvocation.kt
@@ -43,7 +43,7 @@ val StarfallInvocation = card("Starfall Invocation") {
             // Mode 2: Gift a card — opponent draws, destroy all creatures, then return one of yours
             Mode.noTarget(
                 Effects.Composite(listOf(
-                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
+                    DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent)),
                     Effects.DestroyAll(GameObjectFilter.Creature, storeDestroyedAs = "destroyed"),
                     SelectFromCollectionEffect(
                         from = "destroyed",

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarforgedSword.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/StarforgedSword.kt
@@ -55,7 +55,7 @@ val StarforgedSword = card("Starforged Sword") {
                     toughness = 1,
                     colors = setOf(Color.BLUE),
                     creatureTypes = setOf("Fish"),
-                    controller = EffectTarget.PlayerRef(Player.AnOpponent),
+                    controller = EffectTarget.PlayerRef(Player.ChosenOpponent),
                     tapped = true,
                     imageUri = "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109"
                 ).then(Effects.AttachEquipment(EffectTarget.ContextTarget(0)))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ThoughtStalkerWarlock.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ThoughtStalkerWarlock.kt
@@ -50,7 +50,9 @@ val ThoughtStalkerWarlock = card("Thought-Stalker Warlock") {
         trigger = Triggers.EntersBattlefield
         val opponent = target("opponent", Targets.Opponent)
         effect = ConditionalEffect(
-            condition = Conditions.OpponentLostLifeThisTurn,
+            // "If THEY lost life this turn" — bound to the chosen target opponent,
+            // not any opponent (matters in multiplayer)
+            condition = Conditions.PlayerLostLifeThisTurn(Player.ContextPlayer(0)),
             // If they lost life: reveal hand, controller chooses nonland, discard it
             effect = Effects.Composite(
                 listOf(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ValleyRally.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/ValleyRally.kt
@@ -39,7 +39,7 @@ val ValleyRally = card("Valley Rally") {
             ),
             // Mode 2: Gift a Food — opponent creates Food, creatures get +2/+0, target creature gains first strike
             Mode.withTarget(
-                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.AnOpponent))
+                Effects.CreateFood(1, EffectTarget.PlayerRef(Player.ChosenOpponent))
                     .then(pumpAll)
                     .then(Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.ContextTarget(0)))
                     .then(Effects.GiftGiven()),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WearDown.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WearDown.kt
@@ -42,7 +42,7 @@ val WearDown = card("Wear Down") {
             Mode(
                 effect = Effects.Composite(
                     listOf(
-                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
+                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent)),
                         Effects.Destroy(EffectTarget.ContextTarget(0)),
                         Effects.Destroy(EffectTarget.ContextTarget(1)),
                         Effects.GiftGiven()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WildfireHowl.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/WildfireHowl.kt
@@ -48,7 +48,7 @@ val WildfireHowl = card("Wildfire Howl") {
             Mode.withTarget(
                 Effects.Composite(
                     listOf(
-                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.AnOpponent)),
+                        DrawCardsEffect(1, EffectTarget.PlayerRef(Player.ChosenOpponent)),
                         DealDamageEffect(1, EffectTarget.ContextTarget(0)),
                         damageToEachCreature,
                         Effects.GiftGiven()

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/GhituChronicler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/GhituChronicler.kt
@@ -1,12 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
 import com.wingedsheep.sdk.core.Zone
-import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
 import com.wingedsheep.sdk.dsl.Effects
 /**
  * Ghitu Chronicler
@@ -30,7 +31,10 @@ val GhituChronicler = card("Ghitu Chronicler") {
     triggeredAbility {
         trigger = Triggers.EntersBattlefield
         triggerCondition = WasKicked
-        val t = target("target", Targets.InstantOrSorceryInGraveyard)
+        val t = target(
+            "instant or sorcery card in your graveyard",
+            TargetObject(filter = TargetFilter.InstantOrSorceryInYourGraveyard)
+        )
         effect = Effects.Move(
             target = t,
             destination = Zone.HAND

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -277,13 +277,41 @@
                                 {
                                     "type": "EntityMatches",
                                     "entity": "TriggeringEntity",
-                                    "filter": "Otter"
+                                    "filter": {
+                                        "cardPredicates": [
+                                            {
+                                                "type": "HasSubtype",
+                                                "subtype": "Otter"
+                                            },
+                                            {
+                                                "type": "Not",
+                                                "predicate": {
+                                                    "type": "NameEquals",
+                                                    "name": "Alania, Divergent Storm"
+                                                }
+                                            }
+                                        ]
+                                    }
                                 },
                                 {
                                     "type": "Not",
                                     "condition": {
                                         "type": "PlayerCastSpellsThisTurn",
-                                        "filter": "Otter",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                {
+                                                    "type": "HasSubtype",
+                                                    "subtype": "Otter"
+                                                },
+                                                {
+                                                    "type": "Not",
+                                                    "predicate": {
+                                                        "type": "NameEquals",
+                                                        "name": "Alania, Divergent Storm"
+                                                    }
+                                                }
+                                            ]
+                                        },
                                         "atLeast": 2
                                     }
                                 }
@@ -1411,33 +1439,42 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreatePredefinedToken",
-                                "tokenType": "Treasure",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "DealDamage",
-                                "amount": {
-                                    "type": "Fixed",
-                                    "amount": 2
-                                },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            {
-                                "type": "DealDamage",
-                                "amount": {
-                                    "type": "Fixed",
-                                    "amount": 3
-                                },
-                                "target": "TargetController"
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreatePredefinedToken",
+                                        "tokenType": "Treasure",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        },
+                                        "target": "TargetController"
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -3375,54 +3412,63 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                },
-                                "destination": "Battlefield",
-                                "fromZone": "Graveyard"
-                            },
-                            {
-                                "type": "Gated",
-                                "gate": {
-                                    "type": "Gate.WhenCondition",
-                                    "condition": {
-                                        "type": "EntityMatches",
-                                        "entity": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
                                             "type": "ContextTarget",
                                             "index": 0
                                         },
-                                        "filter": {
-                                            "cardPredicates": [
-                                                "IsCreature",
-                                                "IsNonlegendary"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "then": {
-                                    "type": "CreateTokenCopyOfTarget",
-                                    "target": {
-                                        "type": "ContextTarget",
-                                        "index": 0
+                                        "destination": "Battlefield",
+                                        "fromZone": "Graveyard"
                                     },
-                                    "overridePower": 1,
-                                    "overrideToughness": 1
-                                }
-                            },
-                            "GiftGiven"
+                                    {
+                                        "type": "Gated",
+                                        "gate": {
+                                            "type": "Gate.WhenCondition",
+                                            "condition": {
+                                                "type": "EntityMatches",
+                                                "entity": {
+                                                    "type": "ContextTarget",
+                                                    "index": 0
+                                                },
+                                                "filter": {
+                                                    "cardPredicates": [
+                                                        "IsCreature",
+                                                        "IsNonlegendary"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "then": {
+                                            "type": "CreateTokenCopyOfTarget",
+                                            "target": {
+                                                "type": "ContextTarget",
+                                                "index": 0
+                                            },
+                                            "overridePower": 1,
+                                            "overrideToughness": 1
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -3614,40 +3660,49 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "ForceSacrifice",
-                                "filter": {
-                                    "cardPredicates": [
-                                        "IsCreature"
-                                    ],
-                                    "statePredicates": [
-                                        "HasGreatestPower"
-                                    ]
-                                },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 1
-                                },
-                                "destination": "Hand"
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "ForceSacrifice",
+                                        "filter": {
+                                            "cardPredicates": [
+                                                "IsCreature"
+                                            ],
+                                            "statePredicates": [
+                                                "HasGreatestPower"
+                                            ]
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 1
+                                        },
+                                        "destination": "Hand"
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -3936,61 +3991,70 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
-                            "RevealHand",
                             {
-                                "type": "GatherCards",
-                                "source": {
-                                    "type": "FromZone",
-                                    "zone": "Hand",
-                                    "player": {
-                                        "type": "ContextPlayer",
-                                        "index": 0
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
                                     },
-                                    "filter": "nonland"
-                                },
-                                "storeAs": "nonlandCards"
-                            },
-                            {
-                                "type": "SelectFromCollection",
-                                "from": "nonlandCards",
-                                "selection": {
-                                    "type": "ChooseExactly",
-                                    "count": {
-                                        "type": "Fixed",
-                                        "amount": 1
-                                    }
-                                },
-                                "storeSelected": "chosenCard",
-                                "prompt": "Choose a nonland card to exile"
-                            },
-                            {
-                                "type": "MoveCollection",
-                                "from": "chosenCard",
-                                "destination": {
-                                    "type": "ToZone",
-                                    "zone": "Exile",
-                                    "player": {
-                                        "type": "ContextPlayer",
-                                        "index": 0
-                                    }
-                                }
-                            },
-                            {
-                                "type": "GrantMayPlayFromExile",
-                                "from": "chosenCard",
-                                "expiry": "Permanent"
-                            },
-                            "GiftGiven"
+                                    "RevealHand",
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            },
+                                            "filter": "nonland"
+                                        },
+                                        "storeAs": "nonlandCards"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "nonlandCards",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "chosenCard",
+                                        "prompt": "Choose a nonland card to exile"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "chosenCard",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile",
+                                            "player": {
+                                                "type": "ContextPlayer",
+                                                "index": 0
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "GrantMayPlayFromExile",
+                                        "from": "chosenCard",
+                                        "expiry": "Permanent"
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -4064,37 +4128,46 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreatePredefinedToken",
-                                "tokenType": "Food",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "ModifyStats",
-                                "powerModifier": {
-                                    "type": "Fixed",
-                                    "amount": 2
-                                },
-                                "toughnessModifier": {
-                                    "type": "Fixed",
-                                    "amount": 2
-                                },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            {
-                                "type": "GrantKeyword",
-                                "keyword": "INDESTRUCTIBLE",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreatePredefinedToken",
+                                        "tokenType": "Food",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "ModifyStats",
+                                        "powerModifier": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "toughnessModifier": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "GrantKeyword",
+                                        "keyword": "INDESTRUCTIBLE",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -4512,22 +4585,45 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
                                 "type": "Composite",
                                 "effects": [
                                     {
-                                        "type": "GrantEvasionKeyword",
-                                        "keyword": "HEXPROOF"
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GrantEvasionKeyword",
+                                                "keyword": "HEXPROOF"
+                                            },
+                                            {
+                                                "type": "ForEach",
+                                                "space": {
+                                                    "type": "IterationSpace.Group",
+                                                    "filter": {
+                                                        "baseFilter": "permanent ctrl:you"
+                                                    }
+                                                },
+                                                "body": {
+                                                    "type": "GrantKeyword",
+                                                    "keyword": "HEXPROOF",
+                                                    "target": "Self"
+                                                }
+                                            }
+                                        ]
                                     },
                                     {
                                         "type": "ForEach",
@@ -4539,27 +4635,13 @@
                                         },
                                         "body": {
                                             "type": "GrantKeyword",
-                                            "keyword": "HEXPROOF",
+                                            "keyword": "INDESTRUCTIBLE",
                                             "target": "Self"
                                         }
-                                    }
+                                    },
+                                    "GiftGiven"
                                 ]
-                            },
-                            {
-                                "type": "ForEach",
-                                "space": {
-                                    "type": "IterationSpace.Group",
-                                    "filter": {
-                                        "baseFilter": "permanent ctrl:you"
-                                    }
-                                },
-                                "body": {
-                                    "type": "GrantKeyword",
-                                    "keyword": "INDESTRUCTIBLE",
-                                    "target": "Self"
-                                }
-                            },
-                            "GiftGiven"
+                            }
                         ]
                     },
                     "description": "Promise a gift — an opponent draws a card, you and permanents you control gain hexproof until end of turn, permanents you control also gain indestructible until end of turn"
@@ -4690,30 +4772,39 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "ForEach",
-                                "space": "IterationSpace.Targets",
-                                "body": {
-                                    "type": "MoveToZone",
-                                    "target": {
-                                        "type": "ContextTarget",
-                                        "index": 0
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
                                     },
-                                    "destination": "Battlefield",
-                                    "fromZone": "Graveyard"
-                                }
-                            },
-                            "GiftGiven"
+                                    {
+                                        "type": "ForEach",
+                                        "space": "IterationSpace.Targets",
+                                        "body": {
+                                            "type": "MoveToZone",
+                                            "target": {
+                                                "type": "ContextTarget",
+                                                "index": 0
+                                            },
+                                            "destination": "Battlefield",
+                                            "fromZone": "Graveyard"
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -5462,23 +5553,56 @@
                 },
                 {
                     "effect": {
-                        "type": "MoveToZone",
-                        "target": {
-                            "type": "BoundVariable",
-                            "name": "target enchantment to exile"
-                        },
-                        "destination": "Exile"
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Battlefield",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    },
+                                    "filter": "enchantment"
+                                },
+                                "storeAs": "theirEnchantments"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "theirEnchantments",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "chooser": "TargetPlayer",
+                                "storeSelected": "chosenEnchantment",
+                                "prompt": "Choose an enchantment to exile"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "chosenEnchantment",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Exile",
+                                    "player": {
+                                        "type": "ContextPlayer",
+                                        "index": 0
+                                    }
+                                }
+                            }
+                        ]
                     },
                     "targetRequirements": [
                         {
-                            "type": "TargetObject",
-                            "filter": {
-                                "baseFilter": "enchantment ctrl:opponent"
-                            },
-                            "id": "target enchantment to exile"
+                            "type": "TargetOpponent",
+                            "id": "target opponent"
                         }
                     ],
-                    "description": "Exile target enchantment an opponent controls"
+                    "description": "Target opponent exiles an enchantment they control"
                 }
             ]
         }
@@ -9272,31 +9396,40 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreateToken",
-                                "power": 1,
-                                "toughness": 1,
-                                "colors": [
-                                    "BLUE"
-                                ],
-                                "creatureTypes": [
-                                    "Fish"
-                                ],
-                                "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                },
-                                "tapped": true
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                },
-                                "destination": "Hand"
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreateToken",
+                                        "power": 1,
+                                        "toughness": 1,
+                                        "colors": [
+                                            "BLUE"
+                                        ],
+                                        "creatureTypes": [
+                                            "Fish"
+                                        ],
+                                        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        },
+                                        "tapped": true
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "destination": "Hand"
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -10033,21 +10166,30 @@
                                 "type": "Composite",
                                 "effects": [
                                     {
-                                        "type": "DrawCards",
-                                        "count": {
-                                            "type": "Fixed",
-                                            "amount": 1
-                                        },
-                                        "target": {
-                                            "type": "PlayerRef",
-                                            "player": "AnOpponent"
-                                        }
+                                        "type": "ChooseOpponentForSource",
+                                        "prompt": "Choose an opponent to receive the gift"
                                     },
                                     {
-                                        "type": "TapUntap",
-                                        "target": "EnchantedCreature"
-                                    },
-                                    "GiftGiven"
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "DrawCards",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                },
+                                                "target": {
+                                                    "type": "PlayerRef",
+                                                    "player": "ChosenOpponent"
+                                                }
+                                            },
+                                            {
+                                                "type": "TapUntap",
+                                                "target": "EnchantedCreature"
+                                            },
+                                            "GiftGiven"
+                                        ]
+                                    }
                                 ]
                             },
                             "description": "Promise a gift — an opponent draws a card, tap enchanted creature"
@@ -10757,18 +10899,27 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
-                            "Counter",
-                            "GiftGiven"
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    "Counter",
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -10840,43 +10991,52 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreateToken",
-                                "power": 1,
-                                "toughness": 1,
-                                "colors": [
-                                    "BLUE"
-                                ],
-                                "creatureTypes": [
-                                    "Fish"
-                                ],
-                                "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                },
-                                "tapped": true
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "AddCounters",
-                                "counterType": "+1/+1",
-                                "count": 1,
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            {
-                                "type": "Fight",
-                                "target1": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                },
-                                "target2": {
-                                    "type": "ContextTarget",
-                                    "index": 1
-                                }
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreateToken",
+                                        "power": 1,
+                                        "toughness": 1,
+                                        "colors": [
+                                            "BLUE"
+                                        ],
+                                        "creatureTypes": [
+                                            "Fish"
+                                        ],
+                                        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        },
+                                        "tapped": true
+                                    },
+                                    {
+                                        "type": "AddCounters",
+                                        "counterType": "+1/+1",
+                                        "count": 1,
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "Fight",
+                                        "target1": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "target2": {
+                                            "type": "ContextTarget",
+                                            "index": 1
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -11716,50 +11876,59 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreateToken",
-                                "power": 1,
-                                "toughness": 1,
-                                "colors": [
-                                    "BLUE"
-                                ],
-                                "creatureTypes": [
-                                    "Fish"
-                                ],
-                                "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                },
-                                "tapped": true
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 3
-                                },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            {
-                                "type": "TapUntap",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 1
-                                }
-                            },
-                            {
-                                "type": "AddCounters",
-                                "counterType": "stun",
-                                "count": 1,
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 1
-                                }
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreateToken",
+                                        "power": 1,
+                                        "toughness": 1,
+                                        "colors": [
+                                            "BLUE"
+                                        ],
+                                        "creatureTypes": [
+                                            "Fish"
+                                        ],
+                                        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        },
+                                        "tapped": true
+                                    },
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 3
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "TapUntap",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 1
+                                        }
+                                    },
+                                    {
+                                        "type": "AddCounters",
+                                        "counterType": "stun",
+                                        "count": 1,
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 1
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -12608,23 +12777,32 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreatePredefinedToken",
-                                "tokenType": "Food",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                },
-                                "destination": "Graveyard",
-                                "byDestruction": true
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreatePredefinedToken",
+                                        "tokenType": "Food",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "destination": "Graveyard",
+                                        "byDestruction": true
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -13016,31 +13194,40 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreateToken",
-                                "power": 1,
-                                "toughness": 1,
-                                "colors": [
-                                    "BLUE"
-                                ],
-                                "creatureTypes": [
-                                    "Fish"
-                                ],
-                                "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                },
-                                "tapped": true
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                },
-                                "destination": "Exile"
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreateToken",
+                                        "power": 1,
+                                        "toughness": 1,
+                                        "colors": [
+                                            "BLUE"
+                                        ],
+                                        "creatureTypes": [
+                                            "Fish"
+                                        ],
+                                        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        },
+                                        "tapped": true
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "destination": "Exile"
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -13357,33 +13544,42 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                },
-                                "destination": "Hand"
-                            },
-                            {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 1
-                                },
-                                "destination": "Hand"
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "destination": "Hand"
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 1
+                                        },
+                                        "destination": "Hand"
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -15528,49 +15724,58 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreateToken",
-                                "power": 1,
-                                "toughness": 1,
-                                "colors": [
-                                    "BLUE"
-                                ],
-                                "creatureTypes": [
-                                    "Fish"
-                                ],
-                                "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                },
-                                "tapped": true
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 2
-                                },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            {
-                                "type": "ModifyStats",
-                                "powerModifier": {
-                                    "type": "Fixed",
-                                    "amount": 2
-                                },
-                                "toughnessModifier": {
-                                    "type": "Fixed",
-                                    "amount": 0
-                                },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 1
-                                }
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreateToken",
+                                        "power": 1,
+                                        "toughness": 1,
+                                        "colors": [
+                                            "BLUE"
+                                        ],
+                                        "creatureTypes": [
+                                            "Fish"
+                                        ],
+                                        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        },
+                                        "tapped": true
+                                    },
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "ModifyStats",
+                                        "powerModifier": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "toughnessModifier": {
+                                            "type": "Fixed",
+                                            "amount": 0
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 1
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -15879,26 +16084,35 @@
                                 "type": "Composite",
                                 "effects": [
                                     {
-                                        "type": "DrawCards",
-                                        "count": {
-                                            "type": "Fixed",
-                                            "amount": 1
-                                        },
-                                        "target": {
-                                            "type": "PlayerRef",
-                                            "player": "AnOpponent"
-                                        }
+                                        "type": "ChooseOpponentForSource",
+                                        "prompt": "Choose an opponent to receive the gift"
                                     },
                                     {
-                                        "type": "MoveToZone",
-                                        "target": {
-                                            "type": "ContextTarget",
-                                            "index": 0
-                                        },
-                                        "destination": "Graveyard",
-                                        "byDestruction": true
-                                    },
-                                    "GiftGiven"
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "DrawCards",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                },
+                                                "target": {
+                                                    "type": "PlayerRef",
+                                                    "player": "ChosenOpponent"
+                                                }
+                                            },
+                                            {
+                                                "type": "MoveToZone",
+                                                "target": {
+                                                    "type": "ContextTarget",
+                                                    "index": 0
+                                                },
+                                                "destination": "Graveyard",
+                                                "byDestruction": true
+                                            },
+                                            "GiftGiven"
+                                        ]
+                                    }
                                 ]
                             },
                             "targetRequirements": [
@@ -16455,28 +16669,16 @@
                 "id": "ability_1",
                 "trigger": "AttackEvent",
                 "effect": {
-                    "type": "Gated",
-                    "gate": {
-                        "type": "Gate.WhenCondition",
-                        "condition": {
-                            "type": "Exists",
-                            "player": "You",
-                            "zone": "Battlefield",
-                            "filter": "token"
-                        }
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
                     },
-                    "then": {
-                        "type": "ModifyStats",
-                        "powerModifier": {
-                            "type": "Fixed",
-                            "amount": 2
-                        },
-                        "toughnessModifier": {
-                            "type": "Fixed",
-                            "amount": 0
-                        },
-                        "target": "Self"
-                    }
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": "Self"
                 },
                 "triggerCondition": {
                     "type": "Exists",
@@ -17523,62 +17725,71 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
                                 "type": "Composite",
                                 "effects": [
                                     {
-                                        "type": "GatherCards",
-                                        "source": {
-                                            "type": "BattlefieldMatching",
-                                            "filter": "creature"
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
                                         },
-                                        "storeAs": "destroyAll_gathered"
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "GatherCards",
+                                                "source": {
+                                                    "type": "BattlefieldMatching",
+                                                    "filter": "creature"
+                                                },
+                                                "storeAs": "destroyAll_gathered"
+                                            },
+                                            {
+                                                "type": "MoveCollection",
+                                                "from": "destroyAll_gathered",
+                                                "destination": {
+                                                    "type": "ToZone",
+                                                    "zone": "Graveyard"
+                                                },
+                                                "moveType": "Destroy",
+                                                "storeMovedAs": "destroyed"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "destroyed",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "filter": "creature own:you",
+                                        "storeSelected": "returned",
+                                        "prompt": "Choose a creature card put into your graveyard this way to return to the battlefield"
                                     },
                                     {
                                         "type": "MoveCollection",
-                                        "from": "destroyAll_gathered",
+                                        "from": "returned",
                                         "destination": {
                                             "type": "ToZone",
-                                            "zone": "Graveyard"
-                                        },
-                                        "moveType": "Destroy",
-                                        "storeMovedAs": "destroyed"
-                                    }
+                                            "zone": "Battlefield"
+                                        }
+                                    },
+                                    "GiftGiven"
                                 ]
-                            },
-                            {
-                                "type": "SelectFromCollection",
-                                "from": "destroyed",
-                                "selection": {
-                                    "type": "ChooseUpTo",
-                                    "count": {
-                                        "type": "Fixed",
-                                        "amount": 1
-                                    }
-                                },
-                                "filter": "creature own:you",
-                                "storeSelected": "returned",
-                                "prompt": "Choose a creature card put into your graveyard this way to return to the battlefield"
-                            },
-                            {
-                                "type": "MoveCollection",
-                                "from": "returned",
-                                "destination": {
-                                    "type": "ToZone",
-                                    "zone": "Battlefield"
-                                }
-                            },
-                            "GiftGiven"
+                            }
                         ]
                     },
                     "description": "Promise a gift — an opponent draws a card, then destroy all creatures and return one of yours to the battlefield"
@@ -17634,24 +17845,33 @@
                                 "type": "Composite",
                                 "effects": [
                                     {
-                                        "type": "CreateToken",
-                                        "power": 1,
-                                        "toughness": 1,
-                                        "colors": [
-                                            "BLUE"
-                                        ],
-                                        "creatureTypes": [
-                                            "Fish"
-                                        ],
-                                        "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
-                                        "controller": {
-                                            "type": "PlayerRef",
-                                            "player": "AnOpponent"
-                                        },
-                                        "tapped": true
+                                        "type": "ChooseOpponentForSource",
+                                        "prompt": "Choose an opponent to receive the gift"
                                     },
-                                    "AttachEquipment",
-                                    "GiftGiven"
+                                    {
+                                        "type": "Composite",
+                                        "effects": [
+                                            {
+                                                "type": "CreateToken",
+                                                "power": 1,
+                                                "toughness": 1,
+                                                "colors": [
+                                                    "BLUE"
+                                                ],
+                                                "creatureTypes": [
+                                                    "Fish"
+                                                ],
+                                                "imageUri": "https://cards.scryfall.io/normal/front/d/e/de0d6700-49f0-4233-97ba-cef7821c30ed.jpg?1721431109",
+                                                "controller": {
+                                                    "type": "PlayerRef",
+                                                    "player": "ChosenOpponent"
+                                                },
+                                                "tapped": true
+                                            },
+                                            "AttachEquipment",
+                                            "GiftGiven"
+                                        ]
+                                    }
                                 ]
                             },
                             "targetRequirements": [
@@ -19667,7 +19887,10 @@
                             "type": "Compare",
                             "left": {
                                 "type": "TurnTracking",
-                                "player": "EachOpponent",
+                                "player": {
+                                    "type": "ContextPlayer",
+                                    "index": 0
+                                },
                                 "tracker": "LIFE_LOST"
                             },
                             "operator": "GTE",
@@ -20690,43 +20913,52 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "CreatePredefinedToken",
-                                "tokenType": "Food",
-                                "controller": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "ForEach",
-                                "space": {
-                                    "type": "IterationSpace.Group",
-                                    "filter": {
-                                        "baseFilter": "creature ctrl:you"
-                                    }
-                                },
-                                "body": {
-                                    "type": "ModifyStats",
-                                    "powerModifier": {
-                                        "type": "Fixed",
-                                        "amount": 2
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "CreatePredefinedToken",
+                                        "tokenType": "Food",
+                                        "controller": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
                                     },
-                                    "toughnessModifier": {
-                                        "type": "Fixed",
-                                        "amount": 0
+                                    {
+                                        "type": "ForEach",
+                                        "space": {
+                                            "type": "IterationSpace.Group",
+                                            "filter": {
+                                                "baseFilter": "creature ctrl:you"
+                                            }
+                                        },
+                                        "body": {
+                                            "type": "ModifyStats",
+                                            "powerModifier": {
+                                                "type": "Fixed",
+                                                "amount": 2
+                                            },
+                                            "toughnessModifier": {
+                                                "type": "Fixed",
+                                                "amount": 0
+                                            },
+                                            "target": "Self"
+                                        }
                                     },
-                                    "target": "Self"
-                                }
-                            },
-                            {
-                                "type": "GrantKeyword",
-                                "keyword": "FIRST_STRIKE",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            "GiftGiven"
+                                    {
+                                        "type": "GrantKeyword",
+                                        "keyword": "FIRST_STRIKE",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -21602,35 +21834,44 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                },
-                                "destination": "Graveyard",
-                                "byDestruction": true
-                            },
-                            {
-                                "type": "MoveToZone",
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 1
-                                },
-                                "destination": "Graveyard",
-                                "byDestruction": true
-                            },
-                            "GiftGiven"
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "destination": "Graveyard",
+                                        "byDestruction": true
+                                    },
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 1
+                                        },
+                                        "destination": "Graveyard",
+                                        "byDestruction": true
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [
@@ -22176,45 +22417,54 @@
                         "type": "Composite",
                         "effects": [
                             {
-                                "type": "DrawCards",
-                                "count": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "PlayerRef",
-                                    "player": "AnOpponent"
-                                }
+                                "type": "ChooseOpponentForSource",
+                                "prompt": "Choose an opponent to receive the gift"
                             },
                             {
-                                "type": "DealDamage",
-                                "amount": {
-                                    "type": "Fixed",
-                                    "amount": 1
-                                },
-                                "target": {
-                                    "type": "ContextTarget",
-                                    "index": 0
-                                }
-                            },
-                            {
-                                "type": "ForEach",
-                                "space": {
-                                    "type": "IterationSpace.Group",
-                                    "filter": {
-                                        "baseFilter": "creature"
-                                    }
-                                },
-                                "body": {
-                                    "type": "DealDamage",
-                                    "amount": {
-                                        "type": "Fixed",
-                                        "amount": 2
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "DrawCards",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "ChosenOpponent"
+                                        }
                                     },
-                                    "target": "Self"
-                                }
-                            },
-                            "GiftGiven"
+                                    {
+                                        "type": "DealDamage",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        }
+                                    },
+                                    {
+                                        "type": "ForEach",
+                                        "space": {
+                                            "type": "IterationSpace.Group",
+                                            "filter": {
+                                                "baseFilter": "creature"
+                                            }
+                                        },
+                                        "body": {
+                                            "type": "DealDamage",
+                                            "amount": {
+                                                "type": "Fixed",
+                                                "amount": 2
+                                            },
+                                            "target": "Self"
+                                        }
+                                    },
+                                    "GiftGiven"
+                                ]
+                            }
                         ]
                     },
                     "targetRequirements": [

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -4440,17 +4440,17 @@
                     "type": "MoveToZone",
                     "target": {
                         "type": "BoundVariable",
-                        "name": "target"
+                        "name": "instant or sorcery card in your graveyard"
                     },
                     "destination": "Hand"
                 },
                 "targetRequirement": {
                     "type": "TargetObject",
                     "filter": {
-                        "baseFilter": "instant|sorcery",
+                        "baseFilter": "instant|sorcery own:you",
                         "zone": "Graveyard"
                     },
-                    "id": "target"
+                    "id": "instant or sorcery card in your graveyard"
                 },
                 "triggerCondition": "WasKicked"
             }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ChooseNumberForSourceContinuation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/ChooseNumberForSourceContinuation.kt
@@ -23,3 +23,25 @@ data class ChooseNumberForSourceContinuation(
     val controllerId: EntityId,
     val slot: ChoiceSlot
 ) : ContinuationFrame
+
+/**
+ * Resume after a player picks the recipient for a
+ * [com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect]. The resumer writes the
+ * chosen opponent as a [com.wingedsheep.engine.state.components.battlefield.ChoiceValue.EntityChoice]
+ * into the source entity's
+ * [com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent] under
+ * [com.wingedsheep.sdk.scripting.ChoiceSlot.OPPONENT], where
+ * [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent] reads it back.
+ *
+ * @property sourceId The spell or permanent whose cast-choices bag receives the opponent.
+ * @property controllerId The player who made the choice.
+ * @property opponentIds The option list shown to the player, positionally aligned with the
+ *   [com.wingedsheep.engine.core.ChooseOptionDecision]'s options.
+ */
+@Serializable
+data class ChooseOpponentForSourceContinuation(
+    override val decisionId: String,
+    val sourceId: EntityId,
+    val controllerId: EntityId,
+    val opponentIds: List<EntityId>
+) : ContinuationFrame

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -207,6 +207,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ChooseColorThenContinuation::class)
         subclass(ChooseNumberThenContinuation::class)
         subclass(ChooseNumberForSourceContinuation::class)
+        subclass(ChooseOpponentForSourceContinuation::class)
         subclass(ConvertCountersToTokensContinuation::class)
         subclass(ChooseManaColorContinuation::class)
         subclass(ChooseColorForTargetContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -1445,7 +1445,8 @@ class ConditionEvaluator(
             typeLine = card.typeLine,
             manaValue = card.manaValue,
             colors = card.colors,
-            isFaceDown = entity.has<com.wingedsheep.engine.state.components.identity.FaceDownComponent>()
+            isFaceDown = entity.has<com.wingedsheep.engine.state.components.identity.FaceDownComponent>(),
+            name = card.name
         )
         return PredicateEvaluator().matchesFilter(triggeringRecord, filter)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1276,8 +1276,9 @@ class PredicateEvaluator {
             is CardPredicate.PowerLessThanEntity,
             CardPredicate.ToughnessGreaterThanPower -> false
 
-            // Name / printing predicates — not stored in record
-            is CardPredicate.NameEquals -> false
+            // Name predicates — matched against the record's card name; a record without a
+            // name (predating name tracking) is unknown and never equals a given name.
+            is CardPredicate.NameEquals -> record.name == predicate.name
             is CardPredicate.NameEqualsChosen -> false
             CardPredicate.NameNotSharedWithControlledRoom -> false
             is CardPredicate.OriginallyPrintedInSet -> false

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -2720,6 +2720,9 @@ class CastSpellHandler(
                 // way castSpell stamps SpellOnStackComponent.castFromZone. Powers "you haven't cast
                 // a spell from your hand this turn" (Prairie Dog cycle).
                 castFromZone = stackResolver.findCastFromZone(currentState, action.cardId, action.playerId),
+                // Face-down casts hide the card's identity; a face-up cast records the name so
+                // name predicates ("the first Otter spell other than Alania") can match history.
+                name = if (action.castFaceDown) null else cardComponent.name,
             )
             val existing = currentState.spellsCastThisTurnByPlayer[action.playerId] ?: emptyList()
             currentState = currentState.copy(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/ColorChoiceContinuationResumer.kt
@@ -19,6 +19,7 @@ class ColorChoiceContinuationResumer(
         resumer(ChooseColorThenContinuation::class, ::resumeChooseColorThen),
         resumer(ChooseNumberThenContinuation::class, ::resumeChooseNumberThen),
         resumer(ChooseNumberForSourceContinuation::class, ::resumeChooseNumberForSource),
+        resumer(ChooseOpponentForSourceContinuation::class, ::resumeChooseOpponentForSource),
         resumer(ChooseManaColorContinuation::class, ::resumeChooseManaColor),
         resumer(ChooseColorForTargetContinuation::class, ::resumeChooseColorForTarget),
         resumer(ChooseAnyColorTapBonusContinuation::class, ::resumeChooseAnyColorTapBonus)
@@ -90,6 +91,28 @@ class ColorChoiceContinuationResumer(
         }
         val newState = state.updateEntity(continuation.sourceId) { container ->
             container.withCastChoice(continuation.slot, ChoiceValue.NumberChoice(response.number))
+        }
+        return checkForMore(newState, emptyList())
+    }
+
+    fun resumeChooseOpponentForSource(
+        state: GameState,
+        continuation: ChooseOpponentForSourceContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is OptionChosenResponse) {
+            return ExecutionResult.error(state, "Expected option choice response for ChooseOpponentForSource effect")
+        }
+        val chosen = continuation.opponentIds.getOrNull(response.optionIndex)
+            ?: return ExecutionResult.error(state, "Opponent choice index ${response.optionIndex} out of range")
+        // Record the chosen opponent durably on the source (spell or permanent) so
+        // Player.ChosenOpponent reads it for the rest of the resolution and beyond.
+        if (state.getEntity(continuation.sourceId) == null) {
+            return checkForMore(state, emptyList())
+        }
+        val newState = state.updateEntity(continuation.sourceId) { container ->
+            container.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(chosen))
         }
         return checkForMore(newState, emptyList())
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/ChooseOpponentForSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/ChooseOpponentForSourceExecutor.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.ChooseOpponentForSourceContinuation
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.battlefield.withCastChoice
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.PlayerComponent
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [ChooseOpponentForSourceEffect].
+ *
+ * Records the controller's chosen opponent on the source entity's cast-choices bag under
+ * [ChoiceSlot.OPPONENT], where [com.wingedsheep.sdk.scripting.references.Player.ChosenOpponent]
+ * reads it back (gift recipient). With a single opponent the choice is forced and recorded
+ * without a prompt — 2-player games never see a decision. With several opponents it pauses
+ * for a [ChooseOptionDecision] and the [ChooseOpponentForSourceContinuation] resumer writes
+ * the pick. With no source entity or no opponents the effect is a no-op.
+ */
+class ChooseOpponentForSourceExecutor : EffectExecutor<ChooseOpponentForSourceEffect> {
+
+    override val effectType: KClass<ChooseOpponentForSourceEffect> = ChooseOpponentForSourceEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: ChooseOpponentForSourceEffect,
+        context: EffectContext
+    ): EffectResult {
+        val sourceId = context.sourceId ?: return EffectResult.success(state)
+        val source = state.getEntity(sourceId) ?: return EffectResult.success(state)
+
+        val opponents = state.getOpponents(context.controllerId)
+        if (opponents.isEmpty()) return EffectResult.success(state)
+
+        // Sole opponent → forced choice, no prompt.
+        if (opponents.size == 1) {
+            val newState = state.updateEntity(sourceId) { container ->
+                container.withCastChoice(ChoiceSlot.OPPONENT, ChoiceValue.EntityChoice(opponents.single()))
+            }
+            return EffectResult.success(newState)
+        }
+
+        val opponentNames = opponents.map { pid ->
+            state.getEntity(pid)?.get<PlayerComponent>()?.name ?: "Player ${pid.value}"
+        }
+        val decisionId = "choose-opponent-for-source-${sourceId.value}"
+        val decision = ChooseOptionDecision(
+            id = decisionId,
+            playerId = context.controllerId,
+            prompt = effect.prompt,
+            context = DecisionContext(
+                sourceId = sourceId,
+                sourceName = source.get<CardComponent>()?.name ?: "Unknown",
+                phase = DecisionPhase.RESOLUTION
+            ),
+            options = opponentNames
+        )
+        val continuation = ChooseOpponentForSourceContinuation(
+            decisionId = decisionId,
+            sourceId = sourceId,
+            controllerId = context.controllerId,
+            opponentIds = opponents
+        )
+
+        return EffectResult.paused(
+            state.withPendingDecision(decision).pushContinuation(continuation),
+            decision
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -48,6 +48,7 @@ class PlayerExecutors(
         CantCastSpellsExecutor(),
         CantPlayCardsFromHandExecutor(),
         ChooseNumberForSourceExecutor(decisionHandler),
+        ChooseOpponentForSourceExecutor(),
         CreateGlobalTriggeredAbilityExecutor(),
         CreatePermanentEmblemExecutor(),
         EachPlayerChoosesCreatureTypeExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/GameState.kt
@@ -1103,6 +1103,12 @@ data class CastSpellRecord(
     val paidWithTreasureMana: Boolean = false,
     val sourceEntityId: EntityId? = null,
     val castFromZone: Zone? = null,
+    /**
+     * The spell's card name, so name predicates ("the first Otter spell OTHER THAN ALANIA")
+     * can match cast records. Null for records predating name tracking; name predicates
+     * treat a missing name as unknown (NameEquals fails, so its negation matches).
+     */
+    val name: String? = null,
 )
 
 /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/ThoughtStalkerWarlockConditionTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/multiplayer/ThoughtStalkerWarlockConditionTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.multiplayer
+
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.player.LifeLostThisTurnComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.references.Player
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thought-Stalker Warlock (BLB): "choose target opponent. If THEY lost life this turn, …"
+ *
+ * Regression guard: the condition used to be Conditions.OpponentLostLifeThisTurn, which is
+ * true when ANY opponent lost life — in multiplayer you could target opponent B (who lost
+ * nothing) and still get the reveal-hand branch because opponent C bled earlier. The
+ * condition must bind to the chosen target: PlayerLostLifeThisTurn(Player.ContextPlayer(0)).
+ */
+class ThoughtStalkerWarlockConditionTest : FunSpec({
+
+    val vanilla = CardDefinition.creature(
+        name = "Condition Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(com.wingedsheep.sdk.core.Subtype("Bear")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun initFourPlayerGame(): Pair<com.wingedsheep.engine.state.GameState, List<com.wingedsheep.sdk.model.EntityId>> {
+        val registry = CardRegistry()
+        registry.register(vanilla)
+        val deck = Deck(cards = List(40) { "Condition Test Bear" })
+        val result = GameInitializer(registry).initializeGame(
+            GameConfig(
+                players = (1..4).map { PlayerConfig("Player $it", deck, 20) },
+                skipMulligans = true,
+                startingPlayerIndex = 0
+            )
+        )
+        return result.state to result.playerIds
+    }
+
+    test("condition binds to the chosen target opponent, not any opponent") {
+        val (initial, players) = initFourPlayerGame()
+        // players[3] lost life this turn; players[1] and players[2] did not.
+        val state = initial.updateEntity(players[3]) { it.with(LifeLostThisTurnComponent) }
+
+        val evaluator = ConditionEvaluator()
+        val fixed = Conditions.PlayerLostLifeThisTurn(Player.ContextPlayer(0))
+
+        fun contextTargeting(target: com.wingedsheep.sdk.model.EntityId) = EffectContext(
+            sourceId = null,
+            controllerId = players[0],
+            targets = listOf(ChosenTarget.Player(target))
+        )
+
+        // Targeting the bleeding opponent → true; targeting an untouched opponent → false.
+        evaluator.evaluate(state, fixed, contextTargeting(players[3])) shouldBe true
+        evaluator.evaluate(state, fixed, contextTargeting(players[1])) shouldBe false
+
+        // The old any-opponent condition is true regardless of the chosen target — the bug.
+        val old = Conditions.OpponentLostLifeThisTurn
+        evaluator.evaluate(state, old, contextTargeting(players[1])) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlaniaDivergentStormTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AlaniaDivergentStormTest.kt
@@ -138,6 +138,33 @@ class AlaniaDivergentStormTest : FunSpec({
         } shouldBe false
     }
 
+    test("'other than Alania': casting Alania doesn't fire, and a later Otter still counts as first") {
+        val driver = createDriver()
+        val (you, _) = driver.setup()
+
+        // Cast a second Alania — an Otter spell, but the printed "other than Alania"
+        // excludes it: the Otter branch must not fire, and it must not consume the
+        // first-Otter-spell slot for the turn.
+        driver.giveMana(you, Color.BLUE, 1)
+        driver.giveMana(you, Color.RED, 1)
+        driver.giveColorlessMana(you, 3)
+        val alania2 = driver.putCardInHand(you, "Alania, Divergent Storm")
+        driver.castAndDidAlaniaFire(you) {
+            driver.castSpell(you, alania2, emptyList()).error shouldBe null
+        } shouldBe false
+        // Legend rule: keep one Alania (the choice surfaces after the stack empties).
+        repeat(3) { if (driver.pendingDecision != null) driver.autoResolveDecision() }
+
+        // A non-Alania Otter cast later the same turn IS the first Otter spell other
+        // than Alania — the trigger must fire. (The old filter counted Alania herself,
+        // so this used to stay silent.)
+        driver.giveMana(you, Color.BLUE, 1)
+        val otter = driver.putCardInHand(you, "Test Otter")
+        driver.castAndDidAlaniaFire(you) {
+            driver.castSpell(you, otter, emptyList()).error shouldBe null
+        } shouldBe true
+    }
+
     test("guard: does NOT fire on a non-matching spell cast after one matching spell") {
         val driver = createDriver()
         val (you, opponent) = driver.setup()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EarlyWinterTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EarlyWinterTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.EarlyWinter
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Early Winter (BLB), mode 2: "Target opponent exiles an enchantment they control."
+ *
+ * Regression guard: this used to be modeled as "exile target enchantment an opponent
+ * controls" — the caster picked the enchantment and hexproof would block it. The real
+ * card targets the OPPONENT, who then chooses which of their enchantments to exile.
+ */
+class EarlyWinterTest : FunSpec({
+
+    val testGlow: CardDefinition = card("Test Glow") {
+        manaCost = "{W}"
+        typeLine = "Enchantment"
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(EarlyWinter, testGlow))
+        return driver
+    }
+
+    test("the targeted opponent chooses which of their enchantments is exiled") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val glowA = driver.putPermanentOnBattlefield(opponent, "Test Glow")
+        val glowB = driver.putPermanentOnBattlefield(opponent, "Test Glow")
+
+        driver.giveMana(active, Color.BLACK, 1)
+        driver.giveColorlessMana(active, 4)
+        val winter = driver.putCardInHand(active, "Early Winter")
+        driver.submitSuccess(
+            CastSpell(
+                playerId = active,
+                cardId = winter,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Player(opponent))),
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        )
+        driver.bothPass()
+
+        // The OPPONENT (not the caster) picks among their two enchantments.
+        val decision = driver.pendingDecision
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe opponent
+        decision.options shouldContainExactlyInAnyOrder listOf(glowA, glowB)
+
+        driver.submitCardSelection(opponent, listOf(glowB))
+
+        driver.state.getZone(opponent, Zone.EXILE).contains(glowB) shouldBe true
+        driver.findPermanent(opponent, "Test Glow") shouldBe glowA
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhituChroniclerTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhituChroniclerTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.dom.cards.GhituChronicler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Ghitu Chronicler (DOM): "When this creature enters, if it was kicked, return target
+ * instant or sorcery card FROM YOUR GRAVEYARD to your hand."
+ *
+ * Regression guard: the target used the unrestricted any-graveyard filter, letting the
+ * caster pull instants/sorceries out of an opponent's graveyard.
+ */
+class GhituChroniclerTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GhituChronicler))
+        return driver
+    }
+
+    test("kicked ETB can only target instants/sorceries in YOUR graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mine = driver.putCardInGraveyard(active, "Lightning Bolt")
+        val theirs = driver.putCardInGraveyard(opponent, "Lightning Bolt")
+
+        driver.giveMana(active, Color.RED, 2)
+        driver.giveColorlessMana(active, 4)
+        val chronicler = driver.putCardInHand(active, "Ghitu Chronicler")
+        driver.submitSuccess(CastSpell(playerId = active, cardId = chronicler, wasKicked = true))
+
+        // Resolve the creature; the kicked ETB trigger pauses for target selection.
+        repeat(4) {
+            if (driver.pendingDecision == null && driver.state.priorityPlayerId != null) driver.bothPass()
+        }
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        val legal = decision.legalTargets[0].orEmpty()
+        legal shouldContain mine
+        legal shouldNotContain theirs
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiftChosenOpponentTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiftChosenOpponentTest.kt
@@ -1,0 +1,139 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutorRegistry
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.CrumbAndGetIt
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ChooseOpponentForSourceEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Gift mechanic: "You may promise AN OPPONENT a gift as you cast this spell."
+ *
+ * Regression guards for the recipient choice:
+ * - 2-player: the sole opponent is a forced choice — no extra prompt, the gift arrives.
+ * - Multiplayer: the promising player chooses which opponent receives the gift
+ *   (ChooseOpponentForSourceEffect); the choice is recorded on the source and read back
+ *   through Player.ChosenOpponent. Previously the gift always went to the FIRST opponent.
+ */
+class GiftChosenOpponentTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + PredefinedTokens.allTokens + listOf(CrumbAndGetIt))
+        return driver
+    }
+
+    test("2-player gift: sole opponent gets the Food with no extra prompt") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lions = driver.putCreatureOnBattlefield(active, "Savannah Lions")
+
+        driver.giveMana(active, Color.WHITE, 1)
+        val crumb = driver.putCardInHand(active, "Crumb and Get It")
+        // Mode 2 = "Promise a gift"; its target is a creature you control.
+        driver.submitSuccess(
+            CastSpell(
+                playerId = active,
+                cardId = crumb,
+                chosenModes = listOf(1),
+                modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(lions))),
+                targets = listOf(ChosenTarget.Permanent(lions))
+            )
+        )
+        driver.bothPass()
+
+        // The sole opponent is a forced choice: no ChooseOptionDecision may surface.
+        (driver.pendingDecision is ChooseOptionDecision) shouldBe false
+        driver.findPermanent(opponent, "Food") shouldNotBe null
+        driver.findPermanent(active, "Food") shouldBe null
+    }
+
+    test("multiplayer gift: the caster chooses the recipient among three opponents") {
+        val registry = CardRegistry()
+        registry.register(CrumbAndGetIt)
+        val deck = Deck(cards = List(40) { "Crumb and Get It" })
+        val result = GameInitializer(registry).initializeGame(
+            GameConfig(
+                players = (1..4).map { PlayerConfig("Player $it", deck, 20) },
+                skipMulligans = true,
+                startingPlayerIndex = 0
+            )
+        )
+        val state = result.state
+        val players = result.playerIds
+
+        // Materialize a source entity (stands in for the gift spell/permanent).
+        val sourceId = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = CrumbAndGetIt.name,
+                name = CrumbAndGetIt.name,
+                manaCost = ManaCost.parse("{W}"),
+                typeLine = TypeLine.parse("Instant"),
+                ownerId = players[0]
+            ),
+            ControllerComponent(players[0])
+        )
+        val withSource = state
+            .withEntity(sourceId, container)
+            .addToZone(ZoneKey(players[0], Zone.BATTLEFIELD), sourceId)
+
+        // Executing the choose-opponent effect pauses with one option per opponent.
+        val registry2 = EffectExecutorRegistry(cardRegistry = registry)
+        val context = EffectContext(sourceId = sourceId, controllerId = players[0])
+        val execResult = registry2.execute(withSource, ChooseOpponentForSourceEffect(), context)
+
+        execResult.isPaused shouldBe true
+        val decision = execResult.state.pendingDecision
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<ChooseOptionDecision>()
+        decision.playerId shouldBe players[0]
+        decision.options.size shouldBe 3
+
+        // Choosing option index 1 (the SECOND opponent, players[2]) must be honored —
+        // the old Player.AnOpponent behavior always used players[1].
+        val processor = com.wingedsheep.engine.core.ActionProcessor(registry)
+        val afterChoice = processor.process(
+            execResult.state,
+            com.wingedsheep.engine.core.SubmitDecision(
+                players[0],
+                com.wingedsheep.engine.core.OptionChosenResponse(decision.id, optionIndex = 1)
+            )
+        ).result
+
+        afterChoice.isSuccess shouldBe true
+        fun chosen(s: GameState) = s.getEntity(sourceId)?.chosenOpponent()
+        chosen(afterChoice.newState) shouldBe players[2]
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeasonedWarrenguardTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SeasonedWarrenguardTest.kt
@@ -1,0 +1,119 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.blb.cards.SeasonedWarrenguard
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Seasoned Warrenguard (BLB): "Whenever this creature attacks while you control a token,
+ * this creature gets +2/+0 until end of turn."
+ *
+ * Regression guard (printed ruling): the token check happens ONLY when the trigger fires
+ * (attack declaration). If the token leaves before the ability resolves, the pump still
+ * applies. The old implementation re-checked at resolution via a ConditionalEffect.
+ */
+class SeasonedWarrenguardTest : FunSpec({
+
+    val projector = StateProjector()
+
+    val makeRabbit: CardDefinition = card("Test Rabbit Charm") {
+        manaCost = "{W}"
+        typeLine = "Instant"
+        spell {
+            effect = Effects.CreateToken(
+                power = 1, toughness = 1,
+                colors = setOf(Color.WHITE),
+                creatureTypes = setOf("Rabbit")
+            )
+        }
+    }
+
+    val testBreak: CardDefinition = card("Test Break") {
+        manaCost = "{B}"
+        typeLine = "Instant"
+        spell {
+            val t = target("target creature to destroy", Targets.Creature)
+            effect = Effects.Destroy(t)
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SeasonedWarrenguard, makeRabbit, testBreak))
+        return driver
+    }
+
+    fun GameTestDriver.advanceToDeclareAttackersAs(player: com.wingedsheep.sdk.model.EntityId) {
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        var safety = 0
+        while (activePlayer != player && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.DECLARE_ATTACKERS)
+            safety++
+        }
+    }
+
+    test("losing the token in response does not stop the pump (checked at trigger time only)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        var active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        active = driver.activePlayer!!
+
+        val guard = driver.putCreatureOnBattlefield(active, "Seasoned Warrenguard")
+        driver.removeSummoningSickness(guard)
+
+        // Make a Rabbit token via a real spell so it is a token.
+        driver.giveMana(active, Color.WHITE, 1)
+        val charm = driver.putCardInHand(active, "Test Rabbit Charm")
+        driver.castSpell(active, charm)
+        driver.bothPass()
+        val token = driver.findPermanent(active, "Rabbit Token")
+        token.shouldNotBeNull()
+
+        driver.advanceToDeclareAttackersAs(active)
+        driver.declareAttackers(active, listOf(guard), driver.getOpponent(active))
+
+        // The attack trigger is on the stack (condition was true at declaration).
+        // In response, destroy the token before the trigger resolves.
+        driver.giveMana(active, Color.BLACK, 1)
+        val breakSpell = driver.putCardInHand(active, "Test Break")
+        driver.castSpellWithTargets(active, breakSpell, listOf(ChosenTarget.Permanent(token)))
+        driver.bothPass() // destroy resolves — token gone
+        driver.findPermanent(active, "Rabbit Token") shouldBe null
+
+        driver.bothPass() // the Warrenguard trigger resolves
+
+        // Per the ruling the pump still applies: 1/2 base + 2/+0.
+        projector.project(driver.state).getPower(guard) shouldBe 3
+    }
+
+    test("attacking with no token doesn't trigger the pump at all") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40))
+        var active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        active = driver.activePlayer!!
+
+        val guard = driver.putCreatureOnBattlefield(active, "Seasoned Warrenguard")
+        driver.removeSummoningSickness(guard)
+
+        driver.advanceToDeclareAttackersAs(active)
+        driver.declareAttackers(active, listOf(guard), driver.getOpponent(active))
+        driver.bothPass()
+
+        projector.project(driver.state).getPower(guard) shouldBe 1
+    }
+})


### PR DESCRIPTION
## Summary

Follow-up to #1170: fixes every "known-open approximation" that PR listed, each with regression test coverage (7 tests across 6 new/extended test classes). Full `rules-engine`, `mtg-sets`, and `game-server` suites pass.

## Fixes

### Gift recipient is the caster's choice (CR 702.174) — all 21 gift cards
The gift always went to the **first** opponent (`Player.AnOpponent`). New `ChooseOpponentForSourceEffect` / `Effects.ChooseOpponent()`: the controller picks an opponent, stored durably on the source entity under `ChoiceSlot.OPPONENT` and read back via `Player.ChosenOpponent`. With a single opponent the choice is forced and promptless, so **2-player games see no new prompt**. `Patterns.Mechanic.giftSpell` injects the choice into its gift mode, so the 21 card diffs are just `AnOpponent → ChosenOpponent`. Engine side: executor (auto-resolve at 1 opponent, `ChooseOptionDecision` otherwise), continuation + resumer, serialization registration, `CardLinter` slot-declarer entry.

### Early Winter (mode 2)
"**Target opponent** exiles an enchantment **they control**" — now targets the opponent, who picks which of their enchantments to exile (gather → `chooseExactly(chooser = TargetPlayer)` → exile pipeline). Previously the caster targeted the enchantment directly: wrong chooser, and hexproof wrongly applied.

### Thought-Stalker Warlock
"If **they** lost life this turn" now checks the chosen target opponent via new `Conditions.PlayerLostLifeThisTurn(player)` instead of `OpponentLostLifeThisTurn` (true if *any* opponent bled — multiplayer divergence).

### Alania, Divergent Storm
"the first Otter spell **other than Alania**" — the Otter branch now excludes Alania by name. This surfaced an engine gap: `CastSpellRecord` carried no card name and the record matcher hard-coded `NameEquals -> false`, so `Not(NameEquals(…))` matched **every** spell. The record now carries the (face-up) cast name and `NameEquals` matches against it.

### Seasoned Warrenguard
Dropped the resolution-time `ConditionalEffect` re-check of "you control a token". Per the printed ruling the check happens only at attack declaration (`triggerCondition` is fire-time only), so losing the token in response no longer cancels the pump.

### Ghitu Chronicler (DOM) — from the cross-set sweep
Swept all 12 users of the any-graveyard `InstantOrSorceryInGraveyard` filter against their oracle text; only Ghitu Chronicler was wrong — its kicked ETB could return instants/sorceries from **any** graveyard. Now restricted to your graveyard. (The other 11 already used `.ownedByYou()` / genuinely say "a graveyard".)

## Tests

- `GiftChosenOpponentTest` — 2-player: sole opponent gets the Food with no extra prompt; 4-player: choosing the second of three opponents is honored (the old code always picked the first).
- `EarlyWinterTest` — the targeted opponent picks which of their two enchantments is exiled.
- `ThoughtStalkerWarlockConditionTest` — 4-player: condition true only when the *chosen* opponent bled; documents that the old condition was true regardless.
- `AlaniaDivergentStormTest` (extended) — casting Alania doesn't fire the Otter branch and doesn't consume the first-Otter slot; a later Otter still triggers.
- `SeasonedWarrenguardTest` — destroying the token in response to the trigger no longer cancels the +2/+0; no-token attack doesn't trigger at all.
- `GhituChroniclerTest` — kicked ETB's legal targets exclude the opponent's graveyard.

Snapshots re-blessed (BLB gift trees + DOM); SDK language reference updated for `Effects.ChooseOpponent`, `Conditions.PlayerLostLifeThisTurn`, and the `giftSpell` recipient-choice behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)