### PR TITLE
Add Foundations cards: Bulk Up, Cemetery Recruitment, Charming Prince, Faebloom Trick

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CharmingPrince.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/CharmingPrince.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Charming Prince
+ * {1}{W}
+ * Creature — Human Noble
+ * 2/2
+ *
+ * When this creature enters, choose one —
+ * • Scry 2.
+ * • You gain 3 life.
+ * • Exile another target creature you own. Return it to the battlefield under your control at the
+ *   beginning of the next end step.
+ *
+ * Canonical printing lives here in Throne of Eldraine (earliest real printing); Foundations gets a
+ * [com.wingedsheep.sdk.model.Printing] row.
+ *
+ * The blink mode is the only one that targets, so it is a [Mode.withTarget]; the other two are
+ * [Mode.noTarget]. The exiled card is returned by a delayed end-step trigger (SalvationSwan shape).
+ * Since the target must be "a creature you own", returning it to the battlefield puts it under its
+ * owner's — your — control, matching "under your control".
+ */
+val CharmingPrince = card("Charming Prince") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Noble"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, choose one —\n" +
+        "• Scry 2.\n" +
+        "• You gain 3 life.\n" +
+        "• Exile another target creature you own. Return it to the battlefield under your control " +
+        "at the beginning of the next end step."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.noTarget(Effects.Scry(2), "Scry 2."),
+                Mode.noTarget(Effects.GainLife(3), "You gain 3 life."),
+                Mode.withTarget(
+                    effect = Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE)
+                        .then(
+                            CreateDelayedTriggerEffect(
+                                step = Step.END,
+                                effect = Effects.Move(EffectTarget.ContextTarget(0), Zone.BATTLEFIELD)
+                            )
+                        ),
+                    target = TargetCreature(filter = TargetFilter.Creature.ownedByYou().other()),
+                    description = "Exile another target creature you own. Return it to the battlefield " +
+                        "under your control at the beginning of the next end step."
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "8"
+        artist = "Randy Vargas"
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dcb94950-3f3e-4876-84f8-d5e4d9cfecee.jpg?1782707930"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/CemeteryRecruitment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/emn/cards/CemeteryRecruitment.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.emn.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Cemetery Recruitment
+ * {1}{B}
+ * Sorcery
+ *
+ * Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.
+ *
+ * Canonical printing lives here in Eldritch Moon (earliest real printing); Foundations gets a
+ * [com.wingedsheep.sdk.model.Printing] row.
+ *
+ * The "if it's a Zombie card" bonus is checked against the target's printed types before it moves
+ * (the target is still the graveyard card at resolution start, and its type is invariant across the
+ * zone change), so the draw is folded into a [ConditionalEffect] that gates the extra draw.
+ */
+val CemeteryRecruitment = card("Cemetery Recruitment") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card."
+
+    spell {
+        val creature = target(
+            "creature card from your graveyard",
+            TargetObject(filter = TargetFilter.CreatureInYourGraveyard)
+        )
+        effect = ConditionalEffect(
+            condition = Conditions.TargetMatchesFilter(GameObjectFilter.Creature.withSubtype(Subtype.ZOMBIE)),
+            effect = Effects.Move(creature, Zone.HAND).then(Effects.DrawCards(1)),
+            elseEffect = Effects.Move(creature, Zone.HAND)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "83"
+        artist = "Kieran Yanner"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a23adea-9f4a-409c-a37d-323eee781273.jpg?1782711893"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BulkUp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BulkUp.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Bulk Up
+ * {1}{R}
+ * Instant
+ *
+ * Double target creature's power until end of turn.
+ * Flashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ *
+ * "Double its power" is the standard layer-7c +N/+0 modification where N is the creature's power,
+ * read at resolution via [DynamicAmount.EntityProperty] on the target — the same shape used by
+ * "double power and toughness" cards. The bonus is locked when the effect is applied, so it does
+ * not feed back on itself.
+ */
+val BulkUp = card("Bulk Up") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Double target creature's power until end of turn.\n" +
+        "Flashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.ModifyStats(
+            power = DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.Power),
+            toughness = DynamicAmount.Fixed(0),
+            target = creature
+        )
+    }
+
+    keywordAbility(KeywordAbility.flashback("{4}{R}{R}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "80"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/977dcc50-da10-4281-b522-9240c1204f5d.jpg?1782689196"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CemeteryRecruitmentReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CemeteryRecruitmentReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cemetery Recruitment reprint in Foundations. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Eldritch Moon's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val CemeteryRecruitmentReprint = Printing(
+    oracleId = "07792d72-d5db-41b9-871c-e720e12ce659",
+    name = "Cemetery Recruitment",
+    setCode = "FDN",
+    collectorNumber = "517",
+    scryfallId = "34a80873-86d7-44a9-894b-65e8f77dd2ea",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/3/4/34a80873-86d7-44a9-894b-65e8f77dd2ea.jpg?1782688815",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CharmingPrinceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/CharmingPrinceReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Charming Prince reprint in Foundations. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Throne of Eldraine's `cards/` package; this
+ * file contributes only presentation data.
+ */
+val CharmingPrinceReprint = Printing(
+    oracleId = "c48d844c-3976-4fa5-8e0d-3f0e535e7619",
+    name = "Charming Prince",
+    setCode = "FDN",
+    collectorNumber = "568",
+    scryfallId = "aa7b47e1-7e32-4f2f-aecf-bac7ca197081",
+    artist = "Randy Vargas",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa7b47e1-7e32-4f2f-aecf-bac7ca197081.jpg?1782688771",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FaebloomTrick.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FaebloomTrick.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Faebloom Trick
+ * {2}{U}
+ * Instant
+ *
+ * Create two 1/1 blue Faerie creature tokens with flying. When you do, tap target creature an
+ * opponent controls.
+ *
+ * The tap is a reflexive "when you do" trigger: the tokens are always created, and the reflexive
+ * trigger chooses its target afterward — so casting this with no opponent creatures still makes the
+ * tokens and simply has no legal tap target. Modeled with [ReflexiveTriggerEffect] (mandatory
+ * action), not a cast-time target.
+ */
+val FaebloomTrick = card("Faebloom Trick") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Create two 1/1 blue Faerie creature tokens with flying. When you do, tap target " +
+        "creature an opponent controls."
+
+    spell {
+        effect = ReflexiveTriggerEffect(
+            action = Effects.CreateToken(
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.BLUE),
+                creatureTypes = setOf("Faerie"),
+                keywords = setOf(Keyword.FLYING),
+                count = 2,
+                imageUri = "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg?1782727481"
+            ),
+            optional = false,
+            reflexiveEffect = Effects.Tap(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(Targets.CreatureOpponentControls)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "38"
+        artist = "Annie Stegg"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c3bee8f-f5be-4404-a696-c902637799c3.jpg?1782689233"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CemeteryRecruitmentReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/CemeteryRecruitmentReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cemetery Recruitment reprint in Jumpstart 2022. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Eldritch Moon's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val CemeteryRecruitmentReprint = Printing(
+    oracleId = "07792d72-d5db-41b9-871c-e720e12ce659",
+    name = "Cemetery Recruitment",
+    setCode = "J22",
+    collectorNumber = "385",
+    scryfallId = "e3897e9f-363d-42f9-85b1-28143b223b08",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3897e9f-363d-42f9-85b1-28143b223b08.jpg?1782699119",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CemeteryRecruitmentReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/CemeteryRecruitmentReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cemetery Recruitment reprint in Jumpstart. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Eldritch Moon's `cards/` package; this file
+ * contributes only presentation data.
+ */
+val CemeteryRecruitmentReprint = Printing(
+    oracleId = "07792d72-d5db-41b9-871c-e720e12ce659",
+    name = "Cemetery Recruitment",
+    setCode = "JMP",
+    collectorNumber = "217",
+    scryfallId = "88531c36-2330-474b-9426-1e4dd0fe4e3e",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/8/8/88531c36-2330-474b-9426-1e4dd0fe4e3e.jpg?1782706646",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -44,6 +44,97 @@
     ]
 }
 
+// Charming Prince
+{
+    "name": "Charming Prince",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Noble",
+    "oracleText": "When this creature enters, choose one —\n• Scry 2.\n• You gain 3 life.\n• Exile another target creature you own. Return it to the battlefield under your control at the beginning of the next end step.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "Scry",
+                                "count": 2
+                            },
+                            "description": "Scry 2."
+                        },
+                        {
+                            "effect": {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                }
+                            },
+                            "description": "You gain 3 life."
+                        },
+                        {
+                            "effect": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "MoveToZone",
+                                        "target": {
+                                            "type": "ContextTarget",
+                                            "index": 0
+                                        },
+                                        "destination": "Exile"
+                                    },
+                                    {
+                                        "type": "CreateDelayedTrigger",
+                                        "step": "END",
+                                        "effect": {
+                                            "type": "MoveToZone",
+                                            "target": {
+                                                "type": "ContextTarget",
+                                                "index": 0
+                                            },
+                                            "destination": "Battlefield"
+                                        }
+                                    }
+                                ]
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature own:you",
+                                        "excludeSelf": true
+                                    }
+                                }
+                            ],
+                            "description": "Exile another target creature you own. Return it to the battlefield under your control at the beginning of the next end step."
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "RARE",
+        "artist": "Randy Vargas",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dcb94950-3f3e-4876-84f8-d5e4d9cfecee.jpg?1782707930"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Raging Redcap
 {
     "name": "Raging Redcap",

--- a/mtg-sets/src/test/resources/snapshots/cards/EMN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/EMN.json
@@ -83,6 +83,76 @@
     "colorIdentityOverride": []
 }
 
