### PR TITLE
Add Foundations cards: Gnarlback Rhino, Hoarding Dragon, Mild-Mannered Librarian

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GnarlbackRhinoReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GnarlbackRhinoReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gnarlback Rhino reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in M20's `cards/` package
+ * (the card's earliest real printing). This file contributes only the FDN presentation row —
+ * set, collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val GnarlbackRhinoReprint = Printing(
+    oracleId = "1ae339fd-8e64-4e3a-8e27-e4993932ba62",
+    name = "Gnarlback Rhino",
+    setCode = "FDN",
+    collectorNumber = "638",
+    scryfallId = "6b638f3d-7eb6-4675-9538-4a87a7f75c43",
+    artist = "YW Tang",
+    imageUri = "https://cards.scryfall.io/normal/front/6/b/6b638f3d-7eb6-4675-9538-4a87a7f75c43.jpg?1782688709",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HoardingDragonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HoardingDragonReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hoarding Dragon reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in M11's `cards/` package
+ * (the card's earliest real printing). This file contributes only the FDN presentation row.
+ */
+val HoardingDragonReprint = Printing(
+    oracleId = "d36d3c93-ed24-4447-9d15-3071f5c0989b",
+    name = "Hoarding Dragon",
+    setCode = "FDN",
+    collectorNumber = "626",
+    scryfallId = "c3a35b3b-0c92-4b40-8210-86a5b5f275eb",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/c/3/c3a35b3b-0c92-4b40-8210-86a5b5f275eb.jpg?1782688720",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MildManneredLibrarianReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MildManneredLibrarianReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mild-Mannered Librarian reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in J22's `cards/` package
+ * (the card's earliest real printing). This file contributes only the FDN presentation row.
+ */
+val MildManneredLibrarianReprint = Printing(
+    oracleId = "fb7070ab-c234-4d54-8cdc-caf106bf24a6",
+    name = "Mild-Mannered Librarian",
+    setCode = "FDN",
+    collectorNumber = "228",
+    scryfallId = "5389663a-fe25-41b9-8c92-1f4d7721ffc2",
+    artist = "Justyna Dura",
+    imageUri = "https://cards.scryfall.io/normal/front/5/3/5389663a-fe25-41b9-8c92-1f4d7721ffc2.jpg?1782689070",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MildManneredLibrarian.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MildManneredLibrarian.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Mild-Mannered Librarian (J22 #41)
+ * {G}  Creature — Human  1/1
+ *
+ * {3}{G}: This creature becomes a Werewolf. Put two +1/+1 counters on it and you draw a card.
+ * Activate only once.
+ *
+ * "Becomes a Werewolf" replaces its creature subtypes (Human → Werewolf) permanently, so it is a
+ * [Effects.SetCreatureSubtypes] with `Duration.Permanent`. "Activate only once" is
+ * [ActivationRestriction.Once] (once for the lifetime of this permanent, CR-faithful to a
+ * per-object activation limit).
+ */
+val MildManneredLibrarian = card("Mild-Mannered Librarian") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human"
+    power = 1
+    toughness = 1
+    oracleText = "{3}{G}: This creature becomes a Werewolf. Put two +1/+1 counters on it and you " +
+        "draw a card. Activate only once."
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{G}")
+        effect = Effects.Composite(
+            listOf(
+                Effects.SetCreatureSubtypes(setOf("Werewolf"), EffectTarget.Self, Duration.Permanent),
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
+                Effects.DrawCards(1)
+            )
+        )
+        restrictions = listOf(ActivationRestriction.Once)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "41"
+        artist = "Justyna Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3eee6f29-ef06-47f6-99af-fb0ff88f09d0.jpg?1782699338"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/HoardingDragon.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m11/cards/HoardingDragon.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.m11.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.EmitLibrarySearchedEventEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ShuffleLibraryEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hoarding Dragon (M11 #144)
+ * {3}{R}{R}  Creature — Dragon  4/4
+ *
+ * Flying
+ * When this creature enters, you may search your library for an artifact card, exile it,
+ * then shuffle.
+ * When this creature dies, you may put the exiled card into its owner's hand.
+ *
+ * Modeling: the exiled artifact is linked to Hoarding Dragon via `linkToSource = true`, so the
+ * dies trigger can find it again through [CardSource.FromLinkedExile] even though the Dragon has
+ * already left the battlefield. Both triggers are `optional` ("you may"): declining the ETB does
+ * not shuffle; declining the dies trigger leaves the card exiled. The ETB search uses
+ * `ChooseUpTo(1)` so the controller may search and find nothing (CR 701.23b).
+ */
+val HoardingDragon = card("Hoarding Dragon") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\n" +
+        "When this creature enters, you may search your library for an artifact card, exile it, " +
+        "then shuffle.\n" +
+        "When this creature dies, you may put the exiled card into its owner's hand."
+
+    keywords(Keyword.FLYING)
+
+    // ETB: may search library for an artifact card, exile it (linked to this), then shuffle.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        optional = true
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.LIBRARY, Player.You, GameObjectFilter.Artifact),
+                    storeAs = "hoardSearchable"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hoardSearchable",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    storeSelected = "hoardFound",
+                    prompt = "Search for an artifact card to exile"
+                ),
+                MoveCollectionEffect(
+                    from = "hoardFound",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    linkToSource = true
+                ),
+                ShuffleLibraryEffect(),
+                EmitLibrarySearchedEventEffect
+            )
+        )
+    }
+
+    // Dies: may put the linked exiled card into its owner's hand.
+    triggeredAbility {
+        trigger = Triggers.Dies
+        optional = true
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromLinkedExile(),
+                    storeAs = "hoardExiled"
+                ),
+                MoveCollectionEffect(
+                    from = "hoardExiled",
+                    destination = CardDestination.ToZone(Zone.HAND)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "144"
+        artist = "Matt Cavotta"
+        imageUri = "https://cards.scryfall.io/normal/front/1/f/1f8b6932-e62d-4d38-bd0e-9ab8d4a56762.jpg?1782715390"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/HoardingDragonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m15/cards/HoardingDragonReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.m15.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hoarding Dragon reprint in Magic 2015.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in M11's `cards/` package
+ * (the card's earliest real printing). This file contributes only the M15 presentation row.
+ */
+val HoardingDragonReprint = Printing(
+    oracleId = "d36d3c93-ed24-4447-9d15-3071f5c0989b",
+    name = "Hoarding Dragon",
+    setCode = "M15",
+    collectorNumber = "149",
+    scryfallId = "7c4c4a0f-0ee4-422d-b807-f64b77dd6831",
+    artist = "Matt Cavotta",
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7c4c4a0f-0ee4-422d-b807-f64b77dd6831.jpg?1782713199",
+    releaseDate = "2014-07-18",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GnarlbackRhino.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GnarlbackRhino.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gnarlback Rhino (M20 #300)
+ * {2}{G}{G}  Creature — Rhino  4/4
+ *
+ * Trample
+ * Whenever you cast a spell that targets this creature, draw a card.
+ *
+ * The draw trigger uses the [Triggers.youCastSpellTargetingSource] cast-time predicate
+ * (`SpellCastPredicate.TargetsSource`) — it fires as the spell is cast, before it resolves,
+ * so it still triggers even if the spell is later countered or the Rhino leaves play.
+ */
+val GnarlbackRhino = card("Gnarlback Rhino") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Rhino"
+    power = 4
+    toughness = 4
+    oracleText = "Trample\n" +
+        "Whenever you cast a spell that targets this creature, draw a card."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.youCastSpellTargetingSource()
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "300"
+        artist = "YW Tang"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68a69558-aca0-413d-9762-2fa115b44abd.jpg?1782708186"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/J22.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/J22.json
@@ -1,3 +1,65 @@
+// Mild-Mannered Librarian
+{
+    "name": "Mild-Mannered Librarian",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Human",
+    "oracleText": "{3}{G}: This creature becomes a Werewolf. Put two +1/+1 counters on it and you draw a card. Activate only once.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "SetCreatureSubtypes",
+                            "subtypes": [
+                                "Werewolf"
+                            ]
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 2,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "restrictions": [
+                    "Once"
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "UNCOMMON",
+        "artist": "Justyna Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3eee6f29-ef06-47f6-99af-fb0ff88f09d0.jpg?1782699338"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Suspicious Shambler
 {
     "name": "Suspicious Shambler",

--- a/mtg-sets/src/test/resources/snapshots/cards/M11.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M11.json
@@ -90,3 +90,104 @@
         "GREEN"
     ]
 }
+
+// Hoarding Dragon
+{
+    "name": "Hoarding Dragon",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nWhen this creature enters, you may search your library for an artifact card, exile it, then shuffle.\nWhen this creature dies, you may put the exiled card into its owner's hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Library",
+                                "filter": "artifact"
+                            },
+                            "storeAs": "hoardSearchable"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "hoardSearchable",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "hoardFound",
+                            "prompt": "Search for an artifact card to exile"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hoardFound",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "linkToSource": true
+                        },
+                        "ShuffleLibrary",
+                        "EmitLibrarySearchedEvent"
+                    ]
+                },
+                "optional": true
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "FromLinkedExile",
+                            "storeAs": "hoardExiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "hoardExiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                },
+                "optional": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "rarity": "RARE",
+        "artist": "Matt Cavotta",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/f/1f8b6932-e62d-4d38-bd0e-9ab8d4a56762.jpg?1782715390"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -142,6 +142,51 @@
     ]
 }
 
+// Gnarlback Rhino
+{
+    "name": "Gnarlback Rhino",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Rhino",
+    "oracleText": "Trample\nWhenever you cast a spell that targets this creature, draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        "SpellTargetsSource"
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "300",
+        "rarity": "UNCOMMON",
+        "artist": "YW Tang",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68a69558-aca0-413d-9762-2fa115b44abd.jpg?1782708186"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Rapacious Dragon
 {
     "name": "Rapacious Dragon",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HoardingDragonScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HoardingDragonScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.LinkedExileComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Hoarding Dragon (M11 #144, {3}{R}{R}, 4/4 Dragon).
+ *
+ * Flying.
+ * When this creature enters, you may search your library for an artifact card, exile it, then shuffle.
+ * When this creature dies, you may put the exiled card into its owner's hand.
+ *
+ * The novel wiring is the linked exile: the ETB search exiles the found artifact linked to the
+ * Dragon (`linkToSource = true`), so the dies trigger can retrieve it through
+ * [com.wingedsheep.sdk.scripting.effects.CardSource.FromLinkedExile] even though the Dragon has
+ * already left the battlefield. These tests pin the exile+link, the return-to-hand on death, and
+ * the decline path.
+ */
+class HoardingDragonScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hoarding Dragon") {
+
+            fun newGame() = scenario()
+                .withPlayers("Player1", "Player2")
+                .withCardInHand(1, "Hoarding Dragon")
+                .withCardInHand(1, "Murder")
+                // Exactly 2 Mountains force the Dragon's {R}{R} onto them; the 6 Swamps then cover
+                // the Dragon's 3 generic and Murder's {1}{B}{B} deterministically, so auto-pay can't
+                // strand the black mana.
+                .withLandsOnBattlefield(1, "Mountain", 2)
+                .withLandsOnBattlefield(1, "Swamp", 6)
+                .withCardInLibrary(1, "Ornithopter")
+                .withCardInLibrary(1, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withCardInLibrary(2, "Forest")
+                .withActivePlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            fun ornithopterInLibrary(game: TestGame): EntityId? =
+                game.state.getLibrary(game.player1Id).firstOrNull { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Ornithopter"
+                }
+
+            test("ETB search exiles the chosen artifact, linked to the Dragon") {
+                val game = newGame()
+
+                game.castSpell(1, "Hoarding Dragon")
+                game.resolveStack() // Dragon enters → optional ETB "may search" pause
+                game.answerYesNo(true)
+                val orni = ornithopterInLibrary(game)
+                withClue("Ornithopter is available to find in the library") { orni shouldNotBe null }
+                if (game.state.pendingDecision != null) game.selectCards(listOf(orni!!))
+                game.resolveStack() // exile the found artifact, shuffle
+
+                withClue("Ornithopter left the library") { ornithopterInLibrary(game) shouldBe null }
+                withClue("Ornithopter is in player 1's exile") {
+                    game.state.getExile(game.player1Id).any { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Ornithopter"
+                    } shouldBe true
+                }
+                val dragon = game.findPermanent("Hoarding Dragon")!!
+                val linked = game.state.getEntity(dragon)?.get<LinkedExileComponent>()
+                withClue("The exiled artifact is linked to Hoarding Dragon") {
+                    (linked?.exiledIds?.isNotEmpty()) shouldBe true
+                }
+            }
+
+            test("dies returns the linked exiled artifact to its owner's hand") {
+                val game = newGame()
+
+                game.castSpell(1, "Hoarding Dragon")
+                game.resolveStack()
+                game.answerYesNo(true)
+                val orni = ornithopterInLibrary(game)!!
+                if (game.state.pendingDecision != null) game.selectCards(listOf(orni))
+                game.resolveStack()
+
+                val dragon = game.findPermanent("Hoarding Dragon")!!
+                withClue("Murder is cast on the Dragon") {
+                    game.castSpell(1, "Murder", dragon).error shouldBe null
+                }
+                // Murder resolves and the Dragon dies, firing its dies trigger. Drive the game
+                // forward, taking the optional "may return the exiled card" trigger (answering yes
+                // if it surfaces a decision), until the linked exiled card comes back.
+                var guard = 0
+                while (guard++ < 8) {
+                    when {
+                        game.state.pendingDecision != null -> game.answerYesNo(true)
+                        game.state.stack.isNotEmpty() -> game.resolveStack()
+                        else -> game.passPriority()
+                    }
+                    val inHand = game.state.getHand(game.player1Id).any { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Ornithopter"
+                    }
+                    if (inHand) break
+                }
+
+                withClue("The Dragon died (it's in the graveyard)") {
+                    game.state.getGraveyard(game.player1Id).any { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Hoarding Dragon"
+                    } shouldBe true
+                }
+                withClue("The exiled Ornithopter was returned to player 1's hand") {
+                    game.state.getHand(game.player1Id).any { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Ornithopter"
+                    } shouldBe true
+                }
+                withClue("Nothing is left in exile") {
+                    game.state.getExile(game.player1Id).none { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Ornithopter"
+                    } shouldBe true
+                }
+            }
+
+            test("declining the ETB search exiles nothing") {
+                val game = newGame()
+
+                game.castSpell(1, "Hoarding Dragon")
+                game.resolveStack()
+                game.answerYesNo(false) // decline "you may search"
+                game.resolveStack()
+
+                withClue("Ornithopter stays in the library when the search is declined") {
+                    ornithopterInLibrary(game) shouldNotBe null
+                }
+                withClue("Nothing was exiled") {
+                    game.state.getExile(game.player1Id).none { id ->
+                        game.state.getEntity(id)?.get<CardComponent>()?.name == "Ornithopter"
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements a handful of **Foundations (FDN)** cards via the `add-card` workflow. Each is a reprint, so the canonical `CardDefinition` lives in the card's **earliest real printing** and FDN (plus any other scaffolded printing) gets a `Printing` row — no duplicated card scripts.

| Card | Colors | Canonical set | Mechanic |
|------|--------|---------------|----------|
| **Gnarlback Rhino** | G | M20 | Trample + *"whenever you cast a spell that targets this creature, draw a card"* (`Triggers.youCastSpellTargetingSource`) |
| **Hoarding Dragon** | R | M11 | Flying; ETB *may* search library for an artifact and exile it linked to the Dragon; on death *may* return the linked exiled card to its owner's hand |
| **Mild-Mannered Librarian** | G | J22 | `{3}{G}` one-shot: become a Werewolf, add two +1/+1 counters, draw a card (`ActivationRestriction.Once`) |

## Implementation notes

- **No new SDK primitives.** Every card composes existing, already-tested building blocks:
  - Gnarlback Rhino reuses the cast-targeting-source trigger (as on Legolas, Master Archer).
  - Hoarding Dragon composes the atomic `GatherCards → SelectFromCollection → MoveCollection` pipeline with `linkToSource = true`, so the dies trigger retrieves the exiled artifact through `CardSource.FromLinkedExile` even after the Dragon has left the battlefield. Both triggers are optional (`you may`).
  - Mild-Mannered Librarian uses `SetCreatureSubtypes` (permanent), `AddCounters`, `DrawCards`, and the once-per-object activation limit.
- **Canonical placement / reprints** verified with `just check-card-printing` for all three (Hoarding Dragon also required an M15 `Printing` row, which is included).
- All image URIs are the exact Scryfall `image_uris.normal` values (HEAD-checked 200).

## Tests

- New `HoardingDragonScenarioTest` covers the search/exile/link, return-to-hand-on-death, and decline paths.
- Re-blessed the J22 / M11 / M20 card snapshots (only the three new cards are added; no other card trees moved).
- Full `just build` (compile + test across all modules) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)