### PR TITLE
Add Kain, Traitorous Dragoon to Final Fantasy

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -1296,6 +1296,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
     "{2}, {T}: Target opponent gains control of another target permanent you control. If they do, you
     draw a card" → `IfYouDoEffect(GiveControlToTargetPlayer(permanent, opponent), DrawCards(1),
     successCriterion = ControlChanged)`.
+    `GiveControlToTargetPlayer.newController` accepts any player reference, not just a declared target:
+    combat-derived refs like `Player.DefendingPlayer` ("that player" in a "deals combat damage to a
+    player" trigger), chosen-opponent slots, and owner/controller lookups all resolve. Kain,
+    Traitorous Dragoon: "Whenever Kain deals combat damage to a player, that player gains control of
+    Kain. If they do, you draw that many cards, create that many tapped Treasure tokens, then lose that
+    much life" → `IfYouDoEffect(GiveControlToTargetPlayer(Self, PlayerRef(DefendingPlayer)),
+    Composite(DrawCards(TRIGGER_DAMAGE_AMOUNT), CreateTreasure(TRIGGER_DAMAGE_AMOUNT, tapped), LoseLife(...)),
+    successCriterion = ControlChanged)`.
     `CollectionNonEmpty` gates on the action's actual pipeline collection
     (`storedCollections[name].size >= min` after the action runs) — the collections propagate onto
     the gate frame via `exposeCollectionsToNextFrame`, in both the synchronous and the

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/KainTraitorousDragoon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/KainTraitorousDragoon.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kain, Traitorous Dragoon
+ * {2}{B}
+ * Legendary Creature — Human Knight
+ * 2/4
+ *
+ * Jump — During your turn, Kain has flying.
+ * Whenever Kain deals combat damage to a player, that player gains control of Kain. If they do, you
+ * draw that many cards, create that many tapped Treasure tokens, then lose that much life.
+ *
+ * "Jump" is an ability word (no rules meaning); it's modeled as a conditional static grant of flying
+ * to this creature gated on [Conditions.IsYourTurn] — the same shape as Freya Crescent / Dragoon's
+ * Lance.
+ *
+ * The combat-damage rider reuses the [SuccessCriterion.ControlChanged] idiom (Stiltzkin, Moogle
+ * Merchant): the donation of Kain to the damaged player is the gated action, and the draw / Treasure
+ * / life-loss payoff fires only when control actually moves. If Kain has already left the battlefield
+ * by the time the ability resolves, no control changes and the "if they do" rider is withheld, per the
+ * printed wording. "That many / that much" all read the triggering combat-damage amount
+ * ([ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT]); "you" stays the ability's controller (Kain's controller
+ * when it dealt the damage), so the draw, Treasures, and life loss all belong to the original
+ * controller even after control of Kain has changed.
+ */
+val KainTraitorousDragoon = card("Kain, Traitorous Dragoon") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Knight"
+    oracleText = "Jump — During your turn, Kain has flying.\n" +
+        "Whenever Kain deals combat damage to a player, that player gains control of Kain. If they " +
+        "do, you draw that many cards, create that many tapped Treasure tokens, then lose that much life."
+    power = 2
+    toughness = 4
+
+    // Jump — During your turn, Kain has flying.
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(Keyword.FLYING, Filters.Self)
+    }
+
+    // Whenever Kain deals combat damage to a player, that player gains control of Kain. If they do,
+    // you draw that many cards, create that many tapped Treasure tokens, then lose that much life.
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        val damage = DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT)
+        effect = IfYouDoEffect(
+            action = GiveControlToTargetPlayerEffect(
+                permanent = EffectTarget.Self,
+                newController = EffectTarget.PlayerRef(Player.DefendingPlayer),
+            ),
+            ifYouDo = Effects.Composite(
+                listOf(
+                    Effects.DrawCards(damage, EffectTarget.Controller),
+                    Effects.CreateTreasure(damage, tapped = true),
+                    Effects.LoseLife(damage, EffectTarget.Controller),
+                )
+            ),
+            successCriterion = SuccessCriterion.ControlChanged,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "105"
+        artist = "Russell Dongjun Lu"
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8c86be0-e1b3-4a78-9254-238dd936914b.jpg?1782686519"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -9589,6 +9589,97 @@
     ]
 }
 
+// Kain, Traitorous Dragoon
+{
+    "name": "Kain, Traitorous Dragoon",
+    "manaCost": "{2}{B}",
+    "typeLine": "Legendary Creature — Human Knight",
+    "oracleText": "Jump — During your turn, Kain has flying.\nWhenever Kain deals combat damage to a player, that player gains control of Kain. If they do, you draw that many cards, create that many tapped Treasure tokens, then lose that much life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.DoAction",
+                        "action": {
+                            "type": "GiveControlToTargetPlayer",
+                            "permanent": "Self",
+                            "newController": {
+                                "type": "PlayerRef",
+                                "player": "DefendingPlayer"
+                            }
+                        },
+                        "successCriterion": "SuccessCriterion.ControlChanged"
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                }
+                            },
+                            {
+                                "type": "CreatePredefinedToken",
+                                "tokenType": "Treasure",
+                                "tapped": true,
+                                "dynamicCount": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                }
+                            },
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "ContextProperty",
+                                    "key": "TRIGGER_DAMAGE_AMOUNT"
+                                },
+                                "target": "Controller"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "rarity": "RARE",
+        "artist": "Russell Dongjun Lu",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8c86be0-e1b3-4a78-9254-238dd936914b.jpg?1782686519"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Kuja, Genome Sorcerer
 {
     "name": "Kuja, Genome Sorcerer",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/control/GiveControlToTargetPlayerExecutor.kt
@@ -38,7 +38,11 @@ class GiveControlToTargetPlayerExecutor : EffectExecutor<GiveControlToTargetPlay
         val cardComponent = targetContainer.get<CardComponent>()
             ?: return EffectResult.error(state, "Target is not a card")
 
-        val newControllerId = context.resolvePlayerTarget(effect.newController)
+        // State-aware resolution so relational player references resolve too — not just declared
+        // targets (Stiltzkin/Custody Battle) but also combat-derived ones like
+        // Player.DefendingPlayer ("that player" in a "deals combat damage to a player" trigger, e.g.
+        // Kain, Traitorous Dragoon), chosen-opponent slots, and owner/controller lookups.
+        val newControllerId = context.resolvePlayerTarget(effect.newController, state)
             ?: return EffectResult.error(state, "No valid player target for control change")
 
         // Use projected controller so floating-effect-based control changes are respected

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KainTraitorousDragoonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KainTraitorousDragoonScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Kain, Traitorous Dragoon (FIN #105) — {2}{B} 2/4 Legendary Creature.
+ *
+ * "Jump — During your turn, Kain has flying.
+ *  Whenever Kain deals combat damage to a player, that player gains control of Kain. If they do, you
+ *  draw that many cards, create that many tapped Treasure tokens, then lose that much life."
+ *
+ * The rider composes [com.wingedsheep.sdk.scripting.effects.GiveControlToTargetPlayerEffect] (donate
+ * Kain to the damaged player) with an [com.wingedsheep.sdk.scripting.effects.IfYouDoEffect] gated on
+ * [com.wingedsheep.sdk.scripting.effects.SuccessCriterion.ControlChanged]. "That many / that much" all
+ * read the triggering combat-damage amount; "you" stays Kain's original controller.
+ */
+class KainTraitorousDragoonScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("combat damage donates Kain to the defender; original controller draws, makes tapped Treasures, and loses life") {
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Kain, Traitorous Dragoon", summoningSickness = false)
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handBefore = game.state.getHand(game.player1Id).size
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Kain, Traitorous Dragoon" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+            withClue("P2 took 2 combat damage from Kain") {
+                game.getLifeTotal(2) shouldBe 18
+            }
+
+            val kain = game.findPermanent("Kain, Traitorous Dragoon")
+            withClue("Kain should still be on the battlefield") { (kain != null) shouldBe true }
+            withClue("the damaged player (P2) now controls Kain (control change is a projected effect)") {
+                game.state.projectedState.getController(kain!!) shouldBe game.player2Id
+            }
+
+            withClue("original controller (P1) drew 2 cards (equal to the damage dealt)") {
+                game.state.getHand(game.player1Id).size shouldBe handBefore + 2
+            }
+
+            val treasures = game.findAllPermanents("Treasure")
+            withClue("P1 created 2 Treasure tokens") { treasures.size shouldBe 2 }
+            treasures.forEach { id ->
+                withClue("each Treasure is controlled by the original controller (P1)") {
+                    game.state.projectedState.getController(id) shouldBe game.player1Id
+                }
+                withClue("each Treasure entered tapped") {
+                    (game.state.getEntity(id)?.get<TappedComponent>() != null) shouldBe true
+                }
+            }
+
+            withClue("P1 lost 2 life (equal to the damage dealt)") {
+                game.getLifeTotal(1) shouldBe 18
+            }
+        }
+
+        test("no trigger when Kain is blocked and deals no combat damage to a player") {
+            // Jump gives Kain flying on its controller's turn, so the blocker must also be able to
+            // block flyers — Wind Drake (2/2 flying).
+            val game = scenario()
+                .withPlayers("P1", "P2")
+                .withCardOnBattlefield(1, "Kain, Traitorous Dragoon", summoningSickness = false)
+                .withCardOnBattlefield(2, "Wind Drake", summoningSickness = false)
+                .withCardInLibrary(1, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            val handBefore = game.state.getHand(game.player1Id).size
+
+            game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+            game.declareAttackers(mapOf("Kain, Traitorous Dragoon" to 2)).error shouldBe null
+            game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+            game.declareBlockers(mapOf("Wind Drake" to listOf("Kain, Traitorous Dragoon"))).error shouldBe null
+            game.passUntilPhase(Phase.POSTCOMBAT_MAIN, Step.POSTCOMBAT_MAIN)
+
+            withClue("P2 took no combat damage (Kain was blocked)") {
+                game.getLifeTotal(2) shouldBe 20
+            }
+            val kain = game.findPermanent("Kain, Traitorous Dragoon")
+            withClue("Kain stays under its original controller — the trigger never fired") {
+                game.state.projectedState.getController(kain!!) shouldBe game.player1Id
+            }
+            withClue("no Treasures were created") { game.findAllPermanents("Treasure").size shouldBe 0 }
+            withClue("P1 did not draw off the rider") {
+                game.state.getHand(game.player1Id).size shouldBe handBefore
+            }
+            withClue("P1 lost no life off the rider") { game.getLifeTotal(1) shouldBe 20 }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Kain, Traitorous Dragoon** (FIN #105) — `{2}{B}` 2/4 Legendary Creature — Human Knight.

> **Jump** — During your turn, Kain has flying.
> Whenever Kain deals combat damage to a player, that player gains control of Kain. If they do, you draw that many cards, create that many tapped Treasure tokens, then lose that much life.

This was the one remaining FIN card implementable as pure card authoring — the other 14 missing FIN cards each require new engine mechanics (end-the-turn, coin-flip "win the flip" replacements, ability-copying, granted death-trigger doublers, or transform DFCs with novel conditions), which belong in `add-feature`, not `add-card`.

## How it's modeled

- **Jump** reuses the established conditional static-grant idiom (Freya Crescent): `staticAbility { condition = IsYourTurn; ability = GrantKeyword(FLYING, Self) }`. "Jump" is an ability word with no rules meaning.
- **The combat-damage rider** composes existing primitives:
  - `GiveControlToTargetPlayer(permanent = Self, newController = Player.DefendingPlayer)` — donates Kain to the player he damaged.
  - wrapped in `IfYouDoEffect(..., successCriterion = ControlChanged)` — the Stiltzkin, Moogle Merchant idiom, so the payoff fires **only when control actually moves** (e.g. it's withheld if Kain has already left the battlefield).
  - the payoff `Composite(DrawCards, CreateTreasure(tapped), LoseLife)` scales on `TRIGGER_DAMAGE_AMOUNT` ("that many/much") and belongs to **Kain's original controller** ("you"), even after control has changed.

## Engine change

`GiveControlToTargetPlayerExecutor` resolved `newController` with the **stateless** `resolvePlayerTarget` overload, which only handles declared targets (`TargetPlayer`/`TargetOpponent`) and `TriggeringPlayer`. Kain is the first card to use a **combat-derived** player reference here (`DefendingPlayer`), which needs state to resolve. Switched to the existing **state-aware** overload — a one-line generalization that also unlocks chosen-opponent and owner/controller references for this executor. All existing control-change cards (Stiltzkin, Custody Battle, Zidane, Witch Engine, Risky Move, Iroh, Bill Ferny, Jinxed Idol) are unaffected.

## Tests

New `KainTraitorousDragoonScenarioTest`:
- **Happy path** — Kain deals 2 combat damage → the defender gains control of Kain (projected), the original controller draws 2, gets 2 tapped Treasures, and loses 2 life.
- **Negative** — Kain is blocked (by a flyer, since Jump gives Kain flying on its own turn) → deals no combat damage to a player → no trigger, no control change, no payoff.

All green: new scenario test, full `rules-engine` suite, `mtg-sets` snapshot (re-blessed, Kain-only diff), card-lint, and control-change regression tests. SDK reference updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)