### PR TITLE
Persist live tournament standings for in-progress and abandoned tournaments

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/TournamentMatchHandler.kt
@@ -124,6 +124,8 @@ class TournamentMatchHandler(
             ctx.lobbyRepository.saveTournament(lobbyId, tournament)
 
             handleMatchComplete(lobbyId, gameSessionId)
+            // Persist the freshly-updated standings so profiles/dashboard show live results.
+            recordTournamentProgress(lobbyId)
             spectatingHandler.broadcastActiveMatchesToWaitingPlayers(lobbyId)
 
             val lobby = ctx.lobbyRepository.findLobbyById(lobbyId)
@@ -146,6 +148,10 @@ class TournamentMatchHandler(
             val tournament = ctx.lobbyRepository.findTournamentById(lobbyId) ?: return
             tournament.recordAbandon(playerId)
             ctx.lobbyRepository.saveTournament(lobbyId, tournament)
+
+            // Freeze the standings as they stand after the forfeit; the row keeps these if it later
+            // flips to ABANDONED on teardown.
+            recordTournamentProgress(lobbyId)
 
             spectatingHandler.broadcastActiveMatchesToWaitingPlayers(lobbyId)
 
@@ -910,36 +916,60 @@ class TournamentMatchHandler(
         // Record the finished tournament for durable stats. No-op unless accounts are enabled, and
         // only when at least one seat is a human (AI-only / LLM tournaments use a separate path). This
         // upserts the in-progress row recorded when the bracket went live, flipping it to COMPLETED.
-        run {
-            val standings = tournament.getRankedStandings()
-            tournamentResultSink.recordCompleted(
-                com.wingedsheep.gameserver.stats.RecordedTournament(
-                    lobbyId = lobbyId,
-                    name = tournamentDisplayName(lobby),
-                    format = lobby.format.name,
-                    gameMode = lobby.gameMode.name,
-                    setCodes = lobby.setCodes.joinToString(","),
-                    playerCount = lobby.playerCount,
-                    rounds = tournament.getRoundsForPersistence().size,
-                    gamesPerMatch = lobby.gamesPerMatch,
-                    winnerName = standings.firstOrNull { it.rank == 1 }?.standing?.playerName,
-                    startedAt = null,
-                    endedAt = java.time.Instant.now(),
-                    participants = standings.map { rs ->
-                        val identity = lobby.players[rs.standing.playerId]?.identity
-                        com.wingedsheep.gameserver.stats.RecordedTournamentParticipant(
-                            userId = identity?.userId,
-                            playerName = rs.standing.playerName,
-                            isAi = identity?.isAi == true,
-                            placement = rs.rank,
-                            wins = rs.standing.wins,
-                            losses = rs.standing.losses,
-                            draws = rs.standing.draws,
-                        )
-                    },
+        tournamentResultSink.recordCompleted(
+            buildRecordedTournament(lobby, tournament, endedAt = java.time.Instant.now())
+        )
+    }
+
+    /**
+     * Persist the current standings of a still-running tournament, so player profiles and the admin
+     * dashboard show live results (wins/losses/draws and provisional placement) rather than the zeroed
+     * seed written at start. A no-op unless accounts are enabled with a human seat, and the sink only
+     * touches rows still marked IN_PROGRESS. Called after each match result and after an abandon; an
+     * abandoned tournament then keeps these last-known standings when its row flips to ABANDONED.
+     */
+    private fun recordTournamentProgress(lobbyId: String) {
+        val lobby = ctx.lobbyRepository.findLobbyById(lobbyId) ?: return
+        val tournament = ctx.lobbyRepository.findTournamentById(lobbyId) ?: return
+        tournamentResultSink.recordProgress(buildRecordedTournament(lobby, tournament, endedAt = null))
+    }
+
+    /**
+     * Build a [RecordedTournament][com.wingedsheep.gameserver.stats.RecordedTournament] snapshot from the
+     * live tournament's ranked standings. [endedAt] is null while in progress and set on completion; the
+     * winner is only named once the tournament has ended.
+     */
+    private fun buildRecordedTournament(
+        lobby: TournamentLobby,
+        tournament: TournamentManager,
+        endedAt: java.time.Instant?,
+    ): com.wingedsheep.gameserver.stats.RecordedTournament {
+        val standings = tournament.getRankedStandings()
+        return com.wingedsheep.gameserver.stats.RecordedTournament(
+            lobbyId = lobby.lobbyId,
+            name = tournamentDisplayName(lobby),
+            format = lobby.format.name,
+            gameMode = lobby.gameMode.name,
+            setCodes = lobby.setCodes.joinToString(","),
+            playerCount = lobby.playerCount,
+            rounds = tournament.getRoundsForPersistence().size,
+            gamesPerMatch = lobby.gamesPerMatch,
+            winnerName = if (endedAt != null) standings.firstOrNull { it.rank == 1 }?.standing?.playerName else null,
+            startedAt = null,
+            endedAt = endedAt,
+            participants = standings.map { rs ->
+                val identity = lobby.players[rs.standing.playerId]?.identity
+                com.wingedsheep.gameserver.stats.RecordedTournamentParticipant(
+                    userId = identity?.userId,
+                    playerName = rs.standing.playerName,
+                    isAi = identity?.isAi == true,
+                    placement = rs.rank,
+                    wins = rs.standing.wins,
+                    losses = rs.standing.losses,
+                    draws = rs.standing.draws,
                 )
-            )
-        }
+            },
+        )
     }
 
     /** Human-readable tournament name, e.g. "Bloomburrow / Duskmourn Sealed". */

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/TournamentResultSink.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/TournamentResultSink.kt
@@ -50,6 +50,14 @@ interface TournamentResultSink {
     /** Record that a tournament has gone live. Idempotent per lobby; skipped when no seat is human. */
     fun recordStarted(tournament: RecordedTournament)
 
+    /**
+     * Refresh an in-progress tournament's standings (wins/losses/draws and current placement) so
+     * player profiles and the admin dashboard reflect results as they happen, not only at the end.
+     * No-op unless an IN_PROGRESS row already exists for the lobby; never resurrects a
+     * completed/abandoned tournament.
+     */
+    fun recordProgress(tournament: RecordedTournament)
+
     /** Record a tournament's final result, flipping it to COMPLETED. Upserts the in-progress row. */
     fun recordCompleted(tournament: RecordedTournament)
 
@@ -62,6 +70,7 @@ interface TournamentResultSink {
 @ConditionalOnProperty(name = ["accounts.enabled"], havingValue = "false", matchIfMissing = true)
 class NoOpTournamentResultSink : TournamentResultSink {
     override fun recordStarted(tournament: RecordedTournament) = Unit
+    override fun recordProgress(tournament: RecordedTournament) = Unit
     override fun recordCompleted(tournament: RecordedTournament) = Unit
     override fun recordAbandoned(lobbyId: String) = Unit
 }
@@ -78,6 +87,22 @@ class JdbcTournamentResultSink(private val tournaments: TournamentRepository) : 
         if (tournaments.findFirstByLobbyIdOrderByIdDesc(tournament.lobbyId) != null) return
         tournaments.save(tournament.toRow(TournamentStatus.IN_PROGRESS))
         logger.debug("Recorded tournament {} as in progress ({} seats)", tournament.lobbyId, tournament.participants.size)
+    }
+
+    override fun recordProgress(tournament: RecordedTournament) {
+        if (tournament.participants.none { !it.isAi }) return
+        val existing = tournaments.findFirstByLobbyIdOrderByIdDesc(tournament.lobbyId) ?: return
+        // Only refresh a live tournament; never overwrite a completed or abandoned one.
+        if (existing.status != TournamentStatus.IN_PROGRESS.name) return
+        tournaments.save(
+            tournament.toRow(
+                status = TournamentStatus.IN_PROGRESS,
+                id = existing.id,
+                // Keep the start time captured when the bracket went live.
+                startedAt = existing.startedAt,
+            )
+        )
+        logger.debug("Refreshed in-progress standings for tournament {} ({} seats)", tournament.lobbyId, tournament.participants.size)
     }
 
     override fun recordCompleted(tournament: RecordedTournament) {

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/stats/MatchResultSinkTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/stats/MatchResultSinkTest.kt
@@ -109,6 +109,55 @@ class MatchResultSinkTest : FunSpec({
         saved.captured.winnerName shouldBe "Carol"
     }
 
+    test("recordProgress refreshes an in-progress row's standings, keeping its id and start time") {
+        val repo = mockk<TournamentRepository>(relaxed = true)
+        val startedAt = Instant.now()
+        every { repo.findFirstByLobbyIdOrderByIdDesc("l") } returns
+            TournamentRow(id = 7, lobbyId = "l", status = "IN_PROGRESS", startedAt = startedAt)
+        val saved = slot<TournamentRow>()
+        every { repo.save(capture(saved)) } answers { saved.captured }
+
+        JdbcTournamentResultSink(repo).recordProgress(
+            progress(RecordedTournamentParticipant(SOME_USER, "Carol", isAi = false, placement = 1, wins = 2, losses = 1, draws = 0))
+        )
+        saved.captured.id shouldBe 7
+        saved.captured.status shouldBe TournamentStatus.IN_PROGRESS.name
+        saved.captured.startedAt shouldBe startedAt
+        val carol = saved.captured.participants.first { it.playerName == "Carol" }
+        carol.wins shouldBe 2
+        carol.losses shouldBe 1
+        carol.placement shouldBe 1
+    }
+
+    test("recordProgress does not resurrect a completed or abandoned tournament, nor create a missing one") {
+        val repo = mockk<TournamentRepository>(relaxed = true)
+        every { repo.save(any()) } answers { firstArg() }
+        val sink = JdbcTournamentResultSink(repo)
+        val human = progress(RecordedTournamentParticipant(SOME_USER, "Carol", isAi = false, placement = 1, wins = 1, losses = 0, draws = 0))
+
+        // No row yet → nothing to refresh (start hasn't been recorded).
+        every { repo.findFirstByLobbyIdOrderByIdDesc("l") } returns null
+        sink.recordProgress(human)
+
+        // Already completed → left untouched.
+        every { repo.findFirstByLobbyIdOrderByIdDesc("l") } returns TournamentRow(id = 1, lobbyId = "l", status = "COMPLETED")
+        sink.recordProgress(human)
+
+        // Already abandoned → left untouched.
+        every { repo.findFirstByLobbyIdOrderByIdDesc("l") } returns TournamentRow(id = 1, lobbyId = "l", status = "ABANDONED")
+        sink.recordProgress(human)
+
+        verify(exactly = 0) { repo.save(any()) }
+    }
+
+    test("recordProgress skips AI-only tournaments") {
+        val repo = mockk<TournamentRepository>(relaxed = true)
+        JdbcTournamentResultSink(repo).recordProgress(
+            progress(RecordedTournamentParticipant(null, "Bot", isAi = true, placement = 1, wins = 1, losses = 0, draws = 0))
+        )
+        verify(exactly = 0) { repo.save(any()) }
+    }
+
     test("recordAbandoned flips only in-progress rows to ABANDONED") {
         val repo = mockk<TournamentRepository>(relaxed = true)
         val saved = slot<TournamentRow>()
@@ -135,4 +184,11 @@ private fun tournament(vararg p: RecordedTournamentParticipant) = RecordedTourna
     lobbyId = "l", name = "Test", format = "SEALED", gameMode = "TOURNAMENT", setCodes = "DSK",
     playerCount = p.size, rounds = 3, gamesPerMatch = 1, winnerName = "Carol",
     startedAt = null, endedAt = Instant.now(), participants = p.toList(),
+)
+
+/** An in-progress snapshot: no end time and no winner yet, as [TournamentMatchHandler] builds it. */
+private fun progress(vararg p: RecordedTournamentParticipant) = RecordedTournament(
+    lobbyId = "l", name = "Test", format = "SEALED", gameMode = "TOURNAMENT", setCodes = "DSK",
+    playerCount = p.size, rounds = 1, gamesPerMatch = 1, winnerName = null,
+    startedAt = null, endedAt = null, participants = p.toList(),
 )


### PR DESCRIPTION
## Problem

Tournament standings in a player's profile history were not updated for **in-progress** or **abandoned** tournaments — they showed all zeros.

The DB-backed standings the profile reads are written with real values **only at completion**:

- `recordTournamentStarted` seeds every participant row with `placement=0, wins=0, losses=0, draws=0`.
- `recordCompleted` is the only path that fills in real standings.
- `recordAbandoned` only flips `status`/`ended_at`, never touching standings.

There was no mid-tournament update path, so the `TournamentDetailModal`'s "Standings so far" table (and the abandoned-tournament view) rendered the zeroed seed straight from the DB. The live standings existed only in the in-memory `TournamentManager`.

## Fix

- Add `TournamentResultSink.recordProgress(RecordedTournament)` — upserts the **current** ranked standings (wins/losses/draws + provisional placement) onto the `IN_PROGRESS` row. Guarded so it only touches live rows and never resurrects a completed/abandoned tournament.
- Call it from `TournamentMatchHandler` after every match result and after an abandon. In-progress tournaments now show live standings; an abandoned tournament keeps its last-known standings when its row later flips to `ABANDONED` (the existing `recordAbandoned` preserves participant rows).
- Extract the standings snapshot shared with `completeTournament` into a `buildRecordedTournament(lobby, tournament, endedAt)` helper (winner named only once ended).

No frontend change needed — `TournamentDetailModal` already renders a "Standings so far" header and the W/L/D/placement columns for non-completed tournaments; it just wasn't receiving live data.

## Testing

- New unit tests in `MatchResultSinkTest` covering `recordProgress`: refreshes an in-progress row's standings (preserving id/start time), no-ops on missing/completed/abandoned rows, and skips AI-only tournaments.
- `./gradlew :game-server:test --tests "*MatchResultSinkTest"` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)