### PR TITLE
Add Sidequest: Play Blitzball to Final Fantasy

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -5649,6 +5649,17 @@ of `AddMana`. The engine empties pools at end of turn, so:
   turn). Powers "an opponent was dealt combat damage by a legendary creature this turn" — Blitzball —
   via `Compare(TurnTracking(EachOpponent, DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE), GTE, 1)`
   (facade `Conditions.AnOpponentWasDealtCombatDamageByLegendaryCreatureThisTurn`).
+
+For a *combat-damage-amount threshold* that is existential over players — "a player was dealt N or
+more combat damage this turn" — use the dedicated condition
+`Conditions.aPlayerWasDealtCombatDamageThisTurnAtLeast(n)`
+(`AnyPlayerDealtCombatDamageThisTurnAtLeast`), NOT a `TurnTracking` tracker. It reads a per-player
+running total (`CombatDamageReceivedThisTurnComponent`, accumulated at the two combat-damage-to-a-
+player sites in `CombatDamageManager` and cleared at the turn boundary) and returns true when *some
+single* player crossed the threshold. The tracker path would instead sum every player's combat
+damage together (`TurnTracking(Player.Each, …)` sums), which would falsely satisfy the threshold on
+the combined total. Backs Sidequest: Play Blitzball ("if a player was dealt 6 or more combat damage
+this turn").
 - `COUNTERS_PUT_ON_CREATURE` — counters placed.
 - `LANDS_PLAYED` — lands the player explicitly played this turn (from-hand land drops only,
   derived from `LandDropsComponent`).

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -1183,6 +1183,19 @@ object Conditions {
             player = Player.EachOpponent,
         )
 
+    /**
+     * If a player was dealt [amount] or more combat damage this turn — existential over *all*
+     * players (including you): true when some single player's combat-damage-received running total
+     * reaches the threshold. Used by Sidequest: Play Blitzball ("if a player was dealt 6 or more
+     * combat damage this turn").
+     *
+     * Deliberately not a `trackerAtLeast(…, Player.Each)` helper: that path sums every player's
+     * combat damage together, which would falsely satisfy the threshold when the total across
+     * players reaches it but no single player did.
+     */
+    fun aPlayerWasDealtCombatDamageThisTurnAtLeast(amount: Int): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.AnyPlayerDealtCombatDamageThisTurnAtLeast(amount)
+
     // =========================================================================
     // Candidate-player target restrictions (CR 115)
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/TurnConditions.kt
@@ -562,3 +562,24 @@ data class PlayerTurnedPermanentFaceUpThisTurn(val player: Player = Player.You) 
         "if ${player.description} turned a permanent face up this turn"
 }
 