+// Cemetery Recruitment
+{
+    "name": "Cemetery Recruitment",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card.",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "filter": "creature Zombie"
+                }
+            },
+            "then": {
+                "type": "Composite",
+                "effects": [
+                    {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature card from your graveyard"
+                        },
+                        "destination": "Hand"
+                    },
+                    {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                ]
+            },
+            "otherwise": {
+                "type": "MoveToZone",
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "creature card from your graveyard"
+                },
+                "destination": "Hand"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "creature card from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "artist": "Kieran Yanner",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a23adea-9f4a-409c-a37d-323eee781273.jpg?1782711893"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Chittering Host
 {
     "name": "Chittering Host",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -630,6 +630,59 @@
     ]
 }
 
+// Bulk Up
+{
+    "name": "Bulk Up",
+    "manaCost": "{1}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Double target creature's power until end of turn.\nFlashback {4}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{4}{R}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "ModifyStats",
+            "powerModifier": {
+                "type": "EntityProperty",
+                "entity": "Target",
+                "numericProperty": "Power"
+            },
+            "toughnessModifier": {
+                "type": "Fixed",
+                "amount": 0
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "rarity": "UNCOMMON",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/977dcc50-da10-4281-b522-9240c1204f5d.jpg?1782689196"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Cackling Prowler
 {
     "name": "Cackling Prowler",
@@ -1731,6 +1784,63 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Faebloom Trick
+{
+    "name": "Faebloom Trick",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Create two 1/1 blue Faerie creature tokens with flying. When you do, tap target creature an opponent controls.",
+    "script": {
+        "spellEffect": {
+            "type": "ReflexiveTrigger",
+            "action": {
+                "type": "CreateToken",
+                "count": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "power": 1,
+                "toughness": 1,
+                "colors": [
+                    "BLUE"
+                ],
+                "creatureTypes": [
+                    "Faerie"
+                ],
+                "keywords": [
+                    "FLYING"
+                ],
+                "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg?1782727481"
+            },
+            "optional": false,
+            "reflexiveEffect": {
+                "type": "TapUntap",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                }
+            },
+            "reflexiveTargetRequirements": [
+                {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "rarity": "UNCOMMON",
+        "artist": "Annie Stegg",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c3bee8f-f5be-4404-a696-c902637799c3.jpg?1782689233"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BulkUpScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BulkUpScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Bulk Up (FDN #80) — {1}{R} Instant.
+ *
+ * "Double target creature's power until end of turn."
+ *
+ * Verifies the layer-7c +N/+0 doubling: a 3/3 becomes 6/3 (power doubled, toughness untouched),
+ * and the bonus is locked at resolution rather than feeding back on itself.
+ */
+class BulkUpScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Ogre",
+                manaCost = ManaCost.parse("{2}{R}"),
+                subtypes = setOf(Subtype("Ogre")),
+                power = 3,
+                toughness = 3
+            )
+        )
+
+        context("Bulk Up") {
+
+            test("doubles the target creature's power, leaving toughness unchanged") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Test Ogre", summoningSickness = false)
+                    .withCardInHand(1, "Bulk Up")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ogre = game.findPermanent("Test Ogre")!!
+                val cast = game.castSpell(1, "Bulk Up", targetId = ogre)
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                val card = game.getClientState(1).cards.values.first { it.name == "Test Ogre" }
+                withClue("Test Ogre should be 6/3 after doubling its power") {
+                    card.power shouldBe 6
+                    card.toughness shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CemeteryRecruitmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CemeteryRecruitmentScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Cemetery Recruitment (EMN #83, reprinted FDN #517) — {1}{B} Sorcery.
+ *
+ * "Return target creature card from your graveyard to your hand. If it's a Zombie card, draw a card."
+ *
+ * Verifies both the unconditional return and the Zombie-gated bonus draw: returning a Zombie card
+ * draws a card, returning a non-Zombie creature card does not.
+ */
+class CemeteryRecruitmentScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Zombie",
+                manaCost = ManaCost.parse("{2}{B}"),
+                subtypes = setOf(Subtype.ZOMBIE),
+                power = 2,
+                toughness = 2
+            )
+        )
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Bear",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Cemetery Recruitment") {
+
+            test("returning a Zombie card also draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cemetery Recruitment")
+                    .withCardInGraveyard(1, "Test Zombie")
+                    .withCardInLibrary(1, "Swamp")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val cast = game.castSpellTargetingGraveyardCard(1, "Cemetery Recruitment", 1, "Test Zombie")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("Test Zombie should be back in hand") {
+                    game.isInHand(1, "Test Zombie") shouldBe true
+                }
+                // Started with Cemetery Recruitment in hand; it left for the stack (-1), Test Zombie
+                // returned (+1), and the Zombie bonus drew the Swamp (+1) => net +1 vs the start.
+                withClue("Returning a Zombie should net one extra card (the bonus draw)") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+            }
+
+            test("returning a non-Zombie creature card does not draw") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cemetery Recruitment")
+                    .withCardInGraveyard(1, "Test Bear")
+                    .withCardInLibrary(1, "Swamp")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                game.castSpellTargetingGraveyardCard(1, "Cemetery Recruitment", 1, "Test Bear").error shouldBe null
+                game.resolveStack()
+
+                withClue("Test Bear should be back in hand") {
+                    game.isInHand(1, "Test Bear") shouldBe true
+                }
+                // Cemetery Recruitment left (-1), Test Bear returned (+1), no bonus draw => same size.
+                withClue("Returning a non-Zombie should not draw, so hand size is unchanged") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CharmingPrinceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CharmingPrinceScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Charming Prince (ELD #8, reprinted FDN #568) — {1}{W} Creature — Human Noble, 2/2.
+ *
+ * "When this creature enters, choose one —
+ *  • Scry 2.
+ *  • You gain 3 life.
+ *  • Exile another target creature you own. Return it to the battlefield under your control at the
+ *    beginning of the next end step."
+ *
+ * Exercises the modal ETB trigger: the gain-life mode and the exile-then-return-at-end-step blink.
+ */
+class CharmingPrinceScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Ally Bear",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Charming Prince's ETB modal trigger") {
+
+            test("mode 2 gains 3 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Charming Prince")
+                    .withLifeTotal(1, 20)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Charming Prince").error shouldBe null
+                game.resolveStack()
+
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 1))
+                game.resolveStack()
+
+                withClue("Player 1 should have gained 3 life (20 -> 23)") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+            }
+
+            test("mode 3 exiles a creature you own and returns it at the next end step") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Charming Prince")
+                    .withCardOnBattlefield(1, "Ally Bear", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Charming Prince").error shouldBe null
+                game.resolveStack()
+
+                val modeDecision = game.state.pendingDecision as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision; got ${game.state.pendingDecision}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 2))
+
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision after mode pick; got ${game.state.pendingDecision}")
+                val bear = game.findPermanent("Ally Bear")!!
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(bear))))
+                game.resolveStack()
+
+                withClue("Ally Bear should have been exiled off the battlefield") {
+                    game.findPermanent("Ally Bear") shouldBe null
+                }
+
+                // Advance to the end step; the delayed trigger returns the exiled creature.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Ally Bear should be back on the battlefield after the next end step") {
+                    (game.findPermanent("Ally Bear") != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaebloomTrickScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FaebloomTrickScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Faebloom Trick (FDN #38) — {2}{U} Instant.
+ *
+ * "Create two 1/1 blue Faerie creature tokens with flying. When you do, tap target creature an
+ * opponent controls."
+ *
+ * Verifies the reflexive "when you do" trigger: two Faerie tokens are created, and the reflexive
+ * trigger taps a chosen opponent creature.
+ */
+class FaebloomTrickScenarioTest : ScenarioTestBase() {
+
+    init {
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Enemy Bear",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Faebloom Trick") {
+
+            test("creates two Faerie tokens and taps an opponent's creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Faebloom Trick")
+                    .withCardOnBattlefield(2, "Enemy Bear", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Faebloom Trick")
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // The reflexive "when you do" trigger goes on the stack and asks for its tap target.
+                val targetDecision = game.state.pendingDecision as? ChooseTargetsDecision
+                    ?: error("expected a ChooseTargetsDecision for the reflexive tap; got ${game.state.pendingDecision}")
+                val enemyBear = game.findPermanent("Enemy Bear")!!
+                game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(enemyBear))))
+                game.resolveStack()
+
+                withClue("Two 1/1 Faerie tokens should have been created") {
+                    game.findPermanents("Faerie Token").size shouldBe 2
+                }
+                val bearCard = game.getClientState(1).cards.values.first { it.name == "Enemy Bear" }
+                withClue("The opponent's Enemy Bear should be tapped") {
+                    bearCard.isTapped shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements a handful of **Foundations (FDN)** cards, all composed from existing SDK primitives — no new engine building blocks, so no SDK-reference changes.

## Cards

| Card | Placement | Mechanic |
|------|-----------|----------|
| **Bulk Up** (FDN #80) | canonical FDN | Instant. Doubles target creature's power until EOT (layer-7c `+N/+0` read from the target's power); Flashback `{4}{R}{R}`. |
| **Faebloom Trick** (FDN #38) | canonical FDN | Instant. Creates two 1/1 blue flying Faerie tokens, then a reflexive "when you do" trigger taps a target opponent creature. |
| **Cemetery Recruitment** (EMN #83) | canonical **EMN**; `Printing` rows in JMP, J22, FDN | Sorcery. Return a creature card from your graveyard; if it's a Zombie, draw a card. |
| **Charming Prince** (ELD #8) | canonical **ELD**; `Printing` row in FDN | Modal ETB — Scry 2 / gain 3 life / exile-and-return-at-next-end-step blink. |

Two cards are reprints in Foundations, so their canonical `CardDefinition` lives in the earliest real printing (EMN / ELD) with `Printing` rows contributing FDN (and JMP/J22) art per the reprint convention. `just check-card-printing` is green for all four.

## Rules-faithfulness notes
- **Faebloom Trick** models the tap as a reflexive trigger (target chosen after the tokens exist), so casting it with no opponent creatures still makes the tokens.
- **Cemetery Recruitment** checks the Zombie condition against the target's printed types while it's still the graveyard target (type is invariant across the zone change), gating the bonus draw.
- **Charming Prince**'s blink returns the exiled card at the next end step via a delayed trigger; since the target must be a creature *you own*, it returns under your control.

## Tests
Scenario tests in `rules-engine` for each card (double-power, Zombie-gated vs. non-Zombie draw, reflexive tap + token creation, gain-life mode, and the blink's exile → end-step return) — all pass. `mtg-sets` full suite (CardLint, FacadeBoundary, snapshot, discovery) green; card-snapshot goldens re-blessed for ELD, EMN, FDN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)