### PR TITLE
Add Kain, Traitorous Dragoon (Final Fantasy)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/KainTraitorousDragoon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/KainTraitorousDragoon.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kain, Traitorous Dragoon
+ * {2}{B}
+ * Legendary Creature — Human Knight
+ * 2/4
+ *
+ * Jump — During your turn, Kain has flying.
+ * Whenever Kain deals combat damage to a player, that player gains control of Kain. If they do,
+ * you draw that many cards, create that many tapped Treasure tokens, then lose that much life.
+ *
+ * "Jump" is modelled as a conditional static ability (Rule 604): while it's your turn, Kain grants
+ * itself flying via [GroupFilter.source]. The rest of the time it has no evasion, so it can be blocked.
+ *
+ * The combat-damage trigger hands Kain to the damaged player. "That player" is
+ * [Player.TriggeringPlayer], resolved through the existing [GiveControlToTargetPlayerEffect]
+ * (newController = the triggering player, permanent = Kain itself). "If they do" is gated on the
+ * control actually moving via [SuccessCriterion.ControlChanged] — so if a "can't gain control"
+ * effect or Kain leaving the battlefield stops the hand-off, the rider is withheld, per the printed
+ * text. The three riders all scale off the combat damage dealt ("that many/much"), read from
+ * [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT]. They resolve for *you* — the ability's controller,
+ * fixed when it triggered — not the new controller, matching "you draw / you lose".
+ */
+val KainTraitorousDragoon = card("Kain, Traitorous Dragoon") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Knight"
+    oracleText = "Jump — During your turn, Kain has flying.\n" +
+        "Whenever Kain deals combat damage to a player, that player gains control of Kain. " +
+        "If they do, you draw that many cards, create that many tapped Treasure tokens, then lose that much life."
+    power = 2
+    toughness = 4
+
+    // Jump — During your turn, Kain has flying.
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(keyword = Keyword.FLYING, filter = GroupFilter.source())
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val damageDealt = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+        effect = IfYouDoEffect(
+            action = GiveControlToTargetPlayerEffect(
+                permanent = EffectTarget.Self,
+                newController = EffectTarget.PlayerRef(Player.TriggeringPlayer),
+            ),
+            ifYouDo = Effects.Composite(
+                listOf(
+                    Effects.DrawCards(damageDealt),
+                    Effects.CreateTreasure(count = damageDealt, tapped = true),
+                    Effects.LoseLife(amount = damageDealt, target = EffectTarget.PlayerRef(Player.You)),
+                ),
+            ),
+            successCriterion = SuccessCriterion.ControlChanged,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "105"
+        artist = "Russell Dongjun Lu"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8c86be0-e1b3-4a78-9254-238dd936914b.jpg?1782686519"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -9526,6 +9526,100 @@
     ]
 }
 
