### PR TITLE
Add Foundations reprints: Soul-Guide Lantern, Tribute to Hunger, Massacre Wurm

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/TributeToHungerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ddq/cards/TributeToHungerReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.ddq.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tribute to Hunger reprint in Duel Decks: Blessed vs. Cursed.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in ISD's `cards/` package
+ * (the card's earliest real printing). This file contributes only the DDQ presentation row.
+ */
+val TributeToHungerReprint = Printing(
+    oracleId = "dc5a501c-e16c-4d4b-a510-70a14272473e",
+    name = "Tribute to Hunger",
+    setCode = "DDQ",
+    collectorNumber = "65",
+    scryfallId = "fcfc9bd3-4378-4305-b427-4e3dd4e1fba1",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/f/c/fcfc9bd3-4378-4305-b427-4e3dd4e1fba1.jpg?1782750052",
+    releaseDate = "2016-02-26",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MassacreWurmReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MassacreWurmReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Massacre Wurm reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in MBS's `cards/` package
+ * (the card's earliest real printing). This file contributes only the FDN presentation row —
+ * set, collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val MassacreWurmReprint = Printing(
+    oracleId = "93cf50cf-0ecc-4d3e-abea-778c1ebacec4",
+    name = "Massacre Wurm",
+    setCode = "FDN",
+    collectorNumber = "714",
+    scryfallId = "39be2675-986c-4812-9448-99737e797671",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/3/9/39be2675-986c-4812-9448-99737e797671.jpg?1782688645",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SoulGuideLanternReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SoulGuideLanternReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soul-Guide Lantern reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in THB's `cards/` package
+ * (the card's earliest real printing). This file contributes only the FDN presentation row —
+ * set, collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val SoulGuideLanternReprint = Printing(
+    oracleId = "1b5e6560-ff2e-4475-96cb-63f64c8a86db",
+    name = "Soul-Guide Lantern",
+    setCode = "FDN",
+    collectorNumber = "680",
+    scryfallId = "6d3ff537-86f0-405e-b96b-1250720af031",
+    artist = "Iris Compiet",
+    imageUri = "https://cards.scryfall.io/normal/front/6/d/6d3ff537-86f0-405e-b96b-1250720af031.jpg?1782688674",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TributeToHungerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TributeToHungerReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Tribute to Hunger reprint in Foundations.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in ISD's `cards/` package
+ * (the card's earliest real printing). This file contributes only the FDN presentation row —
+ * set, collector number, art — picked up automatically by `CardDiscovery.findPrintingsIn`.
+ */
+val TributeToHungerReprint = Printing(
+    oracleId = "dc5a501c-e16c-4d4b-a510-70a14272473e",
+    name = "Tribute to Hunger",
+    setCode = "FDN",
+    collectorNumber = "614",
+    scryfallId = "11f1b897-bb7d-4217-97a7-c89f2453c8fa",
+    artist = "Dave Kendall",
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/11f1b897-bb7d-4217-97a7-c89f2453c8fa.jpg?1782688731",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/TributeToHunger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/isd/cards/TributeToHunger.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.isd.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.TargetOpponent
+
+/**
+ * Tribute to Hunger
+ * {2}{B}
+ * Instant
+ *
+ * Target opponent sacrifices a creature of their choice. You gain life equal to that creature's toughness.
+ *
+ * The edict records the sacrificed permanent's last-known snapshot in the effect context, so the
+ * downstream [Effects.GainLife] reads [DynamicAmounts.sacrificedToughness] for the creature the
+ * opponent chose — even after it has left the battlefield. If the opponent controls no creatures,
+ * nothing is sacrificed and no life is gained.
+ *
+ * Canonical printing lives in Innistrad (the card's earliest real printing); Foundations contributes
+ * only a [com.wingedsheep.sdk.model.Printing] row.
+ */
+val TributeToHunger = card("Tribute to Hunger") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target opponent sacrifices a creature of their choice. " +
+        "You gain life equal to that creature's toughness."
+
+    spell {
+        val t = target("target", TargetOpponent())
+        effect = Effects.Composite(
+            listOf(
+                ForceSacrificeEffect(GameObjectFilter.Creature, 1, t),
+                Effects.GainLife(DynamicAmounts.sacrificedToughness(0))
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "119"
+        artist = "Dave Kendall"
+        flavorText = "Marella was delighted. The ball had attracted so many suitors for her daughter, " +
+            "including that handsome stranger. She wondered where the two were now . . . ."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f77e0f88-2285-4b59-9165-9948c75d77a3.jpg?1782714761"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MassacreWurmReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/MassacreWurmReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Massacre Wurm reprint in Jumpstart 2022.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in MBS's `cards/` package
+ * (the card's earliest real printing). This file contributes only the J22 presentation row.
+ */
+val MassacreWurmReprint = Printing(
+    oracleId = "93cf50cf-0ecc-4d3e-abea-778c1ebacec4",
+    name = "Massacre Wurm",
+    setCode = "J22",
+    collectorNumber = "441",
+    scryfallId = "ee38fda1-8008-4b2d-a2b6-eb02a8b125e8",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/e/ee38fda1-8008-4b2d-a2b6-eb02a8b125e8.jpg?1782699079",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/MassacreWurmReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m21/cards/MassacreWurmReprint.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.m21.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Massacre Wurm reprints in Core Set 2021.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in MBS's `cards/` package
+ * (the card's earliest real printing). These files contribute only M21 presentation rows —
+ * the regular printing (#114) and the alternate-art variant (#316).
+ */
+val MassacreWurmReprint = Printing(
+    oracleId = "93cf50cf-0ecc-4d3e-abea-778c1ebacec4",
+    name = "Massacre Wurm",
+    setCode = "M21",
+    collectorNumber = "114",
+    scryfallId = "e3185b01-0d91-4927-98e9-bc9df6c20917",
+    artist = "Jason Chan",
+    imageUri = "https://cards.scryfall.io/normal/front/e/3/e3185b01-0d91-4927-98e9-bc9df6c20917.jpg?1782706944",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.MYTHIC,
+)
+
+val MassacreWurmAltArtReprint = Printing(
+    oracleId = "93cf50cf-0ecc-4d3e-abea-778c1ebacec4",
+    name = "Massacre Wurm",
+    setCode = "M21",
+    collectorNumber = "316",
+    scryfallId = "a0523c0a-b9b6-4946-b90d-ed8e13cf1915",
+    artist = "Kekai Kotaki",
+    imageUri = "https://cards.scryfall.io/normal/front/a/0/a0523c0a-b9b6-4946-b90d-ed8e13cf1915.jpg?1782706814",
+    releaseDate = "2020-07-03",
+    rarity = Rarity.MYTHIC,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/MassacreWurm.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/mbs/cards/MassacreWurm.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.mbs.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Massacre Wurm
+ * {3}{B}{B}{B}
+ * Creature — Phyrexian Wurm
+ * 6/5
+ *
+ * When this creature enters, creatures your opponents control get -2/-2 until end of turn.
+ * Whenever a creature an opponent controls dies, that player loses 2 life.
+ *
+ *  - **ETB** — a per-creature -2/-2 floating effect over every creature an opponent controls at
+ *    resolution ([Effects.ForEachInGroup] with the iterated creature as [EffectTarget.Self]).
+ *    Creatures that enter later are unaffected; the set is fixed when the ability resolves.
+ *  - **Death drain** — a [Triggers.leavesBattlefield]-to-graveyard trigger filtered to
+ *    opponent-controlled creatures (fires once per death). [Player.TriggeringPlayer] resolves to
+ *    the dying creature's controller, so "that player" loses 2 life.
+ *
+ * Canonical printing lives in Mirrodin Besieged (the card's earliest real printing); Foundations
+ * contributes only a [com.wingedsheep.sdk.model.Printing] row.
+ */
+val MassacreWurm = card("Massacre Wurm") {
+    manaCost = "{3}{B}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Phyrexian Wurm"
+    power = 6
+    toughness = 5
+    oracleText = "When this creature enters, creatures your opponents control get -2/-2 until end of turn.\n" +
+        "Whenever a creature an opponent controls dies, that player loses 2 life."
+
+    // When this creature enters, creatures your opponents control get -2/-2 until end of turn.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.ForEachInGroup(
+            GroupFilter.AllCreaturesOpponentsControl,
+            Effects.ModifyStats(power = -2, toughness = -2, target = EffectTarget.Self)
+        )
+    }
+
+    // Whenever a creature an opponent controls dies, that player loses 2 life.
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.opponentControls(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.LoseLife(2, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "46"
+        artist = "Jason Chan"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdd32ec2-02a8-41fc-bf45-c9585bb2b3ee.jpg?1782715235"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SoulGuideLantern.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/thb/cards/SoulGuideLantern.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.thb.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soul-Guide Lantern
+ * {1}
+ * Artifact
+ *
+ * When this artifact enters, exile target card from a graveyard.
+ * {T}, Sacrifice this artifact: Exile each opponent's graveyard.
+ * {1}, {T}, Sacrifice this artifact: Draw a card.
+ *
+ * Canonical printing lives in Theros Beyond Death (the card's earliest real printing);
+ * later sets — including Foundations — contribute only a [com.wingedsheep.sdk.model.Printing] row.
+ */
+val SoulGuideLantern = card("Soul-Guide Lantern") {
+    manaCost = "{1}"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, exile target card from a graveyard.\n" +
+        "{T}, Sacrifice this artifact: Exile each opponent's graveyard.\n" +
+        "{1}, {T}, Sacrifice this artifact: Draw a card."
+
+    // When this artifact enters, exile target card from a graveyard.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", Targets.CardInGraveyard)
+        effect = Effects.Move(t, Zone.EXILE)
+    }
+
+    // {T}, Sacrifice this artifact: Exile each opponent's graveyard.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.ExileOpponentsGraveyards()
+    }
+
+    // {1}, {T}, Sacrifice this artifact: Draw a card.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap,
+            Costs.SacrificeSelf
+        )
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "237"
+        artist = "Cliff Childs"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7c850b94-75c9-4457-8b5e-1193352d6fcb.jpg?1782707504"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SoulGuideLanternReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/woe/cards/SoulGuideLanternReprint.kt
@@ -1,0 +1,22 @@
+package com.wingedsheep.mtg.sets.definitions.woe.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Soul-Guide Lantern reprint in Wilds of Eldraine.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in THB's `cards/` package
+ * (the card's earliest real printing). This file contributes only the WOE presentation row.
+ */
+val SoulGuideLanternReprint = Printing(
+    oracleId = "1b5e6560-ff2e-4475-96cb-63f64c8a86db",
+    name = "Soul-Guide Lantern",
+    setCode = "WOE",
+    collectorNumber = "251",
+    scryfallId = "13571173-29e7-4915-af5f-05f13b463061",
+    artist = "Iris Compiet",
+    imageUri = "https://cards.scryfall.io/normal/front/1/3/13571173-29e7-4915-af5f-05f13b463061.jpg?1782696480",
+    releaseDate = "2023-09-08",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/ISD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ISD.json
@@ -4389,6 +4389,53 @@
     "colorIdentityOverride": []
 }
 
+// Tribute to Hunger
+{
+    "name": "Tribute to Hunger",
+    "manaCost": "{2}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target opponent sacrifices a creature of their choice. You gain life equal to that creature's toughness.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Sacrificed",
+                        "numericProperty": "Toughness"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetOpponent",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "119",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Kendall",
+        "flavorText": "Marella was delighted. The ball had attracted so many suitors for her daughter, including that handsome stranger. She wondered where the two were now . . . .",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f77e0f88-2285-4b59-9165-9948c75d77a3.jpg?1782714761"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Typhoid Rats
 {
     "name": "Typhoid Rats",

--- a/mtg-sets/src/test/resources/snapshots/cards/MBS.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/MBS.json
@@ -21,6 +21,80 @@
     "colorIdentityOverride": []
 }
 
+// Massacre Wurm
+{
+    "name": "Massacre Wurm",
+    "manaCost": "{3}{B}{B}{B}",
+    "typeLine": "Creature — Phyrexian Wurm",
+    "oracleText": "When this creature enters, creatures your opponents control get -2/-2 until end of turn.\nWhenever a creature an opponent controls dies, that player loses 2 life.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": -2
+                        },
+                        "target": "Self"
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature ctrl:opponent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "MYTHIC",
+        "artist": "Jason Chan",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdd32ec2-02a8-41fc-bf45-c9585bb2b3ee.jpg?1782715235"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Slagstorm
 {
     "name": "Slagstorm",

--- a/mtg-sets/src/test/resources/snapshots/cards/THB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/THB.json
@@ -44,6 +44,84 @@
     ]
 }
 
+// Soul-Guide Lantern
+{
+    "name": "Soul-Guide Lantern",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, exile target card from a graveyard.\n{T}, Sacrifice this artifact: Exile each opponent's graveyard.\n{1}, {T}, Sacrifice this artifact: Draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": "ExileOpponentsGraveyards"
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "237",
+        "rarity": "UNCOMMON",
+        "artist": "Cliff Childs",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7c850b94-75c9-4457-8b5e-1193352d6fcb.jpg?1782707504"
+    }
+}
+
 // Terror of Mount Velus
 {
     "name": "Terror of Mount Velus",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MassacreWurmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MassacreWurmScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.mbs.cards.MassacreWurm
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Massacre Wurm (MBS #46) — {3}{B}{B}{B} Creature — Phyrexian Wurm 6/5.
+ *
+ *   When this creature enters, creatures your opponents control get -2/-2 until end of turn.
+ *   Whenever a creature an opponent controls dies, that player loses 2 life.
+ *
+ * Exercises the enters group debuff (per-creature -2/-2 over opponents' creatures), the
+ * death-drain trigger (including when the debuff itself kills the creature), that "that player"
+ * resolves to the dead creature's controller, and that your own creatures don't drain you.
+ */
+class MassacreWurmScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun newGame(): Pair<GameTestDriver, EntityId> {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MassacreWurm))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver to driver.activePlayer!!
+    }
+
+    fun GameTestDriver.castWurm(you: EntityId): EntityId {
+        val card = putCardInHand(you, "Massacre Wurm")
+        giveMana(you, Color.BLACK, 3)
+        giveColorlessMana(you, 3)
+        castSpell(you, card).isSuccess shouldBe true
+        bothPass()
+        return card
+    }
+
+    test("enters gives opponents' creatures -2/-2 until end of turn; a survivor does not drain") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        val giant = driver.putCreatureOnBattlefield(opponent, "Hill Giant") // 3/3 -> 1/1
+        val lifeBefore = driver.getLifeTotal(opponent)
+
+        driver.castWurm(you)
+        resolveStack(driver)
+
+        val projected = projector.project(driver.state)
+        projected.getPower(giant) shouldBe 1
+        projected.getToughness(giant) shouldBe 1
+        // The creature survived, so its controller loses no life.
+        driver.getLifeTotal(opponent) shouldBe lifeBefore
+    }
+
+    test("the enters debuff kills a 2/2 and that death makes its controller lose 2 life") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+        val bears = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2 -> 0/0, dies
+        val lifeBefore = driver.getLifeTotal(opponent)
+
+        driver.castWurm(you)
+        resolveStack(driver)
+
+        driver.state.getBattlefield().contains(bears) shouldBe false
+        driver.getLifeTotal(opponent) shouldBe lifeBefore - 2
+    }
+
+    test("a later opponent-creature death also drains that player, but your own creature's death does not") {
+        val (driver, you) = newGame()
+        val opponent = driver.state.turnOrder.first { it != you }
+
+        // Wurm resolves with no opponent creatures out, so the ETB does nothing.
+        driver.castWurm(you)
+        resolveStack(driver)
+
+        val oppLifeBefore = driver.getLifeTotal(opponent)
+        val youLifeBefore = driver.getLifeTotal(you)
+
+        // Kill a fresh opponent creature -> that player loses 2 life.
+        driver.putCreatureOnBattlefield(opponent, "Hill Giant")
+        val giant = driver.findPermanent(opponent, "Hill Giant")!!
+        val bolt1 = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt1, listOf(giant))
+        resolveStack(driver)
+        driver.getLifeTotal(opponent) shouldBe oppLifeBefore - 2
+
+        // Kill your own creature -> no drain (the ability only watches opponents' creatures).
+        driver.putCreatureOnBattlefield(you, "Hill Giant")
+        val ownGiant = driver.findPermanent(you, "Hill Giant")!!
+        val bolt2 = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt2, listOf(ownGiant))
+        resolveStack(driver)
+        driver.getLifeTotal(you) shouldBe youLifeBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TributeToHungerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TributeToHungerScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.isd.cards.TributeToHunger
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tribute to Hunger (ISD #119) — {2}{B} Instant.
+ *
+ *   Target opponent sacrifices a creature of their choice. You gain life equal to that creature's toughness.
+ *
+ * The edict ([com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect]) records the sacrificed
+ * permanent in the effect context; the composed [Effects.GainLife] then reads the sacrificed
+ * creature's *toughness*. When the target opponent controls exactly one creature it is
+ * auto-sacrificed at resolution.
+ */
+class TributeToHungerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TributeToHunger))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        return driver
+    }
+
+    test("opponent sacrifices their only creature and you gain life equal to its toughness") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Goblin Guide is a 2/1 — power 2, toughness 1. Life gained must be 1 (toughness), not 2 (power).
+        driver.putCreatureOnBattlefield(opponent, "Goblin Guide")
+        val lifeBefore = driver.getLifeTotal(you)
+
+        val spell = driver.putCardInHand(you, "Tribute to Hunger")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 2)
+        driver.castSpell(you, spell, listOf(opponent)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.getCreatures(opponent).size shouldBe 0
+        driver.getLifeTotal(you) shouldBe lifeBefore + 1
+    }
+
+    test("resolves harmlessly with no life gain when the opponent controls no creatures") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val lifeBefore = driver.getLifeTotal(you)
+
+        val spell = driver.putCardInHand(you, "Tribute to Hunger")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.giveColorlessMana(you, 2)
+        driver.castSpell(you, spell, listOf(opponent)).error shouldBe null
+        driver.bothPass()
+
+        driver.getLifeTotal(you) shouldBe lifeBefore
+    }
+})


### PR DESCRIPTION
Implements a handful of Foundations (FDN) cards via the `add-card` skill. Each is a reprint whose canonical `CardDefinition` lives in its **earliest real printing**, with `Printing` rows added for every scaffolded reprinting set (so `check-card-printing` passes with no drift).

All three are **pure composition of existing SDK primitives** — no new effects, triggers, conditions, or keywords, and therefore no SDK-reference changes.

## Cards

| Card | Canonical set | Reprint rows added |
|------|---------------|--------------------|
| **Soul-Guide Lantern** `{1}` Artifact | THB | WOE, FDN |
| **Tribute to Hunger** `{2}{B}` Instant | ISD | DDQ, FDN |
| **Massacre Wurm** `{3}{B}{B}{B}` 6/5 | MBS | M21 (×2 collectors), J22, FDN |

### Soul-Guide Lantern
ETB `Effects.Move(target graveyard card, EXILE)`; `{T}, Sacrifice: Effects.ExileOpponentsGraveyards()`; `{1}, {T}, Sacrifice: DrawCards(1)`. Composed from atoms already covered by existing tests (Cremate, Stone of Erech / Dauntless Scrapbot, DrawCards) — relies on the snapshot + lint nets rather than a bespoke scenario test.

### Tribute to Hunger
`ForceSacrificeEffect(Creature, target opponent)` then `GainLife(sacrificedToughness(0))`, which reads the sacrificed creature's last-known toughness from the effect context. Scenario test verifies it gains **toughness** (Goblin Guide 2/1 → +1 life, not +2) and gains 0 with no creature.

### Massacre Wurm
ETB `ForEachInGroup(AllCreaturesOpponentsControl, ModifyStats(-2,-2))`; death-drain trigger uses `Player.TriggeringPlayer` (the dead creature's controller, per `TriggerContext`) so *that player* loses 2 life. Scenario test covers the debuff killing a 2/2 into the drain, a survivor not draining, later unrelated deaths, and own-creature exclusion.

## Testing
- `MassacreWurmScenarioTest` (3 tests) and `TributeToHungerScenarioTest` (2 tests) — pass.
- `CardDefinitionSnapshotTest` re-blessed; diff adds only these three cards to THB/ISD/MBS goldens, nothing else moved.
- `CardLintTest`, `CardDiscoveryTest` — pass; cross-module `assemble` compiles.
- `just check-card-printing` — clean (exit 0) for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)