### PR TITLE
Default newly created lobbies to public

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -165,7 +165,7 @@ sealed interface ClientMessage {
         val boosterCount: Int = 6,         // Sealed: boosters in pool, Draft: packs per player
         val maxPlayers: Int = 8,
         val pickTimeSeconds: Int = 45,     // Draft only
-        val isPublic: Boolean = false,
+        val isPublic: Boolean = true,      // Created lobbies are public by default; host can make private in the lobby.
         /** Master switch for in-app AI assistance (Suggest Pick / Auto-build). Defaults off. */
         val aiAssistEnabled: Boolean = false,
         /** Lobby mode axis: "TOURNAMENT" (default) or "FREE_FOR_ALL" (one multiplayer game, 2-6 players). */
@@ -475,7 +475,8 @@ sealed interface ClientMessage {
     data class CreateQuickGameLobby(
         val vsAi: Boolean = false,
         val setCode: String? = null,
-        val isPublic: Boolean = false,
+        // Created lobbies are public by default; host can make private in the lobby. AI lobbies stay private (see handler).
+        val isPublic: Boolean = true,
         val format: com.wingedsheep.sdk.core.DeckFormat? = null,
         /**
          * When true the lobby plays the Momir Basic Vanguard format: no deckbuilding (fixed 60

--- a/web-client/src/store/slices/lobbySlice.ts
+++ b/web-client/src/store/slices/lobbySlice.ts
@@ -73,7 +73,7 @@ export const createLobbySlice: SliceCreator<LobbySlice> = (set, get) => ({
   disconnectedPlayers: {},
 
   // Actions
-  createTournamentLobby: (setCodes, format = 'SEALED', boosterCount = 6, maxPlayers = 8, pickTimeSeconds = 45, isPublic = false, gameMode = 'TOURNAMENT') => {
+  createTournamentLobby: (setCodes, format = 'SEALED', boosterCount = 6, maxPlayers = 8, pickTimeSeconds = 45, isPublic = true, gameMode = 'TOURNAMENT') => {
     clearDeckState()
     set({ deckBuildingState: null })
     trackEvent('tournament_lobby_created', { set_codes: setCodes, format, booster_count: boosterCount, max_players: maxPlayers, is_public: isPublic, game_mode: gameMode })

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -2402,7 +2402,7 @@ export function createCreateTournamentLobbyMessage(
   boosterCount: number = 6,
   maxPlayers: number = 8,
   pickTimeSeconds: number = 45,
-  isPublic: boolean = false,
+  isPublic: boolean = true,
   gameMode: LobbyGameMode = 'TOURNAMENT'
 ): CreateTournamentLobbyMessage {
   return { type: 'createTournamentLobby', setCodes, format, boosterCount, maxPlayers, pickTimeSeconds, isPublic, gameMode }


### PR DESCRIPTION
## What

Newly created lobbies now default to **public** instead of **private**.

Previously both Quick Game and Tournament lobbies were created with `isPublic = false`, so a host had to open the lobby and flip the Private/Public toggle before their lobby would appear in the public listing (`GET /api/quick-games/public`). This flips the creation default so new lobbies are publicly listed out of the box; the host can still switch to Private inside the lobby.

## Changes

- **`CreateQuickGameLobby.isPublic`** default `false` → `true` (`ClientMessage.kt`). The Quick Game client builder omits `isPublic` when falsy, so the server DTO default is the effective lever. AI lobbies remain private via the existing `message.isPublic && !message.vsAi` guard in `QuickGameLobbyHandler`.
- **`CreateTournamentLobby.isPublic`** default `false` → `true` (`ClientMessage.kt`). Tournament always sends `isPublic` explicitly, so the client defaults are flipped too:
  - `lobbySlice.createTournamentLobby` default param → `true`
  - `createCreateTournamentLobbyMessage` builder default → `true` (the `createCreateSealedLobbyMessage` alias inherits it)

No visibility picker exists at creation time — the two-button Private/Public control lives inside the lobby and is driven by the server-provided `isPublic`, which now starts as Public.

## Testing

- `:game-server:compileKotlin` passes.
- Client change is a pure boolean-default flip (same type); no type surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)