### PR TITLE
Add 3 Foundations reprints: Confiscate, Self-Reflection, Fumigate

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/ConfiscateReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/8ed/cards/ConfiscateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.`8ed`.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Confiscate reprint in 8ED. Canonical CardDefinition lives in its earliest set (USG).
+ */
+val ConfiscateReprint = Printing(
+    oracleId = "d599a38c-7719-443e-bb59-55bd43a8fee6",
+    name = "Confiscate",
+    setCode = "8ED",
+    collectorNumber = "69",
+    scryfallId = "48acfd80-eba3-4aa9-804c-563259ca84de",
+    artist = "Adam Rex",
+    imageUri = "https://cards.scryfall.io/normal/front/4/8/48acfd80-eba3-4aa9-804c-563259ca84de.jpg?1782718873",
+    releaseDate = "2003-07-28",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/ConfiscateReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmr/cards/ConfiscateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.cmr.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Confiscate reprint in CMR. Canonical CardDefinition lives in its earliest set (USG).
+ */
+val ConfiscateReprint = Printing(
+    oracleId = "d599a38c-7719-443e-bb59-55bd43a8fee6",
+    name = "Confiscate",
+    setCode = "CMR",
+    collectorNumber = "62",
+    scryfallId = "09e4a88d-670b-4332-bf36-41c2e2492424",
+    artist = "Adam Rex",
+    imageUri = "https://cards.scryfall.io/normal/front/0/9/09e4a88d-670b-4332-bf36-41c2e2492424.jpg?1782706056",
+    releaseDate = "2020-11-20",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ConfiscateReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ConfiscateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Confiscate reprint in FDN. Canonical CardDefinition lives in its earliest set (USG).
+ */
+val ConfiscateReprint = Printing(
+    oracleId = "d599a38c-7719-443e-bb59-55bd43a8fee6",
+    name = "Confiscate",
+    setCode = "FDN",
+    collectorNumber = "709",
+    scryfallId = "a98a1553-e5f3-4c9c-833d-579e82e1708f",
+    artist = "Caroline Gariba",
+    imageUri = "https://cards.scryfall.io/normal/front/a/9/a98a1553-e5f3-4c9c-833d-579e82e1708f.jpg?1782688650",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FumigateReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/FumigateReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Fumigate reprint in FDN. Canonical CardDefinition lives in its earliest set (KLD).
+ */
+val FumigateReprint = Printing(
+    oracleId = "b17ea905-0696-4e58-b564-557e87236e27",
+    name = "Fumigate",
+    setCode = "FDN",
+    collectorNumber = "575",
+    scryfallId = "e2c1e655-1883-428f-abe8-69c011cfbd4b",
+    artist = "Svetlin Velinov",
+    imageUri = "https://cards.scryfall.io/normal/front/e/2/e2c1e655-1883-428f-abe8-69c011cfbd4b.jpg?1782688765",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SelfReflectionReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SelfReflectionReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Self-Reflection reprint in FDN. Canonical CardDefinition lives in its earliest set (LCI).
+ */
+val SelfReflectionReprint = Printing(
+    oracleId = "5c68853e-4fb8-465e-b262-e6dbaf972533",
+    name = "Self-Reflection",
+    setCode = "FDN",
+    collectorNumber = "163",
+    scryfallId = "e1e6abc9-25b2-4d51-b519-2525079eab51",
+    artist = "Henry Peters",
+    imageUri = "https://cards.scryfall.io/normal/front/e/1/e1e6abc9-25b2-4d51-b519-2525079eab51.jpg?1782689126",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/Fumigate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/kld/cards/Fumigate.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.kld.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Fumigate
+ * {3}{W}{W}
+ * Sorcery
+ * Destroy all creatures. You gain 1 life for each creature destroyed this way.
+ *
+ * Creatures can be regenerated (no "can't be regenerated" clause), and the life gain
+ * counts only creatures actually destroyed — [Effects.DestroyAll.storeDestroyedAs] records
+ * the destroyed set, whose count feeds the life gain (mirrors Decree of Pain's draw-per-kill).
+ */
+val Fumigate = card("Fumigate") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all creatures. You gain 1 life for each creature destroyed this way."
+
+    spell {
+        effect = Effects.DestroyAll(
+            filter = GameObjectFilter.Creature,
+            storeDestroyedAs = "destroyed"
+        ).then(
+            Effects.GainLife(DynamicAmount.VariableReference("destroyed_count"))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "15"
+        artist = "Svetlin Velinov"
+        flavorText = "\"Ghirapur's gremlin population poses a threat to the infrastructure of the " +
+            "fairgrounds. Threats must be eliminated.\"\n—Sram, senior edificer"
+        imageUri = "https://cards.scryfall.io/normal/front/f/0/f00f27a7-9e92-4fbf-baa8-f47a5eee48a6.jpg?1782711619"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SelfReflection.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SelfReflection.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Self-Reflection
+ * {4}{U}{U}
+ * Sorcery
+ * Create a token that's a copy of target creature you control.
+ * Flashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ *
+ * Sorcery-speed sibling of [com.wingedsheep.mtg.sets.definitions.isd.cards.CacklingCounterpart].
+ */
+val SelfReflection = card("Self-Reflection") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Create a token that's a copy of target creature you control.\n" +
+        "Flashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        val t = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.CreateTokenCopyOfTarget(t)
+    }
+    keywordAbility(KeywordAbility.flashback("{3}{U}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "74"
+        artist = "Henry Peters"
+        flavorText = "Some Echoes remember every moment of their past lives and spend their existence " +
+            "contemplating past choices."
+        imageUri = "https://cards.scryfall.io/normal/front/1/2/1242203d-c9b5-4ab6-802e-e222f92291e9.jpg?1782694551"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/Confiscate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/usg/cards/Confiscate.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.usg.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ControlEnchantedPermanent
+
+/**
+ * Confiscate
+ * {4}{U}{U}
+ * Enchantment — Aura
+ * Enchant permanent
+ * You control enchanted permanent.
+ *
+ * Broader sibling of [com.wingedsheep.mtg.sets.definitions.ons.cards.Annex]
+ * (which enchants only lands) — Confiscate can steal any permanent.
+ */
+val Confiscate = card("Confiscate") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant permanent\nYou control enchanted permanent."
+
+    auraTarget = Targets.Permanent
+
+    staticAbility {
+        ability = ControlEnchantedPermanent
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "66"
+        artist = "Adam Rex"
+        flavorText = "\"I don't understand why he works so hard on a device to duplicate a sound so " +
+            "easily made with hand and armpit.\"\n—Barrin, progress report"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7cba6d4a-58d0-42d6-b49b-65c72b86007f.jpg?1782720734"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/KLD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KLD.json
@@ -261,6 +261,56 @@
     "colorIdentityOverride": []
 }
 
+// Fumigate
+{
+    "name": "Fumigate",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all creatures. You gain 1 life for each creature destroyed this way.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "BattlefieldMatching",
+                        "filter": "creature"
+                    },
+                    "storeAs": "destroyAll_gathered"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "destroyAll_gathered",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    },
+                    "moveType": "Destroy",
+                    "storeMovedAs": "destroyed"
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "VariableReference",
+                        "variableName": "destroyed_count"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "rarity": "RARE",
+        "artist": "Svetlin Velinov",
+        "flavorText": "\"Ghirapur's gremlin population poses a threat to the infrastructure of the fairgrounds. Threats must be eliminated.\"\n—Sram, senior edificer",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/0/f00f27a7-9e92-4fbf-baa8-f47a5eee48a6.jpg?1782711619"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Workshop Assistant
 {
     "name": "Workshop Assistant",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3696,6 +3696,51 @@
     ]
 }
 
+// Self-Reflection
+{
+    "name": "Self-Reflection",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a token that's a copy of target creature you control.\nFlashback {3}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{3}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateTokenCopyOfTarget",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature you control"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "rarity": "UNCOMMON",
+        "artist": "Henry Peters",
+        "flavorText": "Some Echoes remember every moment of their past lives and spend their existence contemplating past choices.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/2/1242203d-c9b5-4ab6-802e-e222f92291e9.jpg?1782694551"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Sentinel of the Nameless City
 {
     "name": "Sentinel of the Nameless City",

--- a/mtg-sets/src/test/resources/snapshots/cards/USG.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/USG.json
@@ -1096,6 +1096,35 @@
     ]
 }
 
+// Confiscate
+{
+    "name": "Confiscate",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant permanent\nYou control enchanted permanent.",
+    "script": {
+        "staticAbilities": [
+            "ControlEnchantedPermanent"
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "permanent"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "rarity": "UNCOMMON",
+        "artist": "Adam Rex",
+        "flavorText": "\"I don't understand why he works so hard on a device to duplicate a sound so easily made with hand and armpit.\"\n—Barrin, progress report",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7cba6d4a-58d0-42d6-b49b-65c72b86007f.jpg?1782720734"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Coral Merfolk
 {
     "name": "Coral Merfolk",


### PR DESCRIPTION
Implements three missing Foundations (FDN) cards via the `add-card` skill. Each is a reprint, so the canonical `CardDefinition` lives in the card's earliest real printing and FDN (plus other scaffolded sets) get `Printing` rows.

## Cards

| Card | Canonical set | Mechanic | Reuses |
|------|---------------|----------|--------|
| **Confiscate** `{4}{U}{U}` | USG | Aura — "Enchant permanent / You control enchanted permanent" | `ControlEnchantedPermanent` (any-permanent sibling of Annex) |
| **Self-Reflection** `{4}{U}{U}` | LCI | Sorcery — token copy of target creature you control + Flashback `{3}{U}` | `CreateTokenCopyOfTarget` + `KeywordAbility.flashback` (sorcery-speed Cackling Counterpart) |
| **Fumigate** `{3}{W}{W}` | KLD | Sorcery — destroy all creatures, gain 1 life per creature destroyed this way | `DestroyAll(storeDestroyedAs)` → `GainLife(VariableReference)` (mirrors Decree of Pain) |

All three compose existing, precedent-tested SDK primitives — **no new engine/SDK types**, so no SDK-reference or emitter changes and no new scenario tests (behavior is already covered by the precedent cards' tests).

## Reprint rows added
- Confiscate: FDN (709), 8ED (69), CMR (62)
- Self-Reflection: FDN (163)
- Fumigate: FDN (575)

## Verification
- `just build` green
- `CardDefinitionSnapshotTest` re-blessed — diff adds only these three cards (USG/LCI/KLD goldens), nothing else changed
- `just check-card-printing` clean for all three (canonical in earliest printing, all scaffolded printings have rows)
- All image URIs verified HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)