### PR TITLE
Fix X-spell max X and payment with restricted floating mana

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -930,7 +930,14 @@ class CastSpellHandler(
                 )
                 val partial = pool.payPartial(effectiveCost, spellCtx)
                 val remainingCost = partial.remainingCost
-                if (remainingCost.isEmpty() && xValue == 0) {
+                // Floating mana also covers the {X} portion (execution — explicitPay → autoPay —
+                // spends it before tapping anything), so only ask the chosen sources for the X
+                // the pool can't pay. Eligible restricted mana counts via ManaPool.xCoverage.
+                val xSymbolCount = effectiveCost.xCount.coerceAtLeast(1)
+                val totalXMana = xValue * xSymbolCount
+                val xRemaining = totalXMana -
+                    partial.newPool.xCoverage(totalXMana, xManaRestriction, spellCtx)
+                if (remainingCost.isEmpty() && xRemaining == 0) {
                     null
                 } else {
                     val chosen = action.paymentStrategy.manaAbilitiesToActivate.toSet()
@@ -938,7 +945,7 @@ class CastSpellHandler(
                         .map { it.entityId }
                         .filter { it !in chosen }
                         .toSet()
-                    if (manaSolver.solve(state, action.playerId, remainingCost, xValue, excludeSources = excluded, spellContext = spellCtx) == null) {
+                    if (manaSolver.solve(state, action.playerId, remainingCost, xRemaining, excludeSources = excluded, spellContext = spellCtx, xManaRestriction = xManaRestriction) == null) {
                         "Selected mana sources cannot pay this spell's cost"
                     } else null
                 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -633,7 +633,9 @@ class CastSpellEnumerator : ActionEnumerator {
             // folded in above).
             val hasXCost = effectiveCost.hasX
             val maxAffordableX: Int? = if (hasXCost) {
-                val availableSources = context.manaSolver.getAvailableManaCount(state, playerId, precomputedSources = cachedSources)
+                // Pass the spell context so floating restricted mana this spell may spend
+                // (e.g. "only to cast instant and sorcery spells") raises the X ceiling.
+                val availableSources = context.manaSolver.getAvailableManaCount(state, playerId, precomputedSources = cachedSources, spellContext = spellContext)
                 // Each delve card pays for one generic mana, so it raises the
                 // X ceiling exactly like an additional mana source would.
                 val delveAvailable = if (hasDelve && delveCards != null) delveCards.size else 0
@@ -1850,7 +1852,7 @@ class CastSpellEnumerator : ActionEnumerator {
             // xValue, which "create X tokens" reads via DynamicAmount.XValue.
             val kickedHasXCost = kickedCost.hasX
             val kickedMaxAffordableX: Int? = if (kickedHasXCost) {
-                val availableSources = context.manaSolver.getAvailableManaCount(state, playerId, precomputedSources = context.availableManaSources)
+                val availableSources = context.manaSolver.getAvailableManaCount(state, playerId, precomputedSources = context.availableManaSources, spellContext = kickedSpellContext)
                 val fixedCost = kickedCost.cmc  // X contributes 0 to CMC
                 val xSymbolCount = kickedCost.xCount.coerceAtLeast(1)
                 ((availableSources - fixedCost) / xSymbolCount).coerceAtLeast(0)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaPool.kt
@@ -241,6 +241,25 @@ data class ManaPool(
     }
 
     /**
+     * How much of an {X} amount of [xAmount] this pool can cover: eligible restricted mana first
+     * (entries whose restriction is satisfied by [spellContext] and — for a color-restricted X —
+     * whose color is allowed), then unrestricted mana per [xCoveragePlan]. Mirrors the spending
+     * order of `CastPaymentProcessor.autoPay`, so validation counting with this method never
+     * accepts an X the payment path can't actually cover from the pool.
+     */
+    fun xCoverage(xAmount: Int, xManaRestriction: Set<Color>, spellContext: SpellPaymentContext?): Int {
+        if (xAmount <= 0) return 0
+        val eligibleRestricted = if (spellContext == null) 0 else restrictedMana.count { entry ->
+            entry.restriction.isSatisfiedBy(spellContext) &&
+                // A color-restricted X can't be paid with off-color or colorless restricted mana.
+                (xManaRestriction.isEmpty() || (entry.color != null && entry.color in xManaRestriction))
+        }
+        val fromRestricted = minOf(xAmount, eligibleRestricted)
+        val fromUnrestricted = xCoveragePlan(xAmount - fromRestricted, xManaRestriction).size
+        return fromRestricted + fromUnrestricted
+    }
+
+    /**
      * Check if this pool can pay a mana cost.
      * When [spellContext] is provided, eligible restricted mana is considered (spent first).
      */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -1766,15 +1766,13 @@ class ManaSolver(
         val remainingCost = partialResult.remainingCost
         val poolAfterPartial = partialResult.newPool
 
-        // Calculate how much X mana is needed (multiply by X symbol count for XX costs)
+        // Calculate how much X mana is needed (multiply by X symbol count for XX costs).
+        // Eligible restricted floating mana counts toward X exactly like the payment path
+        // (CastPaymentProcessor.autoPay) spends it; only allowed-color mana counts toward a
+        // color-restricted X.
         val xSymbolCount = cost.xCount.coerceAtLeast(1)
         val totalXMana = xValue * xSymbolCount
-        // Only allowed-color pool mana counts toward a color-restricted X.
-        val xPaidFromPool = if (xManaRestriction.isEmpty()) {
-            poolAfterPartial.total.coerceAtMost(totalXMana)
-        } else {
-            xManaRestriction.sumOf { poolAfterPartial.get(it) }.coerceAtMost(totalXMana)
-        }
+        val xPaidFromPool = poolAfterPartial.xCoverage(totalXMana, xManaRestriction, spellContext)
         val xRemainingToPay = totalXMana - xPaidFromPool
 
         // If nothing remains after using pool (including X), we can pay
@@ -1808,11 +1806,11 @@ class ManaSolver(
                 // Also add colorless bonus mana
                 if (bonus.colorlessMana > 0) p.addColorless(bonus.colorlessMana) else p
             }
-        val augmentedResult = augmentedPool.payPartial(cost)
+        val augmentedResult = augmentedPool.payPartial(cost, spellContext)
         val augmentedRemaining = augmentedResult.remainingCost
         val augmentedPoolAfter = augmentedResult.newPool
 
-        val augmentedXPaid = augmentedPoolAfter.total.coerceAtMost(totalXMana)
+        val augmentedXPaid = augmentedPoolAfter.xCoverage(totalXMana, xManaRestriction, spellContext)
         val augmentedXRemaining = totalXMana - augmentedXPaid
 
         if (augmentedRemaining.isEmpty() && augmentedXRemaining == 0) return true
@@ -1821,13 +1819,26 @@ class ManaSolver(
 
     /**
      * Gets the total available mana for a player (floating mana + untapped sources).
+     *
+     * When [spellContext] is provided, floating restricted mana whose restriction the context
+     * satisfies is counted too (it is spendable on that payment). Without a context restricted
+     * entries are ignored — the conservative choice, since eligibility can't be judged.
      */
-    fun getAvailableManaCount(state: GameState, playerId: EntityId, precomputedSources: List<ManaSource>? = null): Int {
-        // Count floating mana
+    fun getAvailableManaCount(
+        state: GameState,
+        playerId: EntityId,
+        precomputedSources: List<ManaSource>? = null,
+        spellContext: SpellPaymentContext? = null
+    ): Int {
+        // Count floating mana (plus restricted entries eligible for this payment)
         val poolComponent = state.getEntity(playerId)?.get<ManaPoolComponent>()
         val floatingMana = if (poolComponent != null) {
+            val eligibleRestricted = if (spellContext != null) {
+                poolComponent.restrictedMana.count { it.restriction.isSatisfiedBy(spellContext) }
+            } else 0
             poolComponent.white + poolComponent.blue + poolComponent.black +
-                poolComponent.red + poolComponent.green + poolComponent.colorless
+                poolComponent.red + poolComponent.green + poolComponent.colorless +
+                eligibleRestricted
         } else {
             0
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/XSpellFloatingRestrictedManaTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/XSpellFloatingRestrictedManaTest.kt
@@ -1,0 +1,235 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.handlers.ConditionEvaluator
+import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.legalactions.utils.CastPermissionUtils
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.player.RestrictedManaEntry
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Casting an X spell when part of the payment is restricted mana ("Spend this mana only to cast
+ * instant and sorcery spells") — floating in the pool or producible by granted mana abilities.
+ *
+ * Repro board (user report): Resonating Lute grants each land "{T}: Add two mana of any one
+ * color. Spend this mana only to cast instant and sorcery spells." With 2 Islands, 1 Mountain,
+ * an untapped Potioner's Trove ({T}: add one mana of any color), and {U}{R}{R}{R} already
+ * floating, Procrastinate ({X}{U}, sorcery) must be castable with X = 10:
+ *
+ *   floating 4 + (3 lands × 2 restricted) + 1 trove = 11 mana; fixed cost {U} leaves X = 10.
+ *
+ * Bugs pinned here:
+ *  1. `maxAffordableX` must be 10 both before and after floating the restricted mana into the
+ *     pool (the count used to ignore floating restricted-mana entries → showed 4).
+ *  2. Validation (`ManaSolver.canPay`) and payment must accept eligible restricted floating
+ *     mana for the {X} portion.
+ *  3. Restricted mana that is NOT eligible for the spell (a creature spell vs
+ *     instant-or-sorcery-only mana) must not inflate `maxAffordableX`.
+ */
+class XSpellFloatingRestrictedManaTest : ScenarioTestBase() {
+
+    private fun stunCounters(game: TestGame, id: EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    private fun buildGame(handCard: String = "Procrastinate"): TestGame = scenario()
+        .withPlayers("Player1", "Player2")
+        .withCardInHand(1, handCard)
+        .withCardOnBattlefield(1, "Resonating Lute")
+        .withCardOnBattlefield(1, "Potioner's Trove")
+        .withLandsOnBattlefield(1, "Island", 2)
+        .withLandsOnBattlefield(1, "Mountain", 1)
+        .withCardOnBattlefield(2, "Grizzly Bears")
+        .withActivePlayer(1)
+        .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+        .build()
+
+    /** Give player 1 the reported floating mana: {U}{R}{R}{R}, unrestricted. */
+    private fun floatBaseMana(game: TestGame) {
+        game.state = game.state.updateEntity(game.player1Id) { c ->
+            c.with(ManaPoolComponent(blue = 1, red = 3))
+        }
+    }
+
+    private fun maxAffordableX(game: TestGame, spellName: String): Int? =
+        game.getLegalActions(1)
+            .first { info ->
+                val cast = info.action as? CastSpell ?: return@first false
+                game.state.getEntity(cast.cardId)?.get<CardComponent>()?.name == spellName
+            }
+            .maxAffordableX
+
+    /** Activate the Lute-granted "{T}: Add two mana of any one color" ability on a land. */
+    private fun activateGrantedLandAbility(game: TestGame, landId: EntityId, color: Color) {
+        val utils = CastPermissionUtils(cardRegistry, PredicateEvaluator(), ConditionEvaluator())
+        val grants = utils.getStaticGrantedAbilitiesWithGranter(landId, game.state)
+        grants.size shouldBe 1
+        game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = landId,
+                abilityId = grants[0].ability.id,
+                manaColorChoice = color,
+            )
+        ).error shouldBe null
+    }
+
+    /** Activate Potioner's Trove's "{T}: Add one mana of any color". */
+    private fun activateTrove(game: TestGame, color: Color) {
+        val trove = game.findPermanent("Potioner's Trove")!!
+        val abilityId = cardRegistry.requireCard("Potioner's Trove").activatedAbilities[0].id
+        game.execute(
+            ActivateAbility(
+                playerId = game.player1Id,
+                sourceId = trove,
+                abilityId = abilityId,
+                manaColorChoice = color,
+            )
+        ).error shouldBe null
+    }
+
+    init {
+        context("X spell with restricted-mana sources (Resonating Lute board)") {
+
+            test("maxAffordableX is 10 with untapped sources and {U}{R}{R}{R} floating") {
+                val game = buildGame()
+                floatBaseMana(game)
+
+                withClue("4 floating + 3 lands x 2 (granted, restricted) + 1 trove = 11; {U} fixed leaves X=10") {
+                    maxAffordableX(game, "Procrastinate") shouldBe 10
+                }
+            }
+
+            test("casting with X=10 via auto-pay succeeds and puts 20 stun counters") {
+                val game = buildGame()
+                floatBaseMana(game)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.castXSpell(1, "Procrastinate", xValue = 10, targetId = bears)
+                withClue("auto-pay should tap the 3 lands (via the granted 2-mana ability) + trove") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                stunCounters(game, bears) shouldBe 20
+                withClue("all payment mana consumed") {
+                    val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                    pool.total shouldBe 0
+                }
+            }
+
+            test("explicit source selection with floating mana covering part of X succeeds") {
+                // The client's manual mana-selection path submits PaymentStrategy.Explicit with
+                // the chosen sources. The chosen sources can only produce 7 of the X=10; the
+                // other 3 (plus the {U}) come from the floating pool. Validation must apply the
+                // floating mana to X exactly like execution (explicitPay → autoPay) does.
+                val game = buildGame()
+                floatBaseMana(game)
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val cardId = game.state.getHand(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Procrastinate"
+                }
+                val sources = game.findPermanents("Island") +
+                    game.findPermanent("Mountain")!! +
+                    game.findPermanent("Potioner's Trove")!!
+
+                val result = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = cardId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                        xValue = 10,
+                        paymentStrategy = PaymentStrategy.Explicit(manaAbilitiesToActivate = sources),
+                    )
+                )
+                result.error shouldBe null
+                game.resolveStack()
+                stunCounters(game, bears) shouldBe 20
+            }
+
+            test("maxAffordableX is still 10 after floating all mana into the pool") {
+                val game = buildGame()
+                floatBaseMana(game)
+
+                // Manually tap everything, as the user did: each land via the granted
+                // ability (2 restricted mana each), plus the trove (1 unrestricted).
+                val islands = game.findPermanents("Island")
+                islands.size shouldBe 2
+                activateGrantedLandAbility(game, islands[0], Color.BLUE)
+                activateGrantedLandAbility(game, islands[1], Color.BLUE)
+                activateGrantedLandAbility(game, game.findPermanent("Mountain")!!, Color.RED)
+                activateTrove(game, Color.BLUE)
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                withClue("2 unrestricted blue (1 floated + 1 trove) + 3 unrestricted red + 6 restricted") {
+                    pool.blue shouldBe 2
+                    pool.red shouldBe 3
+                    pool.restrictedMana.size shouldBe 6
+                }
+
+                withClue("all 11 floating mana are spendable on a sorcery, so X can be 10") {
+                    maxAffordableX(game, "Procrastinate") shouldBe 10
+                }
+            }
+
+            test("casting with X=10 entirely from the floating pool succeeds") {
+                val game = buildGame()
+                floatBaseMana(game)
+                val islands = game.findPermanents("Island")
+                activateGrantedLandAbility(game, islands[0], Color.BLUE)
+                activateGrantedLandAbility(game, islands[1], Color.BLUE)
+                activateGrantedLandAbility(game, game.findPermanent("Mountain")!!, Color.RED)
+                activateTrove(game, Color.BLUE)
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castXSpell(1, "Procrastinate", xValue = 10, targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                stunCounters(game, bears) shouldBe 20
+                withClue("the whole pool (including restricted entries) is consumed") {
+                    val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()!!
+                    pool.total shouldBe 0
+                    pool.restrictedMana.size shouldBe 0
+                }
+            }
+
+            test("ineligible restricted mana does not inflate maxAffordableX for a creature spell") {
+                // Mockingbird is {X}{U} — a creature spell, so instant-or-sorcery-only
+                // restricted mana can't pay for it.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Mockingbird")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+                game.state = game.state.updateEntity(game.player1Id) { c ->
+                    c.with(
+                        ManaPoolComponent(
+                            blue = 2,
+                            restrictedMana = List(4) {
+                                RestrictedManaEntry(Color.RED, ManaRestriction.InstantOrSorceryOnly)
+                            },
+                        )
+                    )
+                }
+
+                withClue("only the 2 unrestricted blue count: {U} fixed leaves X=1") {
+                    maxAffordableX(game, "Mockingbird") shouldBe 1
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Reported repro: Resonating Lute + Potioner's Trove + 2 Islands + 1 Mountain untapped, {U}{R}{R}{R} floating, casting Procrastinate ({X}{U} sorcery). Total usable mana is 11 (4 floating + 3 lands × 2 restricted "instant/sorcery only" + 1 trove), so max X should be 10.

1. **Max X showed 10 but pressing it failed with "couldn't pay"** — the `Explicit` payment strategy (manual mana-source selection) validated the {X} portion against the chosen sources alone: `validatePayment` applied floating mana to the fixed cost via `payPartial` but never to X, so it demanded the 3 lands + trove produce all 10 X when they can only produce 7. Execution (`explicitPay → autoPay`) would have paid fine — validation was stricter than execution. The branch also ignored the X symbol count (XX costs) and dropped `xManaRestriction` from its solve call.
2. **After manually floating everything, max X showed 4 instead of 10** — floating restricted mana was invisible to both the ceiling and validation:
   - `ManaSolver.getAvailableManaCount` summed only the unrestricted color fields, omitting `restrictedMana` entries entirely.
   - `ManaSolver.canPay` counted the pool's X coverage via `ManaPool.total`, which also excludes restricted entries, so it rejected a fully payable cast with "Not enough mana to cast this spell".
   
   The payment path (`CastPaymentProcessor.autoPay`) already spent eligible restricted mana on X correctly — enumeration and validation just never matched it.

## Fix

- **`ManaPool.xCoverage(x, xManaRestriction, ctx)`** — new shared counter for how much of an {X} amount the pool covers: eligible restricted entries first (color-allowed only when X is color-restricted), then unrestricted per the existing `xCoveragePlan`. Mirrors `autoPay`'s spend order so validation never accepts an X the payment path can't cover.
- **`ManaSolver.canPay`** uses `xCoverage` for both the primary and augmented ("extras") checks, and passes the spell context to the augmented `payPartial`.
- **`ManaSolver.getAvailableManaCount`** gains an optional `spellContext` and counts floating restricted entries the context satisfies (null context keeps the old conservative behavior — e.g. ability-activation X ceilings are unchanged).
- **`CastSpellEnumerator`** passes the spell context (base + kicked paths) so `maxAffordableX` includes eligible restricted floating mana.
- **`CastSpellHandler.validatePayment` (Explicit branch)** subtracts the pool's X coverage before asking the chosen sources for the rest, multiplies by the X symbol count, and forwards `xManaRestriction` to the solver.

No client changes needed — the frontend renders the server's `maxAffordableX` verbatim.

## Tests

`XSpellFloatingRestrictedManaTest` pins the reported board end to end:
- max X = 10 with untapped sources + floating mana
- cast X=10 via auto-pay → 20 stun counters, pool fully consumed
- cast X=10 via **Explicit** source selection with floating mana covering part of X (fails before the fix with "Selected mana sources cannot pay this spell's cost")
- max X still 10 after manually floating all mana (was 4)
- cast X=10 entirely from the floating pool (was rejected with "Not enough mana to cast this spell")
- guard: instant/sorcery-only restricted mana does **not** inflate max X for a creature X spell (Mockingbird)

`just test-rules`, `just test-server`, and `just build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)