### PR TITLE
Add a handful of Foundations cards (Ballyrush Banneret, Divine Resilience, Inspiration from Beyond)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BallyrushBanneretReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BallyrushBanneretReprint.kt
@@ -1,0 +1,21 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ballyrush Banneret reprint in Foundations. Canonical
+ * [com.wingedsheep.sdk.model.CardDefinition] lives in Morningtide's `cards/`
+ * package; this file contributes only presentation data.
+ */
+val BallyrushBanneretReprint = Printing(
+    oracleId = "0ad27d0e-b6c3-4c3f-a389-285d889b6a65",
+    name = "Ballyrush Banneret",
+    setCode = "FDN",
+    collectorNumber = "567",
+    scryfallId = "b18a7daa-a112-4728-9123-594366694915",
+    artist = "Ralph Horsley",
+    imageUri = "https://cards.scryfall.io/normal/front/b/1/b18a7daa-a112-4728-9123-594366694915.jpg?1782688771",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DivineResilience.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DivineResilience.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Divine Resilience
+ * {W}
+ * Instant
+ * Kicker {2}{W}
+ *
+ * Target creature you control gains indestructible until end of turn. If this
+ * spell was kicked, instead any number of target creatures you control gain
+ * indestructible until end of turn.
+ *
+ * Modeled like Fight with Fire (DOM): the kicked cast completely swaps the
+ * targeting mode (any number of target creatures you control) and the effect
+ * (grant indestructible to each chosen target via [ForEachTargetEffect]).
+ */
+val DivineResilience = card("Divine Resilience") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\n" +
+        "Target creature you control gains indestructible until end of turn. If this spell was kicked, " +
+        "instead any number of target creatures you control gain indestructible until end of turn. " +
+        "(Damage and effects that say \"destroy\" don't destroy them.)"
+
+    keywordAbility(KeywordAbility.kicker("{2}{W}"))
+
+    spell {
+        // Unkicked: one target creature you control gains indestructible.
+        target = Targets.CreatureYouControl
+        effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.ContextTarget(0))
+
+        // Kicked: any number of target creatures you control gain indestructible.
+        kickerTarget = TargetObject(
+            unlimited = true,
+            filter = TargetFilter.CreatureYouControl,
+        )
+        kickerEffect = ForEachTargetEffect(
+            effects = listOf(
+                Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.ContextTarget(0))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "10"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/f/3/f3a08245-a535-4d24-b8c0-78759bb9c4b0.jpg?1782689256"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/InspirationFromBeyond.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/InspirationFromBeyond.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Inspiration from Beyond
+ * {2}{U}
+ * Sorcery
+ *
+ * Mill three cards, then return an instant or sorcery card from your graveyard
+ * to your hand.
+ * Flashback {5}{U}{U}
+ *
+ * The returned card is chosen at resolution (not a cast-time target), so a spell
+ * put into the graveyard by the mill is a legal choice. Modeled as
+ * mill → gather instant/sorcery cards from your graveyard → choose one → to hand.
+ */
+val InspirationFromBeyond = card("Inspiration from Beyond") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Sorcery"
+    oracleText = "Mill three cards, then return an instant or sorcery card from your graveyard to your hand.\n" +
+        "Flashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        effect = Patterns.Library.mill(3) then Effects.Pipeline {
+            val spells = gather(
+                CardSource.FromZone(Zone.GRAVEYARD, Player.You, GameObjectFilter.InstantOrSorcery),
+                name = "graveyardSpells",
+            )
+            val returned = chooseExactly(
+                1,
+                from = spells,
+                prompt = "Return an instant or sorcery card to your hand",
+                name = "returned",
+            )
+            toHand(returned)
+        }
+    }
+
+    keywordAbility(KeywordAbility.flashback("{5}{U}{U}"))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "43"
+        artist = "Xavier Ribeiro"
+        flavorText = "When seeking spiritual enlightenment, best to go directly to the source."
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b636fe95-664f-4fb1-aab9-28856edeccd6.jpg?1782689228"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/BallyrushBanneret.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mor/cards/BallyrushBanneret.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.mor.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Ballyrush Banneret
+ * {1}{W}
+ * Creature — Kithkin Soldier
+ * 2/1
+ *
+ * Kithkin spells and Soldier spells you cast cost {1} less to cast.
+ *
+ * Canonical printing (earliest real set: Morningtide). The Foundations reprint
+ * contributes only a [com.wingedsheep.sdk.model.Printing] row.
+ */
+val BallyrushBanneret = card("Ballyrush Banneret") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Kithkin Soldier"
+    power = 2
+    toughness = 1
+    oracleText = "Kithkin spells and Soldier spells you cast cost {1} less to cast."
+
+    staticAbility {
+        // "Kithkin spells and Soldier spells" — a spell qualifies if it has EITHER
+        // subtype, so an OR over the two subtypes (withAnySubtype).
+        ability = ModifySpellCost(
+            target = SpellCostTarget.YouCast(
+                GameObjectFilter.Any.withAnySubtype("Kithkin", "Soldier")
+            ),
+            modification = CostModification.ReduceGeneric(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "1"
+        artist = "Ralph Horsley"
+        flavorText = "Only wool from the side of the springjack turned most often to the sun can be woven into kithkin battle standards. Jackherds record every movement of their woolly-jacks until shearing."
+        imageUri = "https://cards.scryfall.io/normal/front/a/0/a029814e-d84d-43e5-b483-e918871b3333.jpg?1782716266"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -1571,6 +1571,68 @@
     ]
 }
 
+// Divine Resilience
+{
+    "name": "Divine Resilience",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Kicker {2}{W} (You may pay an additional {2}{W} as you cast this spell.)\nTarget creature you control gains indestructible until end of turn. If this spell was kicked, instead any number of target creatures you control gain indestructible until end of turn. (Damage and effects that say \"destroy\" don't destroy them.)",
+    "keywordAbilities": [
+        {
+            "type": "Kicker",
+            "manaCost": "{2}{W}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "GrantKeyword",
+            "keyword": "INDESTRUCTIBLE",
+            "target": {
+                "type": "ContextTarget",
+                "index": 0
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ],
+        "kickerTargetRequirements": [
+            {
+                "type": "TargetObject",
+                "unlimited": true,
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                }
+            }
+        ],
+        "kickerSpellEffect": {
+            "type": "ForEach",
+            "space": "IterationSpace.Targets",
+            "body": {
+                "type": "GrantKeyword",
+                "keyword": "INDESTRUCTIBLE",
+                "target": {
+                    "type": "ContextTarget",
+                    "index": 0
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "10",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/3/f3a08245-a535-4d24-b8c0-78759bb9c4b0.jpg?1782689256"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Dragon Trainer
 {
     "name": "Dragon Trainer",
@@ -3434,6 +3496,95 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Inspiration from Beyond
+{
+    "name": "Inspiration from Beyond",
+    "manaCost": "{2}{U}",
+    "typeLine": "Sorcery",
+    "oracleText": "Mill three cards, then return an instant or sorcery card from your graveyard to your hand.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{5}{U}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 3
+                        },
+                        "isMill": true
+                    },
+                    "storeAs": "milled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "milled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                },
+                {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "filter": "instant|sorcery"
+                            },
+                            "storeAs": "graveyardSpells"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "graveyardSpells",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "returned",
+                            "prompt": "Return an instant or sorcery card to your hand"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "returned",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "43",
+        "rarity": "UNCOMMON",
+        "artist": "Xavier Ribeiro",
+        "flavorText": "When seeking spiritual enlightenment, best to go directly to the source.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b636fe95-664f-4fb1-aab9-28856edeccd6.jpg?1782689228"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/MOR.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MOR.json
@@ -1,3 +1,39 @@
+// Ballyrush Banneret
+{
+    "name": "Ballyrush Banneret",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Kithkin Soldier",
+    "oracleText": "Kithkin spells and Soldier spells you cast cost {1} less to cast.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": {
+                    "type": "YouCast",
+                    "filter": "Kithkin|Soldier"
+                },
+                "modification": {
+                    "type": "ReduceGeneric",
+                    "amount": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "1",
+        "artist": "Ralph Horsley",
+        "flavorText": "Only wool from the side of the springjack turned most often to the sun can be woven into kithkin battle standards. Jackherds record every movement of their woolly-jacks until shearing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/0/a029814e-d84d-43e5-b483-e918871b3333.jpg?1782716266"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Kindled Fury
 {
     "name": "Kindled Fury",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BallyrushBanneretScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BallyrushBanneretScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ballyrush Banneret (MOR #1, reprinted in FDN #567) — {1}{W} Kithkin Soldier, 2/1.
+ *
+ *   "Kithkin spells and Soldier spells you cast cost {1} less to cast."
+ *
+ * Verifies the tribal spell-cost reduction: a Soldier creature spell can be cast for
+ * one mana less than its printed cost, while an unrelated (non-Kithkin, non-Soldier)
+ * spell is unaffected.
+ */
+class BallyrushBanneretScenarioTest : FunSpec({
+
+    // {2}{W} Soldier creature — qualifies for the reduction.
+    val testSoldier = card("Test Soldier") {
+        manaCost = "{2}{W}"
+        typeLine = "Creature — Human Soldier"
+        power = 2
+        toughness = 2
+    }
+
+    // {2}{W} vanilla creature with no matching subtype — should NOT be reduced.
+    val testBear = card("Test Bear") {
+        manaCost = "{2}{W}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(testSoldier)
+        driver.registerCard(testBear)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("a Soldier spell costs {1} less with Ballyrush Banneret out") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(player, "Ballyrush Banneret")
+        val soldier = driver.putCardInHand(player, "Test Soldier")
+
+        // Only 2 mana — enough for the reduced {1}{W}, but not the printed {2}{W}.
+        driver.giveMana(player, Color.WHITE, 2)
+
+        val result = driver.submit(
+            CastSpell(playerId = player, cardId = soldier, paymentStrategy = PaymentStrategy.AutoPay)
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass() // resolve the creature spell
+        driver.getCreatures(player).contains(soldier) shouldBe true
+    }
+
+    test("a non-Kithkin, non-Soldier spell is unaffected by the reduction") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        driver.putCreatureOnBattlefield(player, "Ballyrush Banneret")
+        val bear = driver.putCardInHand(player, "Test Bear")
+
+        // Same 2 mana — not enough for the un-reduced {2}{W}.
+        driver.giveMana(player, Color.WHITE, 2)
+
+        val result = driver.submit(
+            CastSpell(playerId = player, cardId = bear, paymentStrategy = PaymentStrategy.AutoPay)
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DivineResilienceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DivineResilienceScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Divine Resilience (FDN #10) — {W} Instant, Kicker {2}{W}.
+ *
+ *   "Target creature you control gains indestructible until end of turn. If this spell was
+ *    kicked, instead any number of target creatures you control gain indestructible until
+ *    end of turn."
+ *
+ * Verifies the base single-target grant and the kicked multi-target grant (any number of
+ * target creatures you control).
+ */
+class DivineResilienceScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("unkicked: one target creature you control gains indestructible") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val spell = driver.putCardInHand(player, "Divine Resilience")
+        driver.giveMana(player, Color.WHITE, 1) // {W}
+
+        driver.state.projectedState.hasKeyword(bear, Keyword.INDESTRUCTIBLE) shouldBe false
+
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear)),
+                paymentStrategy = PaymentStrategy.AutoPay,
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve
+
+        driver.state.projectedState.hasKeyword(bear, Keyword.INDESTRUCTIBLE) shouldBe true
+    }
+
+    test("kicked: any number of target creatures you control gain indestructible") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+
+        val bear1 = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val bear2 = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        val spell = driver.putCardInHand(player, "Divine Resilience")
+        driver.giveMana(player, Color.WHITE, 4) // {W} + kicker {2}{W}
+
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(bear1), ChosenTarget.Permanent(bear2)),
+                wasKicked = true,
+                paymentStrategy = PaymentStrategy.AutoPay,
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve
+
+        driver.state.projectedState.hasKeyword(bear1, Keyword.INDESTRUCTIBLE) shouldBe true
+        driver.state.projectedState.hasKeyword(bear2, Keyword.INDESTRUCTIBLE) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InspirationFromBeyondScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InspirationFromBeyondScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Inspiration from Beyond (FDN #43) — {2}{U} Sorcery, Flashback {5}{U}{U}.
+ *
+ *   "Mill three cards, then return an instant or sorcery card from your graveyard to your hand."
+ *
+ * Verifies the mill-then-recur pipeline: three cards are milled, then the player chooses an
+ * instant or sorcery card from the graveyard (including one just milled) to return to hand.
+ */
+class InspirationFromBeyondScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("mill three, then return a milled instant to hand") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // Top three (any order): two instants + a land. All three are milled; the two
+        // instants are the eligible choices to return.
+        driver.putCardOnTopOfLibrary(me, "Forest")
+        val bolt1 = driver.putCardOnTopOfLibrary(me, "Lightning Bolt")
+        val bolt2 = driver.putCardOnTopOfLibrary(me, "Lightning Bolt")
+
+        val spell = driver.putCardInHand(me, "Inspiration from Beyond")
+        driver.giveMana(me, Color.BLUE, 3) // {2}{U}
+
+        driver.submit(
+            CastSpell(playerId = me, cardId = spell, paymentStrategy = PaymentStrategy.AutoPay)
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve -> mill three -> pause for the instant/sorcery choice
+
+        driver.isPaused shouldBe true
+        val select = driver.pendingDecision
+        select.shouldBeInstanceOf<SelectCardsDecision>()
+        // Both milled instants are eligible; the milled land is not.
+        select.options.size shouldBe 2
+
+        driver.submitDecision(
+            me,
+            CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(bolt1))
+        )
+        driver.isPaused shouldBe false
+
+        // Chosen instant returned to hand; the other instant stays in the graveyard.
+        driver.getHand(me).contains(bolt1) shouldBe true
+        driver.getGraveyard(me).contains(bolt1) shouldBe false
+        driver.getGraveyard(me).contains(bolt2) shouldBe true
+    }
+})


### PR DESCRIPTION
Implements three Foundations (FDN) cards using existing SDK primitives — no engine/SDK changes.

## Cards

| Card | Cost | Mechanics |
|------|------|-----------|
| **Ballyrush Banneret** | `{1}{W}` | Kithkin Soldier, 2/1. *"Kithkin spells and Soldier spells you cast cost {1} less to cast."* Tribal spell-cost reduction via `ModifySpellCost(YouCast(withAnySubtype("Kithkin","Soldier")), ReduceGeneric(1))`. |
| **Divine Resilience** | `{W}` | Instant, Kicker `{2}{W}`. Base: one target creature you control gains indestructible. Kicked: any number of target creatures you control gain it — `kickerTarget` = unlimited `TargetObject` + `kickerEffect` = `ForEachTargetEffect(GrantKeyword(INDESTRUCTIBLE))`, modeled like Fight with Fire. |
| **Inspiration from Beyond** | `{2}{U}` | Sorcery, Flashback `{5}{U}{U}`. Mill three, then a resolution-time gather → choose → return of an instant/sorcery card from the graveyard to hand (so a just-milled spell is eligible). |

## Reprint placement

Ballyrush Banneret's earliest real printing is **Morningtide (MOR, 2008)**, so its canonical `CardDefinition` lives in `mor/cards/` and FDN gets a `Printing` row. Verified with `just check-card-printing "Ballyrush Banneret"`. Divine Resilience and Inspiration from Beyond are FDN originals.

## Testing

- New rules-engine scenario test per card (tribal reduction applies/doesn't apply; unkicked & kicked indestructible grants; mill-then-recur choice) — all pass.
- `CardDefinitionSnapshotTest` re-blessed (diff adds only the three new cards; no other card moved).
- `CardLintTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)