+
+/**
+ * Condition: "a player was dealt [amount] or more combat damage this turn" — true when ANY single
+ * player (existential, including you) has accumulated at least [amount] combat damage this turn.
+ *
+ * Backed by the per-player `CombatDamageReceivedThisTurnComponent` running total (incremented at
+ * the two combat-damage-to-a-player sites in `CombatDamageManager`, cleared at the turn boundary).
+ * Board-derived, so it reads the same at resolution and under projection.
+ *
+ * Deliberately NOT the summing `DynamicAmount.TurnTracking(Player.Each, …)` path: that adds every
+ * player's combat damage together (7 total across two players would falsely satisfy "6 or more"),
+ * whereas this asks whether some *one* player crossed the threshold. Used by Sidequest: Play
+ * Blitzball's end-of-combat transform ("if a player was dealt 6 or more combat damage this turn").
+ */
+@SerialName("AnyPlayerDealtCombatDamageThisTurnAtLeast")
+@Serializable
+data class AnyPlayerDealtCombatDamageThisTurnAtLeast(
+    val amount: Int
+) : Condition {
+    override val description: String = "if a player was dealt $amount or more combat damage this turn"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestPlayBlitzball.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/SidequestPlayBlitzball.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Sidequest: Play Blitzball // World Champion, Celestial Weapon — Final Fantasy #158
+ * {2}{R} · Enchantment // Legendary Artifact — Equipment
+ *
+ * Front — Sidequest: Play Blitzball:
+ *   At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.
+ *   At the end of combat on your turn, if a player was dealt 6 or more combat damage this turn,
+ *   transform this enchantment, then attach it to a creature you control.
+ *
+ * Back — World Champion, Celestial Weapon:
+ *   Double Overdrive — Equipped creature gets +2/+0 and has double strike.
+ *   Equip {3}
+ *
+ * The end-of-combat ability is an intervening-"if": the 6-combat-damage check gates the whole
+ * trigger, and "a player" is existential over every player (including you) — modelled by
+ * [Conditions.aPlayerWasDealtCombatDamageThisTurnAtLeast], which reads a per-player combat-damage
+ * running total rather than summing every player together. On resolution it transforms (turning
+ * this permanent into the Equipment), then chooses a creature you control to attach to. The attach
+ * is a resolution-time choice, NOT a target: the pipeline's `selectTarget` auto-picks a lone
+ * creature, pauses to choose among several, and — crucially — no-ops when you control none, so the
+ * enchantment still transforms even if you have no creature to hold the weapon.
+ */
+private val WorldChampionCelestialWeapon = card("World Champion, Celestial Weapon") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Double Overdrive — Equipped creature gets +2/+0 and has double strike.\n" +
+        "Equip {3}"
+
+    // Double Overdrive — Equipped creature gets +2/+0 and has double strike.
+    staticAbility {
+        ability = ModifyStats(2, 0)
+    }
+    staticAbility {
+        ability = GrantKeyword(Keyword.DOUBLE_STRIKE)
+    }
+
+    equipAbility("{3}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "158"
+        artist = "Ittoku"
+        flavorText = "\"Sorry for making you wait, Yuna. I had some promises to keep, ya?\""
+        imageUri = "https://cards.scryfall.io/normal/back/3/1/31e2ad37-73cf-4858-8a3a-fc1165cd21a7.jpg?1782686482"
+    }
+}
+
+private val SidequestPlayBlitzballFront = card("Sidequest: Play Blitzball") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of combat on your turn, target creature you control gets +2/+0 " +
+        "until end of turn.\n" +
+        "At the end of combat on your turn, if a player was dealt 6 or more combat damage this " +
+        "turn, transform this enchantment, then attach it to a creature you control."
+
+    // At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        effect = Effects.ModifyStats(2, 0, t)
+    }
+
+    // At the end of combat on your turn, if a player was dealt 6 or more combat damage this turn,
+    // transform this enchantment, then attach it to a creature you control.
+    triggeredAbility {
+        trigger = Triggers.YourEndOfCombat
+        triggerCondition = Conditions.aPlayerWasDealtCombatDamageThisTurnAtLeast(6)
+        effect = Effects.Pipeline {
+            // Transform this enchantment (it becomes World Champion, Celestial Weapon)...
+            run(TransformEffect(EffectTarget.Self))
+            // ...then attach it to a creature you control. Chosen at resolution, not targeted:
+            // auto-selects a lone creature, pauses to choose among several, no-ops with none.
+            val host = selectTarget(
+                TargetCreature(filter = TargetFilter.Creature.youControl()),
+                name = "host",
+            )
+            ifNotEmpty(host) {
+                run(Effects.AttachEquipment(EffectTarget.PipelineTarget(host.key)))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "158"
+        artist = "Ittoku"
+        imageUri = "https://cards.scryfall.io/normal/front/3/1/31e2ad37-73cf-4858-8a3a-fc1165cd21a7.jpg?1782686482"
+    }
+}
+
+val SidequestPlayBlitzball: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = SidequestPlayBlitzballFront,
+    backFace = WorldChampionCelestialWeapon,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -17275,6 +17275,156 @@
     ]
 }
 
