### PR TITLE
Add Ancient Adamantoise and Cloud, Midgar Mercenary (Final Fantasy)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2355,6 +2355,12 @@ work for abilities-on-stack (which carry no `CardComponent`).
   `PreventActivatedAbilities(GameObjectFilter.Permanent.attachedToBySource())`. Resolves
   against `PredicateContext.sourceId`; inert with no source / unattached source, and never matches in
   group-static projection or trigger-gating contexts (no source there).
+- `IsAttachedToSource` (filter builder `attachedToSource()`) — the *mirror* of `IsAttachedToBySource`:
+  matches an Aura/Equipment currently attached **to** the effect's source, read from the candidate's
+  `AttachedToComponent.targetId == sourceId`. Use it to scope a static ability on the *host* to its own
+  attachments — Cloud, Midgar Mercenary's "an Equipment attached to it" via
+  `GameObjectFilter.Artifact.withSubtype("Equipment").attachedToSource()`. Source-relative; inert with no
+  source context.
 - `HasGreatestPower` (filter builder `hasGreatestPower()`) / `HasLeastPower` (filter builder
   `hasLeastPower()`) — has the greatest / least projected power among creatures *its controller*
   controls (ties all qualify). Used for "creature with the greatest/least power" target and edict
@@ -3538,10 +3544,16 @@ staticAbility {
   `mustBeYouControl = false` drops the "X you control" restriction on the cause (Starfield
   Vocalist); adding `BattlefieldDirection.LEAVING` covers Gandalf the White's "entering or leaving
   the battlefield" wording. `TriggerDetector.duplicateETBOrLTBTriggers`; additive across copies.
-- `AdditionalSourceTriggers(sourceFilter, excludeSelf = true)` — Twinflame Travelers: all triggered
-  abilities of permanents matching `sourceFilter` you control trigger an additional time (not just ETB).
-  Set `excludeSelf = false` for "a permanent you control" wording that includes the source itself
-  (Fractured Realm). `TriggerDetector.duplicateSourceTriggers`.
+- `AdditionalSourceTriggers(sourceFilter, excludeSelf = true, alsoSource = false, condition = null)` —
+  Twinflame Travelers: all triggered abilities of permanents matching `sourceFilter` you control trigger
+  an additional time (not just ETB). Set `excludeSelf = false` for "a permanent you control" wording that
+  includes the source itself (Fractured Realm). `alsoSource = true` *also* doubles the doubler's own
+  triggers regardless of the filter — the "a triggered ability of ~ **or** …" wording where the source is
+  one of the doubled objects. `condition` gates the whole ability against the doubler source ("As long as
+  ~ is equipped, …"); a `null` condition always applies. Cloud, Midgar Mercenary combines all three:
+  `AdditionalSourceTriggers(sourceFilter = Artifact.withSubtype("Equipment").attachedToSource(),
+  alsoSource = true, condition = Conditions.SourceMatches(GameObjectFilter.Any.equipped()))`.
+  `TriggerDetector.duplicateSourceTriggers` (and `ActivateAbilityHandler` for triggered mana abilities).
 - `AdditionalAttackTriggers(attackerFilter = GameObjectFilter.Any)` — Windcrag Siege (Mardu): the
   attack-cause analogue of `AdditionalETBOrLTBTriggers`. If a creature matching `attackerFilter`
   being declared as an attacker causes an attack-related triggered ability ("whenever a creature
@@ -3710,6 +3722,12 @@ staticAbility {
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a
   *permanent, player-scoped* "no maximum hand size for the rest of the game" (survives the source
   leaving play), use the effect `Effects.RemoveMaximumHandSize(target)` instead — see §4. (Wisdom of Ages)
+- `DamagePersistsThroughCleanup` — marked damage isn't removed from this permanent during cleanup
+  steps, an exception to the CR 514.2 turn-based damage removal, so damage accumulates turn over turn
+  until it becomes lethal (Ancient Adamantoise). A turn-based read consulted directly by
+  `CleanupPhaseManager` (via `RoomFaceStatics` for the printed case, plus granted instances), not a
+  Rule 613 projection. Only the cleanup removal is suppressed — regeneration and "remove all damage"
+  effects still clear the damage. Add with `staticAbility { ability = DamagePersistsThroughCleanup }`.
 - `GrantCantLoseGame` — controller "can't lose the game" while this permanent is on the battlefield
   (Lich's Mastery, Platinum Angel). Suppresses *all* loss conditions for that player (0-or-less life,
   poison, empty-library draw, effect losses); opponents can still win via "you win the game" effects.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -846,12 +846,20 @@ data class AdditionalETBOrLTBTriggers(
  * @property sourceFilter Which permanents' triggers get doubled (matched via projected state).
  * @property excludeSelf When true, the static ability's own source is excluded from the filter
  *   (matches the "another" wording in oracle text). Defaults to true.
+ * @property alsoSource When true, the doubler *also* doubles its own source's triggered abilities,
+ *   independently of [sourceFilter]/[excludeSelf]. Used for "a triggered ability of ~ **or** …"
+ *   wordings where the source itself is one of the doubled objects (Cloud, Midgar Mercenary:
+ *   "a triggered ability of Cloud or an Equipment attached to it"). Defaults to false.
+ * @property condition Optional gate evaluated against the doubler source; the whole ability applies
+ *   only while it holds ("As long as Cloud is equipped, …"). A `null` condition always applies.
  */
 @SerialName("AdditionalSourceTriggers")
 @Serializable
 data class AdditionalSourceTriggers(
     val sourceFilter: GameObjectFilter,
     val excludeSelf: Boolean = true,
+    val alsoSource: Boolean = false,
+    val condition: Condition? = null,
     override val description: String = "If a triggered ability of another permanent matching the filter you control triggers, it triggers an additional time"
 ) : StaticAbility {
     override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
@@ -974,4 +982,21 @@ data object FreeFirstEquipEachTurn : StaticAbility {
 @Serializable
 data class ReduceEquipCost(val amount: Int) : StaticAbility {
     override val description: String = "Equip abilities you activate cost {$amount} less to activate"
+}
+
+/**
+ * Marked damage isn't removed from this permanent during cleanup steps — an exception to the
+ * CR 514.2 turn-based action that normally removes all marked damage. Models Ancient
+ * Adamantoise ("Damage isn't removed from this creature during cleanup steps"), whose damage
+ * accumulates turn over turn until it becomes lethal.
+ *
+ * This is a *turn-based read*, not a Rule 613 continuous effect: the cleanup step consults it
+ * directly (see [com.wingedsheep.engine.core.CleanupPhaseManager]) rather than projecting a
+ * component. Only the CR 514.2 cleanup removal is suppressed — other damage-removal effects
+ * (regeneration, "remove all damage") still work, per the card's ruling.
+ */
+@SerialName("DamagePersistsThroughCleanup")
+@Serializable
+data object DamagePersistsThroughCleanup : StaticAbility {
+    override val description: String = "Damage isn't removed from this permanent during cleanup steps"
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -673,6 +673,15 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must BE an Aura/Equipment attached to the effect's source permanent — the mirror of
+     * [attachedToBySource]. Source-relative — scopes a static ability on the *host* to its own
+     * attachments, e.g. Cloud, Midgar Mercenary's "an Equipment attached to it".
+     */
+    fun attachedToSource() = copy(
+        statePredicates = statePredicates + StatePredicate.IsAttachedToSource
+    )
+
+    /**
      * Must be attached to a permanent matching [hostFilter] (general form of attachment matching —
      * the host filter may carry a controller predicate, e.g. "a creature you control"). Used by
      * Stolen Uniform's reflexive "if it's attached to a creature you control" guard.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/predicates/StatePredicate.kt
@@ -508,6 +508,19 @@ sealed interface StatePredicate {
     }
 
     /**
+     * The candidate is an Aura/Equipment currently *attached to* the effect's source permanent —
+     * the mirror of [IsAttachedToBySource]. Reads the candidate's `AttachedToComponent` and compares
+     * its target to the source id. Source-relative; false with no source context or an unattached
+     * candidate. Backs "an Equipment attached to it"-style filters where the static ability lives on
+     * the *host* (Cloud, Midgar Mercenary), not on the attachment.
+     */
+    @SerialName("IsAttachedToSource")
+    @Serializable
+    data object IsAttachedToSource : Entity {
+        override val description: String = "attached to this permanent"
+    }
+
+    /**
      * The candidate card is one this effect's source permanent exiled — i.e. its entity id is
      * recorded in the source's `LinkedExileComponent` (the same linkage set by
      * `RedirectZoneChange(linkToSource = true)`, `RedirectZoneChangeWithEffect(linkToSource = true)`,

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AncientAdamantoise.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/AncientAdamantoise.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DamagePersistsThroughCleanup
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.RedirectDamage
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Ancient Adamantoise
+ * {5}{G}{G}{G}
+ * Creature — Turtle
+ * 8/20
+ * Vigilance, ward {3}
+ * Damage isn't removed from this creature during cleanup steps.
+ * All damage that would be dealt to you and other permanents you control is dealt to this
+ * creature instead.
+ * When this creature dies, exile it and create ten tapped Treasure tokens.
+ *
+ * The redirection is modelled as two static [RedirectDamage] replacements — one for damage to
+ * the controller ([RecipientFilter.You]) and one for damage to their permanents
+ * ([RecipientFilter.Matching] over `Permanent.youControl()`). Both redirect to [EffectTarget.Self].
+ * Damage already headed to the Adamantoise itself is left alone (the engine skips a redirect
+ * whose destination equals the original recipient, CR-faithful "other permanents").
+ *
+ * Because it soaks damage from the whole board, the marked damage must persist so it can
+ * eventually become lethal — hence [DamagePersistsThroughCleanup], an exception to the CR 514.2
+ * cleanup damage-removal turn-based action. Per the card's ruling, other damage-removal effects
+ * (regeneration, "remove all damage") are unaffected; only the cleanup step is suppressed.
+ *
+ * The dies trigger functions from the graveyard (`triggerZone = Zone.GRAVEYARD`) so "exile it"
+ * can reference [EffectTarget.Self].
+ */
+val AncientAdamantoise = card("Ancient Adamantoise") {
+    manaCost = "{5}{G}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Turtle"
+    power = 8
+    toughness = 20
+    oracleText = "Vigilance, ward {3}\n" +
+        "Damage isn't removed from this creature during cleanup steps.\n" +
+        "All damage that would be dealt to you and other permanents you control is dealt to " +
+        "this creature instead.\n" +
+        "When this creature dies, exile it and create ten tapped Treasure tokens."
+
+    keywords(Keyword.VIGILANCE, Keyword.WARD)
+    keywordAbility(KeywordAbility.ward("{3}"))
+
+    staticAbility {
+        ability = DamagePersistsThroughCleanup
+    }
+
+    // "All damage that would be dealt to you ... is dealt to this creature instead."
+    replacementEffect(
+        RedirectDamage(
+            redirectTo = EffectTarget.Self,
+            appliesTo = EventPattern.DamageEvent(recipient = RecipientFilter.You),
+        )
+    )
+    // "... and other permanents you control is dealt to this creature instead."
+    replacementEffect(
+        RedirectDamage(
+            redirectTo = EffectTarget.Self,
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.Matching(GameObjectFilter.Permanent.youControl()),
+            ),
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerZone = Zone.GRAVEYARD
+        effect = Effects.Composite(
+            Effects.Exile(EffectTarget.Self),
+            Effects.CreateTreasure(count = 10, tapped = true)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "172"
+        artist = "Kevin Glint"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c139f30-5ecd-48fd-ae7c-ec2cc98889ff.jpg?1782686472"
+        ruling("2025-06-06", "If you control more than one Ancient Adamantoise, you choose which redirection effect to apply. You can't divide damage dealt by a single source between them, and you can't choose to take the damage yourself.")
+        ruling("2025-06-06", "Effects that remove all damage from a permanent (such as regeneration) will still remove damage from Ancient Adamantoise.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CloudMidgarMercenary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/CloudMidgarMercenary.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+
+/**
+ * Cloud, Midgar Mercenary
+ * {W}{W}
+ * Legendary Creature — Human Soldier Mercenary
+ * 2/1
+ * When Cloud enters, search your library for an Equipment card, reveal it, put it into your hand,
+ * then shuffle.
+ * As long as Cloud is equipped, if a triggered ability of Cloud or an Equipment attached to it
+ * triggers, that ability triggers an additional time.
+ *
+ * The doubling reuses [AdditionalSourceTriggers], extended for this card with:
+ *  - `alsoSource = true` — Cloud's *own* triggered abilities are doubled ("a triggered ability of
+ *    Cloud or …"), independently of the filter that catches its Equipment.
+ *  - a `condition` gate — [Conditions.SourceMatches] over `equipped()` ("As long as Cloud is
+ *    equipped, …"); when nothing is attached the whole ability is inert.
+ * The filter `Artifact.withSubtype("Equipment").attachedToSource()` catches the triggers of any
+ * Equipment currently attached to Cloud. Per the ruling this doesn't copy the ability — it makes it
+ * trigger one extra time, with choices made independently for each instance.
+ */
+val CloudMidgarMercenary = card("Cloud, Midgar Mercenary") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Soldier Mercenary"
+    power = 2
+    toughness = 1
+    oracleText = "When Cloud enters, search your library for an Equipment card, reveal it, put it " +
+        "into your hand, then shuffle.\n" +
+        "As long as Cloud is equipped, if a triggered ability of Cloud or an Equipment attached " +
+        "to it triggers, that ability triggers an additional time."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.searchLibrary(
+            filter = GameObjectFilter.Artifact.withSubtype("Equipment"),
+            destination = SearchDestination.HAND,
+            shuffleAfter = true,
+            reveal = true
+        )
+    }
+
+    staticAbility {
+        ability = AdditionalSourceTriggers(
+            sourceFilter = GameObjectFilter.Artifact.withSubtype("Equipment").attachedToSource(),
+            excludeSelf = true,
+            alsoSource = true,
+            condition = Conditions.SourceMatches(GameObjectFilter.Any.equipped()),
+            description = "As long as Cloud is equipped, if a triggered ability of Cloud or an " +
+                "Equipment attached to it triggers, that ability triggers an additional time"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "10"
+        artist = "Kazto Furuya"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2cf7e8a3-fad7-413d-b17c-7519a9cf5fb5.jpg?1782686592"
+        ruling("2025-06-06", "Cloud's last ability doesn't copy the triggered ability; it just causes the ability to trigger an additional time. Any choices made as you put the ability onto the stack, such as modes and targets, are made separately for each instance of the ability. Any choices made on resolution are also made individually.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -757,6 +757,103 @@
     ]
 }
 
+// Ancient Adamantoise
+{
+    "name": "Ancient Adamantoise",
+    "manaCost": "{5}{G}{G}{G}",
+    "typeLine": "Creature — Turtle",
+    "oracleText": "Vigilance, ward {3}\nDamage isn't removed from this creature during cleanup steps.\nAll damage that would be dealt to you and other permanents you control is dealt to this creature instead.\nWhen this creature dies, exile it and create ten tapped Treasure tokens.",
+    "creatureStats": {
+        "power": 8,
+        "toughness": 20
+    },
+    "keywords": [
+        "VIGILANCE",
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{3}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "Self",
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Treasure",
+                            "count": 10,
+                            "tapped": true
+                        }
+                    ]
+                },
+                "activeZone": "Graveyard"
+            }
+        ],
+        "staticAbilities": [
+            "DamagePersistsThroughCleanup"
+        ],
+        "replacementEffects": [
+            {
+                "type": "RedirectDamage",
+                "redirectTo": "Self",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "You"
+                }
+            },
+            {
+                "type": "RedirectDamage",
+                "redirectTo": "Self",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": {
+                        "type": "RecipientMatching",
+                        "filter": "permanent ctrl:you"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "172",
+        "rarity": "MYTHIC",
+        "artist": "Kevin Glint",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c139f30-5ecd-48fd-ae7c-ec2cc98889ff.jpg?1782686472",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "If you control more than one Ancient Adamantoise, you choose which redirection effect to apply. You can't divide damage dealt by a single source between them, and you can't choose to take the damage yourself."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "Effects that remove all damage from a permanent (such as regeneration) will still remove damage from Ancient Adamantoise."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Ardyn, the Usurper
 {
     "name": "Ardyn, the Usurper",
@@ -3795,6 +3892,109 @@
     "colorIdentityOverride": [
         "BLACK",
         "GREEN"
+    ]
+}
+
+// Cloud, Midgar Mercenary
+{
+    "name": "Cloud, Midgar Mercenary",
+    "manaCost": "{W}{W}",
+    "typeLine": "Legendary Creature — Human Soldier Mercenary",
+    "oracleText": "When Cloud enters, search your library for an Equipment card, reveal it, put it into your hand, then shuffle.\nAs long as Cloud is equipped, if a triggered ability of Cloud or an Equipment attached to it triggers, that ability triggers an additional time.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "artifact Equipment"
+                            },
+                            "storeAs": "searchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "searchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "found"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "found",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            },
+                            "revealed": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "AdditionalSourceTriggers",
+                "sourceFilter": {
+                    "cardPredicates": [
+                        "IsArtifact",
+                        {
+                            "type": "HasSubtype",
+                            "subtype": "Equipment"
+                        }
+                    ],
+                    "statePredicates": [
+                        "IsAttachedToSource"
+                    ]
+                },
+                "alsoSource": true,
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "IsEquipped"
+                        ]
+                    }
+                },
+                "description": "As long as Cloud is equipped, if a triggered ability of Cloud or an Equipment attached to it triggers, that ability triggers an additional time"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "MYTHIC",
+        "artist": "Kazto Furuya",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2cf7e8a3-fad7-413d-b17c-7519a9cf5fb5.jpg?1782686592",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "Cloud's last ability doesn't copy the triggered ability; it just causes the ability to trigger an additional time. Any choices made as you put the ability onto the stack, such as modes and targets, are made separately for each instance of the ability. Any choices made on resolution are also made individually."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/BeginningPhaseManager.kt
@@ -481,6 +481,7 @@ class BeginningPhaseManager(
         StatePredicate.IsWarpExiled,
         StatePredicate.NotTargetedByAbilityFromSameNamedSource,
         StatePredicate.IsAttachedToBySource,
+        StatePredicate.IsAttachedToSource,
         StatePredicate.ExiledWithSource,
         StatePredicate.WasCastForWarp -> true
         is StatePredicate.AttachedToCardType -> true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -26,6 +26,7 @@ import com.wingedsheep.engine.state.components.combat.MustAttackThisTurnComponen
 import com.wingedsheep.engine.state.components.combat.PlayerAttackedThisTurnComponent
 import com.wingedsheep.engine.state.components.combat.PlayerAttackersThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.RoomFaceStatics
 import com.wingedsheep.engine.state.components.identity.CopyOfComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.components.identity.RevertCopyAtEndOfTurnComponent
@@ -77,6 +78,7 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.DamagePersistsThroughCleanup
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.PreventManaPoolEmptying
 
@@ -152,7 +154,7 @@ class CleanupPhaseManager(
         // expire with the cleanup step. The hand-size discard (CR 514.1) above early-returns
         // *before* this point; its continuation re-runs the same actions via
         // [applyCleanupTurnBasedActions], so this block must stay side-effect-equivalent there.
-        newState = applyCleanupTurnBasedActions(newState)
+        newState = applyCleanupTurnBasedActions(newState, cardRegistry)
 
         // No priority during cleanup (normally)
         newState = newState.copy(priorityPlayerId = null)
@@ -870,17 +872,23 @@ class CleanupPhaseManager(
          * indestructible (e.g. Saved by the Shell) had been suppressing, which then kills the
          * creature on the following turn's state-based-action check.
          */
-        fun applyCleanupTurnBasedActions(state: GameState): GameState {
+        fun applyCleanupTurnBasedActions(
+            state: GameState,
+            cardRegistry: com.wingedsheep.engine.registry.CardRegistry,
+        ): GameState {
             var newState = state
 
             // Remove damage from all permanents on the battlefield (Rule 514.2).
             // Includes vehicles that reverted from creature status this turn — their damage
-            // (and P/T from the expired floating effect) must be cleared.
+            // (and P/T from the expired floating effect) must be cleared. Permanents with a
+            // [DamagePersistsThroughCleanup] static ability (Ancient Adamantoise) are the
+            // exception — their marked damage is left in place and accumulates.
             val battlefield = newState.getBattlefield().toSet()
             val permanentsWithDamage = newState.entities.filter { (entityId, container) ->
                 entityId in battlefield && container.has<DamageComponent>()
             }.keys
             for (entityId in permanentsWithDamage) {
+                if (damagePersistsThroughCleanup(newState, cardRegistry, entityId)) continue
                 newState = newState.updateEntity(entityId) { it.without<DamageComponent>() }
             }
 
@@ -913,6 +921,28 @@ class CleanupPhaseManager(
             }
 
             return newState
+        }
+
+        /**
+         * True when [entityId]'s permanent has a [DamagePersistsThroughCleanup] static ability —
+         * either printed on its (face-aware) script or granted to it — so the CR 514.2 cleanup
+         * damage removal must skip it (Ancient Adamantoise).
+         */
+        private fun damagePersistsThroughCleanup(
+            state: GameState,
+            cardRegistry: com.wingedsheep.engine.registry.CardRegistry,
+            entityId: EntityId,
+        ): Boolean {
+            val container = state.getEntity(entityId) ?: return false
+            val cardDef = container.get<CardComponent>()
+                ?.let { cardRegistry.getCard(it.cardDefinitionId) }
+            val printed = cardDef != null &&
+                RoomFaceStatics.activeStaticAbilities(container, cardDef)
+                    .any { it is DamagePersistsThroughCleanup }
+            if (printed) return true
+            return state.grantedStaticAbilities.any {
+                it.entityId == entityId && it.ability is DamagePersistsThroughCleanup
+            }
         }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -2802,7 +2802,8 @@ class TriggerDetector(
             val doublerSourceId: EntityId,
             val controllerId: EntityId,
             val filter: GameObjectFilter,
-            val excludeSelf: Boolean
+            val excludeSelf: Boolean,
+            val alsoSource: Boolean
         )
         val doublers = mutableListOf<SourceDoubler>()
 
@@ -2816,12 +2817,21 @@ class TriggerDetector(
             // (CR 709.5) is honoured, not just one in the card's top-level script.
             for (ability in RoomFaceStatics.activeStaticAbilities(container, cardDef)) {
                 if (ability is AdditionalSourceTriggers) {
+                    // Optional gate ("As long as Cloud is equipped, …") — evaluated against the
+                    // doubler source. When it fails, the whole doubler is inert this batch.
+                    val gate = ability.condition
+                    if (gate != null && !conditionEvaluator.evaluate(
+                            state, gate,
+                            EffectContext(sourceId = permanentId, controllerId = controllerId)
+                        )
+                    ) continue
                     doublers.add(
                         SourceDoubler(
                             doublerSourceId = permanentId,
                             controllerId = controllerId,
                             filter = ability.sourceFilter,
-                            excludeSelf = ability.excludeSelf
+                            excludeSelf = ability.excludeSelf,
+                            alsoSource = ability.alsoSource
                         )
                     )
                 }
@@ -2837,6 +2847,13 @@ class TriggerDetector(
             for (trigger in originals) {
                 if (trigger.controllerId != doubler.controllerId) continue
                 val triggerSourceId = trigger.sourceId
+                // `alsoSource` doubles the doubler's own triggered abilities regardless of the
+                // filter — the "or ~ itself" leg of "a triggered ability of ~ or an Equipment
+                // attached to it" (Cloud, Midgar Mercenary).
+                if (doubler.alsoSource && triggerSourceId == doubler.doublerSourceId) {
+                    duplicates.add(trigger)
+                    continue
+                }
                 if (doubler.excludeSelf && triggerSourceId == doubler.doublerSourceId) continue
                 if (!predicateEvaluator.matches(
                         state, projected, triggerSourceId, doubler.filter,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1665,6 +1665,7 @@ class TriggerMatcher(
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsWarpExiled,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.NotTargetedByAbilityFromSameNamedSource,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttachedToBySource,
+        com.wingedsheep.sdk.scripting.predicates.StatePredicate.IsAttachedToSource,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.ExiledWithSource,
         com.wingedsheep.sdk.scripting.predicates.StatePredicate.WasCastForWarp,
         is com.wingedsheep.sdk.scripting.predicates.StatePredicate.AttachedToCardType -> true

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/PredicateEvaluator.kt
@@ -1098,6 +1098,14 @@ class PredicateEvaluator {
                 attachedTo == entityId
             }
 
+            // Mirror of IsAttachedToBySource: the candidate is an Aura/Equipment attached TO the
+            // source (static on the host, e.g. Cloud's "an Equipment attached to it").
+            StatePredicate.IsAttachedToSource -> {
+                val sourceId = context?.sourceId ?: return false
+                val attachedTo = state.getEntity(entityId)?.get<AttachedToComponent>()?.targetId
+                attachedTo == sourceId
+            }
+
             // Source-relative: the candidate card was exiled by the effect's source permanent, i.e.
             // its id is recorded in the source's LinkedExileComponent. Backs "target card exiled
             // with ~" reanimation (The Darkness Crystal). Inert with no source context.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/ability/ActivateAbilityHandler.kt
@@ -1919,6 +1919,17 @@ class ActivateAbilityHandler(
             val classLevel = container.get<ClassLevelComponent>()?.currentLevel
             for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
                 if (ability !is AdditionalSourceTriggers) continue
+                // Optional gate ("as long as ~ is equipped") — evaluated against the doubler source.
+                val gate = ability.condition
+                if (gate != null && !conditionEvaluator.evaluate(
+                        state, gate, EffectContext(sourceId = permanentId, controllerId = controllerId)
+                    )
+                ) continue
+                // `alsoSource` doubles the doubler's own triggers regardless of the filter.
+                if (ability.alsoSource && permanentId == triggerSourceId) {
+                    count++
+                    continue
+                }
                 if (ability.excludeSelf && permanentId == triggerSourceId) continue
                 if (!predicateEvaluator.matches(
                         state, projected, triggerSourceId, ability.sourceFilter,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DiscardAndDrawContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/DiscardAndDrawContinuationResumer.kt
@@ -34,7 +34,7 @@ class DiscardAndDrawContinuationResumer(
         // actions. Finish them now — otherwise marked damage (notably deathtouch damage that an
         // expiring "until end of turn" indestructible had suppressed) persists into the next turn
         // and kills the creature on the following turn's state-based-action check.
-        val cleanedState = CleanupPhaseManager.applyCleanupTurnBasedActions(result.state)
+        val cleanedState = CleanupPhaseManager.applyCleanupTurnBasedActions(result.state, services.cardRegistry)
         return checkForMore(cleanedState, result.events)
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -399,6 +399,7 @@ internal class AffectsFilterResolver {
         // permanent, absent in group-static projection. Only meaningful in target/gather-filter
         // contexts via PredicateEvaluator. Never match here.
         StatePredicate.IsAttachedToBySource -> false
+        StatePredicate.IsAttachedToSource -> false
         // Source-relative exile linkage (LinkedExileComponent on the effect source). Only
         // meaningful in target/gather-filter contexts via PredicateEvaluator; never match in
         // group-static projection.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -100,6 +100,7 @@ import com.wingedsheep.sdk.scripting.CantBlockUnless
 import com.wingedsheep.sdk.scripting.CantBlockUnlessCoBlocker
 import com.wingedsheep.sdk.scripting.CantCastSpellsSharingColorWithLastCast
 import com.wingedsheep.sdk.scripting.CastSpellTypesFromTopOfLibrary
+import com.wingedsheep.sdk.scripting.DamagePersistsThroughCleanup
 import com.wingedsheep.sdk.scripting.DampLandManaProduction
 import com.wingedsheep.sdk.scripting.DivideCombatDamageFreely
 import com.wingedsheep.sdk.scripting.ExtraLoyaltyActivation
@@ -870,6 +871,7 @@ class StaticAbilityHandler(
             is SuppressEntersTriggers,
 
             // Turn-based actions (BeginningPhaseManager / CleanupPhaseManager):
+            is DamagePersistsThroughCleanup,
             is NoMaximumHandSize,
             is SetMaximumHandSize,
             is PreventManaPoolEmptying,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncientAdamantoiseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AncientAdamantoiseScenarioTest.kt
@@ -1,0 +1,118 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ancient Adamantoise:
+ *  - redirects all damage to its controller and their other permanents onto itself,
+ *  - keeps its marked damage through cleanup steps ([DamagePersistsThroughCleanup]),
+ *  - on death exiles itself and makes ten tapped Treasure tokens.
+ */
+class AncientAdamantoiseScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + PredefinedTokens.allTokens)
+        return driver
+    }
+
+    fun GameTestDriver.markDamage(entityId: EntityId, amount: Int) {
+        replaceState(state.updateEntity(entityId) { c -> c.with(DamageComponent(amount)) })
+    }
+
+    fun GameTestDriver.damageOn(entityId: EntityId): Int =
+        state.getEntity(entityId)?.get<DamageComponent>()?.amount ?: 0
+
+    fun GameTestDriver.treasuresControlledBy(playerId: EntityId): List<EntityId> =
+        state.getBattlefield().filter {
+            state.getEntity(it)?.get<CardComponent>()?.name == "Treasure" &&
+                getController(it) == playerId
+        }
+
+    test("damage to you and to your other permanents is redirected onto the Adamantoise") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30, "Mountain" to 10), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val adamantoise = driver.putCreatureOnBattlefield(p1, "Ancient Adamantoise")
+        val bear = driver.putCreatureOnBattlefield(p1, "Centaur Courser") // 3/3 vanilla
+
+        // Bolt aimed at the controller — redirected onto the Adamantoise; life untouched.
+        driver.giveMana(p1, Color.RED, 1)
+        val bolt1 = driver.putCardInHand(p1, "Lightning Bolt")
+        driver.castSpellWithTargets(p1, bolt1, listOf(ChosenTarget.Player(p1)))
+        driver.bothPass()
+
+        driver.getLifeTotal(p1) shouldBe 20
+        driver.damageOn(adamantoise) shouldBe 3
+
+        // Bolt aimed at another permanent you control — also redirected; accumulates.
+        driver.giveMana(p1, Color.RED, 1)
+        val bolt2 = driver.putCardInHand(p1, "Lightning Bolt")
+        driver.castSpellWithTargets(p1, bolt2, listOf(ChosenTarget.Permanent(bear)))
+        driver.bothPass()
+
+        driver.damageOn(bear) shouldBe 0
+        driver.damageOn(adamantoise) shouldBe 6
+    }
+
+    test("marked damage persists through cleanup, unlike an ordinary creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30, "Mountain" to 10), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val adamantoise = driver.putCreatureOnBattlefield(p1, "Ancient Adamantoise")
+        val bear = driver.putCreatureOnBattlefield(p1, "Centaur Courser")
+
+        driver.markDamage(adamantoise, 5) // non-lethal against 20 toughness
+        driver.markDamage(bear, 2)
+
+        // Advance through this turn's cleanup into the opponent's upkeep.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldBe p2
+
+        driver.damageOn(adamantoise) shouldBe 5   // survived the CR 514.2 cleanup removal
+        driver.state.getEntity(bear)?.has<DamageComponent>() shouldBe false // ordinary removal
+    }
+
+    test("dying exiles the Adamantoise and creates ten tapped Treasure tokens") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 30, "Mountain" to 10), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val adamantoise = driver.putCreatureOnBattlefield(p1, "Ancient Adamantoise")
+        // Bring it near death, then finish it with a real damage event so state-based actions run.
+        // A bolt aimed at the Adamantoise itself is not redirected (a redirect whose destination
+        // equals the original recipient is skipped), so all 3 land on it: 18 + 3 = 21 >= 20.
+        driver.markDamage(adamantoise, 18)
+        driver.giveMana(p1, Color.RED, 1)
+        val bolt = driver.putCardInHand(p1, "Lightning Bolt")
+        driver.castSpellWithTargets(p1, bolt, listOf(ChosenTarget.Permanent(adamantoise)))
+        // Resolve the bolt (lethal), then the dies trigger that exiles it and makes Treasures.
+        driver.passPriorityUntil(Step.END)
+
+        driver.state.getBattlefield().contains(adamantoise) shouldBe false
+        driver.getExileCardNames(p1) shouldContain "Ancient Adamantoise"
+
+        val treasures = driver.treasuresControlledBy(p1)
+        treasures.size shouldBe 10
+        treasures.all { driver.isTapped(it) }.shouldBeTrue()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudMidgarMercenaryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CloudMidgarMercenaryScenarioTest.kt
@@ -1,0 +1,160 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.CloudMidgarMercenary
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalSourceTriggers
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Cloud, Midgar Mercenary:
+ *  - ETB tutors an Equipment card into hand,
+ *  - while equipped, an attached Equipment's triggered abilities trigger an additional time,
+ *  - the gate ("as long as Cloud is equipped") turns the doubling off when nothing is attached,
+ *  - the `alsoSource` leg of [AdditionalSourceTriggers] doubles a permanent's own triggers.
+ */
+class CloudMidgarMercenaryScenarioTest : FunSpec({
+
+    // A minimal Equipment that gains its controller 1 life each upkeep — an observable trigger
+    // whose source is the Equipment (so Cloud's doubling applies when it's attached to Cloud).
+    val testAegis = card("Test Aegis") {
+        manaCost = "{2}"
+        typeLine = "Artifact — Equipment"
+        oracleText = "At the beginning of your upkeep, you gain 1 life.\nEquip {2}"
+        triggeredAbility {
+            trigger = Triggers.YourUpkeep
+            effect = Effects.GainLife(1)
+        }
+        equipAbility("{2}")
+    }
+
+    // A creature that doubles its OWN triggered abilities (alsoSource) — no filter match needed.
+    val selfDoubler = card("Self Doubler") {
+        manaCost = "{2}"
+        typeLine = "Creature — Elemental"
+        power = 1
+        toughness = 1
+        oracleText = "At the beginning of your upkeep, you gain 1 life.\n" +
+            "If a triggered ability of this creature triggers, it triggers an additional time."
+        triggeredAbility {
+            trigger = Triggers.YourUpkeep
+            effect = Effects.GainLife(1)
+        }
+        staticAbility {
+            // sourceFilter matches nothing here; only the alsoSource leg contributes.
+            ability = AdditionalSourceTriggers(
+                sourceFilter = GameObjectFilter.Artifact.withSubtype("Equipment"),
+                excludeSelf = true,
+                alsoSource = true
+            )
+        }
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CloudMidgarMercenary, testAegis, selfDoubler))
+        return driver
+    }
+
+    /** Advance to the active player's *next* precombat main (through their untap + upkeep). */
+    fun advanceToNextTurnMain(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+    }
+
+    fun GameTestDriver.attach(equipment: EntityId, creature: EntityId) {
+        replaceState(
+            state
+                .updateEntity(equipment) { it.with(AttachedToComponent(creature)) }
+                .updateEntity(creature) { it.with(AttachmentsComponent(listOf(equipment))) }
+        )
+    }
+
+    test("ETB searches the library for an Equipment card and puts it into hand") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 10), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val aegis = driver.putCardOnTopOfLibrary(p1, "Test Aegis")
+        driver.giveMana(p1, Color.WHITE, 2)
+        val cloud = driver.putCardInHand(p1, "Cloud, Midgar Mercenary")
+        driver.castSpell(p1, cloud)
+        // Resolve Cloud, then its ETB trigger, until the library-search decision pauses the game.
+        var guard = 0
+        while (driver.pendingDecision !is SelectCardsDecision && guard++ < 10) {
+            driver.bothPass()
+        }
+
+        driver.pendingDecision as SelectCardsDecision
+        driver.submitCardSelection(p1, listOf(aegis))
+
+        driver.findCardInHand(p1, "Test Aegis").shouldNotBeNull()
+    }
+
+    test("an Equipment attached to Cloud has its triggered ability doubled") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 10), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val cloud = driver.putCreatureOnBattlefield(p1, "Cloud, Midgar Mercenary")
+        val aegis = driver.putPermanentOnBattlefield(p1, "Test Aegis")
+        driver.attach(aegis, cloud)
+
+        val before = driver.getLifeTotal(p1)
+        advanceToNextTurnMain(driver) // opponent's turn
+        advanceToNextTurnMain(driver) // back to p1 — through p1's upkeep once
+
+        // The Equipment's "gain 1 life" upkeep trigger fired an additional time: +2.
+        driver.getLifeTotal(p1) shouldBe before + 2
+    }
+
+    test("the doubling is off when Cloud is not equipped (gate)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 10), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Cloud is on the battlefield but unequipped; the Equipment hangs off a vanilla creature.
+        driver.putCreatureOnBattlefield(p1, "Cloud, Midgar Mercenary")
+        val bear = driver.putCreatureOnBattlefield(p1, "Centaur Courser")
+        val aegis = driver.putPermanentOnBattlefield(p1, "Test Aegis")
+        driver.attach(aegis, bear)
+
+        val before = driver.getLifeTotal(p1)
+        advanceToNextTurnMain(driver)
+        advanceToNextTurnMain(driver)
+
+        // Not attached to Cloud (and Cloud isn't equipped): the trigger fires once, +1.
+        driver.getLifeTotal(p1) shouldBe before + 1
+    }
+
+    test("alsoSource doubles a permanent's own triggered ability") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30, "Forest" to 10), startingLife = 20)
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(p1, "Self Doubler")
+
+        val before = driver.getLifeTotal(p1)
+        advanceToNextTurnMain(driver)
+        advanceToNextTurnMain(driver)
+
+        driver.getLifeTotal(p1) shouldBe before + 2
+    }
+})


### PR DESCRIPTION
Implements two Final Fantasy cards, each pairing a `cardDef` with a small, reusable engine/SDK addition (designed for the next card, not just this one).

## Ancient Adamantoise — {5}{G}{G}{G}, 8/20
> Vigilance, ward {3}
> Damage isn't removed from this creature during cleanup steps.
> All damage that would be dealt to you and other permanents you control is dealt to this creature instead.
> When this creature dies, exile it and create ten tapped Treasure tokens.

- Redirection modelled as two static `RedirectDamage` replacements (recipient `You` + `Matching(Permanent.youControl())`), both to `Self` — reuses the Martyrs of Korlis machinery; the engine already skips a redirect whose destination equals the original recipient, so "other permanents" falls out naturally.
- **New `DamagePersistsThroughCleanup` static ability** — an exception to the CR 514.2 cleanup damage-removal turn-based action, so marked damage accumulates until it becomes lethal. `CleanupPhaseManager` consults it (printed via `RoomFaceStatics`, plus granted instances). Only the cleanup removal is suppressed — regeneration / "remove all damage" still work, per the card's ruling.
- Dies → exile self + ten tapped Treasures uses existing primitives.

## Cloud, Midgar Mercenary — {W}{W}, 2/1
> When Cloud enters, search your library for an Equipment card, reveal it, put it into your hand, then shuffle.
> As long as Cloud is equipped, if a triggered ability of Cloud or an Equipment attached to it triggers, that ability triggers an additional time.

- ETB Equipment tutor via `Patterns.Library.searchLibrary`.
- **Extends `AdditionalSourceTriggers`** with `alsoSource` (also double the doubler's own triggers — the "a triggered ability of Cloud **or** …" leg) and a `condition` gate ("as long as Cloud is equipped", via `Conditions.SourceMatches(equipped())`). Wired through both `TriggerDetector.duplicateSourceTriggers` and the `ActivateAbilityHandler` triggered-mana path.
- **New `IsAttachedToSource` state predicate + `attachedToSource()` filter builder** — the mirror of `IsAttachedToBySource`, for a static on the *host* matching its own attachments.

## Tests
New `rules-engine` scenario tests, all green:
- **Adamantoise**: redirect (you + your other permanents), damage persistence through cleanup (vs. an ordinary creature), dies → exile + 10 tapped Treasures.
- **Cloud**: ETB Equipment tutor, an attached Equipment's trigger doubling, the equipped-gate (off when not on Cloud), and the `alsoSource` leg.

Full `just build` + `just test-rules` pass. SDK reference (§7 filters, §9 static abilities) updated in the same change; FIN card snapshot re-blessed (diff is only the two new cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)