### PR TITLE
Add Foundations (FDN) archetypes + enable sealed/draft support

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/deck/SetArchetypes.kt
@@ -357,6 +357,32 @@ object SetArchetypes {
                     "Trigger landfall every time a land enters, turning even late-game land draws into damage with angry Chocobos and big beaters. A ramp-and-aggro deck that overwhelms with raw board presence."),
             )
         ),
+        "FDN" to SetSynergies(
+            setCode = "FDN",
+            setName = "Foundations",
+            archetypes = listOf(
+                Archetype("Flyers", listOf(Color.WHITE, Color.BLUE),
+                    "Efficient flying creatures backed by anthem effects and tempo plays. Hold the ground with cheap defenders while an evasive air force races the opponent's clock."),
+                Archetype("Threshold", listOf(Color.BLUE, Color.BLACK),
+                    "Fill your graveyard to seven cards to switch on threshold payoffs. A control-tempo deck that trades early, stocks the bin with card selection, and takes over with upgraded threats."),
+                Archetype("Lifegain", listOf(Color.WHITE, Color.BLACK),
+                    "Gain life through normal gameplay and convert it into growing threats and drain effects. A resilient midrange deck that pulls ahead in every exchange."),
+                Archetype("Sacrifice", listOf(Color.BLACK, Color.RED),
+                    "Feed expendable creatures and tokens to sacrifice outlets for damage and card advantage. An aggressive attrition deck that turns every death into value."),
+                Archetype("Power 4+", listOf(Color.RED, Color.GREEN),
+                    "Ramp into creatures with power four or greater and cash in ferocious payoffs. A stompy midrange deck that wins through raw combat dominance."),
+                Archetype("+1/+1 Counters", listOf(Color.GREEN, Color.WHITE),
+                    "Stack +1/+1 counters on your team and reward every counter placed. A go-tall midrange deck whose creatures outgrow anything blocking them."),
+                Archetype("Spells", listOf(Color.BLUE, Color.RED),
+                    "Cast instants and sorceries to trigger prowess-style payoffs and pump your team. A spell-velocity tempo deck that turns cantrips and burn into combat wins."),
+                Archetype("Morbid", listOf(Color.BLACK, Color.GREEN),
+                    "Make creatures die — yours or theirs — to unlock morbid bonuses and graveyard value. A grindy midrange deck that profits from a full graveyard."),
+                Archetype("Go-Wide Aggro", listOf(Color.RED, Color.WHITE),
+                    "Flood the board with cheap creatures and token makers, then push damage through with mass pump and combat tricks. The format's fastest aggro deck."),
+                Archetype("Ramp Value", listOf(Color.GREEN, Color.BLUE),
+                    "Ramp with extra lands and mana creatures while landfall-style triggers convert each land drop into cards and life. A value-ramp deck that buries opponents in resources."),
+            )
+        ),
     )
 
     /** Get archetypes for a specific set code, or null if not found. */

--- a/web-client/src/components/draft/SetSynergiesOverlay.tsx
+++ b/web-client/src/components/draft/SetSynergiesOverlay.tsx
@@ -805,6 +805,72 @@ const SET_SYNERGIES: Record<string, SetSynergies> = {
       },
     ],
   },
