### PR TITLE
Add a handful of Foundations cards (Raise the Past, Mischievous Mystic, Scrawling Crawler)

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MischievousMystic.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MischievousMystic.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mischievous Mystic
+ * {1}{U}
+ * Creature — Human Wizard
+ * 2/1
+ *
+ * Flying
+ * Whenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying.
+ *
+ * The draw trigger uses [Triggers.NthCardDrawn] (n = 2), the shared "your Nth card each turn"
+ * detector, fired exactly once per turn when your second card is drawn.
+ */
+val MischievousMystic = card("Mischievous Mystic") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Whenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLUE),
+            creatureTypes = setOf("Faerie"),
+            keywords = setOf(Keyword.FLYING),
+            imageUri = "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg?1782727481",
+        )
+        description = "Whenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "47"
+        artist = "Steve Prescott"
+        flavorText = "\"Don't worry about where they're taking me. The more pressing question is, why aren't they taking you?\""
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20d89cec-528b-4b2a-87db-e11ce0000622.jpg?1782689225"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RaiseThePast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/RaiseThePast.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Raise the Past
+ * {2}{W}{W}
+ * Sorcery
+ *
+ * Return all creature cards with mana value 2 or less from your graveyard to the battlefield.
+ *
+ * A mass reanimation: gather every creature card in your graveyard with mana value 2 or less,
+ * then move the whole collection onto the battlefield under their owner's control. No choice or
+ * targeting — the whole matching set returns.
+ */
+val RaiseThePast = card("Raise the Past") {
+    manaCost = "{2}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Return all creature cards with mana value 2 or less from your graveyard to the battlefield."
+
+    spell {
+        effect = Effects.Pipeline {
+            val creatures = gather(
+                CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.You,
+                    filter = GameObjectFilter.Creature.manaValueAtMost(2),
+                ),
+                name = "graveyardCreatures",
+            )
+            move(
+                creatures,
+                CardDestination.ToZone(Zone.BATTLEFIELD),
+                underOwnersControl = true,
+            )
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "22"
+        artist = "Nathaniel Himawan"
+        flavorText = "At Strixhaven University, learning about the past means talking to those who were there."
+        imageUri = "https://cards.scryfall.io/normal/front/6/c/6c6be129-56da-4fe7-a6bd-6a1d402c09e1.jpg?1782689246"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ScrawlingCrawler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ScrawlingCrawler.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Scrawling Crawler
+ * {3}
+ * Artifact Creature — Phyrexian Construct
+ * 3/2
+ *
+ * At the beginning of your upkeep, each player draws a card.
+ * Whenever an opponent draws a card, that player loses 1 life.
+ *
+ * The symmetric group-draw uses `DrawCards(Player.Each)`; the punisher clause fires per card an
+ * opponent draws ([Triggers.OpponentDraws], CR 121.2), draining the player who drew via
+ * `Player.TriggeringPlayer`. Cards an opponent draws from the upkeep clause therefore also drain
+ * them — the two abilities compose without special-casing.
+ */
+val ScrawlingCrawler = card("Scrawling Crawler") {
+    manaCost = "{3}"
+    typeLine = "Artifact Creature — Phyrexian Construct"
+    power = 3
+    toughness = 2
+    oracleText = "At the beginning of your upkeep, each player draws a card.\n" +
+        "Whenever an opponent draws a card, that player loses 1 life."
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.DrawCards(1, EffectTarget.PlayerRef(Player.Each))
+        description = "At the beginning of your upkeep, each player draws a card."
+    }
+
+    triggeredAbility {
+        trigger = Triggers.OpponentDraws
+        effect = Effects.LoseLife(1, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+        description = "Whenever an opponent draws a card, that player loses 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "132"
+        artist = "Miro Petrov"
+        flavorText = "It spreads the machine gospel of New Phyrexia, its task incomplete until all surrender to perfection."
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1176dcf-40ee-4342-aa74-791b8352e99a.jpg?1782689153"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -3972,6 +3972,59 @@
     ]
 }
 
+// Mischievous Mystic
+{
+    "name": "Mischievous Mystic",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Flying\nWhenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Faerie"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1c0556e-ba3c-4a8e-b704-8eaa7c4dba1c.jpg?1782727481"
+                },
+                "descriptionOverride": "Whenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Prescott",
+        "flavorText": "\"Don't worry about where they're taking me. The more pressing question is, why aren't they taking you?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20d89cec-528b-4b2a-87db-e11ce0000622.jpg?1782689225"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Mossborn Hydra
 {
     "name": "Mossborn Hydra",
@@ -4374,6 +4427,49 @@
     "colorIdentityOverride": []
 }
 
+// Raise the Past
+{
+    "name": "Raise the Past",
+    "manaCost": "{2}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return all creature cards with mana value 2 or less from your graveyard to the battlefield.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Graveyard",
+                        "filter": "creature mv<=2"
+                    },
+                    "storeAs": "graveyardCreatures"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "graveyardCreatures",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Battlefield"
+                    },
+                    "underOwnersControl": true
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "22",
+        "rarity": "RARE",
+        "artist": "Nathaniel Himawan",
+        "flavorText": "At Strixhaven University, learning about the past means talking to those who were there.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/c/6c6be129-56da-4fe7-a6bd-6a1d402c09e1.jpg?1782689246"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Refute
 {
     "name": "Refute",
@@ -4639,6 +4735,69 @@
     "colorIdentityOverride": [
         "BLACK"
     ]
+}
+
+// Scrawling Crawler
+{
+    "name": "Scrawling Crawler",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Phyrexian Construct",
+    "oracleText": "At the beginning of your upkeep, each player draws a card.\nWhenever an opponent draws a card, that player loses 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "Each"
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, each player draws a card."
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "DrawEvent",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                },
+                "descriptionOverride": "Whenever an opponent draws a card, that player loses 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "132",
+        "rarity": "RARE",
+        "artist": "Miro Petrov",
+        "flavorText": "It spreads the machine gospel of New Phyrexia, its task incomplete until all surrender to perfection.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1176dcf-40ee-4342-aa74-791b8352e99a.jpg?1782689153"
+    }
 }
 
 // Searslicer Goblin