+// Kain, Traitorous Dragoon
+{
+    "name": "Kain, Traitorous Dragoon",
+    "manaCost": "{2}{B}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "Jump — During your turn, Kain has flying.\nWhenever Kain deals combat damage to a player, that player gains control of Kain. If they do, you draw that many cards, create that many tapped Treasure tokens, then lose that much life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "GiveControlToTargetPlayer",
+                            "permanent": "Self",
+                            "newController": {
+                                "type": "PlayerRef",
+                                "player": "TriggeringPlayer"
+                            }
+                        },
+                        "successCriterion": "SuccessCriterion.ControlChanged"
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                }
+                            },
+                            {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure",
+                                "tapped": true,
+                                "dynamicCount": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                }
+                            },
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "You"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "RARE",
+        "artist": "Russell Dongjun Lu",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8c86be0-e1b3-4a78-9254-238dd936914b.jpg?1782686519"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Kuja, Genome Sorcerer
 {
     "name": "Kuja, Genome Sorcerer",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KainTraitorousDragoonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KainTraitorousDragoonScenarioTest.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.KainTraitorousDragoon
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kain, Traitorous Dragoon (FIN 105) — {2}{B} Legendary Creature — Human Knight, 2/4.
+ *
+ * "Jump — During your turn, Kain has flying.
+ *  Whenever Kain deals combat damage to a player, that player gains control of Kain. If they do,
+ *  you draw that many cards, create that many tapped Treasure tokens, then lose that much life."
+ *
+ * Proves the composition:
+ *  - Jump grants flying only while it's the controller's turn (conditional static ability).
+ *  - On combat damage, control of Kain moves to the damaged player, and — gated on the control
+ *    actually moving — the ability's original controller draws / mints tapped Treasures / loses
+ *    life equal to the combat damage dealt.
+ */
+class KainTraitorousDragoonScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(
+            TestCards.all +
+                com.wingedsheep.mtg.sets.tokens.PredefinedTokens.allTokens +
+                KainTraitorousDragoon,
+        )
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20, skipMulligans = true)
+        return d
+    }
+
+    fun treasureCount(d: GameTestDriver, player: EntityId, tappedOnly: Boolean): Int =
+        d.getPermanents(player).count { id ->
+            d.state.getEntity(id)?.get<CardComponent>()?.name == "Treasure" &&
+                (!tappedOnly || d.isTapped(id))
+        }
+
+    test("Jump — Kain has flying during its controller's turn, but not on the opponent's turn") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+
+        val kain = d.putCreatureOnBattlefield(p1, "Kain, Traitorous Dragoon")
+
+        // p1 is the active player, so it's the controller's turn: Kain has flying.
+        d.state.projectedState.hasKeyword(kain, Keyword.FLYING) shouldBe true
+
+        // Advance to the opponent's turn.
+        var guard = 0
+        while (d.activePlayer != p2 && guard++ < 4) {
+            d.passPriorityUntil(Step.END)
+            d.bothPass()
+        }
+        d.activePlayer shouldBe p2
+
+        // It is no longer Kain's controller's turn, so Jump no longer grants flying.
+        d.state.projectedState.hasKeyword(kain, Keyword.FLYING) shouldBe false
+    }
+
+    test("combat damage hands Kain to the damaged player and pays off the rider") {
+        val d = driver()
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+
+        val kain = d.putCreatureOnBattlefield(p1, "Kain, Traitorous Dragoon")
+        d.removeSummoningSickness(kain)
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(p1, listOf(kain), p2)
+        d.bothPass()
+        d.declareNoBlockers(p2)
+
+        val handBefore = d.getHandSize(p1)
+
+        // Pass priority so combat damage is dealt and the mandatory trigger resolves. The control
+        // change is a Layer.CONTROL floating effect, so it shows up in projected state.
+        var guard = 0
+        while (d.state.projectedState.getController(kain) != p2 && guard++ < 12) {
+            d.bothPass()
+        }
+
+        // Kain (2/4) dealt 2 combat damage → "that player" (p2) now controls Kain.
+        d.state.projectedState.getController(kain) shouldBe p2
+        // "If they do" — control moved, so the riders fire, all scaling off the 2 damage dealt:
+        d.getHandSize(p1) shouldBe handBefore + 2          // you draw that many cards
+        treasureCount(d, p1, tappedOnly = true) shouldBe 2 // create that many tapped Treasure tokens
+        d.getLifeTotal(p1) shouldBe 18                     // then lose that much life
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Kain, Traitorous Dragoon** (FIN #105) — `{2}{B}` Legendary Creature — Human Knight, 2/4.

> Jump — During your turn, Kain has flying.
> Whenever Kain deals combat damage to a player, that player gains control of Kain. If they do, you draw that many cards, create that many tapped Treasure tokens, then lose that much life.

I picked from the 17 remaining unimplemented FIN cards. That pool is the hard tail of a 94%-complete set — every other card needs a **new engine mechanic** (e.g. Ultima → CR 721 "end the turn"; Edgar → coin flips; Gogo → copy an ability; Firion → token-copy an Equipment with an embedded cost reducer) or is a complex transform DFC. Kain is the one card implementable via **pure SDK composition**, so per "pick fewer cards if they are complex" this PR is that single, carefully-modelled card.

## Implementation — no new engine types

- **Jump**: a conditional static ability — `GrantKeyword(FLYING, GroupFilter.source())` gated on `Conditions.IsYourTurn`, so Kain flies only on its controller's turn and can otherwise be blocked.
- **Combat trigger**: routes control of Kain to the damaged player via the existing `GiveControlToTargetPlayerEffect` with `newController = PlayerRef(Player.TriggeringPlayer)`, wrapped in `IfYouDo` with `SuccessCriterion.ControlChanged`. The "if they do" riders (`DrawCards` / tapped `CreateTreasure` / `LoseLife`) fire only when control actually moves, and all scale off `TRIGGER_DAMAGE_AMOUNT`. They resolve for the ability's original controller ("you"), fixed at trigger time — matching "you draw / you lose", not the new controller.

A first pass added a bespoke `GainControlByPlayerEffect`, but the existing `GiveControlToTargetPlayerEffect` already resolves `PlayerRef(TriggeringPlayer)`, so that was reverted in favour of composition (zero engine blast radius).

## Tests

`KainTraitorousDragoonScenarioTest`:
- Jump grants flying on the controller's turn and not on the opponent's turn.
- Full combat pay-off: control hand-off to the damaged player + draw 2 + two tapped Treasures + lose 2 life.

FIN card snapshot re-blessed (only Kain added). `just build`, `CardLintTest`, and `CardDefinitionSnapshotTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)