### PR TITLE
Add Vanille and Ragnarok (Final Fantasy meld pair)

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -245,9 +245,10 @@ so a land // spell Adventure offers *both* "play the land" (PlayLandEnumerator) 
 ## Tier 3 — One-off complex cards (each needs unique new functionality)
 
 - **Meld** (Vanille, Cheerful l'Cie + Fang, Fearless l'Cie → Ragnarok, Divine Deliverance) — ❌ GAP. No `MELD`
-  layout or paired-card exile-and-combine logic. Fang is already implemented as a normal creature; meld is a distinct
-  DFC-combine mechanic. Needs a meld layout + the "exile both, return the combined back face" flow. *(Ragnarok itself
-  is castable/returnable today; only the meld path is missing.)*
+  layout or paired-card exile-and-combine logic. All three cards are now implemented as normal creatures with their
+  non-meld abilities (Fang's graveyard-leave trigger, Vanille's mill-and-return ETB, Ragnarok's dies trigger);
+  following the Brisela precedent, each omits its meld linkage and documents it. Meld remains a distinct DFC-combine
+  mechanic: still needs a meld layout + the "exile both, return the combined back face" flow to wire the trio together.
 - **"Damage you'd deal is doubled" / stagger** (Lightning, Army of One; Kuja's Flare Star; The Earth Crystal counter
   doubling; The Wind Crystal lifegain doubling) — replacement effects that **scale
   outgoing damage / counters / life / mill**. The counter-doubling and damage-doubling one-shots exist; confirm

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RagnarokDivineDeliverance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/RagnarokDivineDeliverance.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Ragnarok, Divine Deliverance
+ * Legendary Creature — Beast Avatar
+ * 7/6
+ * Vigilance, menace, trample, reach, haste
+ * When Ragnarok dies, destroy target permanent and return target nonlegendary permanent card
+ * from your graveyard to the battlefield.
+ *
+ * This is a meld result (Vanille, Cheerful l'Cie + Fang, Fearless l'Cie). Meld itself is a
+ * blocked mechanic, so — following the Brisela, Voice of Nightmares precedent — Ragnarok is
+ * authored as a normal legendary creature with its printed abilities and the meld linkage is
+ * ignored (it has no mana cost, matching the printed card). Ragnarok can still be exercised by
+ * putting it on the battlefield directly.
+ *
+ * The dies trigger has two independent targets chosen when it's put on the stack (CR 603.3d):
+ * a permanent to destroy and a nonlegendary permanent card in your graveyard to reanimate. Each
+ * is a separate [target] declaration, so if one becomes illegal before resolution the other
+ * still resolves (CR 608.2c). [Effects.PutOntoBattlefield] returns the reanimated card as the
+ * same object under the resolving controller.
+ */
+val RagnarokDivineDeliverance = card("Ragnarok, Divine Deliverance") {
+    manaCost = ""
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Beast Avatar"
+    power = 7
+    toughness = 6
+    oracleText = "Vigilance, menace, trample, reach, haste\n" +
+        "When Ragnarok dies, destroy target permanent and return target nonlegendary permanent " +
+        "card from your graveyard to the battlefield."
+
+    keywords(Keyword.VIGILANCE, Keyword.MENACE, Keyword.TRAMPLE, Keyword.REACH, Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val permanent = target("permanent", Targets.Permanent)
+        val reanimate = target(
+            "nonlegendary permanent card from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.Permanent.ownedByYou().nonlegendary(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.Destroy(permanent)
+            .then(Effects.PutOntoBattlefield(reanimate))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "99b"
+        artist = "Simon Dominic"
+        flavorText = "When prayers turn to promises, not even fate can stand in their way."
+        imageUri = "https://cards.scryfall.io/normal/front/0/1/01c5bafe-c995-4cef-90fb-7ccb95858511.jpg?1782686523"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/VanilleCheerfulLCie.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/VanilleCheerfulLCie.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Vanille, Cheerful l'Cie
+ * {3}{G}
+ * Legendary Creature — Human Cleric
+ * 3/2
+ * When Vanille enters, mill two cards, then return a permanent card from your graveyard to your hand.
+ * At the beginning of your first main phase, if you both own and control Vanille and a creature named
+ * Fang, Fearless l'Cie, you may pay {3}{B}{G}. If you do, exile them, then meld them into Ragnarok,
+ * Divine Deliverance.
+ *
+ * MELD OMITTED: meld is a blocked mechanic in this engine (see Brisela, Voice of Nightmares and the
+ * partner card [FangFearlessLCie], which likewise omits its meld linkage). Following that precedent,
+ * Vanille is authored with only its enters-the-battlefield ability; the meld trigger is intentionally
+ * not wired. The meld result, [RagnarokDivineDeliverance], is still defined as a standalone card so it
+ * exists in the corpus for when meld is supported.
+ *
+ * The ETB is a mandatory two-step: mill two ([Patterns.Library.mill]) so freshly-milled permanents
+ * become eligible, then a resolution-time choice of one permanent card in your graveyard to move to
+ * your hand (Gather → Select(1) → Move). If your graveyard holds no permanent card the selection
+ * picks nothing and the ability finishes with nothing returned.
+ */
+val VanilleCheerfulLCie = card("Vanille, Cheerful l'Cie") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 3
+    toughness = 2
+    oracleText = "When Vanille enters, mill two cards, then return a permanent card from your " +
+        "graveyard to your hand.\n" +
+        "At the beginning of your first main phase, if you both own and control Vanille and a " +
+        "creature named Fang, Fearless l'Cie, you may pay {3}{B}{G}. If you do, exile them, then " +
+        "meld them into Ragnarok, Divine Deliverance."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.mill(2),
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.GRAVEYARD, Player.You, GameObjectFilter.Permanent),
+                storeAs = "vanilleGraveyard",
+            ),
+            SelectFromCollectionEffect(
+                from = "vanilleGraveyard",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                storeSelected = "vanilleReturned",
+                showAllCards = true,
+                prompt = "Return a permanent card from your graveyard to your hand",
+            ),
+            MoveCollectionEffect(
+                from = "vanilleReturned",
+                destination = CardDestination.ToZone(Zone.HAND, Player.You),
+            ),
+        )
+        description = "When Vanille enters, mill two cards, then return a permanent card from your " +
+            "graveyard to your hand."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "211"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/91226c1a-63a0-494e-bcf0-77c2d6f49213.jpg?1782686437"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -12820,6 +12820,93 @@
     ]
 }
 
