### PR TITLE
Fix four card/auto-tap bugs (play milled land, spell bounce, pain, bonus mana)

### DIFF
--- a/manual-scenarios/cards/b/badgermole-cub.json
+++ b/manual-scenarios/cards/b/badgermole-cub.json
@@ -30,5 +30,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
 }

--- a/manual-scenarios/cards/j/jeskai-revelation.json
+++ b/manual-scenarios/cards/j/jeskai-revelation.json
@@ -1,0 +1,39 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Jeskai Revelation"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Mountain", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Champion of Dusan"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Nightblade Brigade"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 2,
+  "priorityPlayer": 2,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/cards/t/tablet-of-discovery.json
+++ b/manual-scenarios/cards/t/tablet-of-discovery.json
@@ -1,0 +1,31 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Starting Town", "Tablet of Discovery", "Forest"],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Mountain", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiRevelation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/JeskaiRevelation.kt
@@ -31,7 +31,7 @@ val JeskaiRevelation = card("Jeskai Revelation") {
         val bounceTarget = target("target spell or permanent", TargetSpellOrPermanent())
         val damageTarget = target("any target", Targets.Any)
         effect = Effects.Composite(
-            Effects.ReturnToHand(bounceTarget),
+            Effects.ReturnSpellOrPermanentToOwnersHand(bounceTarget),
             Effects.DealDamage(4, damageTarget),
             Effects.CreateToken(
                 power = 1,

--- a/mtg-sets/src/test/resources/snapshots/cards/TDM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/TDM.json
@@ -7880,12 +7880,11 @@
             "type": "Composite",
             "effects": [
                 {
-                    "type": "MoveToZone",
+                    "type": "ReturnSpellOrPermanentToOwnersHand",
                     "target": {
                         "type": "BoundVariable",
                         "name": "target spell or permanent"
-                    },
-                    "destination": "Hand"
+                    }
                 },
                 {
                     "type": "DealDamage",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/land/PlayLandHandler.kt
@@ -218,6 +218,13 @@ class PlayLandHandler(
             newState = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
                 .unlinkFromAllLinkedExiles(newState, action.cardId)
         }
+        // A generic per-card may-play permission (Tablet of Discovery's "you may play that card
+        // this turn") can also leave the card in the graveyard. Lands bypass the stack, so clean
+        // up the permission here too — otherwise it would silently re-authorize the card if it
+        // returned to the graveyard later this turn. No-op when no per-card permission exists.
+        if (fromZone == Zone.GRAVEYARD) {
+            newState = newState.removeMayPlayPermissionsForCard(action.cardId)
+        }
 
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId)
 
@@ -507,6 +514,12 @@ class PlayLandHandler(
     ): Boolean {
         val graveyardZone = ZoneKey(playerId, Zone.GRAVEYARD)
         if (cardId !in state.getZone(graveyardZone)) return false
+        // Generic per-card may-play permission (e.g. Tablet of Discovery's "mill a card. You
+        // may play that card this turn." — the milled card sits in the graveyard). Mirrors the
+        // exile path in [isInExileWithPlayPermission] and CastFromZoneEnumerator, which already
+        // offers the PlayLand action for such a card; without this the handler would reject the
+        // very action the enumerator advertised.
+        if (state.hasMayPlayFor(cardId, playerId, conditionEvaluator)) return true
         if (hasLandGraveyardPlayPermission(state, playerId)) return true
         return findGraveyardPlayPermissionSource(state, playerId, CardType.LAND.name) != null
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -294,8 +294,18 @@ class CostPaymentService(private val services: EngineServices) {
             current = afterTaps
             events.addAll(tapEvents)
             for ((_, production) in solution.manaProduced) {
-                combined = if (production.color != null) combined.add(production.color)
+                combined = if (production.color != null) combined.add(production.color, production.amount)
                 else combined.addColorless(production.colorless)
+            }
+            // Bonus mana from AdditionalManaOnTap / AdditionalManaOnSourceTap (e.g. Badgermole
+            // Cub's "Whenever you tap a creature for mana, add an additional {G}") and mana auras
+            // is not in `manaProduced`, so credit it here — otherwise the cost comes up short even
+            // though the solver counted the bonus toward affordability. Mirrors the activate-ability
+            // auto-tap path (ActivateAbilityHandler.autoTapForManaCost).
+            for (source in solution.sources) {
+                if (source.bonusManaPerTap > 0 && source.bonusManaColor != null) {
+                    combined = combined.add(source.bonusManaColor!!, source.bonusManaPerTap)
+                }
             }
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaAbilitySideEffectExecutor.kt
@@ -2,15 +2,19 @@ package com.wingedsheep.engine.mechanics.mana
 
 import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.LifeChangeReason
 import com.wingedsheep.engine.core.TappedEvent
 import com.wingedsheep.engine.core.tap
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityCost
 import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.costs.CostAtom
 import com.wingedsheep.sdk.scripting.effects.AddAnyColorManaSpendOnChosenTypeEffect
 import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddDynamicManaEffect
@@ -95,16 +99,32 @@ class ManaAbilitySideEffectExecutor(
             .firstOrNull { abilityProducesColor(it, producedColor) }
             ?: return state to emptyList()
 
+        var currentState = state
+        val events = mutableListOf<GameEvent>()
+
+        // Pain modeled as part of the ability's *cost* (e.g. Starting Town's
+        // "{T}, Pay 1 life: Add one mana of any color") — the auto-tap fast path only
+        // pays the tap, so any life-payment cost atom would otherwise be silently skipped.
+        // (Pain modeled as an *effect*, like Adarkar Wastes, is handled by the sub-effect
+        // loop below.) The solver already tracks these via ManaSource.hasPainCost for tap
+        // priority, but never deducts the life.
+        val lifeCost = payLifeCost(matchingAbility.cost)
+        if (lifeCost > 0) {
+            val (afterLife, lifeEvent) = DamageUtils.loseLife(
+                currentState, controllerId, lifeCost, LifeChangeReason.PAYMENT
+            )
+            currentState = afterLife
+            lifeEvent?.let(events::add)
+        }
+
         val sideEffects = nonManaSubEffects(matchingAbility.effect)
-        if (sideEffects.isEmpty()) return state to emptyList()
+        if (sideEffects.isEmpty()) return currentState to events
 
         val context = EffectContext(
             sourceId = sourceId,
             controllerId = controllerId,
         )
 
-        var currentState = state
-        val events = mutableListOf<GameEvent>()
         for (sub in sideEffects) {
             val result = effectExecutor(currentState, sub, context)
             currentState = result.state
@@ -115,6 +135,17 @@ class ManaAbilitySideEffectExecutor(
             // effect is fully resolved with controller info alone.
         }
         return currentState to events
+    }
+
+    /**
+     * Sum of life-payment ([CostAtom.PayLife]) amounts in a mana ability's cost, recursing
+     * through composite costs (e.g. `{T}, Pay 1 life`). Returns 0 when the cost has no
+     * life component.
+     */
+    private fun payLifeCost(cost: AbilityCost): Int = when (cost) {
+        is AbilityCost.Atom -> (cost.atom as? CostAtom.PayLife)?.amount ?: 0
+        is AbilityCost.Composite -> cost.costs.sumOf { payLifeCost(it) }
+        else -> 0
     }
 
     private fun abilityProducesColor(ability: ActivatedAbility, color: Color?): Boolean =

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AutoTapPainAndBonusReproTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AutoTapPainAndBonusReproTest.kt
@@ -1,0 +1,152 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.StartingTown
+import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
+import com.wingedsheep.mtg.sets.definitions.tla.cards.BadgermoleCub
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.basicLand
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Repro for the auto-tap bugs:
+ *  - Starting Town's colored ability pays 1 life as part of the *cost* — auto-tap must
+ *    still deduct it (bug: "Starting Town -> Autotapper does not give pain").
+ *  - Badgermole Cub's "Whenever you tap a creature for mana, add an additional {G}" — the
+ *    auto-tap solver must both know about and deliver the bonus (bug: "Autotapper does not
+ *    know that Badgermole Cub gives extra mana").
+ */
+class AutoTapPainAndBonusReproTest : FunSpec({
+
+    val TestForest = basicLand("Forest") {}
+
+    // A green mana-dork creature (stands in for an earthbended land — a creature that taps
+    // for mana, which is what actually triggers Badgermole Cub).
+    val tapForGreenCreature = card("Tap-for-Green Elf") {
+        manaCost = "{G}"
+        colorIdentity = "G"
+        typeLine = "Creature — Elf"
+        power = 1
+        toughness = 1
+        oracleText = "{T}: Add {G}."
+        activatedAbility {
+            cost = Costs.Tap
+            effect = Effects.AddMana(Color.GREEN, 1)
+            manaAbility = true
+        }
+    }
+
+    // A vanilla {G}{G} sorcery used to force an auto-tap of a {G}{G} cost.
+    val greenGreenSpell = card("Green Green Test Spell") {
+        manaCost = "{G}{G}"
+        colorIdentity = "G"
+        typeLine = "Sorcery"
+        oracleText = "Draw a card."
+        spell { effect = Effects.DrawCards(1) }
+    }
+
+    // A white one-drop used to force an auto-tap of a single colored pip.
+    val whiteSpell = card("White Test Spell") {
+        manaCost = "{W}"
+        colorIdentity = "W"
+        typeLine = "Sorcery"
+        oracleText = "Draw a card."
+        spell { effect = Effects.DrawCards(1) }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(
+            TestCards.all + AvatarTheLastAirbenderSet.cards + listOf(
+                TestForest, BadgermoleCub, StartingTown,
+                tapForGreenCreature, greenGreenSpell, whiteSpell
+            )
+        )
+        return driver
+    }
+
+    fun createRegistry(): CardRegistry {
+        val registry = CardRegistry()
+        registry.register(
+            TestCards.all + AvatarTheLastAirbenderSet.cards + listOf(
+                TestForest, BadgermoleCub, StartingTown,
+                tapForGreenCreature, greenGreenSpell, whiteSpell
+            )
+        )
+        return registry
+    }
+
+    test("Starting Town pain: auto-paying a colored spell deducts 1 life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Forest" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        // Starting Town is the only source of white — the auto-tap solver must use its
+        // "{T}, Pay 1 life: Add one mana of any color" ability, incurring the pain.
+        val town = driver.putPermanentOnBattlefield(activePlayer, "Starting Town")
+        val spell = driver.putCardInHand(activePlayer, "White Test Spell")
+
+        val before = driver.getLifeTotal(activePlayer)
+        val result = driver.castSpell(activePlayer, spell)
+        result.isSuccess shouldBe true
+
+        driver.isTapped(town) shouldBe true
+        driver.getLifeTotal(activePlayer) shouldBe (before - 1)
+    }
+
+    test("Badgermole Cub bonus: auto-paying {G}{G} needs only one green source") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Forest" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(activePlayer, "Badgermole Cub")
+        val elf = driver.putCreatureOnBattlefield(activePlayer, "Tap-for-Green Elf")
+        driver.removeSummoningSickness(elf)
+        val spell = driver.putCardInHand(activePlayer, "Green Green Test Spell")
+
+        // Only one green source (the Elf), but Badgermole Cub's bonus supplies the 2nd {G}.
+        val result = driver.castSpell(activePlayer, spell)
+        result.isSuccess shouldBe true
+        driver.isTapped(elf) shouldBe true
+    }
+
+    test("Badgermole Cub bonus for an EARTHBENDED LAND: solver knows and auto-pays {G}{G}") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40, "Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+
+        // Earthbend a Forest into a creature-land via Earthbending Lesson.
+        val forest = driver.putLandOnBattlefield(you, "Forest")
+        val lesson = driver.putCardInHand(you, "Earthbending Lesson")
+        driver.giveMana(you, Color.GREEN, 4)
+        driver.castSpell(you, lesson, listOf(forest)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Badgermole Cub in play (static only — putCreatureOnBattlefield doesn't fire its ETB).
+        driver.putCreatureOnBattlefield(you, "Badgermole Cub")
+
+        // The earthbended Forest is the ONLY green source. Tapping it (a creature now) should
+        // yield {G} + Badgermole Cub's bonus {G} — the autotapper must count both.
+        val solver = ManaSolver(createRegistry())
+        solver.canPay(driver.state, you, ManaCost.parse("{G}{G}")) shouldBe true
+
+        val spell = driver.putCardInHand(you, "Green Green Test Spell")
+        driver.castSpell(you, spell).isSuccess shouldBe true
+        driver.isTapped(forest) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JeskaiRevelationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JeskaiRevelationScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.mtg.sets.definitions.tdm.cards.JeskaiRevelation
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Jeskai Revelation:
+ *   {4}{U}{R}{W} Instant — "Return target spell or permanent to its owner's hand. …"
+ *
+ * Regression for the bug "Jeskai Revelation targeting a spell did not send the spell to the hand,
+ * but left it on the stack": the bounce clause targets a "spell or permanent", so it must use the
+ * stack-aware ReturnSpellOrPermanentToOwnersHand effect (not the battlefield-only ReturnToHand).
+ */
+class JeskaiRevelationScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(JeskaiRevelation)
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Ogre",
+                manaCost = ManaCost.parse("{2}{R}"),
+                subtypes = setOf(Subtype("Ogre")),
+                power = 3,
+                toughness = 3
+            )
+        )
+
+        test("bouncing a spell on the stack returns it to its owner's hand; it does not resolve") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Jeskai Revelation")
+                .withCardInHand(2, "Test Ogre")
+                .withLandsOnBattlefield(1, "Island", 3)
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withLandsOnBattlefield(1, "Plains", 2)
+                .withLandsOnBattlefield(2, "Mountain", 3)
+                .withActivePlayer(2)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            // Opponent casts a creature spell; it goes on the stack.
+            game.castSpell(2, "Test Ogre").error shouldBe null
+            val ogreSpellId = game.state.stack.first { entityId ->
+                game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Test Ogre"
+            }
+
+            // Active player passes; Player1 responds with Jeskai Revelation.
+            game.passPriority()
+
+            // Two targets: the spell on the stack (bounce) and a player (the 4 damage).
+            val cast = game.execute(
+                CastSpell(
+                    game.player1Id,
+                    game.findCardsInHand(1, "Jeskai Revelation").single(),
+                    listOf(
+                        ChosenTarget.Spell(ogreSpellId),
+                        ChosenTarget.Player(game.player2Id)
+                    )
+                )
+            )
+            cast.error shouldBe null
+            game.resolveStack()
+
+            withClue("The targeted spell left the stack for its owner's hand (did not resolve)") {
+                game.isInHand(2, "Test Ogre") shouldBe true
+                game.isOnBattlefield("Test Ogre") shouldBe false
+                game.state.stack.none { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Test Ogre"
+                } shouldBe true
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TabletOfDiscoveryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TabletOfDiscoveryScenarioTest.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.sos.cards.TabletOfDiscovery
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Tablet of Discovery:
+ *   {2}{R} Artifact — "When this artifact enters, mill a card. You may play that card this turn."
+ *
+ * Regression for the bug "When I play Tablet of Discovery, I'm unable to play a land": the milled
+ * card lands in the graveyard with a generic may-play permission, and the CastFromZoneEnumerator
+ * offers a PlayLand action for it — but PlayLandHandler used to reject playing a *land* from the
+ * graveyard unless the permission was Crucible/Muldrotha-style. A milled land must be playable.
+ */
+class TabletOfDiscoveryScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(TabletOfDiscovery)
+
+        test("a milled land can be played this turn from the graveyard") {
+            val game = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Tablet of Discovery")
+                .withCardInLibrary(1, "Forest") // sole library card -> milled to graveyard
+                .withLandsOnBattlefield(1, "Mountain", 3) // pays {2}{R}
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            game.castSpell(1, "Tablet of Discovery").error shouldBe null
+            game.resolveStack() // Tablet resolves, enters, ETB mills the Forest
+
+            withClue("The milled Forest is now in the graveyard with a may-play grant") {
+                game.isInGraveyard(1, "Forest") shouldBe true
+            }
+
+            val forestId = game.findCardsInGraveyard(1, "Forest").single()
+            withClue("Playing the milled land from the graveyard succeeds") {
+                game.execute(PlayLand(game.player1Id, forestId)).error shouldBe null
+            }
+            game.isOnBattlefield("Forest") shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes four independent card / auto-tap bugs and adds regression coverage. No new SDK types — the card-level fix reuses an existing stack-aware primitive, and the rest is engine plumbing that mirrors already-established paths.

### Bugs fixed

1. **Jeskai Revelation left a bounced spell on the stack.** The bounce clause targets a "spell or permanent", so it must use the stack-aware `Effects.ReturnSpellOrPermanentToOwnersHand` instead of the battlefield-only `Effects.ReturnToHand`. (`JeskaiRevelation.kt`; `TDM.json` snapshot re-blessed.)

2. **A milled land could not be played** (Tablet of Discovery: "mill a card. You may play that card this turn."). `PlayLandHandler` rejected playing a *land* from the graveyard unless the permission was Crucible/Muldrotha-style, even though `CastFromZoneEnumerator` advertised the `PlayLand` action. It now honours a generic per-card may-play permission via `state.hasMayPlayFor(...)` — mirroring the exile path — and cleans the permission up on play.

3. **Auto-tap ignored pain modeled as a cost** (Starting Town: "{T}, Pay 1 life: Add one mana of any color"). The auto-tap fast path only paid the tap, silently skipping the life-payment cost atom. `ManaAbilitySideEffectExecutor` now deducts `PayLife` cost atoms (recursing composite costs) via `loseLife` / `LifeChangeReason.PAYMENT`.

4. **Auto-tap ignored bonus mana** (Badgermole Cub: "Whenever you tap a creature for mana, add an additional {G}"). Bonus mana from `AdditionalManaOnTap` / `AdditionalManaOnSourceTap` is not in `manaProduced`, so the cast cost came up short even though the solver counted the bonus toward affordability. `CostPaymentService` now credits per-source bonus mana, mirroring the activate-ability auto-tap path. The same hunk also fixes a latent bug where multi-mana colored producers were credited only 1 mana (`add(color)` → `add(color, amount)`).

## Tests

New scenario tests, all passing:

- `AutoTapPainAndBonusReproTest` — Starting Town pain deduction; Badgermole Cub bonus for a mana-dork and for an earthbended creature-land.
- `JeskaiRevelationScenarioTest` — bouncing a spell on the stack returns it to hand and it does not resolve.
- `TabletOfDiscoveryScenarioTest` — a milled land can be played from the graveyard the same turn.

Plus manual self-play scenarios for Tablet of Discovery and Jeskai Revelation.

```
AutoTapPainAndBonusReproTest > Starting Town pain: auto-paying a colored spell deducts 1 life PASSED
AutoTapPainAndBonusReproTest > Badgermole Cub bonus: auto-paying {G}{G} needs only one green source PASSED
AutoTapPainAndBonusReproTest > Badgermole Cub bonus for an EARTHBENDED LAND: solver knows and auto-pays {G}{G} PASSED
JeskaiRevelationScenarioTest > bouncing a spell on the stack returns it to its owner's hand; it does not resolve PASSED
TabletOfDiscoveryScenarioTest > a milled land can be played this turn from the graveyard PASSED
BUILD SUCCESSFUL
```

## Follow-ups (not in this PR)

- The auto-tap payment path credits fixed-color tap bonuses but still skips any-color tap bonuses (`bonusManaIsAnyColor`, e.g. Fertile Ground). This mirrors the existing `ActivateAbilityHandler` gap — the solver counts it toward affordability but payment doesn't credit it. Worth fixing both mirrored sites together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
