### PR TITLE
Add Foundations cards: Skyship Buccaneer, Enigma Drake, Diamond Mare

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/EnigmaDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/akh/cards/EnigmaDrake.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.akh.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CharacteristicValue
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Enigma Drake
+ * {1}{U}{R}
+ * Creature — Drake
+ * Power/toughness: star/4
+ *
+ * Flying
+ * Enigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.
+ *
+ * The characteristic-defining power is a [CharacteristicValue.dynamic] over
+ * [DynamicAmount.Count] of instant/sorcery cards in the controller's graveyard
+ * ([GameObjectFilter.InstantOrSorcery]). Only power is dynamic; toughness stays a printed 4,
+ * so we set `dynamicPower` directly (same shape as Duelist of the Mind).
+ *
+ * Canonical printing lives here (Amonkhet, the earliest real expansion); later sets
+ * (M19, Foundations, …) contribute only [com.wingedsheep.sdk.model.Printing] rows.
+ */
+val EnigmaDrake = card("Enigma Drake") {
+    manaCost = "{1}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Creature — Drake"
+    toughness = 4
+    oracleText = "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard."
+
+    dynamicPower = CharacteristicValue.dynamic(
+        DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.InstantOrSorcery)
+    )
+
+    keywords(Keyword.FLYING)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "198"
+        artist = "Steve Argyle"
+        flavorText = "Many initiates believe it possesses secrets known only to Kefnet himself. Many have become meals trying to learn them."
+        imageUri = "https://cards.scryfall.io/normal/front/6/6/66286631-c16e-410c-b963-25cfe8005d8f.jpg?1782711097"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DiamondMareReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DiamondMareReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Diamond Mare reprint in Foundations. Canonical CardDefinition lives in Core Set 2019
+ * (its earliest real printing); this file contributes only presentation data.
+ */
+val DiamondMareReprint = Printing(
+    oracleId = "9a440122-a015-4af2-b270-37f019884458",
+    name = "Diamond Mare",
+    setCode = "FDN",
+    collectorNumber = "770",
+    scryfallId = "3c39b0ce-db4c-472c-b68e-07e6ba3a4588",
+    artist = "Alayna Danner",
+    imageUri = "https://cards.scryfall.io/normal/front/3/c/3c39b0ce-db4c-472c-b68e-07e6ba3a4588.jpg?1782683448",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/EnigmaDrakeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/EnigmaDrakeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Enigma Drake reprint in Foundations. Canonical CardDefinition lives in Amonkhet
+ * (its earliest real printing); this file contributes only presentation data.
+ */
+val EnigmaDrakeReprint = Printing(
+    oracleId = "62007675-8a0d-4211-83b2-0daf3641dedc",
+    name = "Enigma Drake",
+    setCode = "FDN",
+    collectorNumber = "657",
+    scryfallId = "13ce1338-5a46-4d96-a991-d5fa8d4330ae",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/13ce1338-5a46-4d96-a991-d5fa8d4330ae.jpg?1782688694",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SkyshipBuccaneer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SkyshipBuccaneer.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.core.Keyword
+
+/**
+ * Skyship Buccaneer
+ * {3}{U}{U}
+ * Creature — Human Pirate
+ * 4/3
+ *
+ * Flying
+ * Raid — When this creature enters, if you attacked this turn, draw a card.
+ *
+ * Raid is modeled as an enters-the-battlefield trigger gated by the intervening-if
+ * condition [Conditions.YouAttackedThisTurn] (mirrors Gorehorn Raider / Mardu
+ * Skullhunter). The condition is re-checked on resolution, so the trigger does
+ * nothing if the "you attacked this turn" state no longer holds.
+ */
+val SkyshipBuccaneer = card("Skyship Buccaneer") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    power = 4
+    toughness = 3
+    oracleText = "Flying\nRaid — When this creature enters, if you attacked this turn, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouAttackedThisTurn
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Javier Charro"
+        flavorText = "\"It's a pirate's nature to be free of law. Gravity is no exception.\"\n—Kari Zev, skyship captain"
+        imageUri = "https://cards.scryfall.io/normal/front/6/2/62958fc3-55dc-4b97-a070-490d6ed27820.jpg?1782689223"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DiamondMare.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/DiamondMare.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Diamond Mare
+ * {2}
+ * Artifact Creature — Horse
+ * 1/3
+ *
+ * As this creature enters, choose a color.
+ * Whenever you cast a spell of the chosen color, you gain 1 life.
+ *
+ * The color is stored at ETB via [EntersWithChoice] (ChoiceType.COLOR →
+ * CastChoicesComponent), the same primitive Teferi's Moat / Harsh Judgment use.
+ * The lifegain trigger is a `youCastSpell` filtered by
+ * [GameObjectFilter.sharingChosenColorWithSource] — the spell must include the color
+ * stored on this permanent (CardPredicate.SharesChosenColorWithSource reads the trigger
+ * source's chosen color). Any spell of that color qualifies, so no type restriction.
+ *
+ * Canonical printing lives here (Core Set 2019, the earliest real printing); later
+ * sets (Foundations, …) contribute only [com.wingedsheep.sdk.model.Printing] rows.
+ */
+val DiamondMare = card("Diamond Mare") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Horse"
+    power = 1
+    toughness = 3
+    oracleText = "As this creature enters, choose a color.\n" +
+        "Whenever you cast a spell of the chosen color, you gain 1 life."
+
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Any.sharingChosenColorWithSource()
+        )
+        effect = Effects.GainLife(1)
+        description = "Whenever you cast a spell of the chosen color, you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "231"
+        artist = "Alayna Danner"
+        flavorText = "When it passes, rainbows follow."
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/ca600b3f-2c70-489b-b218-6e3245b90114.jpg?1782709481"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/EnigmaDrakeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m19/cards/EnigmaDrakeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m19.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Enigma Drake reprint in Core Set 2019. Canonical CardDefinition lives in Amonkhet
+ * (its earliest real printing); this file contributes only presentation data.
+ */
+val EnigmaDrakeReprint = Printing(
+    oracleId = "62007675-8a0d-4211-83b2-0daf3641dedc",
+    name = "Enigma Drake",
+    setCode = "M19",
+    collectorNumber = "216",
+    scryfallId = "6e0def77-3528-40fb-a6b2-c3d1e31ade65",
+    artist = "Steve Argyle",
+    imageUri = "https://cards.scryfall.io/normal/front/6/e/6e0def77-3528-40fb-a6b2-c3d1e31ade65.jpg?1782709492",
+    releaseDate = "2018-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/AKH.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/AKH.json
@@ -1,3 +1,37 @@
+// Enigma Drake
+{
+    "name": "Enigma Drake",
+    "manaCost": "{1}{U}{R}",
+    "typeLine": "Creature — Drake",
+    "oracleText": "Flying\nEnigma Drake's power is equal to the number of instant and sorcery cards in your graveyard.",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Graveyard",
+                "filter": "instant|sorcery"
+            }
+        },
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "metadata": {
+        "collectorNumber": "198",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Argyle",
+        "flavorText": "Many initiates believe it possesses secrets known only to Kefnet himself. Many have become meals trying to learn them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/6/66286631-c16e-410c-b963-25cfe8005d8f.jpg?1782711097"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
 // Galestrike
 {
     "name": "Galestrike",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -4104,6 +4104,62 @@
     ]
 }
 
+// Skyship Buccaneer
+{
+    "name": "Skyship Buccaneer",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "Flying\nRaid — When this creature enters, if you attacked this turn, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "PLAYER_ATTACKED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "UNCOMMON",
+        "artist": "Javier Charro",
+        "flavorText": "\"It's a pirate's nature to be free of law. Gravity is no exception.\"\n—Kari Zev, skyship captain",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/2/62958fc3-55dc-4b97-a070-490d6ed27820.jpg?1782689223"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Slumbering Cerberus
 {
     "name": "Slumbering Cerberus",

--- a/mtg-sets/src/test/resources/snapshots/cards/M19.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M19.json
@@ -101,6 +101,55 @@
     ]
 }
 
+// Diamond Mare
+{
+    "name": "Diamond Mare",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Horse",
+    "oracleText": "As this creature enters, choose a color.\nWhenever you cast a spell of the chosen color, you gain 1 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "SharesChosenColorWithSource"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever you cast a spell of the chosen color, you gain 1 life."
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "COLOR"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "231",
+        "rarity": "UNCOMMON",
+        "artist": "Alayna Danner",
+        "flavorText": "When it passes, rainbows follow.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/ca600b3f-2c70-489b-b218-6e3245b90114.jpg?1782709481"
+    }
+}
+
 // Exclusion Mage
 {
     "name": "Exclusion Mage",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiamondMareScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiamondMareScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.m19.cards.DiamondMare
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Diamond Mare (M19 #231, reprinted in Foundations) — "As this creature enters, choose a
+ * color. Whenever you cast a spell of the chosen color, you gain 1 life."
+ *
+ * Verifies the `youCastSpell` trigger filtered by
+ * [com.wingedsheep.sdk.scripting.GameObjectFilter.sharingChosenColorWithSource]: the spell
+ * only pays off when its color includes the color stored on Diamond Mare. The chosen color
+ * is injected directly (the EntersWithChoice(COLOR) → CastChoicesComponent path is covered
+ * elsewhere, e.g. HarshJudgmentTest).
+ */
+class DiamondMareScenarioTest : FunSpec({
+
+    fun newGame(): Triple<GameTestDriver, EntityId, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DiamondMare))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = driver.activePlayer!!
+        return Triple(driver, active, driver.getOpponent(active))
+    }
+
+    fun GameTestDriver.lifeOf(playerId: EntityId): Int =
+        state.getEntity(playerId)?.get<LifeTotalComponent>()?.life ?: 0
+
+    test("gains life when you cast a spell of the chosen color") {
+        val (driver, active, defender) = newGame()
+        val mare = driver.putPermanentOnBattlefield(active, "Diamond Mare")
+        driver.addComponent(mare, CastChoicesComponent(chosen = mapOf(ChoiceSlot.COLOR to ChoiceValue.ColorChoice(Color.RED))))
+
+        // Active player casts a red spell (Lightning Bolt) — matches the chosen color.
+        driver.giveMana(active, Color.RED, 1)
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.castSpellWithTargets(active, bolt, listOf(ChosenTarget.Player(defender)))
+        driver.bothPass()
+
+        driver.lifeOf(active) shouldBe 21
+    }
+
+    test("does not gain life when the spell is a different color") {
+        val (driver, active, defender) = newGame()
+        val mare = driver.putPermanentOnBattlefield(active, "Diamond Mare")
+        driver.addComponent(mare, CastChoicesComponent(chosen = mapOf(ChoiceSlot.COLOR to ChoiceValue.ColorChoice(Color.BLUE))))
+
+        // Red bolt is not the chosen color (blue) — no life gain.
+        driver.giveMana(active, Color.RED, 1)
+        val bolt = driver.putCardInHand(active, "Lightning Bolt")
+        driver.castSpellWithTargets(active, bolt, listOf(ChosenTarget.Player(defender)))
+        driver.bothPass()
+
+        driver.lifeOf(active) shouldBe 20
+    }
+})


