### PR TITLE
Add 5 Foundations cards (Kitesail Corsair, Mocking Sprite, Firespitter Whelp, Giant Cindermaw, Pirate's Cutlass)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/GiantCindermaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/GiantCindermaw.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.PreventLifeGain
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Giant Cindermaw
+ * {2}{R}
+ * Creature — Dinosaur Beast
+ * 4/3
+ * Trample
+ * Players can't gain life.
+ */
+val GiantCindermaw = card("Giant Cindermaw") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur Beast"
+    power = 4
+    toughness = 3
+    oracleText = "Trample\nPlayers can't gain life."
+
+    keywords(Keyword.TRAMPLE)
+
+    replacementEffect(PreventLifeGain(appliesTo = EventPattern.LifeGainEvent(player = Player.Each)))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "136"
+        artist = "Edgar Sánchez Hidalgo"
+        flavorText = "\"Don't excavate too far into those canyons. I promised your parents I'd return you in one piece.\"\n—Tocasia"
+        imageUri = "https://cards.scryfall.io/normal/front/1/3/1349465f-d29f-4d4b-a653-f4388574c336.jpg?1782699769"
+        ruling("2022-10-14", "Spells and abilities that cause players to gain life still resolve while Giant Cindermaw is on the battlefield. No player will gain life, but any other effects of that spell or ability will happen.")
+        ruling("2022-10-14", "If an effect says to set a player's life total to a number that's higher than the player's current life total while Giant Cindermaw is on the battlefield, the player's life total doesn't change.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/KitesailCorsairReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/KitesailCorsairReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kitesail Corsair reprint in Commander Legends. Canonical CardDefinition lives in its earliest set (RIX).
+ */
+val KitesailCorsairReprint = Printing(
+    oracleId = "6103f294-f920-4307-af80-d44cc71167fd",
+    name = "Kitesail Corsair",
+    setCode = "CMR",
+    collectorNumber = "76",
+    scryfallId = "4534ffdd-9965-4e55-9c25-04123720cbba",
+    artist = "Greg Opalinski",
+    imageUri = "https://cards.scryfall.io/normal/front/4/5/4534ffdd-9965-4e55-9c25-04123720cbba.jpg?1782706048",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/PiratesCutlassReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/PiratesCutlassReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pirate's Cutlass reprint in Commander Legends. Canonical CardDefinition lives in its earliest set (XLN).
+ */
+val PiratesCutlassReprint = Printing(
+    oracleId = "ac77591c-39d7-4fd1-a6e9-805f57c6614a",
+    name = "Pirate's Cutlass",
+    setCode = "CMR",
+    collectorNumber = "333",
+    scryfallId = "c5dc0635-0cc4-419e-ab64-c07a69f34f75",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/c/5/c5dc0635-0cc4-419e-ab64-c07a69f34f75.jpg?1782705888",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FirespitterWhelp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FirespitterWhelp.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Firespitter Whelp
+ * {2}{R}
+ * Creature — Dragon
+ * 2/2
+ * Flying
+ * Whenever you cast a noncreature or Dragon spell, this creature deals 1 damage to each opponent.
+ */
+val FirespitterWhelp = card("Firespitter Whelp") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever you cast a noncreature or Dragon spell, this creature deals 1 damage to each opponent."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(
+            spellFilter = GameObjectFilter.Noncreature or GameObjectFilter.Any.withSubtype(Subtype.DRAGON)
+        )
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "761"
+        artist = "David Álvarez"
+        flavorText = "In subsequent terms, first-year students were prohibited from enrolling in Introduction to Dragonkeeping."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddcc3c1b-b564-4444-9a1a-0f62f8e6b8bb.jpg?1782683456"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GiantCindermawReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GiantCindermawReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Giant Cindermaw reprint in FDN. Canonical CardDefinition lives in its earliest set (BRO).
+ */
+val GiantCindermawReprint = Printing(
+    oracleId = "bd0c0e85-ff24-46c9-a547-4f633355c131",
+    name = "Giant Cindermaw",
+    setCode = "FDN",
+    collectorNumber = "624",
+    scryfallId = "d65f5298-0e57-49cf-aaf5-2bb16f3e636c",
+    artist = "Edgar Sánchez Hidalgo",
+    imageUri = "https://cards.scryfall.io/normal/front/d/6/d65f5298-0e57-49cf-aaf5-2bb16f3e636c.jpg?1782688724",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KitesailCorsairReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KitesailCorsairReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kitesail Corsair reprint in FDN. Canonical CardDefinition lives in its earliest set (RIX).
+ */
+val KitesailCorsairReprint = Printing(
+    oracleId = "6103f294-f920-4307-af80-d44cc71167fd",
+    name = "Kitesail Corsair",
+    setCode = "FDN",
+    collectorNumber = "743",
+    scryfallId = "aa127602-10b2-4144-985b-38e075f1e1f7",
+    artist = "Greg Opalinski",
+    imageUri = "https://cards.scryfall.io/normal/front/a/a/aa127602-10b2-4144-985b-38e075f1e1f7.jpg?1782683473",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MockingSpriteReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MockingSpriteReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mocking Sprite reprint in FDN. Canonical CardDefinition lives in its earliest set (WOE).
+ */
+val MockingSpriteReprint = Printing(
+    oracleId = "013ca531-1ff7-4efc-a280-4bc3ab574072",
+    name = "Mocking Sprite",
+    setCode = "FDN",
+    collectorNumber = "744",
+    scryfallId = "d52d16be-c74b-4e40-94f9-2ffa497b6337",
+    artist = "Ben Hill",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d52d16be-c74b-4e40-94f9-2ffa497b6337.jpg?1782683471",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PiratesCutlassReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PiratesCutlassReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pirate's Cutlass reprint in FDN. Canonical CardDefinition lives in its earliest set (XLN).
+ */
+val PiratesCutlassReprint = Printing(
+    oracleId = "ac77591c-39d7-4fd1-a6e9-805f57c6614a",
+    name = "Pirate's Cutlass",
+    setCode = "FDN",
+    collectorNumber = "563",
+    scryfallId = "d9d20aef-d35b-4353-a241-e6cfa9730975",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/d/9/d9d20aef-d35b-4353-a241-e6cfa9730975.jpg?1782688775",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KitesailCorsairReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/KitesailCorsairReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kitesail Corsair reprint in Jumpstart. Canonical CardDefinition lives in its earliest set (RIX).
+ */
+val KitesailCorsairReprint = Printing(
+    oracleId = "6103f294-f920-4307-af80-d44cc71167fd",
+    name = "Kitesail Corsair",
+    setCode = "JMP",
+    collectorNumber = "155",
+    scryfallId = "36056deb-a7f8-4bb3-9c51-890e96f41482",
+    artist = "Greg Opalinski",
+    imageUri = "https://cards.scryfall.io/normal/front/3/6/36056deb-a7f8-4bb3-9c51-890e96f41482.jpg?1782706681",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PiratesCutlassReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jmp/cards/PiratesCutlassReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.jmp.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pirate's Cutlass reprint in Jumpstart. Canonical CardDefinition lives in its earliest set (XLN).
+ */
+val PiratesCutlassReprint = Printing(
+    oracleId = "ac77591c-39d7-4fd1-a6e9-805f57c6614a",
+    name = "Pirate's Cutlass",
+    setCode = "JMP",
+    collectorNumber = "477",
+    scryfallId = "b1ff526b-3822-4073-baab-8ea5f95daf91",
+    artist = "John Stanko",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b1ff526b-3822-4073-baab-8ea5f95daf91.jpg?1782706494",
+    releaseDate = "2020-07-17",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/KitesailCorsair.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/rix/cards/KitesailCorsair.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.rix.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Kitesail Corsair
+ * {1}{U}
+ * Creature — Human Pirate
+ * 2/1
+ * This creature has flying as long as it's attacking.
+ */
+val KitesailCorsair = card("Kitesail Corsair") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Pirate"
+    power = 2
+    toughness = 1
+    oracleText = "This creature has flying as long as it's attacking."
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.FLYING, GroupFilter.source())
+        condition = Conditions.SourceIsAttacking
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Greg Opalinski"
+        flavorText = "\"Why perch in the crow's nest when I can fly like the crows?\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b8d0e8d-c2d4-4682-8095-827ffd79539b.jpg?1782710294"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MockingSprite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/MockingSprite.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Mocking Sprite
+ * {2}{U}
+ * Creature — Faerie Rogue
+ * 2/1
+ * Flying
+ * Instant and sorcery spells you cast cost {1} less to cast.
+ */
+val MockingSprite = card("Mocking Sprite") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Rogue"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\nInstant and sorcery spells you cast cost {1} less to cast."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(GameObjectFilter.InstantOrSorcery),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "62"
+        artist = "Ben Hill"
+        flavorText = "\"Look at me, everyone! I'm a High Fae! Watch me do important High Fae things!\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/5/e595014d-4ff4-4561-b7f2-a9bd56300b01.jpg?1782696613"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/PiratesCutlass.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/xln/cards/PiratesCutlass.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.xln.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Pirate's Cutlass
+ * {3}
+ * Artifact — Equipment
+ * When this Equipment enters, attach it to target Pirate you control.
+ * Equipped creature gets +2/+1.
+ * Equip {2}
+ */
+val PiratesCutlass = card("Pirate's Cutlass") {
+    manaCost = "{3}"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, attach it to target Pirate you control.\n" +
+        "Equipped creature gets +2/+1.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val pirate = target(
+            "target Pirate you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.PIRATE))
+        )
+        effect = Effects.AttachEquipment(pirate)
+    }
+
+    staticAbility {
+        ability = ModifyStats(+2, +1, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "242"
+        artist = "John Stanko"
+        imageUri = "https://cards.scryfall.io/normal/front/b/3/b3e7e871-19cf-486d-bacb-1499fe066974.jpg?1782710346"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BRO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BRO.json
@@ -206,6 +206,52 @@
     ]
 }
 
+// Giant Cindermaw
+{
+    "name": "Giant Cindermaw",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Dinosaur Beast",
+    "oracleText": "Trample\nPlayers can't gain life.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "PreventLifeGain",
+                "appliesTo": {
+                    "type": "LifeGainEvent",
+                    "player": "Each"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "rarity": "UNCOMMON",
+        "artist": "Edgar Sánchez Hidalgo",
+        "flavorText": "\"Don't excavate too far into those canyons. I promised your parents I'd return you in one piece.\"\n—Tocasia",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/3/1349465f-d29f-4d4b-a653-f4388574c336.jpg?1782699769",
+        "rulings": [
+            {
+                "date": "2022-10-14",
+                "text": "Spells and abilities that cause players to gain life still resolve while Giant Cindermaw is on the battlefield. No player will gain life, but any other effects of that spell or ability will happen."
+            },
+            {
+                "date": "2022-10-14",
+                "text": "If an effect says to set a player's life total to a number that's higher than the player's current life total while Giant Cindermaw is on the battlefield, the player's life total doesn't change."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Goblin Firebomb
 {
     "name": "Goblin Firebomb",

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -1977,6 +1977,67 @@
     ]
 }
 
+// Firespitter Whelp
+{
+    "name": "Firespitter Whelp",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhenever you cast a noncreature or Dragon spell, this creature deals 1 damage to each opponent.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            {
+                                "type": "Or",
+                                "predicates": [
+                                    "IsNoncreature",
+                                    {
+                                        "type": "HasSubtype",
+                                        "subtype": "Dragon"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "761",
+        "rarity": "UNCOMMON",
+        "artist": "David Álvarez",
+        "flavorText": "In subsequent terms, first-year students were prohibited from enrolling in Introduction to Dragonkeeping.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/ddcc3c1b-b564-4444-9a1a-0f62f8e6b8bb.jpg?1782683456"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Fleeting Flight
 {
     "name": "Fleeting Flight",

--- a/mtg-sets/src/test/resources/snapshots/cards/RIX.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/RIX.json
@@ -180,6 +180,47 @@
     ]
 }
 
+// Kitesail Corsair
+{
+    "name": "Kitesail Corsair",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Pirate",
+    "oracleText": "This creature has flying as long as it's attacking.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": "attacking"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Greg Opalinski",
+        "flavorText": "\"Why perch in the crow's nest when I can fly like the crows?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b8d0e8d-c2d4-4682-8095-827ffd79539b.jpg?1782710294"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Moment of Craving
 {
     "name": "Moment of Craving",

--- a/mtg-sets/src/test/resources/snapshots/cards/WOE.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WOE.json
@@ -1523,6 +1523,45 @@
     ]
 }
 
+// Mocking Sprite
+{
+    "name": "Mocking Sprite",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Faerie Rogue",
+    "oracleText": "Flying\nInstant and sorcery spells you cast cost {1} less to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "instant|sorcery"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "artist": "Ben Hill",
+        "flavorText": "\"Look at me, everyone! I'm a High Fae! Watch me do important High Fae things!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/5/e595014d-4ff4-4561-b7f2-a9bd56300b01.jpg?1782696613"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Moment of Valor
 {
     "name": "Moment of Valor",

--- a/mtg-sets/src/test/resources/snapshots/cards/XLN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/XLN.json
@@ -352,6 +352,82 @@
     ]
 }
 
+// Pirate's Cutlass
+{
+    "name": "Pirate's Cutlass",
+    "manaCost": "{3}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "When this Equipment enters, attach it to target Pirate you control.\nEquipped creature gets +2/+1.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Pirate you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature Pirate ctrl:you"
+                    },
+                    "id": "target Pirate you control"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "242",
+        "artist": "John Stanko",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/3/b3e7e871-19cf-486d-bacb-1499fe066974.jpg?1782710346"
+    }
+}
+
 // Prosperous Pirates
 {
     "name": "Prosperous Pirates",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FirespitterWhelpScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FirespitterWhelpScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.FirespitterWhelp
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Firespitter Whelp — {2}{R} Creature — Dragon 2/2
+ *
+ * "Flying
+ *  Whenever you cast a noncreature or Dragon spell, this creature deals 1 damage to each opponent."
+ */
+class FirespitterWhelpScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(FirespitterWhelp)
+        return driver
+    }
+
+    test("casting a noncreature spell deals 1 damage to each opponent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.putCreatureOnBattlefield(me, "Firespitter Whelp")
+
+        // A creature for the bolt to hit, so opponent life only reflects the Whelp trigger.
+        val bears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        val bolt = driver.putCardInHand(me, "Lightning Bolt")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, bolt, targets = listOf(bears))
+        driver.bothPass() // resolve the Whelp's cast trigger (1 to each opponent)
+        driver.bothPass() // resolve Lightning Bolt (3 to the Bears)
+
+        driver.getLifeTotal(opponent) shouldBe 19
+    }
+
+    test("casting a Dragon creature spell also triggers the ability") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        driver.putCreatureOnBattlefield(me, "Firespitter Whelp")
+
+        // Casting a second Firespitter Whelp is casting a Dragon spell → the first one triggers.
+        val secondWhelp = driver.putCardInHand(me, "Firespitter Whelp")
+        driver.giveMana(me, Color.RED, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, secondWhelp)
+        driver.bothPass() // resolve the cast trigger (1 to each opponent)
+        driver.bothPass() // resolve the Dragon spell
+
+        driver.getLifeTotal(opponent) shouldBe 19
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiantCindermawScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiantCindermawScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.bro.cards.GiantCindermaw
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Giant Cindermaw — {2}{R} Creature — Dinosaur Beast 4/3
+ *
+ * "Trample
+ *  Players can't gain life."
+ */
+class GiantCindermawScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // Inline test spell: "You gain 3 life." Verifies life gain is prevented while Cindermaw is out.
+    val GainThreeLife = CardDefinition.instant(
+        name = "Gain Three Life",
+        manaCost = ManaCost.parse("{W}"),
+        oracleText = "You gain 3 life.",
+        script = CardScript.spell(effect = Effects.GainLife(3))
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(GiantCindermaw, GainThreeLife))
+        return driver
+    }
+
+    test("has trample") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 30), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val maw = driver.putCreatureOnBattlefield(me, "Giant Cindermaw")
+
+        projector.project(driver.state).hasKeyword(maw, Keyword.TRAMPLE) shouldBe true
+    }
+
+    test("prevents all players from gaining life") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 20, "Plains" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(me, "Giant Cindermaw")
+
+        // A spell would gain 3 life — but no life is gained while Cindermaw is out.
+        val gain = driver.putCardInHand(me, "Gain Three Life")
+        driver.giveMana(me, Color.WHITE, 1)
+        driver.castSpell(me, gain)
+        driver.bothPass()
+
+        driver.getLifeTotal(me) shouldBe 20
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KitesailCorsairScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KitesailCorsairScenarioTest.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rix.cards.KitesailCorsair
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kitesail Corsair — {1}{U} Creature — Human Pirate 2/1
+ *
+ * "This creature has flying as long as it's attacking."
+ */
+class KitesailCorsairScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(KitesailCorsair)
+        return driver
+    }
+
+    test("gains flying only while attacking") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+        val corsair = driver.putCreatureOnBattlefield(me, "Kitesail Corsair")
+        driver.removeSummoningSickness(corsair)
+
+        // Not attacking yet → no flying.
+        projector.project(driver.state).hasKeyword(corsair, Keyword.FLYING) shouldBe false
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(corsair), opponent)
+
+        // While attacking → has flying.
+        projector.project(driver.state).hasKeyword(corsair, Keyword.FLYING) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MockingSpriteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MockingSpriteScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.woe.cards.MockingSprite
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Mocking Sprite — {2}{U} Creature — Faerie Rogue 2/1
+ *
+ * "Flying
+ *  Instant and sorcery spells you cast cost {1} less to cast."
+ */
+class MockingSpriteScenarioTest : FunSpec({
+
+    // Inline {2} instant that gains 2 life — cheap enough to observe the reduction:
+    // with the Sprite out it costs {1}, so a single mana in the pool pays for it.
+    val GainTwoLife = CardDefinition.instant(
+        name = "Gain Two Life",
+        manaCost = ManaCost.parse("{2}"),
+        oracleText = "You gain 2 life.",
+        script = CardScript.spell(effect = Effects.GainLife(2))
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(MockingSprite, GainTwoLife))
+        return driver
+    }
+
+    test("instant and sorcery spells you cast cost {1} less") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        driver.putCreatureOnBattlefield(driver.activePlayer!!, "Mocking Sprite")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val spell = driver.putCardInHand(me, "Gain Two Life")
+
+        // Only one generic mana available. Without the Sprite the {2} spell would be
+        // unaffordable; the {1} reduction makes it castable.
+        driver.giveColorlessMana(me, 1)
+        driver.castSpell(me, spell)
+        driver.bothPass()
+
+        driver.getLifeTotal(me) shouldBe 22
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PiratesCutlassScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PiratesCutlassScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.rix.cards.KitesailCorsair
+import com.wingedsheep.mtg.sets.definitions.xln.cards.PiratesCutlass
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pirate's Cutlass — {3} Artifact — Equipment
+ *
+ * "When this Equipment enters, attach it to target Pirate you control.
+ *  Equipped creature gets +2/+1.
+ *  Equip {2}"
+ */
+class PiratesCutlassScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(listOf(PiratesCutlass, KitesailCorsair))
+        return driver
+    }
+
+    test("ETB attaches to a target Pirate, granting +2/+1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val corsair = driver.putCreatureOnBattlefield(me, "Kitesail Corsair") // 2/1 Pirate
+
+        projector.getProjectedPower(driver.state, corsair) shouldBe 2
+        projector.getProjectedToughness(driver.state, corsair) shouldBe 1
+
+        val cutlass = driver.putCardInHand(me, "Pirate's Cutlass")
+        driver.giveColorlessMana(me, 3)
+        driver.castSpell(me, cutlass)
+        driver.bothPass() // resolve the equipment spell -> it enters -> ETB trigger on stack
+        driver.bothPass() // resolve ETB trigger -> pauses for target selection
+
+        driver.submitTargetSelection(me, listOf(corsair))
+        driver.bothPass()
+
+        // Attached to the Pirate, with +2/+1.
+        val cutlassId = driver.findPermanent(me, "Pirate's Cutlass")!!
+        driver.state.getEntity(cutlassId)?.get<AttachedToComponent>()?.targetId shouldBe corsair
+        projector.getProjectedPower(driver.state, corsair) shouldBe 4
+        projector.getProjectedToughness(driver.state, corsair) shouldBe 2
+    }
+})


### PR DESCRIPTION
## Summary

Implements a handful of **Foundations (FDN)** cards via the `add-card` flow. All five reuse existing engine mechanics — no new SDK types, effects, triggers, conditions, or keywords were introduced. Canonical `CardDefinition`s live in each card's earliest real printing; FDN (and other scaffolded reprint sets) get `Printing` rows.

| Card | Canonical set | Reprint rows | Mechanic |
|------|---------------|--------------|----------|
| Kitesail Corsair | RIX | JMP, CMR, FDN | `GrantKeyword(FLYING)` gated by `Conditions.SourceIsAttacking` |
| Mocking Sprite | WOE | FDN | Flying + `ModifySpellCost(YouCast(InstantOrSorcery), ReduceGeneric(1))` |
| Firespitter Whelp | FDN (native) | — | Flying + `youCastSpell(Noncreature or …Dragon)` → 1 dmg to each opponent |
| Giant Cindermaw | BRO | FDN | Trample + `PreventLifeGain(Each)` |
| Pirate's Cutlass | XLN | JMP, CMR, FDN | ETB `AttachEquipment` to target Pirate, `ModifyStats(+2/+1)`, Equip {2} |

## Testing

- New Kotest scenario tests for all five cards (`:rules-engine`) — **all pass**:
  - Kitesail gains flying only while attacking
  - Firespitter fires on both a noncreature spell and a Dragon creature spell
  - Giant Cindermaw has trample and prevents life gain
  - Pirate's Cutlass ETB-attaches and applies +2/+1
  - Mocking Sprite makes a {2} instant castable for {1}
- `CardDefinitionSnapshotTest` re-blessed for BRO/FDN/RIX/WOE/XLN (diff is additive — only these five card trees).
- `CardLintTest` + full multi-module compile (`build -x test`) pass.
- `just check-card-printing` reports `ok` for all five (canonical in earliest printing, all scaffolded reprints rowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)