### PR TITLE
Add 3 Foundations cards: Fog Bank, Into the Roil, Heraldic Banner

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2188,6 +2188,10 @@ This is the player-arm prerequisite for the planned composable mixed `TargetUnio
 - `.withChosenColor()` — `CardPredicate.HasChosenColor`: matches the color chosen during the current
   effect's resolution (read from `EffectContext.chosenColor`, set by `Effects.ChooseColorThen`). Use with
   `AggregateBattlefield(Player.Each, …)` for "for each permanent of that color" (Coalition Dragon cycle).
+  In a **static ability** (a continuous lord), the chosen color is read from the source permanent's
+  `CastChoicesComponent` (set by `EntersWithChoice(ChoiceType.COLOR)`), so `ModifyStats(filter =
+  GroupFilter(GameObjectFilter.Creature.youControl().withChosenColor()))` expresses "creatures you
+  control of the chosen color get +X/+Y" (Heraldic Banner). Fails closed until a color is chosen.
 - `.sharingCreatureTypeWith(entity)` — `CardPredicate.SharesCreatureTypeWith(entity)`: shares ≥1 (projected)
   creature subtype with a referenced entity. `entity` may be `EntityReference.AffectedEntity`, which resolves
   to the creature a continuous effect is being applied to during projection — combine with
@@ -5935,6 +5939,11 @@ replacementEffect {
   replacement's controller — "a source you control" (Fated Firepower) — without enumerating a
   `GameObjectFilter`. `recipient = RecipientFilter.OpponentOrPermanentTheyControl` matches an opponent
   player **or** any permanent an opponent controls — "an opponent or a permanent an opponent controls".
+  `recipient = RecipientFilter.Self` / `source = SourceFilter.Self` match the permanent that owns the
+  replacement — "damage dealt *to* / *by* this permanent" — for source-relative static foggers like
+  Fog Bank (`DamageEvent(recipient = RecipientFilter.Self, damageType = Combat)` +
+  `DamageEvent(source = SourceFilter.Self, damageType = Combat)` = "prevent all combat damage that would
+  be dealt to and dealt by this creature").
 - `EntersTapped(unlessCondition?, payLifeCost?)` — "this permanent enters tapped" (`unlessCondition = null`),
   or "enters tapped unless `<condition>`" when an `unlessCondition` is supplied. The "slow land" cycle
   (Deathcap Glade, Dreamroot Cascade, Sundown Pass — "enters tapped unless you control two or more other

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -133,6 +133,17 @@ sealed interface SourceFilter {
         override val description = "any source"
     }
 
+    /**
+     * The permanent that owns the effect — i.e. damage dealt *by this permanent*. Mirror of
+     * [RecipientFilter.Self] for the source side. Used by static foggers like Fog Bank
+     * ("prevent all combat damage that would be dealt to and dealt by this creature").
+     */
+    @SerialName("SourceSelf")
+    @Serializable
+    data object Self : SourceFilter {
+        override val description = "this permanent"
+    }
+
     @SerialName("SourceCombat")
     @Serializable
     data object Combat : SourceFilter {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/FogBankReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/FogBankReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fog Bank reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Urza's Saga (`usg`); this file contributes only presentation data.
+ */
+val FogBankReprint = Printing(
+    oracleId = "3a2bb47d-228d-499e-a34b-9e10d99e9b2c",
+    name = "Fog Bank",
+    setCode = "C14",
+    collectorNumber = "110",
+    scryfallId = "7600b28a-6ea3-46d1-9cb3-2b031aa872ba",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/7/6/7600b28a-6ea3-46d1-9cb3-2b031aa872ba.jpg?1782712975",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/IntoTheRoilReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c14/cards/IntoTheRoilReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c14.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Into the Roil reprint in Commander 2014. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Zendikar (`zen`); this file contributes only presentation data.
+ */
+val IntoTheRoilReprint = Printing(
+    oracleId = "c2898bbd-82a4-4d26-b6ee-169b0ebe71b4",
+    name = "Into the Roil",
+    setCode = "C14",
+    collectorNumber = "115",
+    scryfallId = "8637eef0-f5a8-41ce-b885-7d4b26e417d3",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/8/6/8637eef0-f5a8-41ce-b885-7d4b26e417d3.jpg?1782712971",
+    releaseDate = "2014-11-07",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/IntoTheRoilReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/c17/cards/IntoTheRoilReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.c17.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Into the Roil reprint in Commander 2017. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Zendikar (`zen`); this file contributes only presentation data.
+ */
+val IntoTheRoilReprint = Printing(
+    oracleId = "c2898bbd-82a4-4d26-b6ee-169b0ebe71b4",
+    name = "Into the Roil",
+    setCode = "C17",
+    collectorNumber = "86",
+    scryfallId = "17b14898-2862-407b-a581-a027e571007a",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/1/7/17b14898-2862-407b-a581-a027e571007a.jpg?1782710639",
+    releaseDate = "2017-08-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/FogBankReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/FogBankReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fog Bank reprint in Commander 2011. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Urza's Saga (`usg`); this file contributes only presentation data.
+ */
+val FogBankReprint = Printing(
+    oracleId = "3a2bb47d-228d-499e-a34b-9e10d99e9b2c",
+    name = "Fog Bank",
+    setCode = "CMD",
+    collectorNumber = "47",
+    scryfallId = "18846c83-8ffd-4aa0-aca1-a77d91be1c59",
+    artist = "Scott Kirschner",
+    imageUri = "https://cards.scryfall.io/normal/front/1/8/18846c83-8ffd-4aa0-aca1-a77d91be1c59.jpg?1782715093",
+    releaseDate = "2011-06-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/IntoTheRoilReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/IntoTheRoilReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Into the Roil reprint in Commander Legends. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Zendikar (`zen`); this file contributes only presentation data.
+ */
+val IntoTheRoilReprint = Printing(
+    oracleId = "c2898bbd-82a4-4d26-b6ee-169b0ebe71b4",
+    name = "Into the Roil",
+    setCode = "CMR",
+    collectorNumber = "397",
+    scryfallId = "f3463be0-df9e-4cb9-a90f-5d9d2ee729e0",
+    artist = "Kieran Yanner",
+    imageUri = "https://cards.scryfall.io/normal/front/f/3/f3463be0-df9e-4cb9-a90f-5d9d2ee729e0.jpg?1782705849",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/HeraldicBanner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/HeraldicBanner.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ChoiceType
+import com.wingedsheep.sdk.scripting.EntersWithChoice
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Heraldic Banner
+ * {3}
+ * Artifact
+ * As this artifact enters, choose a color.
+ * Creatures you control of the chosen color get +1/+0.
+ * {T}: Add one mana of the chosen color.
+ *
+ * The chosen color is stored via [EntersWithChoice]`(ChoiceType.COLOR)`; the lord filter
+ * (`withChosenColor()`) and the mana ability ([Effects.AddManaOfChosenColor]) both read it
+ * from the source.
+ */
+val HeraldicBanner = card("Heraldic Banner") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "As this artifact enters, choose a color.\n" +
+        "Creatures you control of the chosen color get +1/+0.\n" +
+        "{T}: Add one mana of the chosen color."
+
+    replacementEffect(EntersWithChoice(ChoiceType.COLOR))
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl().withChosenColor())
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChosenColor()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "222"
+        artist = "Ravenna Tran"
+        imageUri = "https://cards.scryfall.io/normal/front/2/e/2e349af5-3f25-46d3-908e-83b2f6028b95.jpg?1782707787"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FogBankReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FogBankReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fog Bank reprint in Foundations. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Urza's Saga (`usg`); this file contributes only presentation data.
+ */
+val FogBankReprint = Printing(
+    oracleId = "3a2bb47d-228d-499e-a34b-9e10d99e9b2c",
+    name = "Fog Bank",
+    setCode = "FDN",
+    collectorNumber = "591",
+    scryfallId = "18748b1d-4161-482c-a726-8762b4c1819c",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/1/8/18748b1d-4161-482c-a726-8762b4c1819c.jpg?1782688751",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HeraldicBannerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HeraldicBannerReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Heraldic Banner reprint in Foundations. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Throne of Eldraine (`eld`); this file contributes only presentation data.
+ */
+val HeraldicBannerReprint = Printing(
+    oracleId = "3525e263-e29a-49bf-a29f-fb3ce43bbd33",
+    name = "Heraldic Banner",
+    setCode = "FDN",
+    collectorNumber = "254",
+    scryfallId = "743ea709-dbb3-4db8-a2ce-544f47eb6339",
+    artist = "Ravenna Tran",
+    imageUri = "https://cards.scryfall.io/normal/front/7/4/743ea709-dbb3-4db8-a2ce-544f47eb6339.jpg?1782689047",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/IntoTheRoilReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/IntoTheRoilReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Into the Roil reprint in Foundations. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Zendikar (`zen`); this file contributes only presentation data.
+ */
+val IntoTheRoilReprint = Printing(
+    oracleId = "c2898bbd-82a4-4d26-b6ee-169b0ebe71b4",
+    name = "Into the Roil",
+    setCode = "FDN",
+    collectorNumber = "509",
+    scryfallId = "25edefa9-9fff-4b71-83ae-696c196a795c",
+    artist = "Campbell White",
+    imageUri = "https://cards.scryfall.io/normal/front/2/5/25edefa9-9fff-4b71-83ae-696c196a795c.jpg?1782688823",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/FogBankReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m13/cards/FogBankReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.m13.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fog Bank reprint in Magic 2013. Canonical [com.wingedsheep.sdk.model.CardDefinition]
+ * lives in Urza's Saga (`usg`); this file contributes only presentation data.
+ */
+val FogBankReprint = Printing(
+    oracleId = "3a2bb47d-228d-499e-a34b-9e10d99e9b2c",
+    name = "Fog Bank",
+    setCode = "M13",
+    collectorNumber = "52",
+    scryfallId = "8a5a69dc-c6f3-459b-9dcd-b3363c26ca34",
+    artist = "Howard Lyon",
+    imageUri = "https://cards.scryfall.io/normal/front/8/a/8a5a69dc-c6f3-459b-9dcd-b3363c26ca34.jpg?1782714387",
+    releaseDate = "2012-07-13",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/FogBank.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/FogBank.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.usg.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.PreventDamage
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Fog Bank
+ * {1}{U}
+ * Creature — Wall
+ * 0/2
+ * Defender (This creature can't attack.)
+ * Flying
+ * Prevent all combat damage that would be dealt to and dealt by this creature.
+ *
+ * Modeled as two static prevention replacement effects — the combat-damage twin of
+ * Sandskin, but source-relative ([RecipientFilter.Self] / [SourceFilter.Self]) rather
+ * than aura-relative.
+ */
+val FogBank = card("Fog Bank") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Wall"
+    power = 0
+    toughness = 2
+    oracleText = "Defender (This creature can't attack.)\n" +
+        "Flying\n" +
+        "Prevent all combat damage that would be dealt to and dealt by this creature."
+
+    keywords(Keyword.DEFENDER, Keyword.FLYING)
+
+    // Prevent combat damage dealt TO this creature.
+    replacementEffect(
+        PreventDamage(
+            amount = null,
+            appliesTo = EventPattern.DamageEvent(
+                recipient = RecipientFilter.Self,
+                damageType = DamageType.Combat
+            )
+        )
+    )
+
+    // Prevent combat damage dealt BY this creature.
+    replacementEffect(
+        PreventDamage(
+            amount = null,
+            appliesTo = EventPattern.DamageEvent(
+                source = SourceFilter.Self,
+                damageType = DamageType.Combat
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "75"
+        artist = "Scott Kirschner"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6ade0d30-5a57-439e-95e8-5f865880031f.jpg?1782720730"
+
+        // Champions of Kamigawa rules update — Walls printed before it received errata granting defender.
+        ruling(
+            "2004-10-04",
+            "As of the Champions of Kamigawa rules update, the Wall creature type no longer inherently " +
+                "prevents attacking. All Walls printed before this update received errata granting the " +
+                "defender keyword."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/IntoTheRoil.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/zen/cards/IntoTheRoil.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.zen.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.conditions.WasKicked
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Into the Roil
+ * {1}{U}
+ * Instant
+ * Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)
+ * Return target nonland permanent to its owner's hand. If this spell was kicked, draw a card.
+ */
+val IntoTheRoil = card("Into the Roil") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\n" +
+        "Return target nonland permanent to its owner's hand. If this spell was kicked, draw a card."
+
+    keywordAbility(KeywordAbility.kicker("{1}{U}"))
+
+    spell {
+        target = Targets.NonlandPermanent
+        effect = Effects.ReturnToHand(EffectTarget.ContextTarget(0)) then ConditionalEffect(
+            condition = WasKicked,
+            effect = Effects.DrawCards(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "48"
+        artist = "Kieran Yanner"
+        flavorText = "\"Roil tide! Roil tide! Tie yourselves down!\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/d/5dba9972-dd8b-407b-9374-a8f0ed1a96db.jpg?1782715668"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/IntoTheRoilReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/znr/cards/IntoTheRoilReprint.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.znr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Into the Roil reprints in Zendikar Rising — the regular (#62) and extended-art (#387) printings.
+ * Canonical [com.wingedsheep.sdk.model.CardDefinition] lives in Zendikar (`zen`); these contribute
+ * only presentation data.
+ */
+val IntoTheRoilReprint = Printing(
+    oracleId = "c2898bbd-82a4-4d26-b6ee-169b0ebe71b4",
+    name = "Into the Roil",
+    setCode = "ZNR",
+    collectorNumber = "62",
+    scryfallId = "899540b0-c17a-4a73-912c-9b8925203de1",
+    artist = "Campbell White",
+    imageUri = "https://cards.scryfall.io/normal/front/8/9/899540b0-c17a-4a73-912c-9b8925203de1.jpg?1782706336",
+    releaseDate = "2020-09-25",
+    rarity = Rarity.COMMON,
+)
+
+val IntoTheRoilExtendedReprint = Printing(
+    oracleId = "c2898bbd-82a4-4d26-b6ee-169b0ebe71b4",
+    name = "Into the Roil",
+    setCode = "ZNR",
+    collectorNumber = "387",
+    scryfallId = "a3c2c3d7-3437-44b8-8d39-d3abe02af50e",
+    artist = "Campbell White",
+    imageUri = "https://cards.scryfall.io/normal/front/a/3/a3c2c3d7-3437-44b8-8d39-d3abe02af50e.jpg?1782706100",
+    releaseDate = "2020-09-25",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -135,6 +135,57 @@
     ]
 }
 
+// Heraldic Banner
+{
+    "name": "Heraldic Banner",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "As this artifact enters, choose a color.\nCreatures you control of the chosen color get +1/+0.\n{T}: Add one mana of the chosen color.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "colorSet": "ManaColorSet.SourceChosenColor"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "HasChosenColor"
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    }
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithChoice",
+                "choiceType": "COLOR"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "222",
+        "rarity": "UNCOMMON",
+        "artist": "Ravenna Tran",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/e/2e349af5-3f25-46d3-908e-83b2f6028b95.jpg?1782707787"
+    },
+    "colorIdentityOverride": []
+}
+
 // Raging Redcap
 {
     "name": "Raging Redcap",

--- a/mtg-sets/src/test/resources/snapshots/cards/USG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/USG.json
@@ -2092,6 +2092,57 @@
     ]
 }
 
+// Fog Bank
+{
+    "name": "Fog Bank",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Wall",
+    "oracleText": "Defender (This creature can't attack.)\nFlying\nPrevent all combat damage that would be dealt to and dealt by this creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEFENDER",
+        "FLYING"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "PreventDamage",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "RecipientSelf",
+                    "damageType": "DamageCombat"
+                }
+            },
+            {
+                "type": "PreventDamage",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "source": "SourceSelf",
+                    "damageType": "DamageCombat"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "75",
+        "rarity": "UNCOMMON",
+        "artist": "Scott Kirschner",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6ade0d30-5a57-439e-95e8-5f865880031f.jpg?1782720730",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "As of the Champions of Kamigawa rules update, the Wall creature type no longer inherently prevents attacking. All Walls printed before this update received errata granting the defender keyword."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Gaea's Bounty
 {
     "name": "Gaea's Bounty",

--- a/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ZEN.json
@@ -237,6 +237,66 @@
     "colorIdentityOverride": []
 }
 
+// Into the Roil
+{
+    "name": "Into the Roil",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Kicker {1}{U} (You may pay an additional {1}{U} as you cast this spell.)\nReturn target nonland permanent to its owner's hand. If this spell was kicked, draw a card.",
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "manaCost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": "WasKicked"
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "48",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"Roil tide! Roil tide! Tie yourselves down!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/d/5dba9972-dd8b-407b-9374-a8f0ed1a96db.jpg?1782715668"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Kor Cartographer
 {
     "name": "Kor Cartographer",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/DamageUtils.kt
@@ -1238,6 +1238,7 @@ object DamageUtils {
                 // Check if the damage source matches the source filter
                 val sourceMatches = when (val source = damageEvent.source) {
                     is SourceFilter.Any -> true
+                    is SourceFilter.Self -> sourceId != null && sourceId == entityId
                     is SourceFilter.EnchantedCreature -> {
                         val attachedTo = container.get<AttachedToComponent>()?.targetId
                         sourceId != null && sourceId == attachedTo

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/AffectsFilterResolver.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.mechanics.layers
 
+import com.wingedsheep.engine.state.components.battlefield.chosenColor
 import com.wingedsheep.engine.state.components.battlefield.chosenCreatureType
 import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
 import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
@@ -282,6 +283,14 @@ internal class AffectsFilterResolver {
                 ?: return emptySet()
         } else null
 
+        // If the base filter keys off the source's durably-chosen color (Heraldic Banner:
+        // "creatures you control of the chosen color"), resolve it once from the source's
+        // CastChoicesComponent. Fail closed (match nothing) when no color has been chosen yet.
+        val needsChosenColor = baseFilter.cardPredicates.any { it == CardPredicate.HasChosenColor }
+        val sourceChosenColor = if (needsChosenColor) {
+            state.getEntity(sourceId)?.chosenColor() ?: return emptySet()
+        } else null
+
         return state.getBattlefield().filter { entityId ->
             if (groupFilter.excludeSelf && entityId == sourceId) return@filter false
 
@@ -323,6 +332,10 @@ internal class AffectsFilterResolver {
                 // applied as a separate constraint below — skip it in the generic projection loop,
                 // which has no source in scope and would fail it closed.
                 if (predicate is CardPredicate.NameEqualsChosenComponent) continue
+                // HasChosenColor is resolved once above (sourceChosenColor) and applied as a
+                // separate constraint below; the generic projection has no source in scope and
+                // would fail it closed.
+                if (predicate == CardPredicate.HasChosenColor) continue
                 if (!matchesCardPredicateForProjection(predicate, card, container, projected, types, subtypes, colors, keywords, isFaceDown)) {
                     return@filter false
                 }
@@ -330,6 +343,11 @@ internal class AffectsFilterResolver {
 
             // Source-chosen card name constraint (from source's CastChoicesComponent).
             if (sourceChosenName != null && !card.name.equals(sourceChosenName, ignoreCase = true)) {
+                return@filter false
+            }
+
+            // Source-chosen color constraint (from source's CastChoicesComponent).
+            if (sourceChosenColor != null && sourceChosenColor.name !in colors) {
                 return@filter false
             }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FogBankScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FogBankScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.usg.cards.FogBank
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Fog Bank (USG #75) — "Prevent all combat damage that would be dealt to and dealt by this creature."
+ *
+ * Exercises the source-relative static prevention pair, including the new
+ * [com.wingedsheep.sdk.scripting.events.SourceFilter.Self] filter used for the "dealt by" half.
+ */
+class FogBankScenarioTest : FunSpec({
+
+    fun newGame(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FogBank))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun GameTestDriver.markedDamage(id: EntityId): Int =
+        state.getEntity(id)?.get<DamageComponent>()?.amount ?: 0
+
+    test("prevents combat damage dealt TO Fog Bank when it blocks") {
+        val driver = newGame()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val attacker = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        driver.removeSummoningSickness(attacker)
+        val fogBank = driver.putCreatureOnBattlefield(opponent, "Fog Bank") // 0/2
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(attacker), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(fogBank to listOf(attacker)))
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // The 3 combat damage to Fog Bank is prevented — it takes 0 and survives its 2 toughness.
+        driver.markedDamage(fogBank) shouldBe 0
+        driver.state.getBattlefield().contains(fogBank) shouldBe true
+    }
+
+    test("prevents combat damage dealt BY Fog Bank (SourceFilter.Self)") {
+        val driver = newGame()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val attacker = driver.putCreatureOnBattlefield(you, "Centaur Courser") // 3/3
+        driver.removeSummoningSickness(attacker)
+        val fogBank = driver.putCreatureOnBattlefield(opponent, "Fog Bank") // 0/2
+
+        // Give Fog Bank a +1/+1 counter so it would deal 1 combat damage — that damage must be
+        // prevented by the "dealt by this creature" half.
+        driver.replaceState(
+            driver.state.updateEntity(fogBank) {
+                it.with(CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+            }
+        )
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(attacker), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(opponent, mapOf(fogBank to listOf(attacker)))
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        resolveStack(driver)
+
+        // Fog Bank's own combat damage is prevented — the attacker takes 0 from it.
+        driver.markedDamage(attacker) shouldBe 0
+        // And the attacker's damage to Fog Bank is prevented too, so Fog Bank survives.
+        driver.state.getBattlefield().contains(fogBank) shouldBe true
+    }
+
+    test("does not prevent noncombat damage to Fog Bank") {
+        val driver = newGame()
+        val you = driver.activePlayer!!
+
+        val fogBank = driver.putCreatureOnBattlefield(you, "Fog Bank") // 0/2
+
+        driver.giveMana(you, Color.RED, 1)
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.castSpellWithTargets(you, bolt, listOf(ChosenTarget.Permanent(fogBank)))
+        resolveStack(driver)
+
+        // Lightning Bolt's 3 noncombat damage is not prevented (prevention is combat-only) — Fog Bank dies.
+        driver.state.getBattlefield().contains(fogBank) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HeraldicBannerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HeraldicBannerScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseColorDecision
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.battlefield.chosenColor
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Heraldic Banner (ELD #222) — "As this artifact enters, choose a color. Creatures you control of
+ * the chosen color get +1/+0. {T}: Add one mana of the chosen color."
+ *
+ * Covers the chosen-color anthem (`ModifyStats` × `withChosenColor()`) and the entry color choice.
+ * The `AddManaOfChosenColor` mana ability reuses the primitive proven by Uncharted Haven.
+ */
+class HeraldicBannerScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Heraldic Banner — chosen-color anthem") {
+
+            test("buffs your creatures of the chosen color, leaves off-color creatures alone") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Heraldic Banner")
+                    .withCardOnBattlefield(1, "Savannah Lions")   // white 1/1
+                    .withCardOnBattlefield(1, "Centaur Courser")  // green 3/3 (off-color)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val banner = game.findPermanent("Heraldic Banner")!!
+                game.state = game.state.updateEntity(banner) { c ->
+                    c.with(
+                        CastChoicesComponent(
+                            chosen = mapOf(ChoiceSlot.COLOR to ChoiceValue.ColorChoice(Color.WHITE))
+                        )
+                    )
+                }
+
+                val lion = game.findPermanent("Savannah Lions")!!
+                val centaur = game.findPermanent("Centaur Courser")!!
+
+                withClue("Savannah Lions (white 1/1) should be +1/+0") {
+                    projector.getProjectedPower(game.state, lion) shouldBe 2
+                    projector.getProjectedToughness(game.state, lion) shouldBe 1
+                }
+                withClue("Centaur Courser (green) is off-color and unaffected") {
+                    projector.getProjectedPower(game.state, centaur) shouldBe 3
+                    projector.getProjectedToughness(game.state, centaur) shouldBe 3
+                }
+            }
+
+            test("casting Heraldic Banner records the chosen color and the anthem then applies") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Heraldic Banner")
+                    .withLandsOnBattlefield(1, "Plains", 3)        // pay {3}
+                    .withCardOnBattlefield(1, "Savannah Lions")    // white 1/1 to observe the anthem
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lion = game.findPermanent("Savannah Lions")!!
+
+                val cast = game.castSpell(1, "Heraldic Banner")
+                withClue("Casting Heraldic Banner ({3}) should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+
+                // As-it-enters color choice (CR 614.12a).
+                game.resolveStack()
+                val decision = game.state.pendingDecision
+                withClue("Heraldic Banner should pause for the color choice") {
+                    (decision is ChooseColorDecision) shouldBe true
+                }
+                game.submitDecision(ColorChosenResponse(decision!!.id, Color.WHITE))
+                game.resolveStack()
+
+                val banner = game.findPermanent("Heraldic Banner")!!
+                withClue("The chosen-color slot should hold WHITE") {
+                    game.state.getEntity(banner)!!.chosenColor() shouldBe Color.WHITE
+                }
+                withClue("Savannah Lions should now be +1/+0 from the recorded chosen color") {
+                    projector.getProjectedPower(game.state, lion) shouldBe 2
+                    projector.getProjectedToughness(game.state, lion) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntoTheRoilScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IntoTheRoilScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.zen.cards.IntoTheRoil
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Into the Roil (ZEN #48) — "Return target nonland permanent to its owner's hand. If this spell
+ * was kicked, draw a card." Exercises the kicker `WasKicked` branch on the bounce.
+ */
+class IntoTheRoilScenarioTest : FunSpec({
+
+    fun newGame(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(IntoTheRoil))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 30 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    test("unkicked: returns target nonland permanent to owner's hand and does not draw") {
+        val driver = newGame()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val creature = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        repeat(2) { driver.putLandOnBattlefield(you, "Island") } // {1}{U}
+
+        val roil = driver.putCardInHand(you, "Into the Roil")
+        val handBefore = driver.getHandSize(you)
+
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = roil,
+                targets = listOf(ChosenTarget.Permanent(creature)),
+                wasKicked = false,
+                paymentStrategy = PaymentStrategy.AutoPay
+            )
+        ).isSuccess shouldBe true
+        resolveStack(driver)
+
+        // Creature bounced off the battlefield; no card drawn (hand only shrank by the spell itself).
+        driver.state.getBattlefield().contains(creature) shouldBe false
+        driver.getHandSize(you) shouldBe handBefore - 1
+    }
+
+    test("kicked: returns the permanent and draws a card") {
+        val driver = newGame()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        val creature = driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+        repeat(4) { driver.putLandOnBattlefield(you, "Island") } // {1}{U} + kicker {1}{U}
+
+        val roil = driver.putCardInHand(you, "Into the Roil")
+        val handBefore = driver.getHandSize(you)
+
+        driver.submit(
+            CastSpell(
+                playerId = you,
+                cardId = roil,
+                targets = listOf(ChosenTarget.Permanent(creature)),
+                wasKicked = true,
+                paymentStrategy = PaymentStrategy.AutoPay
+            )
+        ).isSuccess shouldBe true
+        resolveStack(driver)
+
+        // Creature bounced, and the kicker drew a card: -1 (spell cast) +1 (draw) = net unchanged.
+        driver.state.getBattlefield().contains(creature) shouldBe false
+        driver.getHandSize(you) shouldBe handBefore
+    }
+})


### PR DESCRIPTION
## Summary

Implements three Foundations (FDN) reprints via the `add-card` flow. Each card's
canonical `CardDefinition` lives in its **earliest real printing**; FDN and the
other already-scaffolded sets that reprint them get `Printing` rows.
`just check-card-printing` is green for all three.

| Card | Canonical | Oracle |
|------|-----------|--------|
| **Fog Bank** | USG | Defender, Flying, "prevent all combat damage that would be dealt to and dealt by this creature." |
| **Into the Roil** | ZEN | Kicker {1}{U}; return target nonland permanent to hand, draw a card if kicked. |
| **Heraldic Banner** | ELD | Choose a color on entry; your chosen-color creatures get +1/+0; {T}: add one mana of the chosen color. |

## Engine touches (small, general, needed by the cards)

- **`SourceFilter.Self`** — mirror of the existing `RecipientFilter.Self`, so a static
  fogger can prevent damage *dealt by* the permanent itself (Fog Bank's second half).
  Wired in `DamageUtils` prevention path; documented in the SDK reference.
- **Chosen-color lord in the layer system** — `AffectsFilterResolver` now reads the
  static source's chosen color from `CastChoicesComponent` so `withChosenColor()`
  resolves in a continuous lord (previously it returned `false` in projection),
  mirroring the existing chosen-subtype / chosen-name handling. This makes the
  already-documented `.withChosenColor()` DSL work in `ModifyStats` statics.

## Reprint rows added

Fog Bank: CMD, M13, C14, FDN · Into the Roil: C14, C17, CMR, ZNR (×2), FDN · Heraldic Banner: FDN.

## Tests

- `FogBankScenarioTest` — prevents combat damage to (blocking) and by (pumped, `SourceFilter.Self`); does not prevent noncombat damage.
- `IntoTheRoilScenarioTest` — unkicked bounce (no draw) vs kicked (bounce + draw).
- `HeraldicBannerScenarioTest` — chosen-color anthem buffs on-color / ignores off-color; full cast + color-choice flow records the color and applies the anthem.

Full `just test-rules` and `:mtg-sets:test` (lint + snapshots) pass. Per-set card
snapshots re-blessed (only the three new cards added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)