### PR TITLE
Tournament lobby: random-set pick + extension sets require a base set

### DIFF
--- a/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
+++ b/ai/src/main/kotlin/com/wingedsheep/ai/engine/SealedDeckGenerator.kt
@@ -25,19 +25,22 @@ class SealedDeckGenerator(
     /**
      * Picks a random set code that can actually produce a sealed deck.
      *
-     * Eligible sets must be both [BoosterGenerator.SetConfig.fullyImplemented] *and* large enough to
-     * open 8 boosters on their own. A partial set, or a small supplementary set like "The Big Score"
-     * (BIG, ~30 cards), has a pool too thin for the single-set booster strategy and throws
-     * `No cards available for booster generation`. Random quick/AI games have no host to opt into a
-     * partial set, so they must draw from a full standalone set. The fallbacks widen the pool only if
-     * — unexpectedly — nothing qualifies, so this never throws on an empty pool.
+     * Eligible sets must be [BoosterGenerator.SetConfig.fullyImplemented], not an
+     * [BoosterGenerator.SetConfig.extensionSet] (bonus sheets like "The Big Score" are only playable
+     * alongside a regular set), *and* large enough to open 8 boosters on their own — a pool that is
+     * too thin for the single-set booster strategy throws `No cards available for booster
+     * generation`. Random quick/AI games have no host to opt into a partial set, so they must draw
+     * from a full standalone set. The fallbacks widen the pool only if — unexpectedly — nothing
+     * qualifies, so this never throws on an empty pool.
      */
     fun randomSetCode(): String {
-        val sets = boosterGenerator.availableSets.values
+        val sets = boosterGenerator.availableSets.values.filter { !it.extensionSet }.ifEmpty {
+            boosterGenerator.availableSets.values.toList()
+        }
         val standalone = sets.filter { it.fullyImplemented && it.distinctCardCount >= MIN_STANDALONE_SET_SIZE }
         val pool = standalone
             .ifEmpty { sets.filter { it.fullyImplemented } }
-            .ifEmpty { sets.toList() }
+            .ifEmpty { sets }
         return pool.random().setCode
     }
 

--- a/ai/src/test/kotlin/com/wingedsheep/ai/engine/SealedDeckGeneratorTest.kt
+++ b/ai/src/test/kotlin/com/wingedsheep/ai/engine/SealedDeckGeneratorTest.kt
@@ -46,7 +46,13 @@ class SealedDeckGeneratorTest : FunSpec({
             (1..40).map { card("$prefix Uncommon $it", Rarity.UNCOMMON) } +
             (1..20).map { card("$prefix Rare $it", Rarity.RARE) }
 
-    fun config(code: String, cards: List<CardDefinition>, sealedSupported: Boolean, incomplete: Boolean = false) =
+    fun config(
+        code: String,
+        cards: List<CardDefinition>,
+        sealedSupported: Boolean,
+        incomplete: Boolean = false,
+        extensionSet: Boolean = false,
+    ) =
         BoosterGenerator.SetConfig(
             setCode = code,
             setName = "Set $code",
@@ -54,6 +60,7 @@ class SealedDeckGeneratorTest : FunSpec({
             basicLands = emptyList(),
             sealedSupported = sealedSupported,
             incomplete = incomplete,
+            extensionSet = extensionSet,
         )
 
     test("randomSetCode only returns fully-implemented sets") {
@@ -88,6 +95,33 @@ class SealedDeckGeneratorTest : FunSpec({
 
         val drawn = (1..500).map { gen.randomSetCode() }.toSet()
         drawn.toList() shouldContainExactly listOf("FULL")
+    }
+
+    test("randomSetCode never lands on an extension set, whatever its size") {
+        // An extension set (bonus sheet) is only playable alongside a regular set, so a random
+        // roll — which yields a single set — must never pick one, even a hypothetical large one.
+        val gen = SealedDeckGenerator(
+            BoosterGenerator(
+                mapOf(
+                    "FULL" to config("FULL", largePool("FULL"), sealedSupported = true),
+                    "EXT" to config("EXT", largePool("EXT"), sealedSupported = true, extensionSet = true),
+                )
+            )
+        )
+
+        val drawn = (1..500).map { gen.randomSetCode() }.toSet()
+        drawn.toList() shouldContainExactly listOf("FULL")
+    }
+
+    test("falls back to an extension set only when nothing else exists at all") {
+        // Pathological catalog with a single extension set: still return something rather than throw.
+        val gen = SealedDeckGenerator(
+            BoosterGenerator(
+                mapOf("EXT" to config("EXT", viablePool("EXT"), sealedSupported = true, extensionSet = true))
+            )
+        )
+
+        gen.randomSetCode() shouldBe "EXT"
     }
 
     test("falls back to any complete set when none meet the standalone size threshold") {

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -150,6 +150,10 @@ Optional overrides commonly used by real sets:
   deck building).
 - `printings: List<Printing>` — register reprints whose canonical `CardDefinition` lives in an
   earlier set.
+- `extensionSet = true` — mark a bonus sheet / supplemental release (e.g. The Big Score alongside
+  Outlaws of Thunder Junction) whose pool is too thin to play alone. Extension sets stay fully
+  selectable in the tournament lobby but only together with at least one regular set; single-set
+  pickers and random-set rolls skip them.
 
 ### Step 3: Register in `MtgSetCatalog`
 

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/config/GameBeansConfig.kt
@@ -168,6 +168,7 @@ private fun MtgSet.toBoosterSetConfig(cards: List<CardDefinition>): BoosterGener
         basicLands = (basicLandsFallback ?: this).basicLands,
         incomplete = incomplete,
         sealedSupported = sealedSupported,
+        extensionSet = extensionSet,
         block = block,
         releaseDate = releaseDate,
         boosterStrategy = boosterStrategy,

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/LlmTournamentController.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/controller/LlmTournamentController.kt
@@ -106,6 +106,8 @@ class LlmTournamentController(
         val code: String,
         val name: String,
         val partial: Boolean,
+        /** Extension sets (bonus sheets) can't play alone; the single-set picker hides them. */
+        val extensionSet: Boolean,
         val block: String?,
         val implementedCount: Int,
         val releaseDate: String?
@@ -172,6 +174,7 @@ class LlmTournamentController(
                 code = config.setCode,
                 name = config.setName,
                 partial = !config.fullyImplemented,
+                extensionSet = config.extensionSet,
                 block = config.block,
                 implementedCount = config.distinctCardCount,
                 releaseDate = config.releaseDate

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/ConnectionHandler.kt
@@ -74,6 +74,7 @@ class ConnectionHandler(
             code = config.setCode,
             name = config.setName,
             partial = !config.fullyImplemented,
+            extensionSet = config.extensionSet,
             block = config.block,
             implementedCount = config.distinctCardCount,
             releaseDate = config.releaseDate

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -223,6 +223,7 @@ class LobbyHandler(
             boosterGenerator.getSetConfig(code)
                 ?: error("Unknown set code: $code")
         }
+        extensionOnlyError(setConfigs)?.let { error(it) }
 
         val codes = setConfigs.map { it.setCode }
         val boosterCount = 6
@@ -361,6 +362,10 @@ class LobbyHandler(
                 sender.sendError(session, ErrorCode.INVALID_ACTION, "Unknown set code: $setCode")
                 return
             }
+        }
+        extensionOnlyError(setConfigs)?.let { error ->
+            sender.sendError(session, ErrorCode.INVALID_ACTION, error)
+            return
         }
 
         val sealedSession = SealedSession(
@@ -534,6 +539,18 @@ class LobbyHandler(
     // Lobby CRUD
     // =========================================================================
 
+    /**
+     * Rejection message when a non-empty selection consists solely of extension sets (bonus sheets
+     * like The Big Score) — those supplement a regular set's boosters and can't carry a sealed/draft
+     * pool on their own. Returns null when the selection is fine.
+     */
+    private fun extensionOnlyError(setConfigs: List<BoosterGenerator.SetConfig>): String? {
+        if (setConfigs.isEmpty() || setConfigs.any { !it.extensionSet }) return null
+        val names = setConfigs.joinToString { it.setName }
+        val verb = if (setConfigs.size == 1) "is an extension set" else "are extension sets"
+        return "$names $verb — add at least one regular set to play with"
+    }
+
     private fun handleCreateTournamentLobby(session: WebSocketSession, message: ClientMessage.CreateTournamentLobby) {
         val playerSession = sessionRegistry.getPlayerSession(session.id)
         if (playerSession == null) {
@@ -550,6 +567,10 @@ class LobbyHandler(
         if (setConfigs.size != message.setCodes.size) {
             val invalidCodes = message.setCodes.filter { boosterGenerator.getSetConfig(it) == null }
             sender.sendError(session, ErrorCode.INVALID_ACTION, "Unknown set codes: ${invalidCodes.joinToString()}")
+            return
+        }
+        extensionOnlyError(setConfigs)?.let { error ->
+            sender.sendError(session, ErrorCode.INVALID_ACTION, error)
             return
         }
 
@@ -1147,6 +1168,16 @@ class LobbyHandler(
         if (lobby.playerCount < 2) {
             sender.sendError(session, ErrorCode.INVALID_ACTION, "Need at least 2 players")
             return
+        }
+
+        // Booster-based formats can't run on extension sets alone (Premade brings its own decks
+        // and ignores the set selection). The lobby may hold an extension-only selection while
+        // the host is still assembling it, so this start gate is where the rule is enforced.
+        if (lobby.format != TournamentFormat.PREMADE_DECKS) {
+            extensionOnlyError(lobby.setCodes.mapNotNull { boosterGenerator.getSetConfig(it) })?.let { error ->
+                sender.sendError(session, ErrorCode.INVALID_ACTION, error)
+                return
+            }
         }
 
         // Ranked tournaments adjust ELO, so they only count when every seat is a signed-in account
@@ -1956,6 +1987,8 @@ class LobbyHandler(
         // Update sets if provided (can be empty to disable start)
         message.setCodes?.let { newSetCodes ->
             // Allow empty setCodes to disable start button (but won't be able to start)
+            // An extension-only selection is allowed here as an intermediate state (the host may
+            // add the extension set first, then the base set) — the start handler is the gate.
             if (newSetCodes.isNotEmpty() && !lobby.updateSets(newSetCodes)) {
                 val invalidCodes = newSetCodes.filter { boosterGenerator.getSetConfig(it) == null }
                 sender.sendError(session, ErrorCode.INVALID_ACTION, "Invalid set codes: ${invalidCodes.joinToString()}")

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -1565,6 +1565,7 @@ class TournamentLobby(
                 code = config.setCode,
                 name = config.setName,
                 partial = !config.fullyImplemented,
+                extensionSet = config.extensionSet,
                 block = config.block,
                 implementedCount = config.distinctCardCount,
                 releaseDate = config.releaseDate

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/protocol/ServerMessage.kt
@@ -428,6 +428,12 @@ sealed interface ServerMessage {
          * clients only need this coarser "is it fully ready" signal.)
          */
         val partial: Boolean = false,
+        /**
+         * True for extension sets (bonus sheets like The Big Score): fully implemented but too thin
+         * to play alone. Clients only allow them alongside at least one regular set, and the server
+         * rejects a selection consisting solely of extension sets.
+         */
+        val extensionSet: Boolean = false,
         val block: String? = null,
         val implementedCount: Int? = null,
         val releaseDate: String? = null

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/MtgSet.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/model/MtgSet.kt
@@ -72,6 +72,15 @@ interface MtgSet {
     val sealedSupported: Boolean get() = false
 
     /**
+     * True for extension sets — bonus sheets and other supplemental releases (e.g. The Big Score
+     * alongside Outlaws of Thunder Junction) whose pool is too thin to carry a sealed/draft pool
+     * on its own. Extension sets are still fully selectable, but only *in combination with* at
+     * least one regular set: lobbies reject a selection consisting solely of extension sets, and
+     * random-set rolls never land on one.
+     */
+    val extensionSet: Boolean get() = false
+
+    /**
      * Probability in `[0.0, 1.0]` that an individual card rolled into a booster is shown with one
      * of its alternate-frame printings (showcase / borderless) instead of its canonical art. The
      * roll is per card and only fires for cards that actually have an alternate-frame [Printing]

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/TheBigScoreSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/big/TheBigScoreSet.kt
@@ -20,6 +20,10 @@ object TheBigScoreSet : MtgSet {
     // All 30 cards of the bonus sheet are implemented — surface it as complete, not "partial".
     override val sealedSupported = true
 
+    // A 30-card bonus sheet can't sustain a sealed/draft pool by itself — it is only playable
+    // together with at least one regular set.
+    override val extensionSet = true
+
     override val cards: List<CardDefinition> by lazy {
         CardDiscovery.findIn(CARDS_PACKAGE)
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/limited/BoosterGenerator.kt
@@ -45,6 +45,12 @@ class BoosterGenerator(
          * callers that hand-build configs keep their prior behaviour.
          */
         val sealedSupported: Boolean = true,
+        /**
+         * True for extension sets (bonus sheets like The Big Score) that are fully implemented but
+         * too thin to carry a sealed/draft pool alone. See [com.wingedsheep.sdk.model.MtgSet.extensionSet];
+         * lobbies require at least one non-extension set in any selection containing one.
+         */
+        val extensionSet: Boolean = false,
         val block: String? = null,
         /** Set release date in ISO `YYYY-MM-DD` form, or null if unknown. Used by clients to sort sets chronologically. */
         val releaseDate: String? = null,

--- a/web-client/src/components/ui/GameUI.module.css
+++ b/web-client/src/components/ui/GameUI.module.css
@@ -1814,6 +1814,20 @@
   border-radius: 999px;
 }
 
+/* Extension sets (bonus sheets like The Big Score) — playable only alongside a regular set. */
+.setExtensionBadge {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  font-size: 9px;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #a78bfa;
+  background: rgba(167, 139, 250, 0.14);
+  border: 1px solid rgba(167, 139, 250, 0.4);
+  border-radius: 999px;
+}
+
 .setPickerEmpty {
   font-size: var(--font-sm);
   color: var(--text-disabled);

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -822,6 +822,11 @@ function LobbyOverlay({
   const isAnyDraft = isDraft || isWinston || isGridDraft || isCommanderDraft
   const isAnySealed = isSealed || isCommanderSealed
   const hasSelectedSets = lobbyState.settings.setCodes.length > 0
+  // Extension sets (bonus sheets like The Big Score) can't carry a pool alone — the selection
+  // needs at least one regular set. Unknown codes count as regular; the server re-validates.
+  const hasBaseSet = lobbyState.settings.setCodes.some(
+    (code) => !lobbyState.settings.availableSets.find((s) => s.code === code)?.extensionSet,
+  )
   const playerCount = lobbyState.players.length
   const canSwitchToNormalDraft = playerCount <= 8
   const canSwitchToWinston = playerCount <= 2
@@ -842,7 +847,7 @@ function LobbyOverlay({
     .every((p) => p.deckSubmitted)
   const canStart = isPremade
     ? playerCheck && allConnectedDecksSubmitted
-    : playerCheck && hasSelectedSets
+    : playerCheck && hasSelectedSets && hasBaseSet
 
   const copyLobbyId = () => {
     navigator.clipboard.writeText(lobbyState.lobbyId)
@@ -866,6 +871,16 @@ function LobbyOverlay({
       ? lobbyState.settings.setCodes.filter((c) => c !== code)
       : [...lobbyState.settings.setCodes, code]
     updateLobbySettings({ setCodes: newCodes })
+  }
+
+  // "Random Set" in the picker: add one random complete, standalone set to the selection.
+  // Partial sets stay opt-in and extension sets can't anchor a pool, so neither is rolled.
+  const addRandomSet = () => {
+    const candidates = allSets.filter(
+      (s) => !s.partial && !s.extensionSet && !lobbyState.settings.setCodes.includes(s.code),
+    )
+    const pick = candidates[Math.floor(Math.random() * candidates.length)]
+    if (pick) updateLobbySettings({ setCodes: [...lobbyState.settings.setCodes, pick.code] })
   }
 
   return (
@@ -1218,7 +1233,11 @@ function LobbyOverlay({
                       <span
                         key={set.code}
                         className={`${styles.setChip} ${isAnyDraft ? styles.setChipDraft : ''} ${set.partial ? styles.setChipPartial : ''}`}
-                        title={set.partial ? `${set.name} — partial (reduced card pool)` : set.name}
+                        title={set.partial
+                          ? `${set.name} — partial (reduced card pool)`
+                          : set.extensionSet
+                            ? `${set.name} — extension set (needs a regular set alongside)`
+                            : set.name}
                       >
                         <SetIcon code={set.code} className={styles.setChipIcon} />
                         <span className={styles.setChipName}>{set.name}</span>
@@ -1233,6 +1252,11 @@ function LobbyOverlay({
                   </div>
                 ) : (
                   <span className={styles.setSelectionEmpty}>No sets selected yet</span>
+                )}
+                {hasSelectedSets && !hasBaseSet && (
+                  <span className={styles.setSelectionEmpty}>
+                    Extension sets need a regular set alongside them.
+                  </span>
                 )}
                 <button
                   type="button"
@@ -1690,7 +1714,9 @@ function LobbyOverlay({
                       : undefined
                   : !hasSelectedSets
                     ? 'Select at least one set'
-                    : isWinston && lobbyState.players.length !== 2
+                    : !hasBaseSet
+                      ? 'Extension sets need a regular set alongside them — add one'
+                      : isWinston && lobbyState.players.length !== 2
                       ? 'Winston Draft requires exactly 2 players'
                       : lobbyState.players.length < 2
                         ? 'Need at least 2 players'
@@ -1718,6 +1744,7 @@ function LobbyOverlay({
           sets={allSets}
           selectedCodes={lobbyState.settings.setCodes}
           onToggleSet={toggleSet}
+          onSelectRandom={addRandomSet}
           onClose={() => setShowSetPicker(false)}
         />
       )}

--- a/web-client/src/components/ui/SetPickerModal.tsx
+++ b/web-client/src/components/ui/SetPickerModal.tsx
@@ -4,10 +4,14 @@
  *
  * Every set (complete + partial) lives behind this one modal. It supports two modes:
  *   - `multi`  (default): clicking a row toggles it and the modal stays open. The host builds a
- *               multi-set pool (tournament lobby).
+ *               multi-set pool (tournament lobby). With `onSelectRandom` a top "Random Set" row
+ *               asks the parent to add a random set to the selection.
  *   - `single`: clicking a row selects it and closes the modal. With `onSelectRandom` a top
  *               "Random Set" row clears the selection so the server rolls a random set
  *               (Quick Game random sealed pool).
+ *
+ * Extension sets (bonus sheets like The Big Score) carry an "extension" badge and are only
+ * playable alongside a regular set, so single mode hides them entirely.
  *
  * Visuals come from `GameUI.module.css` (the shared lobby stylesheet — `QuickGameLobbyOverlay`
  * already reuses it) so both lobbies look identical.
@@ -31,8 +35,9 @@ export interface SetPickerModalProps {
    */
   mode?: 'single' | 'multi'
   /**
-   * Single mode only — when provided, a "Random Set" row is shown at the top that clears the
-   * selection (the server then rolls a random set). Selecting it closes the modal.
+   * When provided, a "Random Set" row is shown at the top. In single mode it clears the selection
+   * (the server then rolls a random set) and closes the modal; in multi mode the parent picks a
+   * random set to add to the selection and the modal stays open.
    */
   onSelectRandom?: () => void
   /** Modal heading. Defaults to "Choose sets". */
@@ -87,8 +92,11 @@ export function SetPickerModal({
   //    near-empty sets you'd otherwise see once partial sets are shown).
   const partialSetCount = sets.filter((s) => s.partial).length
   const pickerSets = sets.filter((s) => {
+    // Single mode picks exactly one set, and an extension set can't be played on its own.
+    if (isSingle && s.extensionSet) return false
     if (isSelected(s.code)) return true
     if (s.partial && !showPartialSets) return false
+    if (s.extensionSet) return true // full bonus sheets stay visible despite a thin card count
     if ((s.implementedCount ?? 0) < minCards) return false
     return true
   })
@@ -110,7 +118,7 @@ export function SetPickerModal({
 
   const handleRandom = () => {
     onSelectRandom?.()
-    onClose()
+    if (isSingle) onClose()
   }
 
   // One toggle row inside the picker modal. Incomplete sets get a "partial" tag so the user knows
@@ -129,6 +137,7 @@ export function SetPickerModal({
         <SetIcon code={set.code} className={styles.setPickerIcon} />
         <span className={styles.setPickerName}>{set.name}</span>
         {set.partial && <span className={styles.setPartialBadge}>partial</span>}
+        {set.extensionSet && <span className={styles.setExtensionBadge}>extension</span>}
         {released && <span className={styles.setReleaseDate}>{released}</span>}
         {set.implementedCount != null && (
           <span className={styles.setButtonCardCount}>{set.implementedCount} cards</span>
@@ -191,8 +200,8 @@ export function SetPickerModal({
     )
   }
 
-  const showRandomRow = isSingle && onSelectRandom != null
-  const randomActive = selectedCodes.length === 0
+  const showRandomRow = onSelectRandom != null
+  const randomActive = isSingle && selectedCodes.length === 0
 
   return (
     <div className={styles.deckViewerBackdrop} onClick={onClose}>
@@ -251,6 +260,12 @@ export function SetPickerModal({
           <p className={styles.setPickerNote}>
             Sets tagged <span className={styles.setPartialBadge}>partial</span> aren't fully
             implemented — their boosters draw from a reduced pool of the cards that exist.
+            {!isSingle && pickerSets.some((s) => s.extensionSet) && (
+              <>
+                {' '}Sets tagged <span className={styles.setExtensionBadge}>extension</span> are
+                bonus sheets — pick them together with at least one regular set.
+              </>
+            )}
           </p>
           <div className={styles.setPickerList}>
             {showRandomRow && (

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1241,6 +1241,11 @@ export interface AvailableSet {
    * incomplete). The lobby set picker hides partial sets behind a default-off toggle.
    */
   readonly partial?: boolean
+  /**
+   * True for extension sets (bonus sheets like The Big Score): fully implemented but too thin to
+   * play alone — only selectable together with at least one regular set.
+   */
+  readonly extensionSet?: boolean
   readonly block?: string
   readonly implementedCount?: number
   /** Set release date in ISO `YYYY-MM-DD` form, or undefined if unknown. */


### PR DESCRIPTION
## What

Two tournament-lobby set-selection improvements:

1. **Random Set in the tournament lobby** — the shared `SetPickerModal` already had a "Random Set" row, but only in single-select mode (Quick Game). It now also appears in the tournament lobby's multi-select picker: clicking 🎲 adds one random *complete, standalone* set to the selection (partial sets and extension sets are never rolled).
2. **Extension sets require a base set** — The Big Score (BIG, the 30-card bonus sheet shipped alongside Outlaws of Thunder Junction) was selectable and startable on its own, but its pool can't carry a sealed/draft pool. A new `MtgSet.extensionSet` flag marks such sets, and they are now only playable in combination with at least one regular set.

## How

- **SDK**: `MtgSet.extensionSet` (default `false`), set on `TheBigScoreSet`; documented in `docs/api-guide.md`.
- **Engine**: `BoosterGenerator.SetConfig.extensionSet` carries the flag.
- **Server**:
  - `AvailableSet` DTOs (lobby WebSocket + LLM-tournament REST) expose `extensionSet`.
  - `handleStartTournamentLobby` rejects a selection consisting solely of extension sets (Premade excluded — it ignores sets). Enforcement is at **start**, not settings-update, so a host can add the extension set first and the base set second while assembling the pool. Lobby create / 1v1 sealed create / dev AI-tournament create are also guarded as backstops.
  - `SealedDeckGenerator.randomSetCode()` (quick/AI games) now explicitly never rolls an extension set (it previously skipped BIG only via the size heuristic).
- **Client**:
  - Tournament picker gets the Random Set row (adds a random set, modal stays open).
  - Extension sets get an `extension` badge, a picker note, and stay visible regardless of the min-cards filter (a full bonus sheet is complete at 30 cards).
  - Start button disables with a hint, and the Sets row shows "Extension sets need a regular set alongside them." when only extension sets are selected.
  - Single-set pickers (Quick Game random tab, LLM tournament page) hide extension sets entirely.

## Screenshots

Random Set row in the tournament set picker:

![random row](https://raw.githubusercontent.com/wingedsheep/argentum-engine/tournament-random-extension-screenshots/01-picker-random-row.png)

Extension badge + explanatory note (The Big Score):

![extension badge](https://raw.githubusercontent.com/wingedsheep/argentum-engine/tournament-random-extension-screenshots/02-picker-extension-badge.png)

Extension-only selection blocked with a hint:

![blocked](https://raw.githubusercontent.com/wingedsheep/argentum-engine/tournament-random-extension-screenshots/03-lobby-extension-only-blocked.png)

After clicking Random Set (added Duskmourn next to the default set):

![after random](https://raw.githubusercontent.com/wingedsheep/argentum-engine/tournament-random-extension-screenshots/04-lobby-after-random-pick.png)

*(Screenshots hosted on the throwaway `tournament-random-extension-screenshots` branch.)*

## Testing

- `just test-server` ✅
- `:ai:test` ✅ — including two new `SealedDeckGeneratorTest` cases (random roll never lands on an extension set; falls back gracefully if the catalog is extension-only)
- `npm run typecheck` ✅
- Manual Playwright run against the full stack: random pick adds a set; extension-only selection shows the warning (screenshots above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
