### PR TITLE
Fix saga stage counter overlapping P/T on Saga creatures

### DIFF
--- a/web-client/src/components/game/card/GameCard.tsx
+++ b/web-client/src/components/game/card/GameCard.tsx
@@ -1996,8 +1996,11 @@ function GameCardImpl({
                 )
               })}
             </div>
-            {/* Lore counter badge in P/T position */}
-            {loreCount > 0 && (
+            {/* Lore counter badge in P/T position — suppressed on Saga creatures
+                (e.g. FIN "Summon:" cards, Enchantment Creature — Saga) where the
+                real P/T overlay already occupies this corner. The chapter track
+                along the left edge conveys the current stage on its own. */}
+            {loreCount > 0 && (card.power === null || card.power === undefined) && (
               <div style={{
                 ...styles.sagaLoreBadge,
                 fontSize: responsive.badges.ptFontSize,


### PR DESCRIPTION
## Problem

On Saga *creatures* — e.g. FIN `Summon:` cards like **Summon: Titan** (`Enchantment Creature — Saga`) — the saga lore counter badge (`N / M`) is drawn in the bottom-right P/T corner, right on top of the card's actual power/toughness overlay. The two badges overlap and the P/T becomes unreadable.

## Fix

Gate the lore badge on the card having **no P/T**, so it only shows in the P/T corner for non-creature sagas. This mirrors the existing treatment of the loyalty badge, which is already suppressed on animated planeswalkers that carry a P/T (`GameCard.tsx:1430`).

The chapter progress track along the left edge still shows the current stage on creature sagas, so no information is lost — which is exactly what was requested.

## Testing

- `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)