### PR TITLE
Add Ultima (Final Fantasy) with EndTheTurn (CR 720) support

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -410,6 +410,16 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `TakeExtraTurn(target, loseAtEndStep?)` — target takes an extra turn after this one (Time Walk, Lost Isle Calling).
   Set `loseAtEndStep = true` for "...you lose the game at the beginning of that turn's end step" (Last Chance, Final
   Fortune). Prevented by the `PreventExtraTurns` replacement (Ugin's Nexus).
+- `EndTheTurn` — end the current turn (CR 720): Ultima ("Destroy all artifacts and creatures. End the turn."),
+  Time Stop, Sundial of the Infinite, Discontinuity. When it resolves the whole stack is exiled (including the
+  source and any triggered abilities the resolution queued — even ones that can't be countered — so those never
+  reach the stack, CR 720.1c), creatures are removed from combat, and the game skips straight to the cleanup step
+  (discard to maximum hand size, marked damage wears off, "this turn" / "until end of turn" effects end) before the
+  next turn begins. Takes no target — it always ends the active player's turn. Modeled as a two-step effect: the
+  executor records an `EndTheTurnRequestedComponent` on the active player, and `PassPriorityHandler` runs the
+  sequence via `TurnManager.performEndTheTurn` once the current resolution finishes (so it can exile the *rest* of
+  the stack and drop the pending triggers). Compose after a board wipe with
+  `Effects.Composite(listOf(Effects.DestroyAll(...), Effects.EndTheTurn))`.
 - `ForceExileMultiZone(count, target)` — exile from hand/battlefield/graveyard combined (Lich's Mastery shape).
 
 ### Cards (draw / discard)

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -3211,6 +3211,14 @@ object Effects {
     val AddMainPhase: Effect = com.wingedsheep.sdk.scripting.effects.AddMainPhaseEffect
 
     /**
+     * End the turn (CR 720): exile the whole stack (including this source) and any pending
+     * triggers, remove creatures from combat, then skip straight to the cleanup step (discard to
+     * maximum hand size, damage wears off, "until end of turn" effects end) and begin the next
+     * turn. Used for Ultima ("Destroy all artifacts and creatures. End the turn."), Time Stop, etc.
+     */
+    val EndTheTurn: Effect = com.wingedsheep.sdk.scripting.effects.EndTheTurnEffect
+
+    /**
      * Give the controller [amount] additional upkeep steps after the current phase
      * (Obeka, Splitter of Seconds). Each is a beginning phase containing only an upkeep step
      * (untap and draw skipped, CR 500.10); they occur after any additional combat phases (CR 500.8).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/PlayerEffects.kt
@@ -188,6 +188,30 @@ data class TakeExtraTurnEffect(
 }
 
 /**
+ * End the turn (CR 720). Used for Time Stop, Sundial of the Infinite, Discontinuity, and
+ * Final Fantasy's Ultima ("Destroy all artifacts and creatures. End the turn.").
+ *
+ * When this resolves, in order (CR 720.1):
+ *  - every spell and ability on the stack is exiled, **including the source of this effect**;
+ *  - triggered abilities that would have gone on the stack from the events so far (e.g. the dies
+ *    triggers from a preceding board wipe) are discarded, never put on the stack (CR 720.1c);
+ *  - creatures and players are removed from combat;
+ *  - the game skips straight to the cleanup step — the active player discards down to their
+ *    maximum hand size, marked damage wears off, and "this turn" / "until end of turn" effects end;
+ *  - then the turn ends normally and the next turn begins.
+ *
+ * This is a turn-structure effect: the executor only records the request (see the engine's
+ * `EndTheTurnRequestedComponent`); the actual end-the-turn sequence runs after the current
+ * resolution completes so it can exile the rest of the stack and suppress the pending triggers.
+ * It takes no target — it always ends the current turn regardless of who controls the effect.
+ */
+@SerialName("EndTheTurn")
+@Serializable
+data object EndTheTurnEffect : Effect {
+    override val description: String = "End the turn"
+}
+
+/**
  * Prevent the target player from playing lands for the rest of this turn.
  * Sets the player's remaining land drops to 0.
  * Defaults to the controller (e.g. Rock Jockey); pass a [EffectTarget.PlayerRef]

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Ultima.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/Ultima.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Ultima
+ * {3}{W}{W}
+ * Sorcery
+ * Destroy all artifacts and creatures. End the turn.
+ *
+ * The board wipe resolves first — regeneration still saves creatures (there is no "can't be
+ * regenerated" clause). Then "end the turn" (CR 720): all spells and abilities on the stack are
+ * exiled, including Ultima itself and the dies triggers from the wipe (even those that can't be
+ * countered — they never reach the stack, CR 720.1c); creatures are removed from combat; and the
+ * game skips straight to the cleanup step — the active player discards down to their maximum hand
+ * size, marked damage wears off, and "this turn" / "until end of turn" effects end — before the
+ * next turn begins.
+ */
+val Ultima = card("Ultima") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy all artifacts and creatures. End the turn. (Exile all spells and " +
+        "abilities from the stack, including this card. The player whose turn it is discards down " +
+        "to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of " +
+        "turn\" effects end.)"
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                Effects.DestroyAll(GameObjectFilter.Artifact or GameObjectFilter.Creature),
+                Effects.EndTheTurn,
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "38"
+        artist = "Gintas Galvanauskas"
+        flavorText = "\"Such devastation ... this was not my intention!\"\n—Gaius van Baelsar"
+        imageUri = "https://cards.scryfall.io/normal/front/3/9/39504a0e-f63f-4907-afd7-c4492f6b8a3b.jpg?1782686568"
+        ruling(
+            "2025-06-06",
+            "Ending the turn happens in order: (1) all spells and abilities on the stack are " +
+                "exiled, including the dies triggers from destroying all artifacts and creatures " +
+                "and Ultima itself, even ones that can't be countered; (2) attacking and blocking " +
+                "creatures are removed from combat; (3) state-based actions are checked, no player " +
+                "gets priority, and no triggered abilities are put onto the stack; (4) the game " +
+                "skips straight to the cleanup step, which happens in its entirety."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -18776,6 +18776,60 @@
     ]
 }
 
+// Ultima
+{
+    "name": "Ultima",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy all artifacts and creatures. End the turn. (Exile all spells and abilities from the stack, including this card. The player whose turn it is discards down to their maximum hand size. Damage wears off, and \"this turn\" and \"until end of turn\" effects end.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": "artifact|creature"
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                },
+                "EndTheTurn"
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "rarity": "RARE",
+        "artist": "Gintas Galvanauskas",
+        "flavorText": "\"Such devastation ... this was not my intention!\"\n—Gaius van Baelsar",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/9/39504a0e-f63f-4907-afd7-c4492f6b8a3b.jpg?1782686568",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "Ending the turn happens in order: (1) all spells and abilities on the stack are exiled, including the dies triggers from destroying all artifacts and creatures and Ultima itself, even ones that can't be countered; (2) attacking and blocking creatures are removed from combat; (3) state-based actions are checked, no player gets priority, and no triggered abilities are put onto the stack; (4) the game skips straight to the cleanup step, which happens in its entirety."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Ultima Weapon
 {
     "name": "Ultima Weapon",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -509,6 +509,7 @@ val engineSerializersModule = SerializersModule {
         subclass(FlashGrantsThisTurnComponent::class)
         subclass(PutCounterOnCreatureThisTurnComponent::class)
         subclass(SkipNextTurnComponent::class)
+        subclass(EndTheTurnRequestedComponent::class)
         subclass(PlayerTurnHijackedComponent::class)
         subclass(HotseatControlComponent::class)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -29,6 +29,9 @@ import com.wingedsheep.engine.state.components.player.PlayerTurnHijackedComponen
 import com.wingedsheep.engine.state.components.player.PlayerTurnsTakenComponent
 import com.wingedsheep.engine.state.components.player.SkipCombatPhasesComponent
 import com.wingedsheep.engine.state.components.player.SkipNextTurnComponent
+import com.wingedsheep.engine.state.components.player.EndTheTurnRequestedComponent
+import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
+import com.wingedsheep.engine.mechanics.stack.StackResolver
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
@@ -682,6 +685,144 @@ class TurnManager(
             advanceResult.newState,
             turnResult.events + untapResult.events + goadEvents + advanceResult.events
         )
+    }
+
+    /**
+     * Carry out an "end the turn" effect (CR 720). Invoked by
+     * [com.wingedsheep.engine.handlers.actions.priority.PassPriorityHandler] once the spell or
+     * ability that requested it (via [EndTheTurnRequestedComponent]) has finished resolving.
+     *
+     * In order (CR 720.1):
+     *  - **a.** every spell and ability still on the stack is exiled — spells go to exile, abilities
+     *    cease to exist — and the source of the effect is exiled too;
+     *  - **c.** state-based actions are checked once; no triggered abilities are put on the stack —
+     *    the caller drops the triggers detected from the resolution/board-wipe events and diverts
+     *    here instead of processing them;
+     *  - **b.** all creatures and players are removed from combat;
+     *  - **d.** the game skips straight to the cleanup step, which runs as normal (CR 720.2): the
+     *    active player discards down to their maximum hand size, marked damage wears off, and
+     *    "until end of turn" / "this turn" effects end — then the turn ends into the next turn.
+     *
+     * The cleanup + turn-end reuse the same machinery as a natural cleanup step, so if the active
+     * player is over their maximum hand size this returns paused for the discard, and the game
+     * advances CLEANUP → next turn once the discard resolves (mirrors [advanceStep]'s CLEANUP path).
+     */
+    fun performEndTheTurn(state: GameState): ExecutionResult {
+        val activePlayer = state.activePlayerId
+            ?: return ExecutionResult.error(state, "No active player")
+
+        val request = state.getEntity(activePlayer)?.get<EndTheTurnRequestedComponent>()
+        var newState = state.updateEntity(activePlayer) { it.without<EndTheTurnRequestedComponent>() }
+        val events = mutableListOf<GameEvent>()
+
+        // CR 720.1c: state-based actions are checked. (Creatures destroyed by a preceding board
+        // wipe are already handled by that effect; this catches any other pending SBA.)
+        val sbaResult = sbaChecker.checkAndApply(newState)
+        if (sbaResult.isPaused) {
+            return ExecutionResult.paused(sbaResult.newState, sbaResult.pendingDecision!!, events + sbaResult.events)
+        }
+        newState = sbaResult.newState
+        events.addAll(sbaResult.events)
+        if (newState.gameOver) {
+            return ExecutionResult.success(newState.copy(priorityPlayerId = null), events)
+        }
+
+        // CR 720.1a: exile every remaining spell and ability on the stack. Snapshot the ids first
+        // because exiling mutates the stack.
+        val resolver = StackResolver(cardRegistry = cardRegistry)
+        for (entityId in newState.stack.toList()) {
+            if (entityId !in newState.stack) continue
+            val onStack = newState.getEntity(entityId) ?: continue
+            val result = if (onStack.has<SpellOnStackComponent>()) {
+                resolver.exileSpell(newState, entityId, makePlotted = false)
+            } else {
+                // Triggered / activated abilities on the stack simply cease to exist.
+                resolver.counterAbility(newState, entityId)
+            }
+            if (result.isSuccess) {
+                newState = result.newState
+                events.addAll(result.events)
+            }
+        }
+
+        // CR 720.1a: the source spell/ability is exiled along with the rest of the stack. After its
+        // resolution a spell source has been put into its owner's graveyard — move it to exile.
+        request?.sourceId?.let { sourceId ->
+            val (movedState, moveEvents) = moveSourceToExile(newState, sourceId)
+            newState = movedState
+            events.addAll(moveEvents)
+        }
+
+        // CR 720.1b: remove all creatures and players from combat.
+        if (newState.phase == Phase.COMBAT) {
+            val endCombatResult = combatManager.endCombat(newState)
+            if (endCombatResult.isSuccess) {
+                newState = endCombatResult.newState
+                events.addAll(endCombatResult.events)
+            }
+        }
+
+        // CR 720.1d / 720.2: skip straight to the cleanup step (bypassing the end step and any queued
+        // additional end steps), run its turn-based actions, then end the turn. Mirrors the
+        // Step.CLEANUP branch of [advanceStep] so hand-size discard and end-of-turn cleanup behave
+        // identically.
+        newState = newState.copy(
+            step = Step.CLEANUP,
+            phase = Phase.ENDING,
+            priorityPlayerId = null,
+            priorityPassedBy = emptySet()
+        )
+        events.add(PhaseChangedEvent(Phase.ENDING))
+        events.add(StepChangedEvent(Step.CLEANUP))
+
+        val cleanupResult = cleanupPhaseManager.performCleanupStep(newState)
+        if (cleanupResult.isPaused) {
+            // Over max hand size: pause for the discard. The HandSizeDiscardContinuation finishes the
+            // cleanup turn-based actions, then the game advances CLEANUP → next turn (advanceStep).
+            return ExecutionResult.paused(
+                cleanupResult.newState,
+                cleanupResult.pendingDecision!!,
+                events + cleanupResult.events
+            )
+        }
+        if (cleanupResult.error != null) {
+            return ExecutionResult.error(cleanupResult.newState, cleanupResult.error!!)
+        }
+        newState = cleanupResult.newState
+        events.addAll(cleanupResult.events)
+
+        val endTurnResult = endTurn(newState)
+        if (endTurnResult.isPaused) {
+            return ExecutionResult.paused(
+                endTurnResult.newState,
+                endTurnResult.pendingDecision!!,
+                events + endTurnResult.events
+            )
+        }
+        return ExecutionResult.success(endTurnResult.newState, events + endTurnResult.events)
+    }
+
+    /**
+     * Move an "end the turn" source from its owner's graveyard to exile (CR 720.1a). Best-effort:
+     * if the source is not currently in a graveyard (e.g. it was a token or an ability that already
+     * ceased to exist) it is left untouched.
+     */
+    private fun moveSourceToExile(state: GameState, sourceId: EntityId): Pair<GameState, List<GameEvent>> {
+        val currentKey = state.zones.entries.firstOrNull { (_, ids) -> sourceId in ids }?.key
+            ?: return state to emptyList()
+        if (currentKey.zoneType != Zone.GRAVEYARD) return state to emptyList()
+        val card = state.getEntity(sourceId)?.get<CardComponent>()
+        val ownerId = card?.ownerId ?: currentKey.ownerId
+        val exileKey = ZoneKey(ownerId, Zone.EXILE)
+        val movedState = state.moveToZone(sourceId, currentKey, exileKey)
+        val event = ZoneChangeEvent(
+            entityId = sourceId,
+            entityName = card?.name ?: "",
+            fromZone = Zone.GRAVEYARD,
+            toZone = Zone.EXILE,
+            ownerId = ownerId
+        )
+        return movedState to listOf(event)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/priority/PassPriorityHandler.kt
@@ -21,6 +21,7 @@ import com.wingedsheep.engine.state.components.combat.BlockersDeclaredThisCombat
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.TokenComponent
 import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
+import com.wingedsheep.engine.state.components.player.EndTheTurnRequestedComponent
 import com.wingedsheep.engine.state.components.player.NonTokenCreaturesDiedThisTurnComponent
 import com.wingedsheep.engine.state.components.stack.ActivatedAbilityOnStackComponent
 import com.wingedsheep.engine.state.components.stack.SpellOnStackComponent
@@ -194,6 +195,17 @@ class PassPriorityHandler(
             return result
         }
 
+        // CR 720: an "end the turn" effect (e.g. Final Fantasy's Ultima) resolved. Divert to the
+        // end-the-turn sequence instead of the normal trigger/SBA/priority flow — the triggers
+        // detected from this resolution (dies triggers from a preceding board wipe, etc.) are
+        // intentionally dropped and never put on the stack (CR 720.1c).
+        val endTheTurnPlayer = result.newState.activePlayerId
+        if (endTheTurnPlayer != null &&
+            result.newState.getEntity(endTheTurnPlayer)?.has<EndTheTurnRequestedComponent>() == true
+        ) {
+            return endTheTurn(result.newState, result.events)
+        }
+
         // Track nontoken creature deaths from resolution events
         val trackedState = trackNonTokenCreatureDeaths(result.newState, result.events)
 
@@ -269,6 +281,68 @@ class PassPriorityHandler(
         return ExecutionResult.success(
             postPollState.withPriority(stackItemController),
             combinedEvents
+        )
+    }
+
+    /**
+     * Run the "end the turn" sequence (CR 720) triggered by an [EndTheTurnRequestedComponent] that
+     * was set while [state]'s current spell/ability resolved. [TurnManager.performEndTheTurn] exiles
+     * the rest of the stack, removes creatures from combat and skips to the cleanup step + next turn;
+     * this method then fires only the freshly-begun turn's step/phase triggers (e.g. "at the
+     * beginning of your upkeep"). Battlefield event triggers from the end-the-turn actions and the
+     * preceding resolution are intentionally NOT processed (CR 720.1c).
+     */
+    private fun endTheTurn(state: GameState, resolutionEvents: List<GameEvent>): ExecutionResult {
+        val endResult = turnManager.performEndTheTurn(state)
+        val priorEvents = resolutionEvents + endResult.events
+
+        if (endResult.isPaused) {
+            return ExecutionResult.paused(endResult.newState, endResult.pendingDecision!!, priorEvents)
+        }
+        if (!endResult.isSuccess || endResult.newState.gameOver) {
+            return ExecutionResult.success(endResult.newState, priorEvents)
+        }
+
+        var currentState = endResult.newState
+        val stepChangedEvent = priorEvents.filterIsInstance<StepChangedEvent>().lastOrNull()
+            ?: return ExecutionResult.success(
+                currentState.withPriority(currentState.activePlayerId),
+                priorEvents
+            )
+
+        val (delayedTriggers, consumedIds) = triggerDetector.detectDelayedTriggers(currentState, stepChangedEvent.newStep)
+        if (consumedIds.isNotEmpty()) {
+            currentState = currentState.removeDelayedTriggers(consumedIds)
+        }
+        val triggers = delayedTriggers.toMutableList()
+        currentState.activePlayerId?.let { activePlayer ->
+            triggers.addAll(
+                triggerDetector.detectPhaseStepTriggers(currentState, stepChangedEvent.newStep, activePlayer)
+            )
+        }
+
+        val statePollResult = stateTriggerPoller.poll(currentState)
+        currentState = statePollResult.newState
+        triggers.addAll(statePollResult.pendingTriggers)
+
+        if (triggers.isNotEmpty()) {
+            val triggerResult = triggerProcessor.processTriggers(currentState, triggers)
+            if (triggerResult.isPaused) {
+                return ExecutionResult.paused(
+                    triggerResult.state,
+                    triggerResult.pendingDecision!!,
+                    priorEvents + triggerResult.events
+                )
+            }
+            return ExecutionResult.success(
+                triggerResult.newState.withPriority(currentState.activePlayerId),
+                priorEvents + triggerResult.events
+            )
+        }
+
+        return ExecutionResult.success(
+            currentState.withPriority(currentState.activePlayerId),
+            priorEvents
         )
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/EndTheTurnExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/EndTheTurnExecutor.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.engine.handlers.effects.player
+
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.player.EndTheTurnRequestedComponent
+import com.wingedsheep.sdk.scripting.effects.EndTheTurnEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [EndTheTurnEffect] (CR 720, "end the turn").
+ *
+ * The end-the-turn sequence — exiling the rest of the stack, discarding the pending triggers,
+ * skipping to the cleanup step and starting the next turn — cannot run here: this executor is
+ * invoked mid-resolution, so other objects may still be on the stack, and it has no access to the
+ * turn/stack machinery. Instead it records the request on the active player via
+ * [EndTheTurnRequestedComponent], and [com.wingedsheep.engine.handlers.actions.priority.PassPriorityHandler]
+ * performs the sequence through [com.wingedsheep.engine.core.TurnManager.performEndTheTurn] once
+ * the current resolution finishes.
+ *
+ * The marker is keyed to the active player because "end the turn" always ends the current turn,
+ * regardless of who controls the effect. [context.sourceId] is stored so the source can be exiled
+ * with the rest of the stack (CR 720.1a).
+ */
+class EndTheTurnExecutor : EffectExecutor<EndTheTurnEffect> {
+
+    override val effectType: KClass<EndTheTurnEffect> = EndTheTurnEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: EndTheTurnEffect,
+        context: EffectContext
+    ): EffectResult {
+        val activePlayer = state.activePlayerId
+            ?: return EffectResult.success(state)
+
+        val newState = state.updateEntity(activePlayer) { container ->
+            container.with(EndTheTurnRequestedComponent(sourceId = context.sourceId))
+        }
+        return EffectResult.success(newState)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/player/PlayerExecutors.kt
@@ -51,6 +51,7 @@ class PlayerExecutors(
         CreateGlobalTriggeredAbilityExecutor(),
         CreatePermanentEmblemExecutor(),
         EachPlayerChoosesCreatureTypeExecutor(),
+        EndTheTurnExecutor(),
         GainCitysBlessingExecutor(),
         RemoveMaximumHandSizeExecutor(),
         GiftGivenExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -1045,6 +1045,20 @@ data object WasDealtCombatDamageByLegendaryCreatureThisTurnComponent : Component
 data class SkipNextTurnComponent(val turns: Int = 1) : Component
 
 /**
+ * Marks that an "end the turn" effect (CR 720) has resolved this turn and the end-the-turn
+ * sequence still needs to run. Placed on the active player when [EndTheTurnEffect] resolves; the
+ * executor cannot end the turn itself (it has no access to the turn machinery and the rest of the
+ * stack has not finished resolving), so it records the request and [PassPriorityHandler] carries
+ * out the sequence via [TurnManager.performEndTheTurn] once the current resolution completes.
+ *
+ * @property sourceId The spell/ability that caused the turn to end. CR 720.1a exiles it along with
+ *   the rest of the stack, so it is moved to exile rather than left in the graveyard. Null when the
+ *   source is unknown (defensive — the sequence still runs).
+ */
+@Serializable
+data class EndTheTurnRequestedComponent(val sourceId: EntityId? = null) : Component
+
+/**
  * Tracks a Mindslaver-style "you control target opponent during their next turn" effect.
  *
  * Lifecycle:

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UltimaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UltimaScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.Ultima
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Engine coverage for Ultima ({3}{W}{W} sorcery — "Destroy all artifacts and creatures. End the
+ * turn.") and the underlying [com.wingedsheep.sdk.dsl.Effects.EndTheTurn] effect (CR 720).
+ *
+ * The tests pin the four observable consequences of ending the turn: the board wipe resolves, the
+ * dies triggers from that wipe never reach the stack (CR 720.1c), Ultima exiles itself (CR 720.1a),
+ * and the turn ends into the opponent's turn — with the cleanup step's hand-size discard applied.
+ */
+class UltimaScenarioTest : FunSpec({
+
+    // A minimal non-creature artifact, to prove "all artifacts" (not just artifact creatures) go.
+    val testRelic = CardDefinition(
+        name = "Test Relic",
+        manaCost = ManaCost.parse("{1}"),
+        typeLine = TypeLine.artifact()
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + Ultima + testRelic)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        return driver
+    }
+
+    test("Ultima destroys all artifacts and creatures, exiles itself, and ends the turn") {
+        val driver = createDriver()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // A full board: creatures for both players, an artifact creature, and a non-creature relic.
+        driver.putCreatureOnBattlefield(p1, "Savannah Lions")
+        driver.putCreatureOnBattlefield(p2, "Centaur Courser")
+        driver.putCreatureOnBattlefield(p1, "Artifact Creature")
+        driver.putPermanentOnBattlefield(p1, "Test Relic")
+
+        val ultima = driver.putCardInHand(p1, "Ultima")
+        driver.giveMana(p1, Color.WHITE, 2)
+        driver.giveColorlessMana(p1, 3)
+
+        driver.castSpell(p1, ultima)
+        driver.bothPass() // resolve Ultima -> destroy all -> end the turn
+
+        // Every artifact and creature is destroyed.
+        driver.getCreatures(p1).shouldBeEmpty()
+        driver.getCreatures(p2).shouldBeEmpty()
+        driver.findPermanent(p1, "Artifact Creature") shouldBe null
+        driver.findPermanent(p1, "Test Relic") shouldBe null
+
+        // CR 720.1a: Ultima is exiled along with the stack, not put into the graveyard.
+        driver.getExileCardNames(p1) shouldContain "Ultima"
+        driver.getGraveyardCardNames(p1) shouldNotContain "Ultima"
+
+        // The turn ended: it is now the opponent's turn.
+        driver.activePlayer shouldBe p2
+    }
+
+    test("The dies triggers from Ultima's board wipe never resolve (CR 720.1c)") {
+        val driver = createDriver()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // "When this creature dies, you gain 3 life." If the trigger resolved, p1 would reach 23.
+        driver.putCreatureOnBattlefield(p1, "Death Trigger Test Creature")
+
+        val ultima = driver.putCardInHand(p1, "Ultima")
+        driver.giveMana(p1, Color.WHITE, 2)
+        driver.giveColorlessMana(p1, 3)
+
+        driver.castSpell(p1, ultima)
+        driver.bothPass()
+
+        // The creature was destroyed, but its dies trigger was exiled with the stack, so no life gain.
+        driver.findPermanent(p1, "Death Trigger Test Creature") shouldBe null
+        driver.getLifeTotal(p1) shouldBe 20
+    }
+
+    test("Ending the turn makes the active player discard down to their maximum hand size") {
+        val driver = createDriver()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val ultima = driver.putCardInHand(p1, "Ultima")
+        // Ten spare cards in hand; after Ultima leaves for the stack the cleanup step must trim to 7.
+        repeat(10) { driver.putCardInHand(p1, "Savannah Lions") }
+        driver.giveMana(p1, Color.WHITE, 2)
+        driver.giveColorlessMana(p1, 3)
+
+        driver.castSpell(p1, ultima)
+        driver.bothPass() // resolve -> end the turn -> cleanup pauses for the hand-size discard
+
+        // The cleanup step raised the discard; resolve it and confirm the hand was trimmed to seven.
+        driver.autoResolveDecision()
+        driver.getHand(p1) shouldHaveSize 7
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Ultima** (`{3}{W}{W}` sorcery — *"Destroy all artifacts and creatures. End the turn."*) from Final Fantasy, and the reusable **`Effects.EndTheTurn`** mechanic it needs (CR 720).

The remaining unimplemented Final Fantasy cards are all complex leftovers that each need real engine work; per "pick fewer if complex" I focused on the one with the cleanest, most self-contained + reusable feature. `EndTheTurn` also unlocks Time Stop, Sundial of the Infinite, Discontinuity, etc.

## What `EndTheTurn` does (CR 720)

Modeled as a two-step effect so it can act *after* the current resolution finishes:

1. The executor records an `EndTheTurnRequestedComponent` on the active player.
2. `PassPriorityHandler` detects it once the source resolves and diverts to `TurnManager.performEndTheTurn`, which:
   - exiles the entire stack **including the source** (via `StackResolver.exileSpell`, so even can't-be-countered spells go), CR 720.1a;
   - **drops the triggers the resolution queued** — the board wipe's dies triggers never reach the stack, CR 720.1c;
   - removes creatures from combat, CR 720.1b;
   - reuses the normal cleanup machinery — discard to maximum hand size, marked damage wears off, "this turn"/"until end of turn" effects end — then ends the turn, CR 720.1d/720.2.
   - Only the freshly-begun turn's step/phase triggers (e.g. upkeep) fire.

Verified against the official Ultima rulings.

## Tests

`UltimaScenarioTest` (3 cases, all passing):
- board wipe destroys all artifacts + creatures, Ultima exiles itself, and the turn passes to the opponent;
- the dies triggers from the wipe never resolve (CR 720.1c);
- the active player discards down to their maximum hand size during the forced cleanup.

Full `rules-engine` suite: no regressions from this change (the one unrelated failure is another in-flight card's own scenario test — see note).

Card snapshot golden re-blessed for Ultima; SDK reference (`docs/card-sdk-language-reference.md`) updated. mtgish teaching skipped — the mtgish IR has no "end the turn" opcode to bridge.

## Note for the reviewer

While re-blessing the FIN card-snapshot golden, three unrelated FIN cards (Gilgamesh, Kain, Omega) that are **another agent's in-flight work** were present as untracked files in the worktree and got swept into the rebless. I deliberately isolated the golden diff to **Ultima only** and did not stage, modify, or delete those files. The `FIN.json` change here is byte-identical to `main` plus Ultima's tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)