### PR TITLE
Send a friend request from a player's profile

### DIFF
--- a/web-client/src/pages/PublicProfilePage.tsx
+++ b/web-client/src/pages/PublicProfilePage.tsx
@@ -3,12 +3,20 @@
  * `/api/stats/users/{id}` response and renders the shared {@link StatsDashboard} (plus a compact
  * recent-games list). No auth required — profiles are public — and decklists are never exposed here
  * (the deck viewer stays on the owner's own profile).
+ *
+ * When the viewer is signed in and looking at someone else, a friend control is offered. The
+ * relationship is derived entirely from the already-loaded friends store (friends / outgoing /
+ * incoming lists are all keyed by account id, which equals this profile's userId), so no extra
+ * request or endpoint is needed — sending or accepting reuses the same store actions as the friends
+ * page.
  */
 import { useEffect, useState } from 'react'
 import type React from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { type PublicProfile, ProfileNotFoundError, fetchPublicProfile } from '@/api/account'
 import { StatsDashboard } from '@/components/profile/StatsDashboard'
+import { useAuthStore } from '@/store/authStore'
+import { useFriendsStore } from '@/store/friendsStore'
 
 export function PublicProfilePage() {
   const navigate = useNavigate()
@@ -34,6 +42,64 @@ export function PublicProfilePage() {
       live = false
     }
   }, [userId])
+
+  // Friend control — only meaningful for a signed-in viewer looking at someone else's profile.
+  const authUser = useAuthStore((s) => s.user)
+  const authStatus = useAuthStore((s) => s.status)
+  const accountsEnabled = useAuthStore((s) => s.accountsEnabled)
+  const initAuth = useAuthStore((s) => s.init)
+  const friends = useFriendsStore((s) => s.friends)
+  const incoming = useFriendsStore((s) => s.incoming)
+  const outgoing = useFriendsStore((s) => s.outgoing)
+  const loadFriends = useFriendsStore((s) => s.load)
+  const sendRequest = useFriendsStore((s) => s.sendRequest)
+  const acceptRequest = useFriendsStore((s) => s.accept)
+
+  const [friendBusy, setFriendBusy] = useState(false)
+  const [friendError, setFriendError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (authStatus === 'idle') void initAuth()
+  }, [authStatus, initAuth])
+
+  // Pull the friends/requests lists once we know we're signed in, so the relationship is current
+  // even when landing straight on this page (they may already be loaded from sign-in).
+  useEffect(() => {
+    if (authStatus === 'authenticated') void loadFriends()
+  }, [authStatus, loadFriends])
+
+  const isOwnProfile = !!authUser && authUser.id === userId
+  const canBefriend =
+    authStatus === 'authenticated' && accountsEnabled && !isOwnProfile && !!userId
+  const isFriend = friends.some((f) => f.accountId === userId)
+  const incomingRequest = incoming.find((r) => r.accountId === userId)
+  const outgoingPending = outgoing.some((r) => r.accountId === userId)
+
+  const addFriend = async () => {
+    if (!userId) return
+    setFriendBusy(true)
+    setFriendError(null)
+    try {
+      await sendRequest(userId)
+    } catch (e) {
+      setFriendError(e instanceof Error ? e.message : 'Could not send the request.')
+    } finally {
+      setFriendBusy(false)
+    }
+  }
+
+  const acceptFriend = async () => {
+    if (!incomingRequest) return
+    setFriendBusy(true)
+    setFriendError(null)
+    try {
+      await acceptRequest(incomingRequest.requestId)
+    } catch (e) {
+      setFriendError(e instanceof Error ? e.message : 'Could not accept the request.')
+    } finally {
+      setFriendBusy(false)
+    }
+  }
 
   return (
     <div style={styles.wrap}>
@@ -64,6 +130,34 @@ export function PublicProfilePage() {
           <>
             <h1 style={styles.title}>{profile.displayName}</h1>
             <p style={styles.muted}>Player profile</p>
+            {canBefriend && (
+              <div style={styles.friendRow}>
+                {isFriend ? (
+                  <span style={styles.friendBadge}>✓ Friends</span>
+                ) : incomingRequest ? (
+                  <button
+                    type="button"
+                    style={styles.primary}
+                    disabled={friendBusy}
+                    onClick={() => void acceptFriend()}
+                  >
+                    {friendBusy ? 'Accepting…' : 'Accept friend request'}
+                  </button>
+                ) : outgoingPending ? (
+                  <span style={styles.pending}>Friend request sent</span>
+                ) : (
+                  <button
+                    type="button"
+                    style={styles.primary}
+                    disabled={friendBusy}
+                    onClick={() => void addFriend()}
+                  >
+                    {friendBusy ? 'Sending…' : '+ Add friend'}
+                  </button>
+                )}
+                {friendError && <span style={styles.friendError}>{friendError}</span>}
+              </div>
+            )}
             <StatsDashboard
               stats={profile.stats}
               ratings={profile.ratings}
@@ -93,4 +187,39 @@ const styles: Record<string, React.CSSProperties> = {
   link: { background: 'none', border: 'none', color: '#8b9bff', cursor: 'pointer', fontSize: 14, padding: 0 },
   title: { margin: '4px 0 0', color: '#fff', fontSize: 28 },
   muted: { margin: 0, color: '#888', fontSize: 14 },
+  friendRow: { display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', marginTop: 2 },
+  primary: {
+    alignSelf: 'flex-start',
+    padding: '9px 16px',
+    borderRadius: 8,
+    border: 'none',
+    backgroundColor: '#5b6ee1',
+    color: '#fff',
+    fontWeight: 600,
+    fontSize: 14,
+    cursor: 'pointer',
+  },
+  friendBadge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '7px 14px',
+    borderRadius: 8,
+    border: '1px solid #2f5540',
+    backgroundColor: 'rgba(91,209,110,0.10)',
+    color: '#5bd16e',
+    fontWeight: 600,
+    fontSize: 14,
+  },
+  pending: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '7px 14px',
+    borderRadius: 8,
+    border: '1px solid #2a2a3e',
+    backgroundColor: '#14141f',
+    color: '#888',
+    fontSize: 14,
+  },
+  friendError: { color: '#ff6b6b', fontSize: 13 },
 }


### PR DESCRIPTION
## What

On another player's public profile (`/u/:userId`), a signed-in viewer can now send them a friend request when they aren't already connected. Previously the only way to add a friend was to paste their friend code on the Friends page.

A friend control appears right under the player's display name and reflects the current relationship:

| State | Control |
|-------|---------|
| Not connected | **+ Add friend** button → sends a request |
| You already sent them a request | **Friend request sent** (passive) |
| They already sent you a request | **Accept friend request** button → accepts it |
| Already friends | **✓ Friends** badge |

The control is hidden entirely on your own profile, when signed out, and on servers where the accounts subsystem is disabled.

## How

Frontend-only — no new endpoint, DTO, or DB change. The existing `friendsStore` already holds the `friends`, `outgoing`, and `incoming` lists, all keyed by account id, which is exactly the `userId` a public profile is keyed by. So the relationship is derived client-side and the button reuses the same store actions the Friends page uses:

- `friendsStore.sendRequest(userId)` → `POST /api/friends/requests`
- `friendsStore.accept(requestId)` → `POST /api/friends/requests/{id}/accept`

After either action the store reloads, so the button transitions to its next state automatically. Errors from the server (e.g. "you're already friends") are surfaced inline. `PublicProfilePage` now also runs the standard `authStore.init()` idle-guard and loads the friends lists once authenticated.

Only `web-client/src/pages/PublicProfilePage.tsx` changed.

## Testing

- `npm run typecheck` — no new errors (the 3 remaining errors are pre-existing, in the unrelated `GeoMap.tsx`).

> **Screenshot note:** this is a UI change, but capturing the actual running app requires an accounts-enabled stack (Postgres) with two magic-link accounts to reach a befriendable profile state. Happy to capture the live states if you'd like — flagging rather than committing a mock-up per the web-client screenshot guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)