### PR TITLE
Enrich admin game-mode stats + add most-played tournament sets

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminStatsController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/AdminStatsController.kt
@@ -13,8 +13,9 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 /**
- * Admin-only global stats for the dashboard: totals, games-per-day, mode/color distributions, and an
- * IP-based geolocation estimate. Auth uses the shared `X-Admin-Password` / admin-account gate.
+ * Admin-only global stats for the dashboard: totals, games-per-day, mode/color distributions, the
+ * sets played most in tournaments, and an IP-based geolocation estimate. Auth uses the shared
+ * `X-Admin-Password` / admin-account gate.
  * Mounted only when accounts are enabled (the stats live in Postgres); the geolocation endpoint
  * resolves raw IPs server-side and returns only aggregated locations — raw IPs never reach the client.
  */
@@ -55,6 +56,14 @@ class AdminStatsController(
         @RequestHeader("X-Admin-Password", required = false) password: String?,
         @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
     ): ResponseEntity<Any> = adminAuth.guard(password, authorization) { ResponseEntity.ok(statsQuery.modeDistribution()) }
+
+    @GetMapping("/tournament-sets")
+    fun tournamentSets(
+        @RequestHeader("X-Admin-Password", required = false) password: String?,
+        @RequestHeader(HttpHeaders.AUTHORIZATION, required = false) authorization: String?,
+    ): ResponseEntity<Any> = adminAuth.guard(password, authorization) {
+        ResponseEntity.ok(statsQuery.tournamentSetDistribution())
+    }
 
     @GetMapping("/colors")
     fun colors(

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/stats/StatsQueryService.kt
@@ -894,12 +894,37 @@ class StatsQueryService(
         days,
     )
 
+    /**
+     * Global game-mode distribution, most-played first. The label is a composite `"<gameMode>~<format>"`
+     * (format may be empty) mirroring the per-user [modeBreakdown], so the admin dashboard can render each
+     * mode as a hierarchy (e.g. "Tournament › Draft" vs "Tournament › Sealed") via the shared
+     * `mergeModeBuckets` prettifier rather than a flat, opaque `TOURNAMENT`. `~` never occurs in the enum
+     * names being concatenated.
+     */
     fun modeDistribution(): List<StatBucket> = jdbc.query(
         """
-        SELECT COALESCE(game_mode, 'UNKNOWN') AS label, count(*) AS n
+        SELECT COALESCE(game_mode, 'UNKNOWN') || '~' || COALESCE(format, '') AS label, count(*) AS n
         FROM match_results
-        GROUP BY COALESCE(game_mode, 'UNKNOWN')
+        GROUP BY COALESCE(game_mode, 'UNKNOWN') || '~' || COALESCE(format, '')
         ORDER BY n DESC
+        """.trimIndent(),
+    ) { rs, _ -> StatBucket(rs.getString("label"), rs.getLong("n")) }
+
+    /**
+     * Which card sets appear most across recorded tournaments, most-played first. Each set is counted
+     * once per tournament that used it (splitting the tournament's comma-separated `set_codes`), so this
+     * reflects how often a set is *chosen* for a tournament rather than raw per-game volume — a 4-player
+     * and a 32-player event using DSK both count once. Tournaments with no recorded sets (e.g.
+     * premade-deck events) are omitted since we genuinely don't know which sets they drew from.
+     */
+    fun tournamentSetDistribution(): List<StatBucket> = jdbc.query(
+        """
+        SELECT trim(s) AS label, count(*) AS n
+        FROM tournaments t
+        CROSS JOIN LATERAL unnest(string_to_array(t.set_codes, ',')) AS s
+        WHERE t.set_codes IS NOT NULL AND t.set_codes <> '' AND trim(s) <> ''
+        GROUP BY trim(s)
+        ORDER BY n DESC, label ASC
         """.trimIndent(),
     ) { rs, _ -> StatBucket(rs.getString("label"), rs.getLong("n")) }
 

--- a/web-client/src/api/adminStats.ts
+++ b/web-client/src/api/adminStats.ts
@@ -102,6 +102,9 @@ export const fetchOverview = (auth: AdminAuth) => getAdminStats<GlobalOverview>(
 export const fetchGamesPerDay = (auth: AdminAuth, days = 30) =>
   getAdminStats<DailyCount[]>(auth, `/games-per-day?days=${days}`)
 export const fetchModeDistribution = (auth: AdminAuth) => getAdminStats<StatBucket[]>(auth, '/modes')
+/** Sets played most across recorded tournaments (counted once per tournament that used each set). */
+export const fetchTournamentSets = (auth: AdminAuth) =>
+  getAdminStats<StatBucket[]>(auth, '/tournament-sets')
 export const fetchColorDistribution = (auth: AdminAuth) => getAdminStats<StatBucket[]>(auth, '/colors')
 export const fetchGeo = (auth: AdminAuth) => getAdminStats<GeoBucket[]>(auth, '/geo')
 export const fetchTopCards = (auth: AdminAuth, limit = 50) =>

--- a/web-client/src/components/admin/AdminDashboard.tsx
+++ b/web-client/src/components/admin/AdminDashboard.tsx
@@ -1,7 +1,8 @@
 /**
  * Admin Stats: global, cross-user stats served from `/api/stats/admin/*`. Headline totals, a
- * games-per-day chart, mode/color distributions, the most-played cards and per-card win rates,
- * recorded tournaments, and an IP-based geolocation estimate of where players connect from.
+ * games-per-day chart, mode (broken down by format) / color distributions, the most-played cards and
+ * per-card win rates, the sets played most in tournaments, recorded tournaments, and an IP-based
+ * geolocation estimate of where players connect from.
  *
  * Read-only and gated behind the dashboard's shared {@link AdminAuth}. Raw IPs are never returned —
  * the server resolves them to coarse locations server-side. The screen scrolls itself (see AdminScreen).
@@ -33,13 +34,14 @@ import {
   fetchModeDistribution,
   fetchOverview,
   fetchTopCards,
+  fetchTournamentSets,
   fetchTournaments,
 } from '@/api/adminStats'
 import type { AdminAuth } from '@/api/adminAuth'
 import type { StatBucket } from '@/api/account'
 import { TournamentDetailModal } from '@/components/profile/TournamentDetailModal'
 import { TournamentStatusBadge } from '@/components/tournament/TournamentStatusBadge'
-import { colorLabel } from './statFormat'
+import { colorLabel, gameModeLabel, mergeModeBuckets } from './statFormat'
 import { GeoMap } from './GeoMap'
 import { AdminScreen, Panel, StatCard, Table, adminTheme, cellStyle, chartTooltipStyle } from './adminUi'
 
@@ -54,6 +56,7 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
   const [cards, setCards] = useState<CardStat[]>([])
   const [winRates, setWinRates] = useState<CardWinRate[]>([])
   const [tournaments, setTournaments] = useState<TournamentSummary[]>([])
+  const [tournamentSets, setTournamentSets] = useState<StatBucket[]>([])
   const [geo, setGeo] = useState<GeoBucket[]>([])
   const [showAllCards, setShowAllCards] = useState(false)
   const [showAllWinRates, setShowAllWinRates] = useState(false)
@@ -64,7 +67,7 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
     let cancelled = false
     async function load() {
       try {
-        const [ov, pd, md, cl, cs, wr, tn] = await Promise.all([
+        const [ov, pd, md, cl, cs, wr, tn, ts] = await Promise.all([
           fetchOverview(auth),
           fetchGamesPerDay(auth, 30),
           fetchModeDistribution(auth),
@@ -72,6 +75,7 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
           fetchTopCards(auth, 100),
           fetchCardWinRates(auth, 5, 100),
           fetchTournaments(auth, 25),
+          fetchTournamentSets(auth),
         ])
         if (cancelled) return
         setOverview(ov)
@@ -81,6 +85,7 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
         setCards(cs)
         setWinRates(wr)
         setTournaments(tn)
+        setTournamentSets(ts)
         // Geo can be slow (external lookups) — load it separately so the rest renders first.
         fetchGeo(auth).then((g) => !cancelled && setGeo(g)).catch(() => {})
       } catch (e) {
@@ -119,8 +124,8 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
       </Panel>
 
       <div style={styles.twoCol}>
-        <Panel title="Game modes">
-          <BucketBars data={modes} fill="#5b9ee1" />
+        <Panel title="Game modes" subtitle="Broken down by format — e.g. Tournament › Draft vs Sealed">
+          <BucketBars data={mergeModeBuckets(modes)} fill="#5b9ee1" />
         </Panel>
         <Panel title="Colors played">
           <BucketBars data={colors.map((c) => ({ label: colorLabel(c.label), count: c.count }))} fill="#e1a35b" />
@@ -158,6 +163,10 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
         </Panel>
       </div>
 
+      <Panel title="Sets played most in tournaments" subtitle="Counted once per tournament that used each set">
+        <BucketBars data={tournamentSets} fill="#8f7ad9" />
+      </Panel>
+
       <Panel title="Tournaments">
         {tournaments.length === 0 ? (
           <p style={cellStyle.muted}>No tournaments recorded yet.</p>
@@ -167,7 +176,7 @@ export function AdminDashboard({ auth, onBack }: { auth: AdminAuth; onBack: () =
               <tr key={t.id} style={styles.clickableRow} onClick={() => setOpenTournament(t.id)}>
                 <td style={cellStyle.td}>{t.endedAt.slice(0, 10)}</td>
                 <td style={cellStyle.td}>{t.name ?? '—'}</td>
-                <td style={cellStyle.td}>{t.gameMode ?? '—'}</td>
+                <td style={cellStyle.td}>{tournamentModeLabel(t.gameMode, t.format)}</td>
                 <td style={cellStyle.td}>
                   <TournamentStatusBadge status={t.status} />
                 </td>
@@ -202,6 +211,12 @@ function ShowMoreToggle({ total, expanded, onToggle }: { total: number; expanded
       {expanded ? `Show top ${CARD_PREVIEW}` : `Show all ${total}`}
     </button>
   )
+}
+
+/** A tournament's mode + deck format as a "Tournament › Draft"-style label (falls back to a dash). */
+function tournamentModeLabel(gameMode: string | null, format: string | null): string {
+  const { primary, variant } = gameModeLabel(gameMode, format)
+  return variant ? `${primary} › ${variant}` : primary
 }
 
 function BucketBars({ data, fill }: { data: StatBucket[]; fill: string }) {

--- a/web-client/src/components/admin/adminUi.tsx
+++ b/web-client/src/components/admin/adminUi.tsx
@@ -66,11 +66,13 @@ export function AdminScreen({
 
 export function Panel({
   title,
+  subtitle,
   action,
   children,
   span2,
 }: {
   title?: string
+  subtitle?: string
   action?: React.ReactNode
   children: React.ReactNode
   span2?: boolean
@@ -79,7 +81,10 @@ export function Panel({
     <div style={span2 ? { ...panelStyle.panel, gridColumn: '1 / -1' } : panelStyle.panel}>
       {(title || action) && (
         <div style={panelStyle.panelHead}>
-          {title && <h2 style={panelStyle.panelTitle}>{title}</h2>}
+          <div style={panelStyle.panelTitleBlock}>
+            {title && <h2 style={panelStyle.panelTitle}>{title}</h2>}
+            {subtitle && <p style={panelStyle.panelSubtitle}>{subtitle}</p>}
+          </div>
           {action}
         </div>
       )}
@@ -191,7 +196,9 @@ const panelStyle: Record<string, React.CSSProperties> = {
     gap: 12,
     marginBottom: 14,
   },
+  panelTitleBlock: { display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 },
   panelTitle: { margin: 0, color: adminTheme.text, fontSize: 15, fontWeight: 600 },
+  panelSubtitle: { margin: 0, color: adminTheme.textMuted, fontSize: 12 },
   metric: {
     flex: '1 1 130px',
     backgroundColor: adminTheme.panel,


### PR DESCRIPTION
## What

Two additions to the **Admin → Stats** dashboard, in response to "add more details to game modes, and show which sets are played most in tournaments."

### 1. Game modes broken down by format
The admin "Game modes" panel previously showed flat, opaque enum bars (`TOURNAMENT`, `QUICK_GAME`, …). It now renders the same two-level hierarchy the per-user profile already uses — e.g. **Tournament › Draft** vs **Tournament › Sealed**, **Quick Game**, **Multiplayer › Two-Headed Giant**.

Implementation reuses the existing per-user machinery rather than inventing anything:
- `StatsQueryService.modeDistribution()` now emits the `"<gameMode>~<format>"` composite label that the per-user `modeBreakdown()` already produced.
- The dashboard runs it through the existing `mergeModeBuckets` / `gameModeLabel` prettifiers in `statFormat.ts`.
- The **Tournaments** table's "Mode" column gets the same treatment (was raw `TOURNAMENT`).

### 2. "Sets played most in tournaments" panel
A new bar panel showing which card sets show up most across recorded tournaments.
- New `StatsQueryService.tournamentSetDistribution()` — splits each tournament's comma-separated `tournaments.set_codes` (`unnest(string_to_array(...))`, mirroring the existing per-user `setBreakdown`) and counts each set **once per tournament** that used it. So a 4-player and a 32-player event both count once; the stat reflects how often a set is *chosen* for a tournament, not raw game volume. Premade-deck events (no recorded sets) are omitted.
- New endpoint `GET /api/stats/admin/tournament-sets` + `fetchTournamentSets` client fn.

### Supporting change
- `Panel` (adminUi) gains an optional `subtitle` prop, used for the one-line descriptions under the two new/enriched panel titles.

## Notes
- The `/modes` wire format changes (label is now the `~` composite). Its only consumer is this dashboard, updated here. No tests reference it.
- No DB migration needed — `tournaments.set_codes` already exists (V2).

## Testing
- `web-client`: `npm run typecheck` ✅ clean.
- `game-server`: `:game-server:compileKotlin` ✅ (only pre-existing Redis deprecation warnings).
- No screenshot: the Admin Stats screen requires an accounts-enabled, Postgres-backed deployment with recorded games/tournaments to render non-empty; not available in this environment. The change reuses the already-shipped `Panel` / `BucketBars` presentational components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)