+// Ragnarok, Divine Deliverance
+{
+    "name": "Ragnarok, Divine Deliverance",
+    "manaCost": "",
+    "typeLine": "Legendary Creature — Beast Avatar",
+    "oracleText": "Vigilance, menace, trample, reach, haste\nWhen Ragnarok dies, destroy target permanent and return target nonlegendary permanent card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "keywords": [
+        "VIGILANCE",
+        "MENACE",
+        "TRAMPLE",
+        "REACH",
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "permanent"
+                            },
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        },
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "nonlegendary permanent card from your graveyard"
+                            },
+                            "destination": "Battlefield"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent"
+                    },
+                    "id": "permanent"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsPermanent",
+                                    "IsNonlegendary"
+                                ],
+                                "controllerPredicate": "OwnedByYou"
+                            },
+                            "zone": "Graveyard"
+                        },
+                        "id": "nonlegendary permanent card from your graveyard"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "99b",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "flavorText": "When prayers turn to promises, not even fate can stand in their way.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/1/01c5bafe-c995-4cef-90fb-7ccb95858511.jpg?1782686523"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Random Encounter
 {
     "name": "Random Encounter",
@@ -21617,6 +21704,100 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Vanille, Cheerful l'Cie
+{
+    "name": "Vanille, Cheerful l'Cie",
+    "manaCost": "{3}{G}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "When Vanille enters, mill two cards, then return a permanent card from your graveyard to your hand.\nAt the beginning of your first main phase, if you both own and control Vanille and a creature named Fang, Fearless l'Cie, you may pay {3}{B}{G}. If you do, exile them, then meld them into Ragnarok, Divine Deliverance.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "permanent"
+                            },
+                            "storeAs": "vanilleGraveyard"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "vanilleGraveyard",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "vanilleReturned",
+                            "prompt": "Return a permanent card from your graveyard to your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "vanilleReturned",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When Vanille enters, mill two cards, then return a permanent card from your graveyard to your hand."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "211",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/91226c1a-63a0-494e-bcf0-77c2d6f49213.jpg?1782686437"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RagnarokDivineDeliveranceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RagnarokDivineDeliveranceScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.RagnarokDivineDeliverance
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ragnarok, Divine Deliverance (FIN) — meld back of Vanille + Fang, authored as a plain legendary
+ * (see the card comment). It's a 7/6 with vigilance, menace, trample, reach, haste and a dies
+ * trigger: "destroy target permanent and return target nonlegendary permanent card from your
+ * graveyard to the battlefield."
+ *
+ * Test 1 (keywords) confirms all five keywords project onto Ragnarok.
+ *
+ * Test 2 (dies trigger) drives the payoff: Ragnarok is killed by two Lightning Bolts (6 damage on
+ * the 6-toughness body). Its dies trigger picks two independent targets — an opponent's permanent
+ * to destroy and a nonlegendary creature card in the controller's graveyard to reanimate — and on
+ * resolution the opponent's permanent is destroyed and the graveyard card returns to the
+ * battlefield under the controller.
+ */
+class RagnarokDivineDeliveranceScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(RagnarokDivineDeliverance))
+        return driver
+    }
+
+    test("Ragnarok has vigilance, menace, trample, reach, and haste") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val ragnarok = driver.putCreatureOnBattlefield(driver.player1, "Ragnarok, Divine Deliverance")
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(ragnarok, Keyword.VIGILANCE) shouldBe true
+        projected.hasKeyword(ragnarok, Keyword.MENACE) shouldBe true
+        projected.hasKeyword(ragnarok, Keyword.TRAMPLE) shouldBe true
+        projected.hasKeyword(ragnarok, Keyword.REACH) shouldBe true
+        projected.hasKeyword(ragnarok, Keyword.HASTE) shouldBe true
+    }
+
+    test("dies: destroy target permanent and reanimate a nonlegendary permanent card from your graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe driver.player1
+
+        val ragnarok = driver.putCreatureOnBattlefield(driver.player1, "Ragnarok, Divine Deliverance")
+        // A nonlegendary permanent card in the controller's graveyard is the reanimation target.
+        val reanimateTarget = driver.putCardInGraveyard(driver.player1, "Grizzly Bears")
+        // A permanent the opponent controls is the destroy target.
+        val destroyTarget = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+
+        // Kill Ragnarok with two Lightning Bolts (3 + 3 = 6 damage on the 6-toughness body).
+        val bolt1 = driver.putCardInHand(driver.player1, "Lightning Bolt")
+        val bolt2 = driver.putCardInHand(driver.player1, "Lightning Bolt")
+        driver.giveMana(driver.player1, Color.RED, 2)
+
+        driver.castSpell(driver.player1, bolt1, targets = listOf(ragnarok)).isSuccess shouldBe true
+        driver.bothPass() // resolve first bolt — 3 damage, Ragnarok survives
+        driver.state.getBattlefield().contains(ragnarok) shouldBe true
+
+        driver.castSpell(driver.player1, bolt2, targets = listOf(ragnarok)).isSuccess shouldBe true
+        driver.bothPass() // resolve second bolt — 6 damage, Ragnarok dies, queuing its trigger
+
+        driver.state.getBattlefield().contains(ragnarok) shouldBe false
+
+        // The dies trigger asks for both targets in one decision (index 0 = destroy, 1 = reanimate).
+        driver.pendingDecision as ChooseTargetsDecision
+        driver.submitMultiTargetSelection(
+            driver.player1,
+            mapOf(0 to listOf(destroyTarget), 1 to listOf(reanimateTarget)),
+        )
+        driver.bothPass() // resolve the dies trigger
+
+        // Opponent's permanent is destroyed.
+        driver.state.getBattlefield().contains(destroyTarget) shouldBe false
+        // The graveyard card is reanimated under the controller (getBattlefield(player) filters by controller).
+        driver.getGraveyard(driver.player1).contains(reanimateTarget) shouldBe false
+        driver.state.getBattlefield(driver.player1).contains(reanimateTarget) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VanilleCheerfulLCieScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VanilleCheerfulLCieScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.VanilleCheerfulLCie
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Vanille, Cheerful l'Cie (FIN).
+ *
+ * "When Vanille enters, mill two cards, then return a permanent card from your graveyard to your
+ * hand." (Its meld ability is intentionally omitted — see the card definition.)
+ *
+ * The test casts Vanille for real so its enters-the-battlefield trigger fires, then resolves the
+ * mill and the resolution-time choice: a permanent card already in the graveyard (Grizzly Bears)
+ * is offered and returned to hand. Two cards are milled off the top of the library on the way.
+ */
+class VanilleCheerfulLCieScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(VanilleCheerfulLCie))
+        return driver
+    }
+
+    test("enters: mill two, then return a permanent card from your graveyard to your hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        // A permanent card sitting in your graveyard is the intended return target.
+        val gyBear = driver.putCardInGraveyard(you, "Grizzly Bears")
+        val libraryBefore = driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size
+        val graveyardBefore = driver.getGraveyard(you).size
+
+        // Cast Vanille so its ETB trigger fires.
+        val vanille = driver.putCardInHand(you, "Vanille, Cheerful l'Cie")
+        driver.giveMana(you, Color.GREEN, 4) // {3}{G}
+        driver.castSpell(you, vanille).isSuccess shouldBe true
+
+        // Resolve the creature spell and its ETB trigger (mill 2) until the return choice pauses.
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard++ < 20) driver.bothPass()
+
+        // Two cards were milled from the library into the graveyard.
+        driver.state.getZone(ZoneKey(you, Zone.LIBRARY)).size shouldBe libraryBefore - 2
+
+        // The ability offers a permanent card from your graveyard; Grizzly Bears is among the options.
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val choice = driver.pendingDecision as SelectCardsDecision
+        withClue("Grizzly Bears is offered as a permanent card to return") {
+            choice.playerId shouldBe you
+            choice.options.contains(gyBear) shouldBe true
+        }
+        driver.submitCardSelection(you, listOf(gyBear))
+        while (!driver.isPaused && driver.state.stack.isNotEmpty()) driver.bothPass()
+
+        // Grizzly Bears moved from graveyard to hand; the two milled cards remain in the graveyard.
+        withClue("Grizzly Bears is now in hand and no longer in the graveyard") {
+            driver.getHand(you).contains(gyBear) shouldBe true
+            driver.getGraveyard(you).contains(gyBear) shouldBe false
+        }
+        // Net graveyard: started with Grizzly Bears (graveyardBefore), +2 milled, −1 returned.
+        driver.getGraveyard(you).size shouldBe graveyardBefore + 2 - 1
+    }
+})


