### PR TITLE
Skip heavy replay-divergence fuzzer in CI (opt-in via runReproTests)

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-jvm.gradle.kts
@@ -36,7 +36,9 @@ tasks.withType<Test>().configureEach {
     }
 
     // Forward the anti-hang guard tunables (see TestHangGuard) so they can be set from the CLI.
-    for (prop in listOf("testTimeoutSeconds", "testHardTimeoutSeconds")) {
+    // Also forward the opt-in flags for the heavy replay-divergence fuzzer (ReplayDivergenceReproTest),
+    // which is skipped in CI and only runs when `runReproTests=true` is passed on the CLI.
+    for (prop in listOf("testTimeoutSeconds", "testHardTimeoutSeconds", "runReproTests", "reproGames", "reproSet")) {
         System.getProperty(prop)?.let { systemProperty(prop, it) }
     }
 

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/ReplayDivergenceReproTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/replay/ReplayDivergenceReproTest.kt
@@ -26,18 +26,26 @@ import kotlin.time.Duration.Companion.minutes
  * reconstruction reaches `1 + actions.size` frames with no mid-replay divergence. A failure here is
  * exactly the "only part of the replay was saved" symptom: a recorded action that no longer applies
  * on re-simulation makes [ReplayReconstructor] stop early.
+ *
+ * This is a heavy fuzzer (dozens of real, decision-heavy games) — far too slow for the PR critical
+ * path, so the whole spec is **skipped in CI**. It is opt-in: run it locally with
+ * `-DrunReproTests=true` (optionally `-DreproGames=N -DreproSet=EOE,...`) when investigating a
+ * replay-truncation regression. The fast, deterministic reconstruction/no-truncation guard that
+ * still runs on every PR lives in [CompactReplayReconstructionTest].
  */
 class ReplayDivergenceReproTest : ScenarioTestBase() {
 
     private fun mockWs(id: String): WebSocketSession =
         mockk(relaxed = true) { every { this@mockk.id } returns id }
 
+    private val reproEnabled = System.getProperty("runReproTests")?.toBoolean() == true
     private val numGames = System.getProperty("reproGames")?.toIntOrNull() ?: 5
     private val setCodes = (System.getProperty("reproSet")?.split(",")
         ?: listOf("EOE", "TDM", "DFT", "BLB", "DSK", "MOM"))
 
     init {
-        test("recorded games reconstruct to the full frame stream (no truncation)").config(timeout = 60.minutes) {
+        test("recorded games reconstruct to the full frame stream (no truncation)")
+            .config(enabledIf = { reproEnabled }, timeout = 60.minutes) {
             val enumerator = LegalActionEnumerator.create(cardRegistry)
             val reconstructor = ReplayReconstructor(cardRegistry, null)
             val rng = Random(0x5EED)
@@ -124,7 +132,8 @@ class ReplayDivergenceReproTest : ScenarioTestBase() {
         // separately and re-applied during reconstruction. Without that, the reconstructed game starts
         // with no yields, pauses for a trigger the live game auto-answered, and truncates. This pins the
         // recording + re-application of yields directly.
-        test("a persistent yield set mid-game is captured and reproduced on reconstruction") {
+        test("a persistent yield set mid-game is captured and reproduced on reconstruction")
+            .config(enabledIf = { reproEnabled }) {
             val session = GameSession(cardRegistry = cardRegistry, maxPlayers = 2)
             val p1 = EntityId.of("yield-p1")
             val p2 = EntityId.of("yield-p2")


### PR DESCRIPTION
## What

`ReplayDivergenceReproTest` plays dozens of real, decision-heavy games through the recording path and reconstructs each `CompactReplay` to catch replay truncation. It's a valuable fuzzer but too slow for the PR critical path (it dominates the `server` test group and can approach the 20-min CI watchdog).

This gates the whole spec behind a `runReproTests` system property:
- **CI** (no flag): both tests skipped instantly.
- **Local / opt-in**: `-DrunReproTests=true` (optionally `-DreproGames=N -DreproSet=EOE,...`) when investigating a truncation regression.

Forked test JVMs only receive an allowlist of system properties, so `runReproTests`/`reproGames`/`reproSet` are added to the forwarding list in `kotlin-jvm.gradle.kts`. (`reproGames`/`reproSet` were previously never reaching the test fork at all — the defaults always won.)

## Coverage tradeoff

Skipping the whole class also removes the fast, deterministic yield-truncation repro (`a persistent yield set mid-game…`) from every PR. The general reconstruction/no-truncation path is still guarded on every PR by the fast `CompactReplayReconstructionTest`; the specific out-of-band-yield regression (PR #1131) is now only exercised via the opt-in run.

## Verification

- CI path (`./gradlew :game-server:test`, no flag): `tests="2" skipped="2"`, both instant.
- Opt-in (`-DrunReproTests=true -DreproGames=1 -DreproSet=EOE`): both `PASSED`, `skipped="0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)