+// Sidequest: Play Blitzball
+{
+    "name": "Sidequest: Play Blitzball",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of combat on your turn, target creature you control gets +2/+0 until end of turn.\nAt the end of combat on your turn, if a player was dealt 6 or more combat damage this turn, transform this enchantment, then attach it to a creature you control.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        "Transform",
+                        {
+                            "type": "SelectTarget",
+                            "requirement": {
+                                "type": "TargetObject",
+                                "filter": {
+                                    "baseFilter": "creature ctrl:you"
+                                }
+                            },
+                            "storeAs": "host"
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "host",
+                            "ifNotEmpty": {
+                                "type": "AttachEquipment",
+                                "target": {
+                                    "type": "PipelineTarget",
+                                    "collectionName": "host"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "AnyPlayerDealtCombatDamageThisTurnAtLeast",
+                    "amount": 6
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "World Champion, Celestial Weapon",
+        "manaCost": "",
+        "typeLine": "Legendary Artifact — Equipment",
+        "oracleText": "Double Overdrive — Equipped creature gets +2/+0 and has double strike.\nEquip {3}",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{3}"
+                        }
+                    },
+                    "effect": {
+                        "type": "AttachEquipment",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "creature you control"
+                        }
+                    ],
+                    "timing": "SorcerySpeed",
+                    "isEquipAbility": true
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE"
+                }
+            ]
+        },
+        "equipCost": "{3}",
+        "metadata": {
+            "collectorNumber": "158",
+            "rarity": "UNCOMMON",
+            "artist": "Ittoku",
+            "flavorText": "\"Sorry for making you wait, Yuna. I had some promises to keep, ya?\"",
+            "imageUri": "https://cards.scryfall.io/normal/back/3/1/31e2ad37-73cf-4858-8a3a-fc1165cd21a7.jpg?1782686482"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "rarity": "UNCOMMON",
+        "artist": "Ittoku",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/1/31e2ad37-73cf-4858-8a3a-fc1165cd21a7.jpg?1782686482"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Sidequest: Raise a Chocobo
 {
     "name": "Sidequest: Raise a Chocobo",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -59,6 +59,7 @@ import com.wingedsheep.engine.state.components.player.PutCounterOnCreatureThisTu
 import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
 import com.wingedsheep.engine.state.components.player.SacrificedFoodThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageByLegendaryCreatureThisTurnComponent
+import com.wingedsheep.engine.state.components.player.CombatDamageReceivedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.state.components.player.CreaturesDiedThisTurnComponent
@@ -653,6 +654,9 @@ class CleanupPhaseManager(
                 }
                 if (result.has<WasDealtCombatDamageThisTurnComponent>()) {
                     result = result.without<WasDealtCombatDamageThisTurnComponent>()
+                }
+                if (result.has<CombatDamageReceivedThisTurnComponent>()) {
+                    result = result.without<CombatDamageReceivedThisTurnComponent>()
                 }
                 if (result.has<WasDealtCombatDamageByLegendaryCreatureThisTurnComponent>()) {
                     result = result.without<WasDealtCombatDamageByLegendaryCreatureThisTurnComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -471,6 +471,7 @@ val engineSerializersModule = SerializersModule {
         subclass(CardsDrawnThisTurnComponent::class)
         subclass(EquipActivationsThisTurnComponent::class)
         subclass(WasDealtCombatDamageThisTurnComponent::class)
+        subclass(CombatDamageReceivedThisTurnComponent::class)
         subclass(WasDealtCombatDamageByLegendaryCreatureThisTurnComponent::class)
         subclass(AdditionalPhasesComponent::class)
         subclass(InAdditionalCombatPhaseComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -38,6 +38,7 @@ import com.wingedsheep.engine.state.components.player.InAdditionalCombatPhaseCom
 import com.wingedsheep.engine.state.components.player.InAdditionalEndStepComponent
 import com.wingedsheep.engine.state.components.player.LandDropsComponent
 import com.wingedsheep.engine.state.components.player.PlayerTurnsTakenComponent
+import com.wingedsheep.engine.state.components.player.CombatDamageReceivedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageThisTurnComponent
 import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
@@ -52,6 +53,7 @@ import com.wingedsheep.sdk.scripting.conditions.YouControlMostOfChosenType
 import com.wingedsheep.sdk.scripting.conditions.AllConditions
 import com.wingedsheep.sdk.scripting.conditions.AnyCondition
 import com.wingedsheep.sdk.scripting.conditions.APlayerLifeAtMost
+import com.wingedsheep.sdk.scripting.conditions.AnyPlayerDealtCombatDamageThisTurnAtLeast
 import com.wingedsheep.sdk.scripting.conditions.Compare
 import com.wingedsheep.sdk.scripting.conditions.NumberMatches
 import com.wingedsheep.sdk.scripting.conditions.NumberProperty
@@ -197,6 +199,13 @@ class ConditionEvaluator(
             // CR 805 — "your turn" is the active team's turn for every member of that team.
             is IsYourTurn -> ctx.controllerId?.let { state.isActiveTurnFor(it) } ?: false
             is IsNotYourTurn -> ctx.controllerId?.let { !state.isActiveTurnFor(it) } ?: false
+
+            // Existential over all players: does some single player's combat-damage-received running
+            // total reach the threshold? Board-derived (reads a per-player accumulator), so it works
+            // identically at resolution and under projection. Not the summing TurnTracking path.
+            is AnyPlayerDealtCombatDamageThisTurnAtLeast -> state.turnOrder.any { playerId ->
+                (state.getEntity(playerId)?.get<CombatDamageReceivedThisTurnComponent>()?.amount ?: 0) >= condition.amount
+            }
 
             // Board-derived (current step + active player), so it works identically at resolution
             // and under projection — used as a ConditionalStaticAbility gate (Zurgo's end step).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/CombatDamageManager.kt
@@ -16,6 +16,7 @@ import com.wingedsheep.engine.state.components.battlefield.HasDealtCombatDamageT
 import com.wingedsheep.engine.state.components.battlefield.HasDealtDamageComponent
 import com.wingedsheep.engine.state.components.battlefield.WasDealtDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageByLegendaryCreatureThisTurnComponent
+import com.wingedsheep.engine.state.components.player.CombatDamageReceivedThisTurnComponent
 import com.wingedsheep.engine.state.components.player.WasDealtCombatDamageThisTurnComponent
 import com.wingedsheep.engine.state.components.combat.AttackerOrderComponent
 import com.wingedsheep.engine.state.components.combat.AttackingComponent
@@ -905,9 +906,11 @@ internal class CombatDamageManager(
                     .with(DealtCombatDamageToPlayersThisTurnComponent(priorRecipients + targetId))
             }
         }
-        // Track that player was dealt combat damage this turn
+        // Track that player was dealt combat damage this turn (boolean marker + running total).
         newState = newState.updateEntity(targetId) { container ->
+            val priorCombat = container.get<CombatDamageReceivedThisTurnComponent>()?.amount ?: 0
             container.with(WasDealtCombatDamageThisTurnComponent)
+                .with(CombatDamageReceivedThisTurnComponent(priorCombat + effectiveAmount))
         }
         // Track when the damaging source is a legendary creature (Blitzball etc.)
         if (state.projectedState.isCreature(sourceId) && state.projectedState.isLegendary(sourceId)) {
@@ -1057,9 +1060,11 @@ internal class CombatDamageManager(
                         .with(DealtCombatDamageToPlayersThisTurnComponent(priorRecipients + targetId))
                 }
             }
-            // Track that player was dealt combat damage this turn
+            // Track that player was dealt combat damage this turn (boolean marker + running total).
             newState = newState.updateEntity(targetId) { container ->
+                val priorCombat = container.get<CombatDamageReceivedThisTurnComponent>()?.amount ?: 0
                 container.with(WasDealtCombatDamageThisTurnComponent)
+                    .with(CombatDamageReceivedThisTurnComponent(priorCombat + amount))
             }
             // Track when the damaging source is a legendary creature (Blitzball etc.)
             if (projected.isCreature(sourceId) && projected.isLegendary(sourceId)) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -1151,6 +1151,24 @@ data object PutCounterOnCreatureThisTurnComponent : Component
 data object WasDealtCombatDamageThisTurnComponent : Component
 
 /**
+ * Accumulates the total *combat* damage dealt to a player this turn. Distinct from
+ * [DamageReceivedThisTurnComponent] (which counts all damage, combat and non-combat) and from the
+ * boolean [WasDealtCombatDamageThisTurnComponent] marker — this carries the running amount so a
+ * threshold ("6 or more combat damage") can be tested. Only actually-dealt damage is accumulated
+ * (prevented/redirected-to-zero damage never reaches the two combat-damage-to-a-player sites in
+ * [com.wingedsheep.engine.mechanics.combat.CombatDamageManager] where it is incremented, mirroring
+ * the boolean marker exactly). Cleared at end of turn by CleanupPhaseManager.
+ *
+ * Backs the "a player was dealt N or more combat damage this turn" condition (Sidequest: Play
+ * Blitzball), read via
+ * [com.wingedsheep.sdk.dsl.Conditions.aPlayerWasDealtCombatDamageThisTurnAtLeast].
+ */
+@Serializable
+data class CombatDamageReceivedThisTurnComponent(
+    val amount: Int = 0
+) : Component
+
+/**
  * Marks a player as having been dealt combat damage by a legendary creature this turn.
  * Cleared at end of turn by CleanupPhaseManager.
  * Backs the DEALT_COMBAT_DAMAGE_BY_LEGENDARY_CREATURE turn tracker

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SidequestPlayBlitzballScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SidequestPlayBlitzballScenarioTest.kt
@@ -1,0 +1,128 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.SidequestPlayBlitzball
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sidequest: Play Blitzball // World Champion, Celestial Weapon (FIN).
+ *
+ * Front:
+ *   - At the beginning of combat on your turn, target creature you control gets +2/+0 EOT.
+ *   - At the end of combat on your turn, if a player was dealt 6+ combat damage this turn,
+ *     transform this enchantment, then attach it to a creature you control.
+ * Back — World Champion, Celestial Weapon: equipped creature gets +2/+0 and has double strike.
+ *
+ * Test 1 (transform path): a 6/6 attacks unblocked, gets +2/+0 at begin of combat (→8/6), deals 8
+ *   combat damage (≥6). At end of combat the enchantment transforms into World Champion and attaches
+ *   to the attacker, which then has double strike and the equipment's +2/+0.
+ * Test 2 (threshold gate): a 2/2 attacks unblocked, buffed to 4/2, deals only 4 combat damage (<6),
+ *   so the intervening-"if" fails and the enchantment does not transform.
+ */
+class SidequestPlayBlitzballScenarioTest : FunSpec({
+
+    val bigBeast = card("Test Big Beast") {
+        manaCost = "{6}"
+        typeLine = "Creature — Beast"
+        power = 6
+        toughness = 6
+    }
+    val smallBeast = card("Test Small Beast") {
+        manaCost = "{1}"
+        typeLine = "Creature — Beast"
+        power = 2
+        toughness = 2
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(SidequestPlayBlitzball, bigBeast, smallBeast))
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        return d
+    }
+
+    // Advance to declare-attackers, resolving the begin-of-combat +2/+0 trigger by targeting
+    // [creature]. (passPriorityUntil can't auto-resolve the ChooseTargetsDecision it raises.)
+    fun GameTestDriver.resolveBeginCombatBuff(me: EntityId, creature: EntityId) {
+        var guard = 0
+        while (state.step != Step.DECLARE_ATTACKERS && guard++ < 100) {
+            val decision = pendingDecision
+            when {
+                decision is ChooseTargetsDecision -> submitTargetSelection(decision.playerId, listOf(creature))
+                decision != null -> autoResolveDecision()
+                state.priorityPlayerId != null -> passPriority(state.priorityPlayerId!!)
+                else -> break
+            }
+        }
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard++ < 50) bothPass()
+    }
+
+    test("transforms into the Celestial Weapon and attaches when a player took 6+ combat damage") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opponent = d.getOpponent(me)
+
+        val enchant = d.putPermanentOnBattlefield(me, "Sidequest: Play Blitzball")
+        val beast = d.putCreatureOnBattlefield(me, "Test Big Beast")
+        d.removeSummoningSickness(beast)
+
+        // Begin of combat: target creature you control gets +2/+0 (6/6 -> 8/6).
+        d.resolveBeginCombatBuff(me, beast)
+        d.state.projectedState.getPower(beast) shouldBe 8
+
+        // Attack unblocked; 8 combat damage to the opponent (>= 6).
+        d.declareAttackers(me, listOf(beast), opponent)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareNoBlockers(opponent)
+        // Pass through the combat-damage step (auto-resolves damage) to end of combat.
+        d.passPriorityUntil(Step.END_COMBAT)
+        d.assertLifeTotal(opponent, 12)
+
+        // End of combat: the intervening-"if" holds, so it transforms and attaches to the beast.
+        d.resolveStack()
+
+        d.getCardName(enchant) shouldBe "World Champion, Celestial Weapon"
+        d.state.getEntity(enchant)?.get<AttachedToComponent>()?.targetId shouldBe beast
+        // The equipment's static abilities now apply to the equipped creature.
+        d.state.projectedState.hasKeyword(beast, Keyword.DOUBLE_STRIKE) shouldBe true
+    }
+
+    test("does not transform when no player took 6 or more combat damage") {
+        val d = driver()
+        val me = d.activePlayer!!
+        val opponent = d.getOpponent(me)
+
+        val enchant = d.putPermanentOnBattlefield(me, "Sidequest: Play Blitzball")
+        val beast = d.putCreatureOnBattlefield(me, "Test Small Beast")
+        d.removeSummoningSickness(beast)
+
+        // Begin of combat: 2/2 -> 4/2.
+        d.resolveBeginCombatBuff(me, beast)
+        d.state.projectedState.getPower(beast) shouldBe 4
+
+        // Attack unblocked; only 4 combat damage (< 6).
+        d.declareAttackers(me, listOf(beast), opponent)
+        d.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        d.declareNoBlockers(opponent)
+        d.passPriorityUntil(Step.END_COMBAT)
+        d.assertLifeTotal(opponent, 16)
+
+        d.resolveStack()
+
+        // Intervening-"if" failed → still the enchantment, unattached, untransformed.
+        d.getCardName(enchant) shouldBe "Sidequest: Play Blitzball"
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Sidequest: Play Blitzball // World Champion, Celestial Weapon** (FIN #158), a `{2}{R}` transforming enchantment → Legendary Equipment double-faced card, via the `add-card` flow.

### Card behaviour
- **Front — Sidequest: Play Blitzball** (Enchantment):
  - At the beginning of combat on your turn, **target creature you control gets +2/+0** until end of turn.
  - At the end of combat on your turn, **if a player was dealt 6 or more combat damage this turn**, transform this enchantment, then **attach it to a creature you control**.
- **Back — World Champion, Celestial Weapon** (Legendary Artifact — Equipment): equipped creature gets **+2/+0 and has double strike**; Equip `{3}`.

### New reusable engine capability
- `Conditions.aPlayerWasDealtCombatDamageThisTurnAtLeast(n)` (the `AnyPlayerDealtCombatDamageThisTurnAtLeast` condition): **existential over all players** — true when *some single* player crossed the combat-damage threshold this turn.
  - Backed by a new per-player `CombatDamageReceivedThisTurnComponent` running total, accumulated at the two combat-damage-to-a-player sites in `CombatDamageManager` (mirroring the existing `WasDealtCombatDamageThisTurnComponent` boolean, so it's single-count per instance) and cleared at end of turn.
  - Deliberately **not** the summing `DynamicAmount.TurnTracking(Player.Each, …)` path, which would add every player's combat damage together and falsely satisfy the threshold on the combined total.

### Faithfulness notes
- The end-of-combat ability is an intervening-"if"; the transform-then-attach reuses existing primitives (`Effects.Pipeline`: transform the source → `selectTarget` a creature you control at resolution → `AttachEquipment` via `EffectTarget.PipelineTarget`).
- The attach is a **resolution-time choice, not a target**: it auto-picks a lone creature, pauses to choose among several, and no-ops with none — so the enchantment still transforms even when you control no creature to hold the weapon (which a targeted ability could not do).

## Tests
- New `SidequestPlayBlitzballScenarioTest` covers the transform+attach path (8 combat damage → transforms, attaches, equipped creature gains double strike) and the sub-threshold gate (4 combat damage → no transform).
- Full `just build` (all modules) and full `rules-engine` suite pass; `CardLintTest` and the re-blessed FIN `CardDefinitionSnapshotTest` pass (snapshot diff isolated to the new card). SDK reference (§ turn conditions) updated.

## Scope note
FIN is ~97% implemented — only the 9 hardest cards remain, and **every** one requires substantial new engine features. Per the "pick fewer cards if they are complex" guidance, this PR delivers the most self-contained of them, fully and faithfully. The others each warrant their own dedicated, reviewed change — notably **The Masamune** (trigger-multiplication scoped to the equipped creature + emblems, granted via equipment) and **Ultima, Origin of Oblivion** (a cross-layer blight-counter land continuous — a reusable FIN set mechanic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)