### PR TITLE
Add Sidequest: Catch a Fish to Final Fantasy

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -374,3 +374,37 @@ Resolved (was deferred):
   evaluate the gate against the granting permanent (mirroring the existing graveyard-play / equip
   conditional handling), so the land-play and spell-cast paths both honor the "attacked this turn"
   gate. Scenario test: `TheLunarWhaleScenarioTest`.
+
+## Implementation pass — 2026-07-03 (add-card batch)
+
+Implemented (pure authoring, no engine change):
+- **Sidequest: Catch a Fish** (#31) — `Enchantment // Land` transform DFC. Front upkeep ability is a
+  look-top → may-take → reflexive pipeline: `Effects.Pipeline { gather(TopOfLibrary(1)); chooseUpTo(1,
+  filter = Artifact or Creature); ifNotEmpty(kept) { toHand(kept); run(CreateFood()); run(TransformEffect(Self)) } }`
+  — the `ifNotEmpty` gate reproduces "if you put a card into your hand this way" exactly (a declined or
+  non-matching top card leaves the card on top and the enchantment un-transformed, per the 2025-06-06
+  ruling). The back **Cooking Campsite** is a colorless `Land`: `{T}: Add {W}` mana ability + a
+  sorcery-speed `{3},{T}, Sacrifice an artifact` activated ability that puts a +1/+1 counter on each
+  creature you control (`ForEachInGroup(Creature.youControl()) { AddCounters(PLUS_ONE_PLUS_ONE) }`).
+  Scenario test: `SidequestCatchAFishScenarioTest` (take → Food + transform; land top → no take, no Food,
+  no transform).
+
+Screened but deferred (each needs `add-feature`, not pure authoring — confirmed against source):
+- **Kain, Traitorous Dragoon** — "that player (the one dealt combat damage) gains control of Kain … you
+  draw/treasure/lose that many": no EffectTarget/Player for the damaged player as a `newController` on the
+  non-batch `DealsCombatDamageToPlayer` trigger, and no triggering-combat-damage-amount `DynamicAmount`.
+- **Firion, Wild Rose Warrior** — "create a token copy of the entering Equipment, except it has [equip-cost
+  reduction static]": `CreateTokenCopyOfTargetEffect` grants added *keywords/activated/triggered* abilities
+  but has no `addedStaticAbilities`, and equip-cost-reduction isn't a grantable static on a token copy.
+- **Emet-Selch, Unsundered** — back "During your turn, you may play cards from your graveyard" needs a
+  conditional (your-turn) wrapper the graveyard-play readers don't unwrap (only the top-of-library readers
+  do, via The Lunar Whale's fix), plus a controller-scoped "cards → exile instead of graveyard" replacement
+  (Rest in Peace's is all-players).
+- **Sidequest: Play Blitzball** — end-of-combat "if a player was dealt 6+ combat damage this turn"
+  condition doesn't exist (only a legendary-creature-specific variant), and there's no "transform this,
+  then attach it to a creature you control" effect.
+- The remaining missing FIN cards are the documented Tier-3 one-offs (Ultima → *End the turn*; Ultima,
+  Origin of Oblivion → blight land-strip; The Masamune → trigger-doubling; Gogo → copy-ability-N-times;
+  Joshua → any-number total-MV reanimation; Edgar → coin-flip-win replacement; Esper Origins →
+  spell-becomes-permanent; Kefka/Sephiroth/Zenos/Terra transform backs → per-card chapter/emblem/win-rider
+  primitives). All are `add-feature` scope.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestCatchAFish.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestCatchAFish.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Sidequest: Catch a Fish // Cooking Campsite — Final Fantasy #31
+ * {2}{W} · Enchantment // Land
+ *
+ * Front — Sidequest: Catch a Fish:
+ *   At the beginning of your upkeep, look at the top card of your library. If it's an
+ *   artifact or creature card, you may reveal it and put it into your hand. If you put a
+ *   card into your hand this way, create a Food token and transform this enchantment.
+ *
+ * Back — Cooking Campsite:
+ *   {T}: Add {W}.
+ *   {3}, {T}, Sacrifice an artifact: Put a +1/+1 counter on each creature you control.
+ *   Activate only as a sorcery.
+ *
+ * The upkeep ability is a look-top → may-take → reflexive pipeline: gather the top card,
+ * offer only an artifact/creature card for the hand, and gate the Food + transform on a card
+ * actually being taken (the reveal is a "may", so declining leaves the card on top and the
+ * enchantment un-transformed — see the 2025-06-06 ruling). The transform side lives on the
+ * land back face's activated abilities.
+ */
+private val CookingCampsite = card("Cooking Campsite") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Land"
+    oracleText = "{T}: Add {W}.\n" +
+        "{3}, {T}, Sacrifice an artifact: Put a +1/+1 counter on each creature you control. " +
+        "Activate only as a sorcery."
+
+    // {T}: Add {W}.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    // {3}, {T}, Sacrifice an artifact: Put a +1/+1 counter on each creature you control.
+    // Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{3}"),
+            Costs.Tap,
+            Costs.Sacrifice(GameObjectFilter.Artifact)
+        )
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.ForEachInGroup(
+            GroupFilter(GameObjectFilter.Creature.youControl()),
+            AddCountersEffect(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "31"
+        artist = "Gal Or"
+        flavorText = "\"Seeing how you enjoy fishing, you should learn how to prepare your catch.\"\n" +
+            "—Ignis Scientia"
+        imageUri = "https://cards.scryfall.io/normal/back/b/d/bdb5452e-d97f-409b-91d0-2664f39b09b8.jpg?1782686574"
+    }
+}
+
+private val SidequestCatchAFishFront = card("Sidequest: Catch a Fish") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your upkeep, look at the top card of your library. If it's " +
+        "an artifact or creature card, you may reveal it and put it into your hand. If you put a " +
+        "card into your hand this way, create a Food token and transform this enchantment."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Pipeline {
+            // Look at the top card of your library.
+            val looked = gather(CardSource.TopOfLibrary(DynamicAmount.Fixed(1), player = Player.You))
+            // If it's an artifact or creature card, you may reveal it and put it into your hand.
+            val kept = chooseUpTo(
+                count = 1,
+                from = looked,
+                filter = GameObjectFilter.Artifact or GameObjectFilter.Creature,
+                showAllCards = true,
+                prompt = "You may reveal this card and put it into your hand",
+                selectedLabel = "Put into your hand",
+            )
+            // If you put a card into your hand this way, create a Food token and transform.
+            ifNotEmpty(kept) {
+                toHand(kept, revealed = true)
+                run(Effects.CreateFood())
+                run(TransformEffect(EffectTarget.Self))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "31"
+        artist = "Gal Or"
+        flavorText = "\"I am Noctis, Prince of Lucis and King of Fishing!\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bdb5452e-d97f-409b-91d0-2664f39b09b8.jpg?1782686574"
+
+        ruling(
+            "2025-06-06",
+            "You don't have to reveal the card even if it's an artifact or creature card. You may " +
+                "choose not to reveal it and instead leave it on top of your library."
+        )
+    }
+}
+
+val SidequestCatchAFish: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = SidequestCatchAFishFront,
+    backFace = CookingCampsite,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -16319,6 +16319,166 @@
     ]
 }
 
