### PR TITLE
Add Foundations cards: Devout Decree, Authority of the Consuls, Gnarlid Colony

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AuthorityOfTheConsulsReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/AuthorityOfTheConsulsReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Authority of the Consuls reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in the KLD (Kaladesh) `cards/`
+ * package — its earliest real printing. This file contributes only the FDN presentation row,
+ * picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val AuthorityOfTheConsulsReprint = Printing(
+    oracleId = "55f3c721-e13a-406e-bc8e-d6cdc91ac477",
+    name = "Authority of the Consuls",
+    setCode = "FDN",
+    collectorNumber = "137",
+    scryfallId = "42ce2d7f-5924-47c0-b5ed-dacf9f9617a0",
+    artist = "Lake Hurwitz",
+    imageUri = "https://cards.scryfall.io/normal/front/4/2/42ce2d7f-5924-47c0-b5ed-dacf9f9617a0.jpg?1782689147",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DevoutDecreeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DevoutDecreeReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Devout Decree reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in the M20 (Core Set 2020)
+ * `cards/` package — its earliest real printing. This file contributes only the FDN
+ * presentation row, picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val DevoutDecreeReprint = Printing(
+    oracleId = "92f8c8b1-1fd5-4e80-b8a9-51671937aaf2",
+    name = "Devout Decree",
+    setCode = "FDN",
+    collectorNumber = "571",
+    scryfallId = "d174cb01-b1cf-444c-a893-cc61ddf88b8c",
+    artist = "Zoltan Boros",
+    imageUri = "https://cards.scryfall.io/normal/front/d/1/d174cb01-b1cf-444c-a893-cc61ddf88b8c.jpg?1782688768",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GnarlidColonyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GnarlidColonyReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gnarlid Colony reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in the ZNR (Zendikar Rising)
+ * `cards/` package — its earliest real printing. This file contributes only the FDN presentation
+ * row, picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val GnarlidColonyReprint = Printing(
+    oracleId = "e5481431-c952-4ad9-94fe-355076ef632b",
+    name = "Gnarlid Colony",
+    setCode = "FDN",
+    collectorNumber = "224",
+    scryfallId = "47565d10-96bf-4fb0-820f-f20a44a76b6f",
+    artist = "Izzy",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/47565d10-96bf-4fb0-820f-f20a44a76b6f.jpg?1782689074",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/AuthorityOfTheConsuls.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/AuthorityOfTheConsuls.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Authority of the Consuls
+ * {W}
+ * Enchantment
+ *
+ * Creatures your opponents control enter tapped.
+ * Whenever a creature an opponent controls enters, you gain 1 life.
+ *
+ * - "Creatures your opponents control enter tapped" is a global [PermanentsEnterTapped] runtime
+ *   replacement (the group counterpart of the self-only `EntersTapped`) whose `appliesTo` filter
+ *   describes the *affected* permanents — creatures an opponent of Authority's controller controls.
+ *   The controller-relative `opponentControls()` predicate is resolved against Authority's own
+ *   controller at entry time.
+ * - The gain-life clause is an ANY-binding enters trigger over the same opponent-creature filter;
+ *   it fires once per opponent creature that enters (tokens included).
+ */
+val AuthorityOfTheConsuls = card("Authority of the Consuls") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Creatures your opponents control enter tapped.\n" +
+        "Whenever a creature an opponent controls enters, you gain 1 life."
+
+    // Creatures your opponents control enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Creature.opponentControls(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    // Whenever a creature an opponent controls enters, you gain 1 life.
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.opponentControls(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.GainLife(1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "5"
+        artist = "Lake Hurwitz"
+        flavorText = "Citizens are free to do as they wish, within the confines of the Consulate's laws."
+        imageUri = "https://cards.scryfall.io/normal/front/3/2/324b2f55-1e09-490e-8f7e-bfde85a91ac4.jpg?1782711627"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DevoutDecree.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/DevoutDecree.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Devout Decree
+ * {1}{W}
+ * Sorcery
+ *
+ * Exile target creature or planeswalker that's black or red. Scry 1.
+ *
+ * The target is a single creature-or-planeswalker restricted to black or red via
+ * [GameObjectFilter.CreatureOrPlaneswalker] + `withAnyColor(BLACK, RED)`. The two
+ * clauses run in order with [Effects.Composite]: exile the target, then Scry 1.
+ */
+val DevoutDecree = card("Devout Decree") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Exile target creature or planeswalker that's black or red. Scry 1. " +
+        "(Look at the top card of your library. You may put that card on the bottom.)"
+
+    spell {
+        val victim = target(
+            "target creature or planeswalker that's black or red",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter.CreatureOrPlaneswalker.withAnyColor(Color.BLACK, Color.RED),
+                ),
+            ),
+        )
+        effect = Effects.Composite(
+            Effects.Exile(victim),
+            Effects.Scry(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "13"
+        artist = "Zoltan Boros"
+        flavorText = "\"It is not punishment. I am simply making things as they should be.\"\n—Sephara, Sky's Blade"
+        imageUri = "https://cards.scryfall.io/normal/front/2/d/2dcde8fe-d4a4-4c6e-926e-c4a1b45045e4.jpg?1782708383"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/GnarlidColony.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/GnarlidColony.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gnarlid Colony
+ * {1}{G}
+ * Creature — Beast
+ * 2/2
+ *
+ * Kicker {2}{G}
+ * If this creature was kicked, it enters with two +1/+1 counters on it.
+ * Each creature you control with a +1/+1 counter on it has trample.
+ *
+ * - The kicked-counter clause is a self-only [EntersWithCounters] replacement gated on
+ *   [WasKicked], so Gnarlid enters *already* carrying its two counters (CR 121 / 614) — which
+ *   matters because the trample-granting static below reads counters in projected state.
+ * - "Each creature you control with a +1/+1 counter on it has trample" is a [GrantKeyword] static
+ *   over `Creature.youControl().withCounter(+1/+1)` (default `excludeSelf = false`, so a kicked
+ *   Gnarlid grants trample to itself too).
+ */
+val GnarlidColony = card("Gnarlid Colony") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Beast"
+    power = 2
+    toughness = 2
+    oracleText = "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\n" +
+        "If this creature was kicked, it enters with two +1/+1 counters on it.\n" +
+        "Each creature you control with a +1/+1 counter on it has trample. (It can deal excess " +
+        "combat damage to the player or planeswalker it's attacking.)"
+
+    keywordAbility(KeywordAbility.kicker("{2}{G}"))
+
+    // If this creature was kicked, it enters with two +1/+1 counters on it.
+    replacementEffect(
+        EntersWithCounters(
+            count = 2,
+            selfOnly = true,
+            condition = WasKicked,
+        )
+    )
+
+    // Each creature you control with a +1/+1 counter on it has trample.
+    staticAbility {
+        ability = GrantKeyword(
+            Keyword.TRAMPLE,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.youControl().withCounter(Counters.PLUS_ONE_PLUS_ONE),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "185"
+        artist = "Izzy"
+        flavorText = "Where mana flows, the gnarlids follow."
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/7327289d-eed8-44b1-8495-7172e2b49d5f.jpg?1782706243"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/KLD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KLD.json
@@ -39,6 +39,54 @@
     ]
 }
 
+// Authority of the Consuls
+{
+    "name": "Authority of the Consuls",
+    "manaCost": "{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Creatures your opponents control enter tapped.\nWhenever a creature an opponent controls enters, you gain 1 life.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "RARE",
+        "artist": "Lake Hurwitz",
+        "flavorText": "Citizens are free to do as they wish, within the confines of the Consulate's laws.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/2/324b2f55-1e09-490e-8f7e-bfde85a91ac4.jpg?1782711627"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Brazen Scourge
 {
     "name": "Brazen Scourge",

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -57,6 +57,52 @@
     ]
 }
 
+// Devout Decree
+{
+    "name": "Devout Decree",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile target creature or planeswalker that's black or red. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker that's black or red"
+                    },
+                    "destination": "Exile"
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|planeswalker black|red"
+                },
+                "id": "target creature or planeswalker that's black or red"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "13",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "flavorText": "\"It is not punishment. I am simply making things as they should be.\"\n—Sephara, Sky's Blade",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/d/2dcde8fe-d4a4-4c6e-926e-c4a1b45045e4.jpg?1782708383"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Empyrean Eagle
 {
     "name": "Empyrean Eagle",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZNR.json
@@ -60,6 +60,63 @@
     ]
 }
 
+// Gnarlid Colony
+{
+    "name": "Gnarlid Colony",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Beast",
+    "oracleText": "Kicker {2}{G} (You may pay an additional {2}{G} as you cast this spell.)\nIf this creature was kicked, it enters with two +1/+1 counters on it.\nEach creature you control with a +1/+1 counter on it has trample. (It can deal excess combat damage to the player or planeswalker it's attacking.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "manaCost": "{2}{G}"
+        }
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "HasCounter",
+                                "counterType": "+1/+1"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true,
+                "condition": "WasKicked"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "185",
+        "artist": "Izzy",
+        "flavorText": "Where mana flows, the gnarlids follow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/7327289d-eed8-44b1-8495-7172e2b49d5f.jpg?1782706243"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Highborn Vampire
 {
     "name": "Highborn Vampire",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1421,6 +1421,27 @@ class StackResolver(
         newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
             .place(newState, controllerId, spellId)
 
+        // Global "[filter] enter tapped" replacements sourced from OTHER battlefield permanents
+        // (Authority of the Consuls — "Creatures your opponents control enter tapped"). The
+        // self-only EntersTapped handled earlier covers a permanent's own printed clause; a
+        // permanent cast normally must ALSO be tapped by another permanent's global
+        // PermanentsEnterTapped, matching the PlayLand (PlayLandHandler) and moveToZone /
+        // reanimation (ZoneTransitionService) paths that already consult it. Checked after the
+        // entity is on the battlefield so its controller/type resolve for the filter. CR 614: an
+        // applicable "enters untapped" replacement still wins, and a self-EntersTapped that already
+        // tapped it stands. Sneak sets its own tapped-and-attacking state below, so skip it here.
+        if (cardDef != null && !spellComponent.castFaceDown && !spellComponent.wasSneaked) {
+            val alreadyTapped = newState.getEntity(spellId)?.has<TappedComponent>() == true
+            val entersUntapped = com.wingedsheep.engine.handlers.effects.EnterUntappedReplacements
+                .entersUntapped(newState, spellId, controllerId)
+            if (!alreadyTapped && !entersUntapped &&
+                com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                    .entersTapped(newState, spellId, controllerId)
+            ) {
+                newState = newState.updateEntity(spellId) { c -> c.with(TappedComponent) }
+            }
+        }
+
         // Sneak (CR 702.190b / 506.3a): a permanent spell whose sneak cost was paid enters
         // tapped and attacking the same player or planeswalker the returned unblocked creature
         // was attacking. A non-creature permanent can't attack, so it just enters tapped (506.3a).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AuthorityOfTheConsulsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AuthorityOfTheConsulsScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.kld.cards.AuthorityOfTheConsuls
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Authority of the Consuls (KLD) — {W} Enchantment
+ *
+ * "Creatures your opponents control enter tapped.
+ *  Whenever a creature an opponent controls enters, you gain 1 life."
+ *
+ * Both clauses only fire on the real entry pipeline, so the opponent's creature must actually be
+ * cast and resolved (not stamped straight onto the battlefield).
+ */
+class AuthorityOfTheConsulsScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AuthorityOfTheConsuls)
+        return driver
+    }
+
+    test("an opponent's creature enters tapped and its controller's opponent gains 1 life") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AuthorityOfTheConsuls)
+        // player2 is the active player — it will cast the creature; player1 controls Authority.
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingPlayer = 1)
+        val authorityController = driver.player1
+        val caster = driver.player2 // the active player / "an opponent" of the Authority controller
+
+        driver.putPermanentOnBattlefield(authorityController, "Authority of the Consuls")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.getLifeTotal(authorityController) shouldBe 20
+
+        driver.giveMana(caster, Color.WHITE, 1)
+        val lions = driver.putCardInHand(caster, "Savannah Lions")
+        driver.castSpell(caster, lions)
+        driver.bothPass() // resolve the creature spell → it enters tapped, gain-life trigger on stack
+        driver.bothPass() // resolve the "you gain 1 life" trigger
+
+        val entered = driver.findPermanent(caster, "Savannah Lions")
+        entered shouldNotBe null
+        driver.isTapped(entered!!) shouldBe true
+        driver.getLifeTotal(authorityController) shouldBe 21
+    }
+
+    test("your own creature enters untapped and does not gain the opponent life") {
+        val driver = createDriver()
+        // player1 is active and controls Authority; it casts its own creature.
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30), startingPlayer = 0)
+        val you = driver.player1
+
+        driver.putPermanentOnBattlefield(you, "Authority of the Consuls")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.getLifeTotal(you) shouldBe 20
+
+        driver.giveMana(you, Color.WHITE, 1)
+        val lions = driver.putCardInHand(you, "Savannah Lions")
+        driver.castSpell(you, lions)
+        driver.bothPass() // resolve the creature spell
+
+        val entered = driver.findPermanent(you, "Savannah Lions")
+        entered shouldNotBe null
+        // A creature YOU control is unaffected: not tapped and no life gained.
+        driver.isTapped(entered!!) shouldBe false
+        driver.getLifeTotal(you) shouldBe 20
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DevoutDecreeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DevoutDecreeScenarioTest.kt
@@ -1,0 +1,78 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.m20.cards.DevoutDecree
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Devout Decree (M20) — {1}{W} Sorcery
+ *
+ * "Exile target creature or planeswalker that's black or red. Scry 1."
+ */
+class DevoutDecreeScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(DevoutDecree)
+        return driver
+    }
+
+    test("exiles a black creature and then scries") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30))
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A black creature the opponent controls — a legal target ("black or red").
+        val victim = driver.putCreatureOnBattlefield(opponent, "Black Creature")
+        driver.findPermanent(opponent, "Black Creature") shouldNotBe null
+
+        // Ensure Scry 1 has a card to look at.
+        driver.putCardOnTopOfLibrary(you, "Plains")
+
+        val decree = driver.putCardInHand(you, "Devout Decree")
+        driver.giveMana(you, Color.WHITE, 2)
+        val cast = driver.castSpell(you, decree, targets = listOf(victim))
+        cast.isSuccess shouldBe true
+
+        driver.bothPass() // resolve Devout Decree: exile the target, then pause for Scry 1
+        // Resolve the Scry decision (SelectCardsDecision, min 0 → keep on top).
+        while (driver.pendingDecision != null) {
+            driver.autoResolveDecision()
+        }
+
+        // The black creature is exiled (exile is owner-keyed → owner is the opponent).
+        driver.findPermanent(opponent, "Black Creature") shouldBe null
+        driver.getExileCardNames(opponent).contains("Black Creature") shouldBe true
+
+        // Devout Decree itself is in its owner's graveyard.
+        driver.getGraveyardCardNames(you).contains("Devout Decree") shouldBe true
+    }
+
+    test("a white creature is not a legal target") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30))
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Savannah Lions is white — neither black nor red, so it can't be targeted.
+        val whiteCreature = driver.putCreatureOnBattlefield(opponent, "Savannah Lions")
+
+        val decree = driver.putCardInHand(you, "Devout Decree")
+        driver.giveMana(you, Color.WHITE, 2)
+        val cast = driver.castSpell(you, decree, targets = listOf(whiteCreature))
+
+        // Casting with an illegal target must fail; the white creature stays on the battlefield.
+        cast.isSuccess shouldBe false
+        driver.findPermanent(opponent, "Savannah Lions") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GnarlidColonyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GnarlidColonyScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.znr.cards.GnarlidColony
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Gnarlid Colony (ZNR) — {1}{G} Creature — Beast, 2/2, Kicker {2}{G}
+ *
+ * "Each creature you control with a +1/+1 counter on it has trample."
+ *
+ * Projection test: the trample-granting static reads +1/+1 counters in projected state.
+ */
+class GnarlidColonyScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GnarlidColony)
+        return driver
+    }
+
+    fun addPlusOneCounter(driver: GameTestDriver, id: EntityId) {
+        driver.addComponent(id, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+    }
+
+    test("grants trample only to creatures you control that have a +1/+1 counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30))
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gnarlid = driver.putCreatureOnBattlefield(you, "Gnarlid Colony")
+        val ally = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val enemy = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        // Without any counters, nobody has trample (Gnarlid itself included — it needs a counter).
+        var projected = projector.project(driver.state)
+        projected.hasKeyword(gnarlid, Keyword.TRAMPLE) shouldBe false
+        projected.hasKeyword(ally, Keyword.TRAMPLE) shouldBe false
+
+        // Give the ally a +1/+1 counter → it gains trample.
+        addPlusOneCounter(driver, ally)
+        projected = projector.project(driver.state)
+        projected.hasKeyword(ally, Keyword.TRAMPLE) shouldBe true
+
+        // Give Gnarlid itself a counter → it grants trample to itself (excludeSelf = false).
+        addPlusOneCounter(driver, gnarlid)
+        projected = projector.project(driver.state)
+        projected.hasKeyword(gnarlid, Keyword.TRAMPLE) shouldBe true
+
+        // An opponent's creature with a +1/+1 counter is NOT affected ("you control").
+        addPlusOneCounter(driver, enemy)
+        projected = projector.project(driver.state)
+        projected.hasKeyword(enemy, Keyword.TRAMPLE) shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary
Implements three **Foundations (FDN)** reprints. Each canonical `CardDefinition` lives in its **earliest real printing's** set; FDN gets a `Printing` row (art/collector metadata only).

| Card | Canonical set | Mechanics |
|------|---------------|-----------|
| **Devout Decree** | M20 | `{1}{W}` Sorcery — exile target creature-or-planeswalker that's black or red (`TargetObject` + `CreatureOrPlaneswalker.withAnyColor(BLACK, RED)`), then Scry 1 |
| **Authority of the Consuls** | KLD | `{W}` Enchantment — `PermanentsEnterTapped` over opponents' creatures + ANY-binding enters trigger `GainLife(1)` |
| **Gnarlid Colony** | ZNR | `{1}{G}` 2/2 Beast — Kicker `{2}{G}`; `EntersWithCounters(2, selfOnly, WasKicked)`; `GrantKeyword(TRAMPLE)` to creatures you control with a +1/+1 counter |

All three use existing SDK primitives (no new effect/trigger/condition/keyword), so no SDK-reference doc change.

## Engine fix (surfaced by the Authority scenario test)
The creature-**spell** cast path (`StackResolver.enterPermanentOnBattlefield`) never consulted the **global** `PermanentsEnterTapped` replacement sourced from *other* battlefield permanents — so "creatures your opponents control enter tapped" did nothing for a normally-cast creature (the common case). The `PlayLand` and `moveToZone`/reanimation paths already consulted it; only the cast path missed it.

The fix consults `EnterTappedReplacements` right after the permanent is placed, gated on: not already tapped, no applicable enters-untapped replacement (CR 614 — enters-untapped wins), and skipping the Sneak path (which sets its own tapped-and-attacking state). Reuses the existing SDK type; no new effect. Full existing enter-tapped/untapped suite still passes.

## Tests
- Scenario tests (rules-engine) for all three cards:
  - **Devout Decree** — exiles a black creature + resolves Scry; a white creature is not a legal target.
  - **Authority of the Consuls** — an opponent's cast creature enters **tapped** and the Authority controller gains **1 life**; your own creature enters untapped with no life gain.
  - **Gnarlid Colony** — projection test: trample is granted to creatures you control that carry a +1/+1 counter (including Gnarlid itself once countered), not to counterless or opponent creatures.
- Card-snapshot goldens re-blessed for **KLD / M20 / ZNR** — purely additive (0 removals), one new card each.
- `just check-card-printing` OK for all three (canonical in earliest set + FDN reprint row).
- `just build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)