### PR DESCRIPTION
## Summary

Implements three Foundations (FDN) cards via the `add-card` skill, all composed from **existing SDK primitives** — no new engine mechanics.

| Card | Canonical set | Mechanic |
|------|---------------|----------|
| **Skyship Buccaneer** | FDN (only printing) | Flying + Raid ETB draw |
| **Enigma Drake** | Amonkhet (reprint rows in M19 + FDN) | `*`-power = instant/sorcery cards in your graveyard |
| **Diamond Mare** | Core Set 2019 (reprint row in FDN) | ETB choose a color; gain 1 life on casting a spell of that color |

## Details

- **Skyship Buccaneer** — `EntersBattlefield` trigger gated by the intervening-if `Conditions.YouAttackedThisTurn` (same Raid shape as Gorehorn Raider / Mardu Skullhunter), effect `Effects.DrawCards(1)`.
- **Enigma Drake** — characteristic-defining power via `CharacteristicValue.dynamic(DynamicAmount.Count(Player.You, Zone.GRAVEYARD, GameObjectFilter.InstantOrSorcery))`; toughness stays a printed 4.
- **Diamond Mare** — `EntersWithChoice(ChoiceType.COLOR)` stores the chosen color (same primitive as Teferi's Moat / Harsh Judgment); a `Triggers.youCastSpell` filtered by `GameObjectFilter.Any.sharingChosenColorWithSource()` pays off `Effects.GainLife(1)`.

## Reprint placement

Each canonical `CardDefinition` lives in the card's **earliest real printing**; later sets contribute only `Printing` rows. Validated with `just check-card-printing` for all three (Enigma Drake also gets an M19 `Printing` row since M19 is scaffolded).

## Tests

- `DiamondMareScenarioTest` — verifies the chosen-color cast trigger gains life on a matching-color spell and stays silent on a different color.
- Skyship Buccaneer (Raid) and Enigma Drake (dynamic Count) reuse mechanics already covered elsewhere.
- Card snapshot goldens re-blessed for AKH / M19 / FDN — **additions only**, no unrelated card moved.
- `just` recipe run: `:mtg-sets:test` (snapshot + `CardLintTest`) and the new scenario test — **BUILD SUCCESSFUL**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)