### PR DESCRIPTION
Implements three **Foundations-native** cards (FDN is each card's earliest real printing), all composed from existing SDK primitives — no new engine mechanics.

## Cards

| Card | Cost | What it does |
|------|------|--------------|
| **Raise the Past** | `{2}{W}{W}` Sorcery | Return all creature cards with mana value 2 or less from your graveyard to the battlefield. |
| **Mischievous Mystic** | `{1}{U}` 2/1 Human Wizard | Flying. Whenever you draw your second card each turn, create a 1/1 blue Faerie creature token with flying. |
| **Scrawling Crawler** | `{3}` 3/2 Artifact Creature | At the beginning of your upkeep, each player draws a card. Whenever an opponent draws a card, that player loses 1 life. |

## Implementation notes

- **Raise the Past** — mass reanimation via `Effects.Pipeline { gather(...); move(...) }`: gathers `GameObjectFilter.Creature.manaValueAtMost(2)` from your graveyard and moves the whole collection onto the battlefield under owners' control. No choice/targeting.
- **Mischievous Mystic** — `Triggers.NthCardDrawn(2)` (the shared "your Nth card each turn" detector) + `Effects.CreateToken`, mirroring the existing FDN card Erudite Wizard.
- **Scrawling Crawler** — `DrawCards(Player.Each)` for the symmetric group-draw; `Triggers.OpponentDraws` + `Effects.LoseLife(Player.TriggeringPlayer)` for the punisher (same shape as Razorkin Needlehead). Cards an opponent draws from the upkeep clause also drain them — the two abilities compose without special-casing.

## Not included

Considered **Hidetsugu's Second Rite** in the same pass but dropped it: its earliest real printing is Saviors of Kamigawa (2005), which isn't scaffolded in the repo, so its canonical `CardDefinition` doesn't belong in FDN (confirmed via `check-card-printing`). Scaffolding a whole new set for one card was out of scope for this PR.

## Verification

- All three verified via `check-card-printing` — canonical placement in FDN, no drift.
- Card snapshot golden re-blessed (`FDN.json`); diff adds only these three cards, nothing unrelated moved.
- `mtg-sets` suite green: `CardLintTest`, `FacadeBoundaryTest`, `CardDefinitionSnapshotTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)