+// Sidequest: Catch a Fish
+{
+    "name": "Sidequest: Catch a Fish",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your upkeep, look at the top card of your library. If it's an artifact or creature card, you may reveal it and put it into your hand. If you put a card into your hand this way, create a Food token and transform this enchantment.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeAs": "gathered0"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "gathered0",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "artifact|creature",
+                            "storeSelected": "selected1",
+                            "prompt": "You may reveal this card and put it into your hand",
+                            "selectedLabel": "Put into your hand",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "selected1",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "selected1",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Hand"
+                                        },
+                                        "revealed": true
+                                    },
+                                    {
+                                        "type": "CreatePredefinedToken",
+                                        "tokenType": "Food"
+                                    },
+                                    "Transform"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Cooking Campsite",
+        "manaCost": "",
+        "typeLine": "Land",
+        "oracleText": "{T}: Add {W}.\n{3}, {T}, Sacrifice an artifact: Put a +1/+1 counter on each creature you control. Activate only as a sorcery.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_2",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "AddMana",
+                        "color": "WHITE"
+                    },
+                    "timing": "ManaAbility",
+                    "isManaAbility": true
+                },
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{3}"
+                                }
+                            },
+                            "CostTap",
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomSacrifice",
+                                    "filter": "artifact"
+                                }
+                            }
+                        ]
+                    },
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        }
+                    },
+                    "timing": "SorcerySpeed"
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "31",
+            "rarity": "UNCOMMON",
+            "artist": "Gal Or",
+            "flavorText": "\"Seeing how you enjoy fishing, you should learn how to prepare your catch.\"\n—Ignis Scientia",
+            "imageUri": "https://cards.scryfall.io/normal/back/b/d/bdb5452e-d97f-409b-91d0-2664f39b09b8.jpg?1782686574"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "31",
+        "rarity": "UNCOMMON",
+        "artist": "Gal Or",
+        "flavorText": "\"I am Noctis, Prince of Lucis and King of Fishing!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bdb5452e-d97f-409b-91d0-2664f39b09b8.jpg?1782686574",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "You don't have to reveal the card even if it's an artifact or creature card. You may choose not to reveal it and instead leave it on top of your library."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Sidequest: Hunt the Mark
 {
     "name": "Sidequest: Hunt the Mark",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SidequestCatchAFishScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SidequestCatchAFishScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SidequestCatchAFish
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sidequest: Catch a Fish // Cooking Campsite (FIN).
+ *
+ * Front upkeep ability: look at the top card of your library; if it's an artifact or creature
+ * card you may put it into your hand, and only if you did do you create a Food token and
+ * transform the enchantment into the Cooking Campsite land.
+ *
+ * Test 1 (happy path): top card is a creature — the controller takes it, gets a Food token, and
+ * the enchantment transforms into Cooking Campsite (asserted on the same entity).
+ *
+ * Test 2 (reflexive gate): top card is a land — the "put into hand" reveal is declined (nothing
+ * eligible), so there is no Food and no transform; the permanent is still the enchantment.
+ */
+class SidequestCatchAFishScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(SidequestCatchAFish))
+        d.registerCard(PredefinedTokens.Food) // GameTestDriver doesn't auto-register tokens
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        return d
+    }
+
+    // Player 1 may not be active at game start — advance until it's player 1's upkeep.
+    fun GameTestDriver.advanceToPlayer1Upkeep() {
+        passPriorityUntil(Step.UPKEEP)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.UPKEEP)
+            safety++
+        }
+    }
+
+    // Resolve the beginning-of-upkeep trigger; it pauses on the look-at-top choice.
+    fun GameTestDriver.resolveUpkeepTrigger() {
+        var guard = 0
+        while (!isPaused && guard++ < 40) {
+            bothPass()
+            if (state.step != Step.UPKEEP && state.stack.isEmpty()) break
+        }
+    }
+
+    fun GameTestDriver.foodToken(playerId: EntityId): EntityId? = findPermanent(playerId, "Food")
+
+    test("takes an artifact/creature top card, creates Food, and transforms") {
+        val d = driver()
+        val enchant = d.putPermanentOnBattlefield(d.player1, "Sidequest: Catch a Fish")
+        val topCreature = d.putCardOnTopOfLibrary(d.player1, "Grizzly Bears")
+
+        d.advanceToPlayer1Upkeep()
+        d.resolveUpkeepTrigger()
+
+        // The look-at-top offers the creature card; take it into hand.
+        val pick = d.pendingDecision as SelectCardsDecision
+        pick.options.contains(topCreature) shouldBe true
+        d.submitDecision(d.player1, CardsSelectedResponse(decisionId = pick.id, selectedCards = listOf(topCreature)))
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // A Food token was created and the enchantment transformed into Cooking Campsite (same entity).
+        d.foodToken(d.player1).shouldNotBeNull()
+        d.getCardName(enchant) shouldBe "Cooking Campsite"
+    }
+
+    test("declines to transform when the top card is not an artifact or creature") {
+        val d = driver()
+        val enchant = d.putPermanentOnBattlefield(d.player1, "Sidequest: Catch a Fish")
+        val topLand = d.putCardOnTopOfLibrary(d.player1, "Forest")
+
+        d.advanceToPlayer1Upkeep()
+        d.resolveUpkeepTrigger()
+
+        // The land is not an artifact or creature, so it's not an eligible option. If the engine
+        // still surfaces a (declinable) look-at-top prompt, decline it by selecting nothing.
+        (d.pendingDecision as? SelectCardsDecision)?.let { pick ->
+            pick.options.contains(topLand) shouldBe false
+            d.submitDecision(d.player1, CardsSelectedResponse(decisionId = pick.id, selectedCards = emptyList()))
+            while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+        }
+
+        // No card was put into hand this way → no Food and no transform.
+        d.foodToken(d.player1).shouldBeNull()
+        d.getCardName(enchant) shouldBe "Sidequest: Catch a Fish"
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Sidequest: Catch a Fish // Cooking Campsite** (FIN #31), a `Enchantment // Land` transform DFC — pure authoring, no new engine primitives.

I picked from the 17 remaining unimplemented FIN cards and screened them for feasibility. FIN is 94% done and the remainder is the documented hard tail: **every one except Catch a Fish requires `add-feature` engine work** (control-to-damaged-player, added-static-on-token-copy, conditional graveyard-play, "End the turn", trigger-doubling, win-the-game riders, etc.). So this PR ships the one genuinely pure-authoring card, done thoroughly, and records the screening in the backlog.

### Card

**Front — Sidequest: Catch a Fish** ({2}{W} Enchantment):
> At the beginning of your upkeep, look at the top card of your library. If it's an artifact or creature card, you may reveal it and put it into your hand. If you put a card into your hand this way, create a Food token and transform this enchantment.

Modeled as an inline `Effects.Pipeline`:
```
gather(TopOfLibrary(1))
  -> chooseUpTo(1, filter = Artifact or Creature)   // "you may reveal ... put into hand"
  -> ifNotEmpty(kept) { toHand(kept); CreateFood(); TransformEffect(Self) }
```
The `ifNotEmpty` gate reproduces *"if you put a card into your hand this way"* exactly — a declined or non-matching top card is left on top and the enchantment does **not** transform (per the 2025-06-06 ruling).

**Back — Cooking Campsite** (colorless Land): `{T}: Add {W}` + a sorcery-speed `{3}, {T}, Sacrifice an artifact:` put a +1/+1 counter on each creature you control.

### Tests
- `SidequestCatchAFishScenarioTest` — creature on top → take + Food + transform to Cooking Campsite; land on top → no take, no Food, no transform. ✅
- `mtg-sets` suite (CardDefinitionSnapshotTest re-blessed, CardLintTest, FacadeBoundaryTest). ✅ Golden diff is only this card.
- Scryfall re-verified: name/cost/types/oracle/collector (31)/rarity/artist/images (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)