### PR TITLE
Default newly created lobbies to private again

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ClientMessage.kt
@@ -165,7 +165,7 @@ sealed interface ClientMessage {
         val boosterCount: Int = 6,         // Sealed: boosters in pool, Draft: packs per player
         val maxPlayers: Int = 8,
         val pickTimeSeconds: Int = 45,     // Draft only
-        val isPublic: Boolean = true,      // Created lobbies are public by default; host can make private in the lobby.
+        val isPublic: Boolean = false,     // Created lobbies are private by default; host can make public in the lobby.
         /** Master switch for in-app AI assistance (Suggest Pick / Auto-build). Defaults off. */
         val aiAssistEnabled: Boolean = false,
         /** Lobby mode axis: "TOURNAMENT" (default) or "FREE_FOR_ALL" (one multiplayer game, 2-6 players). */
@@ -475,8 +475,8 @@ sealed interface ClientMessage {
     data class CreateQuickGameLobby(
         val vsAi: Boolean = false,
         val setCode: String? = null,
-        // Created lobbies are public by default; host can make private in the lobby. AI lobbies stay private (see handler).
-        val isPublic: Boolean = true,
+        // Created lobbies are private by default; host can make public in the lobby. AI lobbies stay private (see handler).
+        val isPublic: Boolean = false,
         val format: com.wingedsheep.sdk.core.DeckFormat? = null,
         /**
          * When true the lobby plays the Momir Basic Vanguard format: no deckbuilding (fixed 60

--- a/web-client/src/store/slices/lobbySlice.ts
+++ b/web-client/src/store/slices/lobbySlice.ts
@@ -73,7 +73,7 @@ export const createLobbySlice: SliceCreator<LobbySlice> = (set, get) => ({
   disconnectedPlayers: {},
 
   // Actions
-  createTournamentLobby: (setCodes, format = 'SEALED', boosterCount = 6, maxPlayers = 8, pickTimeSeconds = 45, isPublic = true, gameMode = 'TOURNAMENT') => {
+  createTournamentLobby: (setCodes, format = 'SEALED', boosterCount = 6, maxPlayers = 8, pickTimeSeconds = 45, isPublic = false, gameMode = 'TOURNAMENT') => {
     clearDeckState()
     set({ deckBuildingState: null })
     trackEvent('tournament_lobby_created', { set_codes: setCodes, format, booster_count: boosterCount, max_players: maxPlayers, is_public: isPublic, game_mode: gameMode })

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -2402,7 +2402,7 @@ export function createCreateTournamentLobbyMessage(
   boosterCount: number = 6,
   maxPlayers: number = 8,
   pickTimeSeconds: number = 45,
-  isPublic: boolean = true,
+  isPublic: boolean = false,
   gameMode: LobbyGameMode = 'TOURNAMENT'
 ): CreateTournamentLobbyMessage {
   return { type: 'createTournamentLobby', setCodes, format, boosterCount, maxPlayers, pickTimeSeconds, isPublic, gameMode }


### PR DESCRIPTION
Reverts the creation-default flip from d5edf2736 ("Default newly created lobbies to public"). New Quick Game and Tournament lobbies are once again created **private** (`isPublic = false`); the host can still flip the Private/Public toggle inside the lobby to make it publicly listable.

## Changes
- `CreateQuickGameLobby.isPublic` and `CreateTournamentLobby.isPublic` server DTO defaults back to `false`. AI lobbies were already private via the `message.isPublic && !message.vsAi` guard in `QuickGameLobbyHandler`.
- Client defaults (`lobbySlice.createTournamentLobby` and the tournament message builder) back to `false`. Quick Game already omits `isPublic` when falsy, so it inherits the server default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)