### PR TITLE
Empty unspent mana at the end of every step and phase (CR 500.5)

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -755,9 +755,10 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `RetainUnspentMana(vararg colors)` — "Until end of turn, you don't lose unspent mana of these colours
   as steps and phases end." The colour-filtered, single-player, turn-scoped one-shot cousin of the
   permanent-static `PreventManaPoolEmptying` (Upwelling, which stops *all* emptying for *everyone*).
-  Confers a `RetainUnspentManaComponent` on the resolving controller; at the end-of-turn mana-empty step
-  (`CleanupPhaseManager`) the kept colours survive `ManaPoolComponent.emptyExcept(...)` once, then the
-  marker clears. The Last Agni Kai (`RetainUnspentMana(Color.RED)`).
+  Confers a `RetainUnspentManaComponent` on the resolving controller; at every step/phase-end mana
+  emptying (CR 500.5, `CleanupPhaseManager.emptyManaPools` → `ManaPoolComponent.emptyAtBoundary(...)`)
+  the kept colours survive while everything else empties, until the marker clears at end-of-turn
+  cleanup. The Last Agni Kai (`RetainUnspentMana(Color.RED)`).
 - `AddManaOfChoice(colorSet, amount?, restriction?, riders?)` — **unified primitive.** Add N mana of one color the controller picks from a resolved [ManaColorSet](#manacolorset). All "any-color from a constrained pool" cards (any color, commander identity, among permanents, lands could produce, source-chosen color) are expressed as this effect plus a different `ManaColorSet`. `riders` is a `Set<ManaSpellRider>` consumed when the mana pays for a spell (e.g. Path of Ancestry tags its mana with `ScryOnSharedTypeWithCommander`); when riders are set without a `restriction`, the engine stores the entries under `ManaRestriction.AnySpend` to preserve the rider through the pool.
 - `AddAnyColorMana(amount?, restriction?)` — sugar for `AddManaOfChoice(ManaColorSet.AnyColor, amount)`. "Add N mana of any **one** color" (Gilded Lotus): one chosen color, N of it. For "any **combination** of colors" use `AddManaInAnyCombination`.
 - `AddManaOfChosenColor(amount?)` — sugar for `AddManaOfChoice(ManaColorSet.SourceChosenColor, amount)`.
@@ -3819,10 +3820,11 @@ staticAbility {
   of any type can be spent to activate Sharkey's abilities" → `GroupFilter.source()`.)
 - `PreventManaPoolEmptying` — mana pools don't empty between steps/phases. (Upwelling)
 - `ConvertEmptyingManaToRed` — "If you would lose unspent mana, that mana becomes red instead."
-  The colour-converting cousin of `PreventManaPoolEmptying`: at the mana-empty point (end-of-turn
-  cleanup, `CleanupPhaseManager`) the *controller's* whole pool becomes that many red mana instead
-  of emptying (CR 500.5 / 703.4q emptying replaced per CR 614). Scoped to the controller of the
-  bearing permanent, unlike Upwelling's all-players prevention. (Ozai, the Phoenix King)
+  The colour-converting cousin of `PreventManaPoolEmptying`: at every step/phase-end mana emptying
+  (`CleanupPhaseManager.emptyManaPools`, and for firebending mana at `CombatManager.endCombat`) the
+  *controller's* would-be-lost mana becomes that many red mana instead of emptying (CR 500.5 / 703.4q
+  emptying replaced per CR 614). Scoped to the controller of the bearing permanent, unlike Upwelling's
+  all-players prevention. (Ozai, the Phoenix King)
 - `NoMaximumHandSize` — controller has no hand-size limit *while this permanent is on the
   battlefield*. (Thought Vessel, Reliquary Tower) For a one-shot resolution effect that confers a
   *permanent, player-scoped* "no maximum hand size for the rest of the game" (survives the source

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -582,9 +582,9 @@ data class SuppressEntersTriggers(
  * Prevents mana pools from emptying as steps and phases end.
  * Used for Upwelling: "Players don't lose unspent mana as steps and phases end."
  *
- * The engine checks for this static ability on any permanent on the battlefield
- * during mana pool cleanup. While any permanent with this ability is on the battlefield,
- * mana pools are not emptied.
+ * The engine checks for this static ability on any permanent on the battlefield at every
+ * step/phase-end mana emptying (CR 500.5). While any permanent with this ability is on the
+ * battlefield, mana pools are not emptied.
  */
 @SerialName("PreventManaPoolEmptying")
 @Serializable
@@ -601,9 +601,10 @@ data object PreventManaPoolEmptying : StaticAbility {
  * empties as each step and phase ends) with an equal amount of red. Scoped to the controller of the
  * permanent bearing the ability, unlike Upwelling's all-players prevention.
  *
- * The engine checks for this static ability at the single mana-empty point (end-of-turn cleanup in
- * [com.wingedsheep.engine.core.CleanupPhaseManager]); for each controller of a permanent with this
- * ability, the pool is replaced by that many red mana rather than emptied.
+ * The engine checks for this static ability at every step/phase-end mana emptying (CR 500.5, in
+ * `CleanupPhaseManager.emptyManaPools`, and again for firebending mana in `CombatManager.endCombat`);
+ * for each controller of a permanent with this ability, the would-be-lost mana is replaced by that
+ * many red mana rather than emptied.
  */
 @SerialName("ConvertEmptyingManaToRed")
 @Serializable

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -391,6 +391,9 @@ class CleanupPhaseManager(
      * handled instead by `CombatManager.endCombat`, since it lasts until end of combat, not step end.
      */
     fun emptyManaPools(state: GameState): GameState {
+        // Runs on every step/phase boundary; almost always every pool is already empty (no mana
+        // floated), so skip the battlefield scans below in that common case.
+        if (state.turnOrder.all { state.getEntity(it)?.get<ManaPoolComponent>()?.isEmpty != false }) return state
         if (isManaPoolEmptyingPrevented(state)) return state
         var newState = state
         val convertToRedPlayers = playersConvertingEmptyingManaToRed(state, cardRegistry)
@@ -505,9 +508,10 @@ class CleanupPhaseManager(
             newState = newState.copy(activeCounterPlacementModifiers = remainingCounterModifiers)
         }
 
-        // 2. Empty mana pools as this (cleanup) step ends — the last of the per-step/phase emptyings
-        // (CR 500.5 / 703.4q). The RetainUnspentManaComponent marker (The Last Agni Kai) still keeps
-        // its colours here; the marker itself is cleared in step 4 below.
+        // 2. Empty mana pools as this (cleanup) step ends — one of the per-step/phase emptyings
+        // (CR 500.5 / 703.4q; if cleanup grants priority, advanceStep empties once more, idempotently).
+        // The RetainUnspentManaComponent marker (The Last Agni Kai) still keeps its colours here; the
+        // marker itself is cleared in step 4 below.
         newState = emptyManaPools(newState)
 
         // 3. Reset per-turn trackers (land drops reset at start of turn, but clean up here too)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CleanupPhaseManager.kt
@@ -379,6 +379,41 @@ class CleanupPhaseManager(
     }
 
     /**
+     * Empty every player's unspent mana as a step or phase ends (CR 500.5 / 703.4q — a turn-based
+     * action that doesn't use the stack). This is the single mana-emptying primitive, called at
+     * every step/phase transition ([com.wingedsheep.engine.core.TurnManager.advanceStep]) and again
+     * as the cleanup step ends (end of turn). It applies the per-player mana-loss statics:
+     *  - Upwelling ([PreventManaPoolEmptying]) — no one loses mana at all (whole action skipped).
+     *  - Ozai, the Phoenix King ([ConvertEmptyingManaToRed]) — the controller's would-be-lost mana
+     *    becomes that many red mana instead (CR 614).
+     *  - The Last Agni Kai ([RetainUnspentManaComponent]) — the named colours are kept.
+     * Firebending (END_OF_COMBAT) mana is preserved by [ManaPoolComponent.emptyAtBoundary] and
+     * handled instead by `CombatManager.endCombat`, since it lasts until end of combat, not step end.
+     */
+    fun emptyManaPools(state: GameState): GameState {
+        if (isManaPoolEmptyingPrevented(state)) return state
+        var newState = state
+        val convertToRedPlayers = playersConvertingEmptyingManaToRed(state, cardRegistry)
+        for (playerId in state.turnOrder) {
+            newState = newState.updateEntity(playerId) { container ->
+                val manaPool = container.get<ManaPoolComponent>()
+                if (manaPool != null && !manaPool.isEmpty) {
+                    val retained = container.get<RetainUnspentManaComponent>()?.colors ?: emptySet()
+                    container.with(
+                        manaPool.emptyAtBoundary(
+                            convertToRed = playerId in convertToRedPlayers,
+                            retain = retained
+                        )
+                    )
+                } else {
+                    container
+                }
+            }
+        }
+        return newState
+    }
+
+    /**
      * Check if any permanent on the battlefield has the PreventManaPoolEmptying static ability.
      * Used for cards like Upwelling: "Players don't lose unspent mana as steps and phases end."
      */
@@ -470,31 +505,10 @@ class CleanupPhaseManager(
             newState = newState.copy(activeCounterPlacementModifiers = remainingCounterModifiers)
         }
 
-        // 2. Empty mana pools for all players (unless prevented by a static ability like Upwelling).
-        // A player carrying a RetainUnspentManaComponent (The Last Agni Kai) keeps mana of the
-        // named colours through this emptying; the marker itself is cleared in step 4 below.
-        // A player controlling a ConvertEmptyingManaToRed permanent (Ozai, the Phoenix King) has
-        // their whole pool turned into that many red mana instead of emptied — CR 500.5 / 703.4q
-        // (unspent mana empties as each step and phase ends), replaced here per CR 614.
-        if (!isManaPoolEmptyingPrevented(newState)) {
-            val convertToRedPlayers = playersConvertingEmptyingManaToRed(newState, cardRegistry)
-            for (playerId in newState.turnOrder) {
-                newState = newState.updateEntity(playerId) { container ->
-                    val manaPool = container.get<ManaPoolComponent>()
-                    if (manaPool != null && !manaPool.isEmpty) {
-                        val retained = container.get<RetainUnspentManaComponent>()?.colors
-                        when {
-                            playerId in convertToRedPlayers -> container.with(manaPool.convertToRed())
-                            retained != null && retained.isNotEmpty() ->
-                                container.with(manaPool.emptyExcept(retained))
-                            else -> container.with(manaPool.empty())
-                        }
-                    } else {
-                        container
-                    }
-                }
-            }
-        }
+        // 2. Empty mana pools as this (cleanup) step ends — the last of the per-step/phase emptyings
+        // (CR 500.5 / 703.4q). The RetainUnspentManaComponent marker (The Last Agni Kai) still keeps
+        // its colours here; the marker itself is cleared in step 4 below.
+        newState = emptyManaPools(newState)
 
         // 3. Reset per-turn trackers (land drops reset at start of turn, but clean up here too)
         for (playerId in newState.turnOrder) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/TurnManager.kt
@@ -237,7 +237,14 @@ class TurnManager(
      * Advance to the next step.
      * Handles automatic step-based actions and turn transitions.
      */
-    fun advanceStep(state: GameState): ExecutionResult {
+    fun advanceStep(state: GameState): ExecutionResult =
+        // CR 500.5 / 703.4q: as the ending step or phase closes, each player's unspent mana empties
+        // (a turn-based action). This is the general per-step/phase emptying — the same action
+        // end-of-turn cleanup performs — applying the Upwelling / Ozai / Last Agni Kai statics.
+        // Firebending (END_OF_COMBAT) mana is preserved and handled by CombatManager.endCombat.
+        advanceStepFromEndedStep(cleanupPhaseManager.emptyManaPools(state))
+
+    private fun advanceStepFromEndedStep(state: GameState): ExecutionResult {
         val currentStep = state.step
         val activePlayer = state.activePlayerId
             ?: return ExecutionResult.error(state, "No active player")

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/player/PlayerComponents.kt
@@ -142,32 +142,45 @@ data class ManaPoolComponent(
     fun empty(): ManaPoolComponent = ManaPoolComponent()
 
     /**
-     * Convert every would-be-lost mana into an equal amount of red instead of emptying
-     * (Ozai, the Phoenix King: "If you would lose unspent mana, that mana becomes red instead").
-     * The whole pool — all colours, colorless, and restricted entries counted by [total] — becomes
-     * that many plain red mana; treasure and restriction tags do not carry over. An empty pool
-     * stays empty.
+     * Empty the pool as a step or phase ends (CR 500.5 / 703.4q), the engine's turn-based
+     * mana-loss action. This is the single emptying primitive for every mana-loss point, applying
+     * the per-player mana-loss statics:
+     *  - [convertToRed] = true (Ozai, the Phoenix King, [ConvertEmptyingManaToRed]): the would-be-lost
+     *    mana becomes that many plain red mana instead of emptying (CR 614).
+     *  - [retain] non-empty (The Last Agni Kai, [RetainUnspentManaComponent]): mana of those colours —
+     *    plain counters and same-colour ordinary restricted entries — survives; everything else empties.
+     *  - neither: the ordinary mana empties.
+     * [convertToRed] takes precedence over [retain] (Ozai fully replaces the loss).
+     *
+     * **Firebending mana is preserved.** Restricted entries with [ManaExpiry.END_OF_COMBAT] "last
+     * until end of combat", not until the end of each step — so they survive every step/phase-end
+     * emptying within combat and are handled instead by `CombatManager.endCombat`. Only ordinary
+     * ([ManaExpiry.END_OF_TURN]) mana is subject to this action. (At end of turn no combat-duration
+     * mana remains, so preservation is a no-op there.)
      */
-    fun convertToRed(): ManaPoolComponent = ManaPoolComponent(red = total)
-
-    /**
-     * Empty the pool except for mana of [keep] colours, which is retained. Used by the
-     * colour-filtered, turn-scoped retention ([RetainUnspentManaComponent], The Last Agni Kai):
-     * at end-of-turn cleanup the kept colours' plain counters and any same-colour restricted
-     * entries survive, while every other colour, colorless, treasure, and off-colour restricted
-     * mana empties as normal. An empty [keep] set is identical to [empty].
-     */
-    fun emptyExcept(keep: Set<Color>): ManaPoolComponent =
-        ManaPoolComponent(
-            white = if (Color.WHITE in keep) white else 0,
-            blue = if (Color.BLUE in keep) blue else 0,
-            black = if (Color.BLACK in keep) black else 0,
-            red = if (Color.RED in keep) red else 0,
-            green = if (Color.GREEN in keep) green else 0,
-            colorless = 0,
-            restrictedMana = restrictedMana.filter { it.color != null && it.color in keep },
-            treasureMana = 0
-        )
+    fun emptyAtBoundary(convertToRed: Boolean, retain: Set<Color>): ManaPoolComponent {
+        val preserved = restrictedMana.filter { it.expiry == ManaExpiry.END_OF_COMBAT }
+        val lostRestricted = restrictedMana.filter { it.expiry != ManaExpiry.END_OF_COMBAT }
+        return when {
+            convertToRed -> {
+                // Count the would-be-lost mana the way `total` does (the treasure counter is a tag on
+                // already-counted colour mana, not extra mana); the treasure tag doesn't carry over.
+                val lostTotal = white + blue + black + red + green + colorless + lostRestricted.size
+                ManaPoolComponent(red = lostTotal, restrictedMana = preserved)
+            }
+            retain.isNotEmpty() -> ManaPoolComponent(
+                white = if (Color.WHITE in retain) white else 0,
+                blue = if (Color.BLUE in retain) blue else 0,
+                black = if (Color.BLACK in retain) black else 0,
+                red = if (Color.RED in retain) red else 0,
+                green = if (Color.GREEN in retain) green else 0,
+                colorless = 0,
+                restrictedMana = preserved + lostRestricted.filter { it.color != null && it.color in retain },
+                treasureMana = 0
+            )
+            else -> ManaPoolComponent(restrictedMana = preserved)
+        }
+    }
 }
 
 /**
@@ -179,12 +192,13 @@ data class ManaPoolComponent(
  * [com.wingedsheep.sdk.scripting.PreventManaPoolEmptying] (Upwelling): rather than stopping all
  * emptying for everyone while a permanent is in play, it spares only this player's [colors] mana.
  *
- * Read by [com.wingedsheep.engine.core.CleanupPhaseManager] during the end-of-turn mana-emptying
- * step (the engine's only mana-pool-emptying point): the player's pool is emptied via
- * [ManaPoolComponent.emptyExcept] keeping [colors], then the component is removed if its
- * [removeOn] is [PlayerEffectRemoval.EndOfTurn] (the default).
+ * Read by [com.wingedsheep.engine.core.CleanupPhaseManager.emptyManaPools] at every step/phase-end
+ * mana emptying (CR 500.5): the player's pool is emptied via [ManaPoolComponent.emptyAtBoundary]
+ * keeping [colors]. The component persists across the turn's boundaries and is removed at end-of-turn
+ * cleanup if its [removeOn] is [PlayerEffectRemoval.EndOfTurn] (the default), so the kept mana is
+ * finally lost on the following turn once the retention has ended.
  *
- * @property colors Mana colours kept through this turn's pool emptying.
+ * @property colors Mana colours kept as steps and phases end this turn.
  * @property removeOn When this component is removed.
  */
 @Serializable

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BorneUponAWindTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BorneUponAWindTest.kt
@@ -82,8 +82,9 @@ class BorneUponAWindTest : FunSpec({
         driver.bothPass()
 
         val sorcery = driver.putCardInHand(p1, "Test Sorcery")
-        driver.giveMana(p1, Color.RED, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(p1, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
@@ -111,9 +112,11 @@ class BorneUponAWindTest : FunSpec({
         driver.state.getEntity(p1)?.get<FlashGrantsThisTurnComponent>().shouldBeNull()
 
         val sorcery = driver.putCardInHand(p1, "Test Sorcery")
-        driver.giveMana(p1, Color.RED, 2)
         driver.passPriorityUntil(Step.END)
         driver.passPriority(p2) // priority on p1 during p2's end step
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because the flash grant has expired, not for lack of mana
+        driver.giveMana(p1, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DonatellosTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DonatellosTechniqueTest.kt
@@ -19,8 +19,9 @@ class DonatellosTechniqueTest : FunSpec({
         driver.initMirrorMatch(deck = Deck.of("Island" to 30), startingLife = 20)
         val player = driver.activePlayer!!
         val spell = driver.putCardInHand(player, "Donatello's Technique")
-        driver.giveMana(player, Color.BLUE, 3)
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.BLUE, 3)
         val before = driver.getHandSize(player)
         driver.castSpell(player, spell).isSuccess shouldBe true
         while (driver.state.stack.isNotEmpty()) driver.bothPass()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FootNinjasTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FootNinjasTest.kt
@@ -26,10 +26,11 @@ class FootNinjasTest : FunSpec({
 
         val player = driver.activePlayer!!
         val foot = driver.putCardInHand(player, "Foot Ninjas")
-        // {4}{W/B}{W/B}: six white mana pays the four generic and both hybrid pips.
-        driver.giveMana(player, Color.WHITE, 6)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // {4}{W/B}{W/B}: six white mana pays the four generic and both hybrid pips.
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.WHITE, 6)
         driver.castSpell(player, foot).isSuccess shouldBe true
         while (driver.state.stack.isNotEmpty()) driver.bothPass()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfFriendOfTheShireTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfFriendOfTheShireTest.kt
@@ -90,8 +90,9 @@ class GandalfFriendOfTheShireTest : FunSpec({
 
         driver.putPermanentOnBattlefield(p1, "Gandalf, Friend of the Shire")
         val sorcery = driver.putCardInHand(p1, "Test Sorcery")
-        driver.giveMana(p1, Color.RED, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(p1, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
@@ -107,8 +108,10 @@ class GandalfFriendOfTheShireTest : FunSpec({
 
         driver.putPermanentOnBattlefield(p1, "Gandalf, Friend of the Shire")
         val beast = driver.putCardInHand(p1, "Test Beast")
-        driver.giveMana(p1, Color.GREEN, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because a creature spell isn't granted flash, not for lack of mana
+        driver.giveMana(p1, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = beast, paymentStrategy = PaymentStrategy.FromPool)
@@ -125,9 +128,11 @@ class GandalfFriendOfTheShireTest : FunSpec({
 
         driver.putPermanentOnBattlefield(p1, "Gandalf, Friend of the Shire")
         val sorcery = driver.putCardInHand(p2, "Test Sorcery")
-        driver.giveMana(p2, Color.RED, 2)
         driver.passPriorityUntil(Step.END)
         driver.passPriority(p1)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because the static is controller-only, not for lack of mana
+        driver.giveMana(p2, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p2, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheWhiteTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GandalfTheWhiteTest.kt
@@ -185,8 +185,9 @@ class GandalfTheWhiteTest : FunSpec({
 
         driver.putPermanentOnBattlefield(p1, "Gandalf the White")
         val legendary = driver.putCardInHand(p1, "Test Legendary Beast")
-        driver.giveMana(p1, Color.GREEN, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(p1, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = legendary, paymentStrategy = PaymentStrategy.FromPool)
@@ -202,8 +203,9 @@ class GandalfTheWhiteTest : FunSpec({
 
         driver.putPermanentOnBattlefield(p1, "Gandalf the White")
         val trinket = driver.putCardInHand(p1, "Test Trinket")
-        driver.giveColorlessMana(p1, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveColorlessMana(p1, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = trinket, paymentStrategy = PaymentStrategy.FromPool)
@@ -219,8 +221,10 @@ class GandalfTheWhiteTest : FunSpec({
 
         driver.putPermanentOnBattlefield(p1, "Gandalf the White")
         val bear = driver.putCardInHand(p1, "Test Bear")
-        driver.giveMana(p1, Color.GREEN, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because a vanilla creature isn't granted flash, not for lack of mana
+        driver.giveMana(p1, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = bear, paymentStrategy = PaymentStrategy.FromPool)
@@ -237,9 +241,11 @@ class GandalfTheWhiteTest : FunSpec({
 
         driver.putPermanentOnBattlefield(p1, "Gandalf the White")
         val legendary = driver.putCardInHand(p2, "Test Legendary Beast")
-        driver.giveMana(p2, Color.GREEN, 2)
         driver.passPriorityUntil(Step.END)
         driver.passPriority(p1)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because the static is controller-only, not for lack of mana
+        driver.giveMana(p2, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p2, cardId = legendary, paymentStrategy = PaymentStrategy.FromPool)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrantFlashToSpellsEffectTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrantFlashToSpellsEffectTest.kt
@@ -95,8 +95,10 @@ class GrantFlashToSpellsEffectTest : FunSpec({
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
         val sorcery = driver.putCardInHand(p1, "Test Sorcery")
-        driver.giveMana(p1, Color.RED, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because there is no flash grant, not for lack of mana
+        driver.giveMana(p1, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
@@ -111,7 +113,6 @@ class GrantFlashToSpellsEffectTest : FunSpec({
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
         val sorcery = driver.putCardInHand(p1, "Test Sorcery")
-        driver.giveMana(p1, Color.RED, 2)
 
         // Seed the player-scoped flash permission directly (any spell, EOT duration).
         driver.replaceState(
@@ -125,6 +126,8 @@ class GrantFlashToSpellsEffectTest : FunSpec({
             }
         )
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(p1, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
@@ -140,7 +143,6 @@ class GrantFlashToSpellsEffectTest : FunSpec({
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
         val sorcery = driver.putCardInHand(p2, "Test Sorcery")
-        driver.giveMana(p2, Color.RED, 2)
 
         // Grant on p1 — p2's sorcery must NOT inherit flash.
         driver.replaceState(
@@ -155,6 +157,9 @@ class GrantFlashToSpellsEffectTest : FunSpec({
         )
         driver.passPriorityUntil(Step.END)
         driver.passPriority(p1) // give p2 priority
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because the grant is owner-scoped to p1, not for lack of mana
+        driver.giveMana(p2, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p2, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)
@@ -169,7 +174,6 @@ class GrantFlashToSpellsEffectTest : FunSpec({
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
         val beast = driver.putCardInHand(p1, "Test Beast")
-        driver.giveMana(p1, Color.GREEN, 2)
 
         driver.replaceState(
             driver.state.updateEntity(p1) { container ->
@@ -182,6 +186,9 @@ class GrantFlashToSpellsEffectTest : FunSpec({
             }
         )
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because a creature isn't matched by the Sorcery-only grant, not for lack of mana
+        driver.giveMana(p1, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = beast, paymentStrategy = PaymentStrategy.FromPool)
@@ -196,7 +203,6 @@ class GrantFlashToSpellsEffectTest : FunSpec({
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
 
         val sorcery = driver.putCardInHand(p1, "Test Sorcery")
-        driver.giveMana(p1, Color.RED, 2)
 
         driver.replaceState(
             driver.state.updateEntity(p1) { container ->
@@ -209,6 +215,8 @@ class GrantFlashToSpellsEffectTest : FunSpec({
             }
         )
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(p1, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(playerId = p1, cardId = sorcery, paymentStrategy = PaymentStrategy.FromPool)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JarethLeonineTitanTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JarethLeonineTitanTest.kt
@@ -144,10 +144,11 @@ class JarethLeonineTitanTest : FunSpec({
         val jareth = driver.putCreatureOnBattlefield(player2, "Jareth, Leonine Titan")
         driver.removeSummoningSickness(jareth)
 
-        // Give player 2 white mana and activate protection from red
-        driver.giveMana(player2, Color.WHITE, 1)
-
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Give player 2 white mana and activate protection from red
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player2, Color.WHITE, 1)
 
         // Pass priority to player 2
         driver.passPriority(player1)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JennikasTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JennikasTechniqueTest.kt
@@ -22,9 +22,10 @@ class JennikasTechniqueTest : FunSpec({
         driver.putCreatureOnBattlefield(player, "Grizzly Bears")   // 2/2
         driver.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2
         val spell = driver.putCardInHand(player, "Jennika's Technique")
-        driver.giveMana(player, Color.RED, 3)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.RED, 3)
         driver.castSpell(player, spell).isSuccess shouldBe true
         while (driver.state.stack.isNotEmpty()) driver.bothPass()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaraisTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaraisTechniqueTest.kt
@@ -24,10 +24,11 @@ class KaraisTechniqueTest : FunSpec({
 
         val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears") // 2/2
         val spell = driver.putCardInHand(player, "Karai's Technique")
-        driver.giveMana(player, Color.WHITE, 2)
-        driver.giveMana(player, Color.BLACK, 1)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.WHITE, 2)
+        driver.giveMana(player, Color.BLACK, 1)
         driver.submit(
             CastSpell(
                 playerId = player,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaEmptyingPerStepTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ManaEmptyingPerStepTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Per-step / per-phase mana emptying — CR 500.5 / 703.4q: "As a step or phase ends ... any unspent
+ * mana left in a player's mana pool empties." It's a turn-based action applied at *every* step and
+ * phase transition (`TurnManager.advanceStep` → `CleanupPhaseManager.emptyManaPools`), not only at
+ * end of turn. Upwelling (`PreventManaPoolEmptying`) suppresses it for everyone; the colour/convert
+ * statics (The Last Agni Kai, Ozai) are proven in their own scenario tests.
+ */
+class ManaEmptyingPerStepTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun GameTestDriver.pool(playerId: EntityId): ManaPoolComponent =
+        state.getEntity(playerId)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
+
+    test("unspent mana empties as a step or phase ends") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.giveMana(active, Color.GREEN, 3)
+        driver.pool(active).total shouldBe 3
+
+        // Crossing one boundary (precombat main → beginning of combat) empties the unspent mana.
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
+        driver.pool(active).total shouldBe 0
+    }
+
+    test("Upwelling keeps unspent mana across step and phase boundaries") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val active = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(active, "Upwelling")
+        driver.giveMana(active, Color.GREEN, 3)
+
+        // Upwelling ("Players don't lose unspent mana as steps and phases end") suppresses the
+        // per-step emptying, so the mana survives the boundary.
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
+        driver.pool(active).total shouldBe 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenExhaleBeholdFlashTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenExhaleBeholdFlashTest.kt
@@ -60,10 +60,11 @@ class MoltenExhaleBeholdFlashTest : FunSpec({
         val dragon = driver.putCreatureOnBattlefield(p1, "Test Dragon")
         val ogre = driver.putCreatureOnBattlefield(p2, "Test Ogre")
         val moltenExhale = driver.putCardInHand(p1, "Molten Exhale")
-        driver.giveMana(p1, Color.RED, 2)
 
         // Past the main phase — sorcery speed no longer applies.
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(p1, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(
@@ -93,9 +94,11 @@ class MoltenExhaleBeholdFlashTest : FunSpec({
 
         val ogre = driver.putCreatureOnBattlefield(p2, "Test Ogre")
         val moltenExhale = driver.putCardInHand(p1, "Molten Exhale")
-        driver.giveMana(p1, Color.RED, 2)
 
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because it's a sorcery cast at instant speed without beholding, not for lack of mana
+        driver.giveMana(p1, Color.RED, 2)
 
         // Plain cast (no behold) at instant speed is illegal — it's a sorcery.
         val result = driver.submit(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NewGenerationsTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NewGenerationsTechniqueTest.kt
@@ -22,9 +22,10 @@ class NewGenerationsTechniqueTest : FunSpec({
         driver.initMirrorMatch(deck = Deck.of("Forest" to 30), startingLife = 20)
         val player = driver.activePlayer!!
         val spell = driver.putCardInHand(player, "New Generation's Technique")
-        driver.giveMana(player, Color.GREEN, 4)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.GREEN, 4)
         val forestsBefore = driver.getPermanents(player).count {
             driver.state.getEntity(it)?.get<com.wingedsheep.engine.state.components.identity.CardComponent>()?.name == "Forest"
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OzaiThePhoenixKingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OzaiThePhoenixKingScenarioTest.kt
@@ -36,7 +36,7 @@ class OzaiThePhoenixKingScenarioTest : FunSpec({
     fun GameTestDriver.pool(playerId: EntityId): ManaPoolComponent =
         state.getEntity(playerId)?.get<ManaPoolComponent>() ?: ManaPoolComponent()
 
-    test("would-be-lost mana becomes that many red instead of emptying while Ozai is out") {
+    test("would-be-lost mana becomes that many red at each step/phase boundary while Ozai is out") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!
@@ -51,18 +51,18 @@ class OzaiThePhoenixKingScenarioTest : FunSpec({
         driver.giveColorlessMana(active, 1)
         driver.giveMana(opponent, Color.GREEN, 2)
 
-        // Cross this turn's cleanup into the opponent's turn (the engine's only mana-empty point).
-        driver.passPriorityUntil(Step.UPKEEP)
-        driver.activePlayer shouldBe opponent
+        // Cross a single step/phase boundary within the turn (CR 500.5: unspent mana empties as the
+        // precombat main phase ends). No need to wait for end of turn.
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
 
-        // Ozai's controller: nothing lost — the 3 mana became {R}{R}{R}, kept in the pool.
+        // Ozai's controller: nothing lost — the 3 would-be-lost mana became {R}{R}{R}, kept in the pool.
         driver.pool(active).red shouldBe 3
         driver.pool(active).total shouldBe 3
         driver.pool(active).white shouldBe 0
         driver.pool(active).blue shouldBe 0
         driver.pool(active).colorless shouldBe 0
 
-        // Opponent controls no Ozai — their pool emptied normally.
+        // Opponent controls no Ozai — their pool emptied as the phase ended.
         driver.pool(opponent).total shouldBe 0
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuickSliverTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuickSliverTest.kt
@@ -84,10 +84,11 @@ class QuickSliverTest : FunSpec({
 
         // Put the card in hand and give mana, then pass to upkeep (next turn)
         val flashCreature = driver.putCardInHand(activePlayer, "Flash Creature")
-        driver.giveMana(activePlayer, Color.GREEN, 2)
 
-        // Pass to end step — not sorcery speed
+        // Pass to end step — not sorcery speed. Mana is added here (in the end step) because unspent
+        // mana empties as each step/phase ends (CR 500.5), so it can't be floated from an earlier step.
         driver.passPriorityUntil(Step.END)
+        driver.giveMana(activePlayer, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(
@@ -140,8 +141,8 @@ class QuickSliverTest : FunSpec({
 
         // Try to cast a Sliver at end step
         val sliver = driver.putCardInHand(activePlayer, "Test Sliver")
-        driver.giveMana(activePlayer, Color.RED, 2)
         driver.passPriorityUntil(Step.END)
+        driver.giveMana(activePlayer, Color.RED, 2)
 
         val result = driver.submit(
             CastSpell(
@@ -197,10 +198,10 @@ class QuickSliverTest : FunSpec({
 
         // Opponent gets a Sliver in hand
         val sliver = driver.putCardInHand(opponent, "Test Sliver")
-        driver.giveMana(opponent, Color.RED, 2)
 
-        // Advance to end step
+        // Advance to end step; add mana there (it empties as each step/phase ends, CR 500.5).
         driver.passPriorityUntil(Step.END)
+        driver.giveMana(opponent, Color.RED, 2)
 
         // Pass priority to opponent
         driver.passPriority(activePlayer)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RaffCapashenShipsMageTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RaffCapashenShipsMageTest.kt
@@ -89,8 +89,9 @@ class RaffCapashenShipsMageTest : FunSpec({
         driver.putPermanentOnBattlefield(activePlayer, "Raff Proxy")
 
         val legendary = driver.putCardInHand(activePlayer, "Legendary Bear")
-        driver.giveMana(activePlayer, Color.GREEN, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(activePlayer, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(
@@ -115,8 +116,9 @@ class RaffCapashenShipsMageTest : FunSpec({
         driver.putPermanentOnBattlefield(activePlayer, "Raff Proxy")
 
         val artifact = driver.putCardInHand(activePlayer, "Test Artifact")
-        driver.giveColorlessMana(activePlayer, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveColorlessMana(activePlayer, 2)
 
         val result = driver.submit(
             CastSpell(
@@ -141,8 +143,10 @@ class RaffCapashenShipsMageTest : FunSpec({
         driver.putPermanentOnBattlefield(activePlayer, "Raff Proxy")
 
         val bear = driver.putCardInHand(activePlayer, "Plain Bear")
-        driver.giveMana(activePlayer, Color.GREEN, 2)
         driver.passPriorityUntil(Step.END)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because a non-historic creature isn't granted flash, not for lack of mana
+        driver.giveMana(activePlayer, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(
@@ -170,10 +174,12 @@ class RaffCapashenShipsMageTest : FunSpec({
 
         // Opponent gets a legendary creature
         val legendary = driver.putCardInHand(opponent, "Legendary Bear")
-        driver.giveMana(opponent, Color.GREEN, 2)
 
         driver.passPriorityUntil(Step.END)
         driver.passPriority(activePlayer)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); the cast must
+        // still fail because the flash grant is controller-only, not for lack of mana
+        driver.giveMana(opponent, Color.GREEN, 2)
 
         val result = driver.submit(
             CastSpell(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShreddersTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShreddersTechniqueTest.kt
@@ -23,9 +23,10 @@ class ShreddersTechniqueTest : FunSpec({
 
         val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
         val spell = driver.putCardInHand(player, "Shredder's Technique")
-        driver.giveMana(player, Color.BLACK, 3)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.BLACK, 3)
         driver.castSpellWithTargets(player, spell, listOf(ChosenTarget.Permanent(victim))).isSuccess shouldBe true
         while (driver.state.stack.isNotEmpty()) driver.bothPass()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SneakTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SneakTest.kt
@@ -195,7 +195,6 @@ class SneakTest : FunSpec({
         val brawler = driver.putCreatureOnBattlefield(attacker, "Plain Brawler")
         driver.removeSummoningSickness(brawler)
         driver.putCardInHand(attacker, "Sneaky Ninja")
-        driver.giveMana(attacker, Color.GREEN, 2)
 
         val enumerator = LegalActionEnumerator.create(driver.cardRegistry)
         fun sneakActions() = enumerator.enumerate(driver.state, attacker)
@@ -208,6 +207,8 @@ class SneakTest : FunSpec({
 
         // Declare blockers with the Brawler unblocked: the sneak option appears.
         driver.openSneakWindow(attacker, defender, brawler)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(attacker, Color.GREEN, 2)
         sneakActions().isNotEmpty().shouldBeTrue()
     }
 
@@ -240,10 +241,10 @@ class SneakTest : FunSpec({
         val attacker = driver.activePlayer!!
 
         val ninja = driver.putCardInHand(attacker, "Sneaky Ninja")
-        // Pay the full {4}{G}.
-        driver.giveMana(attacker, Color.GREEN, 5)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // Pay the full {4}{G}. mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(attacker, Color.GREEN, 5)
         driver.castSpell(attacker, ninja).isSuccess shouldBe true
         while (driver.state.stack.isNotEmpty()) driver.bothPass()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SplintersTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SplintersTechniqueTest.kt
@@ -21,9 +21,10 @@ class SplintersTechniqueTest : FunSpec({
         driver.initMirrorMatch(deck = Deck.of("Swamp" to 30), startingLife = 20)
         val player = driver.activePlayer!!
         val spell = driver.putCardInHand(player, "Splinter's Technique")
-        driver.giveMana(player, Color.BLACK, 4)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.BLACK, 4)
         val handBefore = driver.getHandSize(player)
         driver.castSpell(player, spell).isSuccess shouldBe true
         while (driver.state.stack.isNotEmpty() && driver.pendingDecision == null) driver.bothPass()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SteerClearCastTimeCaptureTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SteerClearCastTimeCaptureTest.kt
@@ -63,9 +63,10 @@ class SteerClearCastTimeCaptureTest : FunSpec({
         // The caster controls a Mount and holds Steer Clear.
         val mount = driver.putCreatureOnBattlefield(caster, "Giant Beaver")
         val steer = driver.putCardInHand(caster, "Steer Clear")
-        driver.giveMana(caster, Color.WHITE, 1)
 
         driver.attackThenGiveCasterPriority(attacker, caster, courser)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(caster, Color.WHITE, 1)
 
         val cast = driver.submit(
             CastSpell(
@@ -96,9 +97,10 @@ class SteerClearCastTimeCaptureTest : FunSpec({
         driver.removeSummoningSickness(courser)
         // No Mount on the caster's side.
         val steer = driver.putCardInHand(caster, "Steer Clear")
-        driver.giveMana(caster, Color.WHITE, 1)
 
         driver.attackThenGiveCasterPriority(attacker, caster, courser)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(caster, Color.WHITE, 1)
 
         val cast = driver.submit(
             CastSpell(
@@ -125,9 +127,10 @@ class SteerClearCastTimeCaptureTest : FunSpec({
         val courser = driver.putCreatureOnBattlefield(attacker, "Centaur Courser")
         driver.removeSummoningSickness(courser)
         val steer = driver.putCardInHand(caster, "Steer Clear")
-        driver.giveMana(caster, Color.WHITE, 1)
 
         driver.attackThenGiveCasterPriority(attacker, caster, courser)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(caster, Color.WHITE, 1)
 
         val cast = driver.submit(
             CastSpell(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TesterOfTheTangentialScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TesterOfTheTangentialScenarioTest.kt
@@ -57,9 +57,11 @@ class TesterOfTheTangentialScenarioTest : FunSpec({
         val chosen = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
         val decoy = driver.putCreatureOnBattlefield(driver.player1, "Savannah Lions")
         driver.addComponent(tester, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 3)))
-        driver.giveMana(driver.player1, Color.BLUE, 5)
 
         driver.advanceToPlayer1BeginCombat()
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); it must be
+        // present for the may-pay-{X} payment during the begin-combat trigger
+        driver.giveMana(driver.player1, Color.BLUE, 5)
 
         // BeginCombat trigger goes on the stack; resolving it presents the MayPayX number chooser.
         driver.bothPass()
@@ -84,9 +86,11 @@ class TesterOfTheTangentialScenarioTest : FunSpec({
         val tester = driver.putCreatureOnBattlefield(driver.player1, "Tester of the Tangential")
         val other = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
         driver.addComponent(tester, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 3)))
-        driver.giveMana(driver.player1, Color.BLUE, 5)
 
         driver.advanceToPlayer1BeginCombat()
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); it must be
+        // present for the may-pay-{X} payment during the begin-combat trigger
+        driver.giveMana(driver.player1, Color.BLUE, 5)
 
         driver.bothPass()
         val payDecision = driver.pendingDecision
@@ -105,9 +109,11 @@ class TesterOfTheTangentialScenarioTest : FunSpec({
         val tester = driver.putCreatureOnBattlefield(driver.player1, "Tester of the Tangential")
         val other = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
         driver.addComponent(tester, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 3)))
-        driver.giveMana(driver.player1, Color.BLUE, 5)
 
         driver.advanceToPlayer1BeginCombat()
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5); it must be
+        // present for the may-pay-{X} payment during the begin-combat trigger
+        driver.giveMana(driver.player1, Color.BLUE, 5)
 
         driver.bothPass()
         val payDecision = driver.pendingDecision

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLastAgniKaiScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLastAgniKaiScenarioTest.kt
@@ -100,7 +100,7 @@ class TheLastAgniKaiScenarioTest : FunSpec({
         driver.red(active) shouldBe 0
     }
 
-    test("red mana is retained through the end-of-turn pool emptying while other colours empty") {
+    test("red mana is retained through each step/phase emptying while other colours empty, until end of turn") {
         val driver = createDriver()
         driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
         val active = driver.activePlayer!!
@@ -120,12 +120,15 @@ class TheLastAgniKaiScenarioTest : FunSpec({
         driver.giveMana(active, Color.GREEN, 2)
         driver.green(active) shouldBe 2
 
-        // Cross this turn's cleanup into the opponent's turn (the engine's only mana-empty point).
-        driver.passPriorityUntil(Step.UPKEEP)
-        driver.activePlayer shouldBe opponent
-
-        // Red survived the end-of-turn emptying; green did not.
+        // Cross a step/phase boundary within the turn (CR 500.5). Red is retained by the Agni Kai
+        // rider; the unprotected green empties as the phase ends.
+        driver.passPriorityUntil(Step.BEGIN_COMBAT)
         driver.red(active) shouldBe 3
         driver.green(active) shouldBe 0
+
+        // The retention is turn-scoped ("until end of turn"): by the opponent's turn the red is gone.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldBe opponent
+        driver.red(active) shouldBe 0
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLastRoninsTechniqueTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheLastRoninsTechniqueTest.kt
@@ -23,9 +23,10 @@ class TheLastRoninsTechniqueTest : FunSpec({
         val player = driver.activePlayer!!
 
         val spell = driver.putCardInHand(player, "The Last Ronin's Technique")
-        driver.giveMana(player, Color.WHITE, 4)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.WHITE, 4)
         driver.castSpell(player, spell).isSuccess shouldBe true
         while (driver.state.stack.isNotEmpty()) driver.bothPass()
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRiseOfSozinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheRiseOfSozinScenarioTest.kt
@@ -248,14 +248,15 @@ private fun GameTestDriver.attackAndPayX(
     sozin: EntityId,
     payX: Int
 ): ChooseTargetsDecision {
-    // Mana to pay {X} (firebending also adds {R}{R}{R} live in combat). Given up front, as in the
-    // proven combat-damage flow above.
-    giveColorlessMana(me, payX + 2)
     passPriorityUntil(Step.DECLARE_ATTACKERS)
     declareAttackers(me, listOf(sozin), opp)
     resolveStackSozin() // firebending attack trigger
 
     passPriorityUntil(Step.COMBAT_DAMAGE)
+    // Mana to pay {X} (firebending also adds {R}{R}{R} live in combat). Added here, at the
+    // combat-damage step, because unspent mana now empties as each step/phase ends (CR 500.5) —
+    // given earlier it would drain before the "deals combat damage" pay-{X} trigger resolves.
+    giveColorlessMana(me, payX + 2)
     var g = 0
     while (pendingDecision == null && state.step != Step.POSTCOMBAT_MAIN && g++ < 40) {
         bothPass()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TurncoatKunoichiTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TurncoatKunoichiTest.kt
@@ -23,9 +23,10 @@ class TurncoatKunoichiTest : FunSpec({
 
         val victim = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
         val turncoat = driver.putCardInHand(player, "Turncoat Kunoichi")
-        driver.giveMana(player, Color.WHITE, 3)
 
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        // mana added here — unspent mana empties as each step/phase ends (CR 500.5)
+        driver.giveMana(player, Color.WHITE, 3)
         driver.castSpell(player, turncoat).isSuccess shouldBe true
         // Resolve Turncoat; its ETB trigger then asks for the target opponent creature.
         while (driver.pendingDecision == null && driver.state.stack.isNotEmpty()) driver.bothPass()


### PR DESCRIPTION
## Empty unspent mana at the end of every step and phase (CR 500.5)

Previously the engine emptied mana pools only at end-of-turn cleanup, so a player could
illegally float mana across step/phase boundaries (e.g. main → combat, upkeep → draw). Per
**CR 500.5 / 703.4q**, unspent mana empties as *each* step and phase ends — a turn-based
action that doesn't use the stack.

### What changed

- **Single emptying primitive.** `ManaPoolComponent.convertToRed()` + `emptyExcept()` are
  consolidated into one `emptyAtBoundary(convertToRed, retain)`, and
  `CleanupPhaseManager.emptyManaPools` becomes the sole emptying entry point, now invoked from
  `TurnManager.advanceStep` (every step/phase transition) as well as end-of-turn cleanup. No new
  SDK types — the existing statics are reused across more call sites.
- **Statics preserved.** Upwelling (`PreventManaPoolEmptying`), Ozai
  (`ConvertEmptyingManaToRed`, CR 614), and The Last Agni Kai (`RetainUnspentManaComponent`) all
  apply at every boundary.
- **Firebending untouched.** `END_OF_COMBAT` restricted mana is preserved by `emptyAtBoundary`
  and remains owned by `CombatManager.endCombat` (CR 702.189a — "until end of combat").
- **Fast path.** `emptyManaPools` skips its battlefield scans when every pool is already empty
  (the common case, since it now fires on every boundary).

### Tests

- New `ManaEmptyingPerStepTest` — base per-boundary emptying + Upwelling suppression.
- `OzaiThePhoenixKingScenarioTest` / `TheLastAgniKaiScenarioTest` updated to assert the statics
  at a *mid-turn* boundary; Agni Kai additionally proves the retention is finally lost once the
  turn-scoped marker clears.
- ~20 scenario tests adjusted to add mana in the casting step (mana can no longer be floated
  across steps).
- Unchanged `FirebendingScenarioTest` passes — a regression check that combat-duration mana
  survives per-step emptying and clears at end of combat.

All cited CR numbers verified against the Comprehensive Rules (500.5, 703.4q, 614, 702.189a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
