### PR TITLE
Add 4 Foundations reprints: River's Rebuke, Storm Fleet Spy, Mold Adder, Mindsparker

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MindsparkerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MindsparkerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mindsparker reprint in FDN. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2014 (M14); this file contributes only the FDN presentation row.
+ */
+val MindsparkerReprint = Printing(
+    oracleId = "54866c25-b332-46c8-a2c5-1a71b702ddc0",
+    name = "Mindsparker",
+    setCode = "FDN",
+    collectorNumber = "628",
+    scryfallId = "4c8b3e58-be07-451e-a5c7-61c70cc3a5a2",
+    artist = "Wayne Reynolds",
+    imageUri = "https://cards.scryfall.io/normal/front/4/c/4c8b3e58-be07-451e-a5c7-61c70cc3a5a2.jpg?1782688719",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MoldAdderReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MoldAdderReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mold Adder reprint in FDN. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Magic 2010 (M10); this file contributes only the FDN presentation row.
+ */
+val MoldAdderReprint = Printing(
+    oracleId = "2091eb7e-2357-4ef8-b15e-1e6f82176340",
+    name = "Mold Adder",
+    setCode = "FDN",
+    collectorNumber = "640",
+    scryfallId = "48d665cd-a2c6-4b81-8032-379e476b5ea5",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/4/8/48d665cd-a2c6-4b81-8032-379e476b5ea5.jpg?1782688709",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RiversRebukeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RiversRebukeReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * River's Rebuke reprint in FDN. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Ixalan (XLN); this file contributes only the FDN presentation row.
+ */
+val RiversRebukeReprint = Printing(
+    oracleId = "c52cfb41-18f3-4e73-b5e7-d75baf74e578",
+    name = "River's Rebuke",
+    setCode = "FDN",
+    collectorNumber = "595",
+    scryfallId = "32ae984e-5d1e-4497-9a71-7406f78c09f3",
+    artist = "Raymond Swanland",
+    imageUri = "https://cards.scryfall.io/normal/front/3/2/32ae984e-5d1e-4497-9a71-7406f78c09f3.jpg?1782688748",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/StormFleetSpyReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/StormFleetSpyReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Storm Fleet Spy reprint in FDN. Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in
+ * Ixalan (XLN); this file contributes only the FDN presentation row.
+ */
+val StormFleetSpyReprint = Printing(
+    oracleId = "42081a57-b521-45c2-928d-0a0a4641818d",
+    name = "Storm Fleet Spy",
+    setCode = "FDN",
+    collectorNumber = "515",
+    scryfallId = "f6c5206e-63db-44c0-86ab-f645cd358b3b",
+    artist = "Scott Murphy",
+    imageUri = "https://cards.scryfall.io/normal/front/f/6/f6c5206e-63db-44c0-86ab-f645cd358b3b.jpg?1782688816",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/MoldAdder.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m10/cards/MoldAdder.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.m10.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mold Adder
+ * {G}
+ * Creature — Fungus Snake
+ * 1/1
+ * Whenever an opponent casts a blue or black spell, you may put a +1/+1 counter on this creature.
+ *
+ * The trigger watches any opponent spell whose color set includes blue or black
+ * ([GameObjectFilter.withAnyColor]); the "you may" is the controller's optional choice
+ * ([MayEffect]) to grow this creature with a +1/+1 counter on itself ([EffectTarget.Self]).
+ */
+val MoldAdder = card("Mold Adder") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fungus Snake"
+    power = 1
+    toughness = 1
+    oracleText = "Whenever an opponent casts a blue or black spell, you may put a +1/+1 counter on this creature."
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(GameObjectFilter.Any.withAnyColor(Color.BLUE, Color.BLACK))
+        effect = MayEffect(
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "194"
+        artist = "Matt Cavotta"
+        flavorText = "The more you struggle against its coils, the tighter they get."
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a216a729-6283-4c2b-90fe-ec8f3b9c570f.jpg?1782715707"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/Mindsparker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m14/cards/Mindsparker.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.m14.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mindsparker
+ * {1}{R}{R}
+ * Creature — Elemental
+ * 3/2
+ * First strike
+ * Whenever an opponent casts a white or blue instant or sorcery spell, this creature deals 2 damage
+ * to that player.
+ *
+ * The trigger matches any opponent instant or sorcery whose color set includes white or blue
+ * ([GameObjectFilter.InstantOrSorcery] narrowed by [GameObjectFilter.withAnyColor]); "that player" is
+ * the caster of the triggering spell ([Player.TriggeringPlayer]). It is a mandatory triggered ability
+ * (not a "may"), so it always deals 2 damage to that player.
+ */
+val Mindsparker = card("Mindsparker") {
+    manaCost = "{1}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 2
+    oracleText = "First strike\n" +
+        "Whenever an opponent casts a white or blue instant or sorcery spell, this creature deals 2 damage to that player."
+
+    keywords(Keyword.FIRST_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.opponentCasts(
+            GameObjectFilter.InstantOrSorcery.withAnyColor(Color.WHITE, Color.BLUE)
+        )
+        effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "146"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a94295dc-d078-4f3f-9856-bd0a1899a9ca.jpg?1782713919"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/RiversRebukeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ncc/cards/RiversRebukeReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.ncc.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * River's Rebuke reprint in New Capenna Commander (NCC). Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Ixalan (XLN); this file contributes only the
+ * NCC presentation row.
+ */
+val RiversRebukeReprint = Printing(
+    oracleId = "c52cfb41-18f3-4e73-b5e7-d75baf74e578",
+    name = "River's Rebuke",
+    setCode = "NCC",
+    collectorNumber = "231",
+    scryfallId = "fc2a70b1-bce6-43c3-94e1-ab9a7bb2638a",
+    artist = "Raymond Swanland",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fc2a70b1-bce6-43c3-94e1-ab9a7bb2638a.jpg?1782701805",
+    releaseDate = "2022-04-29",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RiversRebuke.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/RiversRebuke.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * River's Rebuke
+ * {4}{U}{U}
+ * Sorcery
+ * Return all nonland permanents target player controls to their owner's hand.
+ *
+ * Targets a player ([Targets.Player] — either player, including the caster), then bounces every
+ * nonland permanent that player *controls* back to its owner's hand. The controller-axis match is
+ * [GameObjectFilter.targetPlayerControls], reading `context.targetPlayerId`; because
+ * [Patterns.Group.returnAllToHand] gathers with `BattlefieldMatching(player = Player.Each)` and the
+ * move routes each card to its owner's hand, a permanent the target controls but another player owns
+ * is still returned to its rightful owner (not the target).
+ */
+val RiversRebuke = card("River's Rebuke") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Return all nonland permanents target player controls to their owner's hand."
+
+    spell {
+        target("target player", Targets.Player)
+        effect = Patterns.Group.returnAllToHand(
+            GroupFilter(GameObjectFilter.NonlandPermanent.targetPlayerControls())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Raymond Swanland"
+        flavorText = "Carefully following the thaumatic compass Bolas had given her, Vraska blundered straight into the River Heralds' trap."
+        imageUri = "https://cards.scryfall.io/normal/front/f/d/fda8ef30-bbfa-4857-9750-0dd0def8b13f.jpg?1782710457"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/StormFleetSpy.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/StormFleetSpy.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Storm Fleet Spy
+ * {2}{U}
+ * Creature — Human Pirate
+ * 2/2
+ * Raid — When this creature enters, if you attacked this turn, draw a card.
+ *
+ * Raid (ability word, CR 207.2c — flavor only) is modeled as the intervening-if
+ * [Conditions.YouAttackedThisTurn] on the enters trigger (Rule 603.4): the condition is checked both
+ * when the trigger would be put on the stack and again as it resolves. "You attacked this turn" reads
+ * the controller's [com.wingedsheep.sdk.model.components.PlayerAttackedThisTurnComponent], stamped at
+ * declare-attackers and cleared at end of turn.
+ */
+val StormFleetSpy = card("Storm Fleet Spy") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    power = 2
+    toughness = 2
+    oracleText = "Raid — When this creature enters, if you attacked this turn, draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouAttackedThisTurn
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "84"
+        artist = "Scott Murphy"
+        flavorText = "\"They're searching in the same direction we are. And for the same thing, I'll wager.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7c33ef4-60bb-4f95-92a5-7abedaac6767.jpg?1782710448"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M10.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M10.json
@@ -80,6 +80,67 @@
     ]
 }
 
+// Mold Adder
+{
+    "name": "Mold Adder",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Fungus Snake",
+    "oracleText": "Whenever an opponent casts a blue or black spell, you may put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasColor",
+                                        "color": "BLUE"
+                                    },
+                                    {
+                                        "type": "HasColor",
+                                        "color": "BLACK"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "UNCOMMON",
+        "artist": "Matt Cavotta",
+        "flavorText": "The more you struggle against its coils, the tighter they get.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a216a729-6283-4c2b-90fe-ec8f3b9c570f.jpg?1782715707"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Rootbound Crag
 {
     "name": "Rootbound Crag",

--- a/mtg-sets/src/test/resources/snapshots/cards/M14.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M14.json
@@ -66,6 +66,77 @@
     "colorIdentityOverride": []
 }
 
+// Mindsparker
+{
+    "name": "Mindsparker",
+    "manaCost": "{1}{R}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "First strike\nWhenever an opponent casts a white or blue instant or sorcery spell, this creature deals 2 damage to that player.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FIRST_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsInstant",
+                                    "IsSorcery"
+                                ]
+                            },
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    {
+                                        "type": "HasColor",
+                                        "color": "WHITE"
+                                    },
+                                    {
+                                        "type": "HasColor",
+                                        "color": "BLUE"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "146",
+        "rarity": "RARE",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a94295dc-d078-4f3f-9856-bd0a1899a9ca.jpg?1782713919"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Primeval Bounty
 {
     "name": "Primeval Bounty",

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -389,6 +389,53 @@
     ]
 }
 
+// River's Rebuke
+{
+    "name": "River's Rebuke",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return all nonland permanents target player controls to their owner's hand.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "nonland permanent ctrl:target-player"
+                    },
+                    "storeAs": "returnAllToHand_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "returnAllToHand_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target player"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "Raymond Swanland",
+        "flavorText": "Carefully following the thaumatic compass Bolas had given her, Vraska blundered straight into the River Heralds' trap.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/d/fda8ef30-bbfa-4857-9750-0dd0def8b13f.jpg?1782710457"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sailor of Means
 {
     "name": "Sailor of Means",
@@ -492,6 +539,59 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Storm Fleet Spy
+{
+    "name": "Storm Fleet Spy",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "Raid — When this creature enters, if you attacked this turn, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "PLAYER_ATTACKED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Murphy",
+        "flavorText": "\"They're searching in the same direction we are. And for the same thing, I'll wager.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7c33ef4-60bb-4f95-92a5-7abedaac6767.jpg?1782710448"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 


### PR DESCRIPTION
## Summary

Implements a handful of cards from Foundations (FDN). Each is a reprint, so the canonical `CardDefinition` lives in its **earliest real printing** and FDN gets a `Printing` row only (River's Rebuke also gets an NCC row, since that set is scaffolded).

| Card | Canonical set | Oracle |
|------|---------------|--------|
| **River's Rebuke** | XLN | Return all nonland permanents target player controls to their owner's hand. |
| **Storm Fleet Spy** | XLN | Raid — When this creature enters, if you attacked this turn, draw a card. |
| **Mold Adder** | M10 | Whenever an opponent casts a blue or black spell, you may put a +1/+1 counter on this creature. |
| **Mindsparker** | M14 | First strike; whenever an opponent casts a white or blue instant or sorcery spell, deal 2 damage to that player. |

## Implementation notes

All four compose **existing** SDK building blocks — no new engine mechanics:

- **River's Rebuke** → `Patterns.Group.returnAllToHand(GroupFilter(GameObjectFilter.NonlandPermanent.targetPlayerControls()))`. Gathers with `Player.Each` and routes each card to its *owner's* hand, so control-changed permanents still return to their rightful owner.
- **Storm Fleet Spy** → enters trigger with the intervening-if `triggerCondition = Conditions.YouAttackedThisTurn` (Raid is an ability word, flavor only).
- **Mold Adder** → `Triggers.opponentCasts(GameObjectFilter.Any.withAnyColor(BLUE, BLACK))` + `MayEffect(AddCounters(+1/+1, Self))`.
- **Mindsparker** → `Triggers.opponentCasts(GameObjectFilter.InstantOrSorcery.withAnyColor(WHITE, BLUE))` + `DealDamage(2, PlayerRef(TriggeringPlayer))`, plus First Strike.

## Verification

- `just build` green (compile + `CardLintTest` + `CardDefinitionSnapshotTest` + rules-engine tests).
- Re-blessed M10/M14/XLN card snapshots — diff is **only** the 4 new cards added (232 insertions, 0 deletions; no other card trees changed).
- `just check-card-printing` passes for all four (canonical in earliest real set; every scaffolded printing has a row).

Since these cards introduce no new effects/triggers/conditions, no new scenario tests are required (per the add-card skill); correctness rests on the existing executors they reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)