### PR DESCRIPTION
Implements two more missing **Final Fantasy (FIN)** cards, completing the meld trio's
non-meld behavior (Fang, Fearless l'Cie was already present).

Both are authored as normal creatures with their printed non-meld abilities. Following the
**Brisela, Voice of Nightmares** precedent, the meld linkage is intentionally omitted and
documented in each card — meld is still a blocked engine mechanic (tracked in
`backlog/fin-engine-gaps.md`, note updated here).

## Cards

- **Vanille, Cheerful l'Cie** `{3}{G}` — 3/2 Legendary Creature. ETB: mill two cards, then
  return a chosen permanent card from your graveyard to your hand. Modeled as
  `mill(2) → Gather(graveyard permanents) → Select(1) → Move(hand)`.
- **Ragnarok, Divine Deliverance** — the meld back (7/6, no mana cost). Vigilance, menace,
  trample, reach, haste. Dies trigger: destroy target permanent **and** return target
  nonlegendary permanent card from your graveyard to the battlefield — two independent
  targets, so one becoming illegal doesn't cancel the other.

Both compose existing SDK primitives; **no new engine types**, so no DSL-reference or mtgish
changes.

## Testing

- `RagnarokDivineDeliveranceScenarioTest` — keyword projection + the two-target dies trigger
  (kill via two Lightning Bolts, destroy an opponent permanent, reanimate from graveyard).
- `VanilleCheerfulLCieScenarioTest` — cast Vanille, mill two, return the offered permanent
  card to hand.
- Card snapshot re-blessed (only these two cards added); `CardLintTest` + `FacadeBoundaryTest`
  pass; `check-card-printing` confirms both canonical in FIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)