+  FDN: {
+    setCode: 'FDN',
+    setName: 'Foundations',
+    archetypes: [
+      {
+        name: 'Flyers',
+        colors: ['W', 'U'],
+        keyCard: 'Empyrean Eagle',
+        description: "Efficient flying creatures backed by anthem effects and tempo plays. Hold the ground with cheap defenders while an evasive air force races the opponent's clock.",
+      },
+      {
+        name: 'Threshold',
+        colors: ['U', 'B'],
+        keyCard: 'Dreadwing Scavenger',
+        description: 'Fill your graveyard to seven cards to switch on threshold payoffs. A control-tempo deck that trades early, stocks the bin with card selection, and takes over with upgraded threats.',
+      },
+      {
+        name: 'Lifegain',
+        colors: ['W', 'B'],
+        keyCard: 'Fiendish Panda',
+        description: 'Gain life through normal gameplay and convert it into growing threats and drain effects. A resilient midrange deck that pulls ahead in every exchange.',
+      },
+      {
+        name: 'Sacrifice',
+        colors: ['B', 'R'],
+        keyCard: 'Garna, Bloodfist of Keld',
+        description: 'Feed expendable creatures and tokens to sacrifice outlets for damage and card advantage. An aggressive attrition deck that turns every death into value.',
+      },
+      {
+        name: 'Power 4+',
+        colors: ['R', 'G'],
+        keyCard: 'Ruby, Daring Tracker',
+        description: 'Ramp into creatures with power four or greater and cash in ferocious payoffs. A stompy midrange deck that wins through raw combat dominance.',
+      },
+      {
+        name: '+1/+1 Counters',
+        colors: ['G', 'W'],
+        keyCard: 'Good-Fortune Unicorn',
+        description: 'Stack +1/+1 counters on your team and reward every counter placed. A go-tall midrange deck whose creatures outgrow anything blocking them.',
+      },
+      {
+        name: 'Spells',
+        colors: ['U', 'R'],
+        keyCard: 'Balmor, Battlemage Captain',
+        description: 'Cast instants and sorceries to trigger prowess-style payoffs and pump your team. A spell-velocity tempo deck that turns cantrips and burn into combat wins.',
+      },
+      {
+        name: 'Morbid',
+        colors: ['B', 'G'],
+        keyCard: 'Wardens of the Cycle',
+        description: 'Make creatures die — yours or theirs — to unlock morbid bonuses and graveyard value. A grindy midrange deck that profits from a full graveyard.',
+      },
+      {
+        name: 'Go-Wide Aggro',
+        colors: ['R', 'W'],
+        keyCard: 'Heroic Reinforcements',
+        description: "Flood the board with cheap creatures and token makers, then push damage through with mass pump and combat tricks. The format's fastest aggro deck.",
+      },
+      {
+        name: 'Ramp Value',
+        colors: ['G', 'U'],
+        keyCard: 'Tatyova, Benthic Druid',
+        description: 'Ramp with extra lands and mana creatures while landfall-style triggers convert each land drop into cards and life. A value-ramp deck that buries opponents in resources.',
+      },
+    ],
+  },
 }
 
 /**


### PR DESCRIPTION
## Summary

Two changes that together make Foundations a first-class limited set:

### 1. FDN draft/sealed archetypes

Added to both archetype files, kept in lockstep:

- `ai/.../deck/SetArchetypes.kt` (backend source of truth — AI deckbuilder + `GET /api/sets/{code}/archetypes`)
- `web-client/.../draft/SetSynergiesOverlay.tsx` (deckbuilder overlay, with `keyCard` art crops)

All ten two-color pairs, matching the set's real limited structure and keyed off its gold signpost uncommons (names verified against Scryfall, so the `keyCard` art crops resolve):

| Pair | Archetype | Signpost |
|------|-----------|----------|
| WU | Flyers | Empyrean Eagle |
| UB | Threshold | Dreadwing Scavenger |
| WB | Lifegain | Fiendish Panda |
| BR | Sacrifice | Garna, Bloodfist of Keld |
| RG | Power 4+ | Ruby, Daring Tracker |
| GW | +1/+1 Counters | Good-Fortune Unicorn |
| UR | Spells | Balmor, Battlemage Captain |
| BG | Morbid | Wardens of the Cycle |
| RW | Go-Wide Aggro | Heroic Reinforcements |
| GU | Ramp Value | Tatyova, Benthic Druid |

### 2. Sealed/draft support for FDN

- `sealedSupported = true` + dropped `incomplete`, so FDN shows in set pickers by default (`fullyImplemented` gates the default list; `sealedSupported` alone is never read independently).
- `basicLandsFallback = PortalSet` — FDN defines no basics of its own; without the fallback, sealed deckbuilding would offer **zero basic lands** (the standard pattern used by KHM, USG, MMQ, …).
- Release date 2024-11-15 → the 13-card `PlayBooster` strategy applies automatically.

**Coverage caveat:** FDN is at **187/262 (71%)** of its draftable pool — below the 95–100% norm of other fully-implemented sets (FIN at 95% still carries `incomplete = true`). The pool is healthy per rarity (~159 C / ~135 U / 68 R / 10 M) and boosters sample only implemented cards, but drafts will skew toward what's implemented. If that's premature, reverting is one line (`incomplete = true` back on).

### 3. New net: `SealedSupportedSetsTest`

Pins the sealed contract for every fully-implemented set: a 6-booster sealed pool generates at full size, and all five basic land types resolve for deckbuilding (this is what would have silently broken for FDN without the basics fallback — it only fails at deckbuild time in a live lobby otherwise).

**Pre-existing issue surfaced by this test (not fixed here):** **BIG (The Big Score)** is flagged `sealedSupported` (so it reads as "complete" in pickers) but is a 30-card all-mythic bonus sheet — a single-set BIG sealed/draft throws `IllegalStateException: No cards available for booster generation` in ~87.5% of packs (whenever the R/M slot doesn't roll mythic). It's exempted from the test with a comment; probably worth either un-flagging it or teaching the lobby it's OTJ-companion-only.

## Verification

- `:game-server:test` — all pass, including the new `SealedSupportedSetsTest` (FDN sealed pool + basics ✓)
- `:ai:compileKotlin`, `:mtg-sets:compileKotlin`, `:rules-engine:test --tests "*Booster*"` ✓
- `npm run typecheck` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)