### PR TITLE
Add Foundations cards: Dryad Militant, Scavenging Ooze, Chart a Course

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/ChartACourseReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blc/cards/ChartACourseReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.blc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chart a Course reprint in Bloomburrow Commander (BLC). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan's `cards/` package;
+ * this file contributes only the BLC presentation row.
+ */
+val ChartACourseReprint = Printing(
+    oracleId = "05878e49-93ad-4144-9c50-a0bb86126c2e",
+    name = "Chart a Course",
+    setCode = "BLC",
+    collectorNumber = "110",
+    scryfallId = "b005b866-b83c-4413-9db7-465f614a4029",
+    artist = "Olena Richards",
+    imageUri = "https://cards.scryfall.io/normal/front/b/0/b005b866-b83c-4413-9db7-465f614a4029.jpg?1782690209",
+    releaseDate = "2024-08-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ScavengingOoze.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/ScavengingOoze.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Scavenging Ooze — Commander 2011 #170 (canonical printing)
+ * {1}{G} · Creature — Ooze · 2/2
+ *
+ * {G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on
+ * this creature and you gain 1 life.
+ *
+ * The activated ability exiles a single (non-optional) targeted graveyard card, then gates the
+ * growth on [Conditions.TargetIsCreatureCard] — which reads the card's printed type in exile, so
+ * it is correctly true only when the exiled card was a creature card. Same "exile then check the
+ * exiled card's type" shape as Raven Eagle.
+ */
+val ScavengingOoze = card("Scavenging Ooze") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Ooze"
+    power = 2
+    toughness = 2
+    oracleText = "{G}: Exile target card from a graveyard. If it was a creature card, " +
+        "put a +1/+1 counter on this creature and you gain 1 life."
+
+    activatedAbility {
+        cost = Costs.Mana(ManaCost.parse("{G}"))
+        val exiled = target("target card in a graveyard", Targets.CardInGraveyard)
+        effect = Effects.Composite(
+            Effects.Exile(exiled),
+            ConditionalEffect(
+                condition = Conditions.TargetIsCreatureCard(0),
+                effect = Effects.Composite(
+                    Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+                    Effects.GainLife(1),
+                ),
+            ),
+        )
+        description = "{G}: Exile target card from a graveyard. If it was a creature card, " +
+            "put a +1/+1 counter on this creature and you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "170"
+        artist = "Austin Hsu"
+        flavorText = "In nature, not a single bone or scrap of flesh goes to waste."
+        imageUri = "https://cards.scryfall.io/normal/front/3/7/371ceb58-f498-4616-a7f0-eb118fe2e4ff.jpg?1782715022"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ChartACourseReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ChartACourseReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chart a Course reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan's `cards/` package;
+ * this file contributes only the FDN presentation row.
+ */
+val ChartACourseReprint = Printing(
+    oracleId = "05878e49-93ad-4144-9c50-a0bb86126c2e",
+    name = "Chart a Course",
+    setCode = "FDN",
+    collectorNumber = "586",
+    scryfallId = "7599d459-fe71-48f4-8c65-0f519bb63a68",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/7/5/7599d459-fe71-48f4-8c65-0f519bb63a68.jpg?1782688757",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CrusaderOfOdricReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CrusaderOfOdricReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crusader of Odric reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2013's `cards/` package;
+ * this file contributes only the FDN presentation row.
+ */
+val CrusaderOfOdricReprint = Printing(
+    oracleId = "ea384b0d-3091-4d50-b15f-1f6763647b7c",
+    name = "Crusader of Odric",
+    setCode = "FDN",
+    collectorNumber = "731",
+    scryfallId = "2fd0400a-ef3e-4b03-9852-63e28304da53",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/2/f/2fd0400a-ef3e-4b03-9852-63e28304da53.jpg?1782683484",
+    releaseDate = "2026-04-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DryadMilitantReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DryadMilitantReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dryad Militant reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Return to Ravnica's `cards/` package;
+ * this file contributes only the FDN presentation row.
+ */
+val DryadMilitantReprint = Printing(
+    oracleId = "b8ca5877-ac9e-4b15-8c23-c70f61b01895",
+    name = "Dryad Militant",
+    setCode = "FDN",
+    collectorNumber = "656",
+    scryfallId = "8fb36712-26e9-4ec7-8946-626bb7094c15",
+    artist = "Aaron J. Riley",
+    imageUri = "https://cards.scryfall.io/normal/front/8/f/8fb36712-26e9-4ec7-8946-626bb7094c15.jpg?1782688696",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ScavengingOozeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ScavengingOozeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scavenging Ooze reprint in FDN. The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Commander 2011's `cards/` package;
+ * this file contributes only the FDN presentation row.
+ */
+val ScavengingOozeReprint = Printing(
+    oracleId = "1ff25f67-36a7-4cfa-a2b1-2135b5b6fb67",
+    name = "Scavenging Ooze",
+    setCode = "FDN",
+    collectorNumber = "232",
+    scryfallId = "8c504c23-1e9a-411b-9cfe-4180d0c744f6",
+    artist = "Austin Hsu",
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8c504c23-1e9a-411b-9cfe-4180d0c744f6.jpg?1782689065",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CrusaderOfOdricReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inr/cards/CrusaderOfOdricReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.inr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Crusader of Odric reprint in Innistrad Remastered (INR). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Magic 2013's `cards/` package;
+ * this file contributes only the INR presentation row.
+ */
+val CrusaderOfOdricReprint = Printing(
+    oracleId = "ea384b0d-3091-4d50-b15f-1f6763647b7c",
+    name = "Crusader of Odric",
+    setCode = "INR",
+    collectorNumber = "18",
+    scryfallId = "d6ae6566-3df8-4e09-b487-f0362622ca04",
+    artist = "Michael Komarck",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d6ae6566-3df8-4e09-b487-f0362622ca04.jpg?1782726879",
+    releaseDate = "2025-01-24",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ChartACourseReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/ChartACourseReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chart a Course reprint in Jumpstart (JMP). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan's `cards/` package;
+ * this file contributes only the JMP presentation row.
+ */
+val ChartACourseReprint = Printing(
+    oracleId = "05878e49-93ad-4144-9c50-a0bb86126c2e",
+    name = "Chart a Course",
+    setCode = "JMP",
+    collectorNumber = "142",
+    scryfallId = "1a6f256b-943e-4cfb-9fc9-d1ded68b5f97",
+    artist = "James Ryman",
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1a6f256b-943e-4cfb-9fc9-d1ded68b5f97.jpg?1782706688",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ChartACourseReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ChartACourseReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Chart a Course reprint in The Lost Caverns of Ixalan (LCI). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan's `cards/` package;
+ * this file contributes only the LCI presentation row.
+ */
+val ChartACourseReprint = Printing(
+    oracleId = "05878e49-93ad-4144-9c50-a0bb86126c2e",
+    name = "Chart a Course",
+    setCode = "LCI",
+    collectorNumber = "48",
+    scryfallId = "233beaac-37a4-4824-8f31-438b6bfe794b",
+    artist = "Josu Solano",
+    imageUri = "https://cards.scryfall.io/normal/front/2/3/233beaac-37a4-4824-8f31-438b6bfe794b.jpg?1782694572",
+    releaseDate = "2023-11-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ScavengingOozeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/ScavengingOozeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scavenging Ooze reprint in Magic 2014 (M14). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Commander 2011's `cards/` package;
+ * this file contributes only the M14 presentation row.
+ */
+val ScavengingOozeReprint = Printing(
+    oracleId = "1ff25f67-36a7-4cfa-a2b1-2135b5b6fb67",
+    name = "Scavenging Ooze",
+    setCode = "M14",
+    collectorNumber = "195",
+    scryfallId = "ec30153a-36b5-42f8-beed-9efab09f1051",
+    artist = "Austin Hsu",
+    imageUri = "https://cards.scryfall.io/normal/front/e/c/ec30153a-36b5-42f8-beed-9efab09f1051.jpg?1782713895",
+    releaseDate = "2013-07-19",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ScavengingOozeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/ScavengingOozeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scavenging Ooze reprint in Core Set 2021 (M21). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Commander 2011's `cards/` package;
+ * this file contributes only the M21 presentation row.
+ */
+val ScavengingOozeReprint = Printing(
+    oracleId = "1ff25f67-36a7-4cfa-a2b1-2135b5b6fb67",
+    name = "Scavenging Ooze",
+    setCode = "M21",
+    collectorNumber = "204",
+    scryfallId = "487116ab-b885-406b-aa54-56cb67eb3ca5",
+    artist = "Austin Hsu",
+    imageUri = "https://cards.scryfall.io/normal/front/4/8/487116ab-b885-406b-aa54-56cb67eb3ca5.jpg?1782706889",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ScavengingOozeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/ScavengingOozeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scavenging Ooze reprint in New Capenna Commander (NCC). The canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Commander 2011's `cards/` package;
+ * this file contributes only the NCC presentation row.
+ */
+val ScavengingOozeReprint = Printing(
+    oracleId = "1ff25f67-36a7-4cfa-a2b1-2135b5b6fb67",
+    name = "Scavenging Ooze",
+    setCode = "NCC",
+    collectorNumber = "309",
+    scryfallId = "67d93e17-13fd-4cf5-a53c-a7b6c57a8351",
+    artist = "Austin Hsu",
+    imageUri = "https://cards.scryfall.io/normal/front/6/7/67d93e17-13fd-4cf5-a53c-a7b6c57a8351.jpg?1782701754",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DryadMilitant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rtr/cards/DryadMilitant.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.rtr.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+
+/**
+ * Dryad Militant — Return to Ravnica #214 (canonical printing)
+ * {G/W} · Creature — Dryad Soldier · 2/1
+ *
+ * If an instant or sorcery card would be put into a graveyard from anywhere, exile it instead.
+ *
+ * A static replacement effect, the instant/sorcery-only sibling of Rest in Peace's blanket
+ * "card or token" redirect: the reusable [RedirectZoneChange] with an unrestricted
+ * `to = GRAVEYARD` event pattern filtered to `GameObjectFilter.InstantOrSorcery`, so it redirects
+ * any player's instant or sorcery *card* headed to any graveyard (from the stack, hand, library,
+ * or battlefield) into exile instead. Tokens are never cards, so token spells are unaffected.
+ */
+val DryadMilitant = card("Dryad Militant") {
+    manaCost = "{G/W}"
+    colorIdentity = "GW"
+    typeLine = "Creature — Dryad Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "({G/W} can be paid with either {G} or {W}.)\n" +
+        "If an instant or sorcery card would be put into a graveyard from anywhere, exile it instead."
+
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.InstantOrSorcery,
+                to = Zone.GRAVEYARD,
+            ),
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Terese Nielsen"
+        flavorText = "\"We will defend the Worldsoul from Izzet 'progress' at any cost.\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/b/2bb8cb8c-0d03-4cbf-b7f2-a97324817698.jpg?1782714188"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ChartACourse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/ChartACourse.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+
+/**
+ * Chart a Course — Ixalan #48 (canonical printing)
+ * {1}{U} · Sorcery
+ *
+ * Draw two cards. Then discard a card unless you attacked this turn.
+ *
+ * Draw is unconditional; the discard is gated on the negation of [Conditions.YouAttackedThisTurn]
+ * so it only happens when you did not declare an attacker this turn. The condition is evaluated at
+ * resolution (CR 608.2), after the two cards are drawn, so the discard sees your post-draw hand.
+ */
+val ChartACourse = card("Chart a Course") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Draw two cards. Then discard a card unless you attacked this turn."
+
+    spell {
+        effect = Effects.DrawCards(2).then(
+            ConditionalEffect(
+                condition = Conditions.Not(Conditions.YouAttackedThisTurn),
+                effect = Effects.Discard(1),
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "48"
+        artist = "James Ryman"
+        flavorText = "While other pirates prowl for treasure, Captain Parrish plunders secrets."
+        imageUri = "https://cards.scryfall.io/normal/front/9/8/98291778-2ec2-47e2-ac99-5f8cfbb3cf24.jpg?1782710474"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/CMD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CMD.json
@@ -40,3 +40,88 @@
     },
     "colorIdentityOverride": []
 }
+
+// Scavenging Ooze
+{
+    "name": "Scavenging Ooze",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Ooze",
+    "oracleText": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on this creature and you gain 1 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target card in a graveyard"
+                            },
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": "TargetIsCreatureCard"
+                            },
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "AddCounters",
+                                        "counterType": "+1/+1",
+                                        "count": 1,
+                                        "target": "Self"
+                                    },
+                                    {
+                                        "type": "GainLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target card in a graveyard"
+                    }
+                ],
+                "descriptionOverride": "{G}: Exile target card from a graveyard. If it was a creature card, put a +1/+1 counter on this creature and you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "170",
+        "rarity": "RARE",
+        "artist": "Austin Hsu",
+        "flavorText": "In nature, not a single bone or scrap of flesh goes to waste.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/7/371ceb58-f498-4616-a7f0-eb118fe2e4ff.jpg?1782715022"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/RTR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RTR.json
@@ -43,6 +43,42 @@
     ]
 }
 
+// Dryad Militant
+{
+    "name": "Dryad Militant",
+    "manaCost": "{G/W}",
+    "typeLine": "Creature — Dryad Soldier",
+    "oracleText": "({G/W} can be paid with either {G} or {W}.)\nIf an instant or sorcery card would be put into a graveyard from anywhere, exile it instead.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "RedirectZoneChange",
+                "newDestination": "Exile",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "instant|sorcery",
+                    "to": "Graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Terese Nielsen",
+        "flavorText": "\"We will defend the Worldsoul from Izzet 'progress' at any cost.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/b/2bb8cb8c-0d03-4cbf-b7f2-a97324817698.jpg?1782714188"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Fencing Ace
 {
     "name": "Fencing Ace",

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -22,6 +22,95 @@
     ]
 }
 
+// Chart a Course
+{
+    "name": "Chart a Course",
+    "manaCost": "{1}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Draw two cards. Then discard a card unless you attacked this turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "Not",
+                            "condition": {
+                                "type": "Compare",
+                                "left": {
+                                    "type": "TurnTracking",
+                                    "player": "You",
+                                    "tracker": "PLAYER_ATTACKED"
+                                },
+                                "operator": "GTE",
+                                "right": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Hand"
+                                },
+                                "storeAs": "hand"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "hand",
+                                "selection": {
+                                    "type": "ChooseExactly",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "discarded",
+                                "prompt": "Choose 1 card to discard"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "discarded",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Graveyard"
+                                },
+                                "moveType": "Discard"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "rarity": "UNCOMMON",
+        "artist": "James Ryman",
+        "flavorText": "While other pirates prowl for treasure, Captain Parrish plunders secrets.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/8/98291778-2ec2-47e2-ac99-5f8cfbb3cf24.jpg?1782710474"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dive Down
 {
     "name": "Dive Down",


### PR DESCRIPTION
## Summary

Implements a handful of **Foundations (FDN)** reprints. Each is a reprint whose canonical `CardDefinition` lives in the card's **earliest real printing**; FDN (and the other already-scaffolded sets that print them) get `Printing` rows.

All three new cards compose existing SDK primitives — **no new engine effects, keywords, triggers, or conditions**.

### New canonical cards
| Card | Canonical set | Mechanic |
|------|---------------|----------|
| **Dryad Militant** | RTR | Static `RedirectZoneChange` replacement filtered to instant/sorcery *cards* → exile (the instant/sorcery-only sibling of Rest in Peace's blanket redirect) |
| **Scavenging Ooze** | CMD | `{G}`: exile a targeted graveyard card; the `+1/+1` counter + 1 life is gated on `Conditions.TargetIsCreatureCard`, which reads the exiled card's printed type |
| **Chart a Course** | XLN | Draw 2, then `Discard(1)` gated on the negation of `Conditions.YouAttackedThisTurn` |

**Crusader of Odric** was already implemented in M13 (`*/*` = creatures you control); it only needed an FDN `Printing` row.

### Printing rows
`just check-card-printing` reports **no drift** for all four cards. Rows added:
- **FDN** for all four (the requested set)
- **INR** (Crusader of Odric)
- **M14 / M21 / NCC** (Scavenging Ooze)
- **JMP / LCI / BLC** (Chart a Course)

### Testing
- `just build` ✅
- `:mtg-sets:test` (CardLintTest, CardDefinitionSnapshotTest, printing/legality tests) ✅
- Re-blessed CMD/RTR/XLN card snapshots — diff adds **only** the three new card trees, no unrelated card moved.
- `just check-card-printing` clean for all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)