### PR TITLE
Add The Masamune (Final Fantasy) with death-trigger doubling

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3575,11 +3575,18 @@ staticAbility {
   names a smaller `max` (most restrictive per filter wins). Inert when the player has `≤ max` matching
   permanents tapped.
 - `MustBlock(filter = source())` — matching creatures must block each combat if able (Grand Melee).
-- `MustBeBlocked(allCreatures = false)` — static: the source creature must be blocked while active —
-  "if able" (≥1 blocker, default) or by **all** able blockers (`allCreatures = true`, Lure-style).
-  Static counterpart of `MustBeBlockedEffect`; `BlockPhaseManager` honors it alongside the floating
-  must-be-blocked modifications. Wrap in `ConditionalStaticAbility(_, condition)` for the gated form
-  (Frodo Baggins: `ConditionalStaticAbility(MustBeBlocked(), Conditions.SourceIsRingBearer)`).
+- `MustBeBlocked(allCreatures = false, filter = null)` — static: a creature must be blocked while
+  active — "if able" (≥1 blocker, default) or by **all** able blockers (`allCreatures = true`,
+  Lure-style). Static counterpart of `MustBeBlockedEffect`; `BlockPhaseManager` honors it alongside
+  the floating must-be-blocked modifications. With `filter = null` (default) the requirement applies
+  to the ability's own **source**; wrap in `ConditionalStaticAbility(_, condition)` for the gated
+  form (Frodo Baggins: `ConditionalStaticAbility(MustBeBlocked(), Conditions.SourceIsRingBearer)`).
+  Set `filter` to project the requirement onto a **different** creature, resolved relative to the
+  static's source — e.g. an Equipment: "equipped creature … must be blocked if able" (The Masamune)
+  uses `MustBeBlocked(filter = GroupFilter.attachedCreature())`. Source-relative scopes
+  (`attachedCreature()`, `source()`) resolve correctly; a `Battlefield`-scope filter matches every
+  attacker. No separate "while attacking" gate is needed — must-be-blocked only bites while the
+  creature attacks.
 - `CantBeBlockedByMoreThan(maxBlockers)` — static cap on how many creatures may block the source (CR
   509.1b). For the **turn-scoped, granted** form (Glorfindel, Dauntless Rescuer: "can't be blocked by
   more than one creature each combat this turn"), grant `AbilityFlag.CANT_BE_BLOCKED_BY_MORE_THAN_ONE`
@@ -3660,6 +3667,19 @@ staticAbility {
   being declared as an attacker causes an attack-related triggered ability ("whenever a creature
   attacks" / "whenever you attack") of a permanent you control to trigger, that ability triggers an
   additional time. `TriggerDetector.duplicateAttackTriggers`; additive across copies.
+- `AdditionalDeathTriggers(attachedCreature = false, permanentsYouControl = null, includeEmblems = false)`
+  — the **death-cause** analogue: if a creature dying (put into a graveyard from the battlefield,
+  continuous effects included) causes a **death/leave-the-battlefield** triggered ability within
+  scope to trigger, that ability triggers an additional time. Scope: `permanentsYouControl` (a
+  filter) for "a permanent you control" (Teysa Karlov = `AdditionalDeathTriggers(permanentsYouControl
+  = GameObjectFilter.Any)`); `attachedCreature = true` for "this creature" on an Equipment/Aura (The
+  Masamune, modelled as an equipment-level doubler scoped to the equipped creature); `includeEmblems
+  = true` for "an emblem you own". Only death/leave triggers are doubled — abilities responding to the
+  event that *caused* the death (e.g. "whenever you sacrifice a creature") are not (their EventPattern
+  isn't a battlefield-exit `ZoneChangeEvent`). `TriggerDetector.duplicateDeathTriggers`; additive
+  across copies (N doublers → N+1 firings). Limitation: a scoped source's own "when this creature
+  dies" trigger fired by *itself* dying isn't doubled (post-death trigger detection no longer exposes
+  the doubler's attachment) — the same constraint `AdditionalSourceTriggers` has.
 
 **Spell cost statics — `ModifySpellCost`**
 

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/CombatStaticAbilities.kt
@@ -85,11 +85,20 @@ data class MustBlock(
 @SerialName("MustBeBlockedStatic")
 @Serializable
 data class MustBeBlocked(
-    val allCreatures: Boolean = false
+    val allCreatures: Boolean = false,
+    val filter: GroupFilter? = null
 ) : StaticAbility {
-    override val description: String =
-        if (allCreatures) "This creature must be blocked by all creatures able to block it"
-        else "This creature must be blocked each combat if able"
+    override val description: String = buildString {
+        append(if (filter == null) "This creature" else filter.description)
+        append(
+            if (allCreatures) " must be blocked by all creatures able to block it"
+            else " must be blocked each combat if able"
+        )
+    }
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newFilter = filter?.applyTextReplacement(replacer)
+        return if (newFilter !== filter) copy(filter = newFilter) else this
+    }
 }
 
 /**

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/MiscStaticAbilities.kt
@@ -949,6 +949,56 @@ data class AdditionalAttackTriggers(
 }
 
 /**
+ * If a creature dying causes a triggered ability within the doubler's *scope* to trigger, that
+ * ability triggers an additional time. The **death-cause** analogue of [AdditionalAttackTriggers]:
+ * where that doubles triggers caused by an attack being declared, this doubles triggers caused by a
+ * creature being put into a graveyard from the battlefield (CR 603.2d, CR 700.4 "dies").
+ *
+ * Concrete shapes:
+ *  - **Teysa Karlov** ("If a creature dying causes a triggered ability of a permanent you control to
+ *    trigger, that ability triggers an additional time") ->
+ *    `AdditionalDeathTriggers(permanentsYouControl = GameObjectFilter.Any)`.
+ *  - **The Masamune** ("Equipped creature has 'If a creature dying causes a triggered ability of
+ *    this creature or an emblem you own to trigger, that ability triggers an additional time.'") ->
+ *    modelled as an equipment-level doubler scoped to the attached creature and emblems:
+ *    `AdditionalDeathTriggers(attachedCreature = true, includeEmblems = true)`.
+ *
+ * Only the *death/leave-the-battlefield* triggered abilities of scoped sources are doubled - those
+ * that respond to a creature being put into a graveyard from the battlefield ("dies", "leaves the
+ * battlefield" by dying). Abilities that respond to the *event that caused* the death (e.g. "whenever
+ * you sacrifice a creature") are **not** doubled, per the printed rulings.
+ *
+ * Multiple copies are additive: N doublers add N extra firings of each affected trigger (N+1 total).
+ *
+ * @property attachedCreature When true, the scope includes the creature this permanent is attached
+ *   to ("this creature" on an Equipment/Aura). Resolved via the doubler source's attachment.
+ * @property permanentsYouControl When non-null, the scope includes battlefield permanents the
+ *   doubler's controller controls whose projected state matches this filter (Teysa: `Any`).
+ * @property includeEmblems When true, the scope also includes emblems owned by the doubler's
+ *   controller ("an emblem you own"). No emblem in the engine currently carries a *triggered*
+ *   ability (emblems are modelled as static floating effects), so this clause is presently inert
+ *   but faithfully modelled and honoured by the detector should a triggered-ability emblem land.
+ *
+ * The "cause" is always **a creature dying** (a creature being put into a graveyard from the
+ * battlefield, continuous effects included - an animated land that dies counts), the printed wording
+ * of every card using this ability, so it isn't parameterised.
+ */
+@SerialName("AdditionalDeathTriggers")
+@Serializable
+data class AdditionalDeathTriggers(
+    val attachedCreature: Boolean = false,
+    val permanentsYouControl: GameObjectFilter? = null,
+    val includeEmblems: Boolean = false,
+    override val description: String =
+        "If a creature dying causes a triggered ability of a permanent you control to trigger, that ability triggers an additional time"
+) : StaticAbility {
+    override fun applyTextReplacement(replacer: TextReplacer): StaticAbility {
+        val newControlled = permanentsYouControl?.applyTextReplacement(replacer)
+        return if (newControlled !== permanentsYouControl) copy(permanentsYouControl = newControlled) else this
+    }
+}
+
+/**
  * You may play additional lands on each of your turns.
  * Used for permanents like Hugs, Grisly Guardian and Oracle of Mul Daya.
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheMasamune.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TheMasamune.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AdditionalDeathTriggers
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.MustBeBlocked
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * The Masamune
+ * {3}
+ * Legendary Artifact - Equipment
+ * As long as equipped creature is attacking, it has first strike and must be blocked if able.
+ * Equipped creature has "If a creature dying causes a triggered ability of this creature or an
+ *   emblem you own to trigger, that ability triggers an additional time."
+ * Equip {2}
+ *
+ * Modelled with three continuous statics on the Equipment (no new one-shot machinery):
+ *  1. First strike while attacking - GrantKeyword of FIRST_STRIKE to the equipped creature
+ *     (Filters.EquippedCreature), gated by a ConditionalStaticAbility on
+ *     EntityMatches(EquippedCreature, attacking) so it applies only while the equipped creature is
+ *     an attacker (and not while it blocks). The gate is required because an AttachedTo-scoped grant
+ *     filter drops its base-filter predicates during projection, so ".attacking()" on the filter
+ *     alone would not gate.
+ *  2. Must be blocked if able while attacking - the filtered MustBeBlocked static
+ *     (filter = attachedCreature(), allCreatures = false) projects the "must be blocked if able"
+ *     requirement onto the equipped creature. Must-be-blocked only affects a creature while it
+ *     attacks, so no separate attacking gate is needed.
+ *  3. Death-trigger doubling - AdditionalDeathTriggers scoped to the equipped creature
+ *     (attachedCreature = true) and emblems you own (includeEmblems = true). Per the printed rulings
+ *     this doubles only the equipped creature's / an owned emblem's death and leave-the-battlefield
+ *     triggers that fire because a creature died - not abilities that respond to the event that
+ *     caused the death (e.g. "whenever you sacrifice a creature", which fires once). N copies are
+ *     additive (N+1 firings). No emblem in the engine currently carries a triggered ability (emblems
+ *     are static floating effects), so that leg is presently inert but modelled. Known limitation,
+ *     shared with the engine's other death/leave doublers: the equipped creature's own "when this
+ *     creature dies" trigger fired by itself dying is not doubled - trigger detection runs on
+ *     post-death state and the doubler's attachment is gone by then.
+ */
+val TheMasamune = card("The Masamune") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "As long as equipped creature is attacking, it has first strike and must be " +
+        "blocked if able.\n" +
+        "Equipped creature has \"If a creature dying causes a triggered ability of this creature " +
+        "or an emblem you own to trigger, that ability triggers an additional time.\"\n" +
+        "Equip {2}"
+
+    // 1. First strike while attacking (only while the equipped creature is an attacker).
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FIRST_STRIKE, Filters.EquippedCreature),
+            condition = Conditions.EntityMatches(
+                EffectTarget.EquippedCreature,
+                GameObjectFilter.Any.attacking()
+            )
+        )
+    }
+
+    // 1b. Must be blocked if able (relevant only while the equipped creature attacks).
+    staticAbility {
+        ability = MustBeBlocked(allCreatures = false, filter = GroupFilter.attachedCreature())
+    }
+
+    // 2. Equipped creature's death/leave triggers (and owned emblems') trigger an additional time.
+    staticAbility {
+        ability = AdditionalDeathTriggers(attachedCreature = true, includeEmblems = true)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "264"
+        artist = "Masateru Ikeda"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc408575-8ef7-4043-b6b7-b38cef7c97d1.jpg?1782686391"
+
+        ruling(
+            "2025-06-06",
+            "An ability that triggers on an event that causes a creature to die doesn't trigger " +
+                "twice. For example, an ability that triggers \"whenever you sacrifice a creature\" " +
+                "triggers only once."
+        )
+        ruling(
+            "2025-06-06",
+            "The granted ability's effect doesn't copy the triggered ability; it just causes the " +
+                "ability to trigger twice. Choices such as modes and targets are made separately " +
+                "for each instance of the ability."
+        )
+        ruling(
+            "2025-06-06",
+            "An ability of the equipped creature or an emblem you own that triggers when a creature " +
+                "\"leaves the battlefield\" will trigger twice if that creature leaves by dying."
+        )
+        ruling(
+            "2025-06-06",
+            "If you control two of The Masamune and they're equipped to creatures you control, a " +
+                "creature dying causes abilities of emblems you own to trigger three times, not four."
+        )
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -21145,6 +21145,98 @@
     ]
 }
 
+// The Masamune
+{
+    "name": "The Masamune",
+    "manaCost": "{3}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "As long as equipped creature is attacking, it has first strike and must be blocked if able.\nEquipped creature has \"If a creature dying causes a triggered ability of this creature or an emblem you own to trigger, that ability triggers an additional time.\"\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE"
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "EquippedCreature",
+                    "filter": "attacking"
+                }
+            },
+            {
+                "type": "MustBeBlockedStatic",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "AdditionalDeathTriggers",
+                "attachedCreature": true,
+                "includeEmblems": true
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "264",
+        "rarity": "RARE",
+        "artist": "Masateru Ikeda",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc408575-8ef7-4043-b6b7-b38cef7c97d1.jpg?1782686391",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "An ability that triggers on an event that causes a creature to die doesn't trigger twice. For example, an ability that triggers \"whenever you sacrifice a creature\" triggers only once."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "The granted ability's effect doesn't copy the triggered ability; it just causes the ability to trigger twice. Choices such as modes and targets are made separately for each instance of the ability."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "An ability of the equipped creature or an emblem you own that triggers when a creature \"leaves the battlefield\" will trigger twice if that creature leaves by dying."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "If you control two of The Masamune and they're equipped to creatures you control, a creature dying causes abilities of emblems you own to trigger three times, not four."
+            }
+        ]
+    },
+    "colorIdentityOverride": []
+}
+
 // The Prima Vista
 {
     "name": "The Prima Vista",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerDetector.kt
@@ -27,6 +27,7 @@ import com.wingedsheep.engine.state.components.battlefield.SagaComponent
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredEverComponent
 import com.wingedsheep.engine.state.components.battlefield.TriggeredAbilityFiredThisTurnComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.EmblemSourceComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.sdk.scripting.GameObjectFilter
@@ -315,6 +316,10 @@ class TriggerDetector(
         // Duplicate triggers caused by a creature being declared as an attacker (Windcrag Siege's
         // Mardu mode). The attack-cause analogue of duplicateETBTriggers.
         duplicateAttackTriggers(state, events, triggers)
+
+        // Duplicate death/leave-the-battlefield triggers caused by a creature dying (Teysa Karlov;
+        // The Masamune's granted ability). The death-cause analogue of duplicateAttackTriggers.
+        duplicateDeathTriggers(state, events, triggers)
 
         // Duplicate triggers for "all triggers from a filtered source trigger again" static
         // abilities (e.g., Twinflame Travelers). For each pending trigger whose source matches
@@ -2778,6 +2783,131 @@ class TriggerDetector(
         }
 
         triggers.addAll(duplicates)
+    }
+
+    /**
+     * Duplicate death/leave-the-battlefield triggers for [AdditionalDeathTriggers] static abilities
+     * (Teysa Karlov; The Masamune's granted ability). The death-cause analogue of
+     * [duplicateAttackTriggers]: for each creature put into a graveyard from the battlefield this
+     * batch, a scoped source's triggered ability that fired *from that death* triggers an additional
+     * time per doubler.
+     *
+     * Only *death/leave-the-battlefield* triggers are doubled ("dies", "leaves the battlefield" by
+     * dying) - abilities responding to the event that *caused* the death (e.g. "whenever you
+     * sacrifice a creature") are not doubled, per the printed rulings. That falls out naturally:
+     * their EventPattern is not a battlefield-exit [EventPattern.ZoneChangeEvent], so
+     * [isDeathCausedTrigger] rejects them.
+     *
+     * Multiple copies are additive: N doublers add N extra firings of each affected trigger (N+1
+     * total), matching the rulings (two Masamunes on emblems -> three firings, not four).
+     *
+     * Known limitation: a scoped source's own "when this creature dies" trigger fired by *that same
+     * source* dying is not doubled - once the source is in the graveyard the doubler's attachment to
+     * it is no longer exposed to the (post-death) trigger pipeline. See [AdditionalDeathTriggers].
+     */
+    private fun duplicateDeathTriggers(
+        state: GameState,
+        events: List<EngineGameEvent>,
+        triggers: MutableList<PendingTrigger>
+    ) {
+        if (triggers.isEmpty()) return
+
+        // Creatures put into a graveyard from the battlefield this batch, taking continuous effects
+        // into account via last-known type line (an animated land that dies counts, CR 700.4).
+        val dyingCreatures = events.filterIsInstance<ZoneChangeEvent>()
+            .filter { it.fromZone == Zone.BATTLEFIELD && it.toZone == Zone.GRAVEYARD }
+            .filter { it.lastKnown?.typeLine?.isCreature == true }
+            .map { it.entityId }
+            .toSet()
+        if (dyingCreatures.isEmpty()) return
+
+        val registry = cardRegistry
+        val projected = state.projectedState
+
+        data class DeathDoubler(
+            val sourceId: EntityId,
+            val controllerId: EntityId,
+            val ability: AdditionalDeathTriggers,
+        )
+        val doublers = mutableListOf<DeathDoubler>()
+        for (permanentId in state.getBattlefield()) {
+            val container = state.getEntity(permanentId) ?: continue
+            val card = container.get<CardComponent>() ?: continue
+            if (container.has<FaceDownComponent>()) continue
+            val controllerId = projected.getController(permanentId) ?: continue
+            val cardDef = registry.getCard(card.cardDefinitionId) ?: continue
+            val classLevel = container.get<ClassLevelComponent>()?.currentLevel
+            for (ability in cardDef.script.effectiveStaticAbilities(classLevel)) {
+                val unwrapped: AdditionalDeathTriggers? = when (ability) {
+                    is AdditionalDeathTriggers -> ability
+                    is ConditionalStaticAbility ->
+                        (ability.ability as? AdditionalDeathTriggers)?.takeIf {
+                            conditionEvaluator.evaluate(
+                                state, ability.condition,
+                                EffectContext(sourceId = permanentId, controllerId = controllerId)
+                            )
+                        }
+                    else -> null
+                }
+                if (unwrapped != null) doublers.add(DeathDoubler(permanentId, controllerId, unwrapped))
+            }
+        }
+        if (doublers.isEmpty()) return
+
+        val duplicates = mutableListOf<PendingTrigger>()
+        val originals = triggers.toList()
+        for (doubler in doublers) {
+            val attachedCreatureId =
+                if (doubler.ability.attachedCreature) {
+                    state.getEntity(doubler.sourceId)?.get<AttachedToComponent>()?.targetId
+                } else null
+            val controlledFilter = doubler.ability.permanentsYouControl
+            for (trigger in originals) {
+                if (trigger.controllerId != doubler.controllerId) continue
+                if (!isDeathCausedTrigger(trigger, dyingCreatures)) continue
+                val src = trigger.sourceId
+                val inScope = when {
+                    attachedCreatureId != null && src == attachedCreatureId -> true
+                    controlledFilter != null && src in state.getBattlefield() &&
+                        predicateEvaluator.matches(
+                            state, projected, src, controlledFilter,
+                            PredicateContext(controllerId = doubler.controllerId, sourceId = doubler.sourceId)
+                        ) -> true
+                    doubler.ability.includeEmblems && isEmblemOwnedBy(state, src, doubler.controllerId) -> true
+                    else -> false
+                }
+                if (inScope) duplicates.add(trigger)
+            }
+        }
+        triggers.addAll(duplicates)
+    }
+
+    /**
+     * A pending trigger is "death-caused" when its [EventPattern] responds to a permanent being put
+     * into a graveyard from the battlefield (dies / leaves-the-battlefield-by-dying) and the specific
+     * triggering entity is one of the creatures that died this batch. Batch "creatures you control
+     * died" triggers are inherently death-caused. Sacrifice/destroy triggers use non-battlefield-exit
+     * patterns and so never match here.
+     */
+    private fun isDeathCausedTrigger(trigger: PendingTrigger, dyingCreatures: Set<EntityId>): Boolean {
+        return when (val pattern = trigger.ability.trigger) {
+            is EventPattern.ZoneChangeEvent -> {
+                if (pattern.from != Zone.BATTLEFIELD) return false
+                if (pattern.to != null && pattern.to != Zone.GRAVEYARD) return false
+                trigger.triggerContext.triggeringEntityId in dyingCreatures
+            }
+            is EventPattern.CreatureDealtDamageBySourceDiesEvent ->
+                trigger.triggerContext.triggeringEntityId in dyingCreatures
+            is EventPattern.CreaturesYouControlDiedEvent -> true
+            else -> false
+        }
+    }
+
+    /** True if [entityId] is an emblem (synthetic [EmblemSourceComponent] source) owned by [controllerId]. */
+    private fun isEmblemOwnedBy(state: GameState, entityId: EntityId, controllerId: EntityId): Boolean {
+        val container = state.getEntity(entityId) ?: return false
+        if (container.get<EmblemSourceComponent>() == null) return false
+        return container.get<ControllerComponent>()?.playerId == controllerId
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -36,7 +36,9 @@ import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
 import com.wingedsheep.sdk.scripting.CantBlock
 import com.wingedsheep.sdk.scripting.CantBlockUnless
 import com.wingedsheep.sdk.scripting.CantBlockUnlessCoBlocker
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
 import com.wingedsheep.sdk.scripting.filters.unified.Scope
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
 import java.util.UUID
 
 /**
@@ -863,24 +865,88 @@ internal class BlockPhaseManager(
      */
     private fun attackersWithMustBeBlockedStatic(state: GameState, allCreatures: Boolean): List<EntityId> {
         val attackers = state.findEntitiesWith<AttackingComponent>().map { it.first }
-        return attackers.filter { attackerId ->
-            val cardName = state.getEntity(attackerId)?.get<CardComponent>()?.cardDefinitionId ?: return@filter false
+        if (attackers.isEmpty()) return emptyList()
+        val projected = state.projectedState
+        val attackerSet = attackers.toSet()
+        val result = mutableSetOf<EntityId>()
+
+        // (a) An attacker's own source-scoped MustBeBlocked static (filter == null), including the
+        // conditional form (Frodo Baggins, gated on SourceIsRingBearer).
+        for (attackerId in attackers) {
+            val cardName = state.getEntity(attackerId)?.get<CardComponent>()?.cardDefinitionId ?: continue
             val statics = cardRegistry.getCard(cardName)?.staticAbilities.orEmpty()
-            statics.any { ability ->
+            val active = statics.any { ability ->
                 val unwrapped = if (ability is ConditionalStaticAbility) ability.ability else ability
-                if (unwrapped !is MustBeBlocked || unwrapped.allCreatures != allCreatures) return@any false
+                if (unwrapped !is MustBeBlocked || unwrapped.filter != null || unwrapped.allCreatures != allCreatures) {
+                    return@any false
+                }
                 if (ability is ConditionalStaticAbility) {
-                    val controller = state.projectedState.getController(attackerId) ?: return@any false
+                    val controller = projected.getController(attackerId) ?: return@any false
                     conditionEvaluator.evaluate(
                         state,
                         ability.condition,
-                        EffectContext(
-                            sourceId = attackerId,
-                            controllerId = controller
-                        )
+                        EffectContext(sourceId = attackerId, controllerId = controller)
                     )
                 } else true
             }
+            if (active) result.add(attackerId)
+        }
+
+        // (b) A battlefield permanent projecting MustBeBlocked onto a *different* creature via a
+        // filter - e.g. an Equipment granting "equipped creature ... must be blocked if able"
+        // (The Masamune, filter = GroupFilter.attachedCreature()). The filter is resolved relative
+        // to the permanent carrying the static.
+        for (sourceId in state.getBattlefield()) {
+            val container = state.getEntity(sourceId) ?: continue
+            if (container.has<FaceDownComponent>()) continue
+            val cardName = container.get<CardComponent>()?.cardDefinitionId ?: continue
+            val statics = cardRegistry.getCard(cardName)?.staticAbilities.orEmpty()
+            for (ability in statics) {
+                val unwrapped = if (ability is ConditionalStaticAbility) ability.ability else ability
+                if (unwrapped !is MustBeBlocked || unwrapped.allCreatures != allCreatures) continue
+                val filter = unwrapped.filter ?: continue
+                val controller = projected.getController(sourceId) ?: continue
+                if (ability is ConditionalStaticAbility &&
+                    !conditionEvaluator.evaluate(
+                        state, ability.condition, EffectContext(sourceId = sourceId, controllerId = controller)
+                    )
+                ) continue
+                result.addAll(
+                    resolveFilteredMustBeBlockedAttackers(state, projected, sourceId, controller, filter, attackerSet)
+                )
+            }
+        }
+
+        return result.toList()
+    }
+
+    /**
+     * Resolve which declared attackers a filtered [MustBeBlocked] static (carried by [sourceId])
+     * applies to. Source-relative scopes resolve against [sourceId]: `AttachedTo` -> the creature it
+     * is attached to (equipped creature), `Self` -> the source, `Specific` -> the bound entity;
+     * `Battlefield` matches every attacker against the base filter. Only attackers pass, and each
+     * must also satisfy the base filter (evaluated with the static's source as context).
+     */
+    private fun resolveFilteredMustBeBlockedAttackers(
+        state: GameState,
+        projected: ProjectedState,
+        sourceId: EntityId,
+        controllerId: EntityId,
+        filter: GroupFilter,
+        attackerSet: Set<EntityId>,
+    ): List<EntityId> {
+        val candidates: List<EntityId> = when (val scope = filter.scope) {
+            is Scope.AttachedTo -> listOfNotNull(state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId)
+            is Scope.Self -> listOf(sourceId)
+            is Scope.Specific -> listOf(scope.entityId)
+            is Scope.Battlefield -> attackerSet.toList()
+        }
+        return candidates.filter { id ->
+            id in attackerSet &&
+                predicateEvaluator.matches(
+                    state, projected, id, filter.baseFilter,
+                    PredicateContext(sourceId = sourceId, controllerId = controllerId)
+                )
         }
     }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -75,6 +75,7 @@ import com.wingedsheep.sdk.scripting.GrantProtectionToController
 import com.wingedsheep.sdk.scripting.GrantShroudToController
 import com.wingedsheep.sdk.scripting.StationUsingToughness
 import com.wingedsheep.sdk.scripting.AdditionalAttackTriggers
+import com.wingedsheep.sdk.scripting.AdditionalDeathTriggers
 import com.wingedsheep.sdk.scripting.AdditionalETBOrLTBTriggers
 import com.wingedsheep.sdk.scripting.AdditionalManaOnSourceTap
 import com.wingedsheep.sdk.scripting.AdditionalManaOnTap
@@ -778,6 +779,7 @@ class StaticAbilityHandler(
 
             // Trigger system (TriggerDetector / TriggerAbilityResolver / TriggerIndex):
             is AdditionalAttackTriggers,
+            is AdditionalDeathTriggers,
             is AdditionalETBOrLTBTriggers,
             is AdditionalSourceTriggers,
             is GrantTriggeredAbility,

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMasamuneScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMasamuneScenarioTest.kt
@@ -1,0 +1,150 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Masamune (FIN #264) - {3} Legendary Artifact - Equipment.
+ *
+ * "As long as equipped creature is attacking, it has first strike and must be blocked if able.
+ *  Equipped creature has 'If a creature dying causes a triggered ability of this creature or an
+ *  emblem you own to trigger, that ability triggers an additional time.'
+ *  Equip {2}"
+ *
+ * Exercises the filtered MustBeBlocked static, the attacking-gated first-strike grant, and the new
+ * AdditionalDeathTriggers death-cause trigger doubler.
+ */
+class TheMasamuneScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    private val graveChronicler = CardDefinition.creature(
+        name = "Grave Chronicler",
+        manaCost = ManaCost.parse("{2}{W}"),
+        subtypes = setOf(Subtype("Human"), Subtype("Cleric")),
+        power = 3,
+        toughness = 3,
+        oracleText = "Whenever a creature dies, you gain 2 life.",
+        script = CardScript.creature(
+            TriggeredAbility.create(
+                trigger = EventPattern.ZoneChangeEvent(
+                    filter = GameObjectFilter.Creature,
+                    from = Zone.BATTLEFIELD,
+                    to = Zone.GRAVEYARD
+                ),
+                binding = TriggerBinding.ANY,
+                effect = GainLifeEffect(2)
+            )
+        )
+    )
+
+    init {
+        cardRegistry.register(graveChronicler)
+
+        context("The Masamune") {
+            test("equipped creature has first strike while attacking but not otherwise") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "The Masamune", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                withClue("Not attacking (main phase) -> no first strike") {
+                    projector.project(game.state).hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe false
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+
+                withClue("While attacking -> has first strike") {
+                    projector.project(game.state).hasKeyword(bears, Keyword.FIRST_STRIKE) shouldBe true
+                }
+            }
+
+            test("equipped attacker must be blocked if able") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "The Masamune", "Grizzly Bears")
+                    .withCardOnBattlefield(2, "Savannah Lions")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                withClue("Defender has an able blocker -> declining to block is illegal") {
+                    game.declareNoBlockers().isSuccess shouldBe false
+                }
+                withClue("Blocking the equipped attacker is legal") {
+                    game.declareBlockers(mapOf("Savannah Lions" to listOf("Grizzly Bears"))).isSuccess shouldBe true
+                }
+            }
+
+            test("equipped creature's death trigger triggers an additional time") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grave Chronicler")
+                    .withCardAttachedTo(1, "The Masamune", "Grave Chronicler")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Pyroclasm")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Pyroclasm").error shouldBe null
+                game.resolveStack()
+
+                withClue("The 2/2 Grizzly Bears died; the 3/3 Chronicler survived") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 0
+                    (game.findPermanent("Grave Chronicler") != null) shouldBe true
+                }
+                withClue("One creature dying fires the gain-2 trigger twice (20 + 2 + 2 = 24)") {
+                    game.getLifeTotal(1) shouldBe 24
+                }
+            }
+
+            test("without The Masamune the death trigger fires only once") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grave Chronicler")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardInHand(1, "Pyroclasm")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Pyroclasm").error shouldBe null
+                game.resolveStack()
+
+                withClue("No doubler -> gain 2 once (20 + 2 = 22)") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **The Masamune** ({3} Legendary Artifact — Equipment, FIN #264) — the most self-contained of Final Fantasy's remaining unimplemented cards. All eight leftover FIN cards are the set's hardest bombs and each needs new engine capability, not just card authoring; The Masamune was chosen because its one genuinely new primitive (a death-cause trigger doubler) is broadly reusable (it's also Teysa Karlov's ability) and it's single-faced.

Oracle text:
> As long as equipped creature is attacking, it has first strike and must be blocked if able.
> Equipped creature has "If a creature dying causes a triggered ability of this creature or an emblem you own to trigger, that ability triggers an additional time."
> Equip {2}

## New / changed SDK primitives (both general-purpose)

- **`AdditionalDeathTriggers`** — the death-cause analogue of `AdditionalAttackTriggers`. If a creature dying causes a **death/leave-the-battlefield** triggered ability within scope to trigger, that ability triggers an additional time. Scope: `permanentsYouControl` (Teysa Karlov), `attachedCreature` ("this creature" on an Equipment/Aura), and/or `includeEmblems`. Per the printed rulings, abilities that respond to the *event that caused* the death (e.g. "whenever you sacrifice a creature") are **not** doubled — that falls out naturally because their `EventPattern` isn't a battlefield-exit `ZoneChangeEvent`. Wired in `TriggerDetector.duplicateDeathTriggers` (additive across copies, N doublers → N+1 firings) and classified in `StaticAbilityHandler`.
- **`MustBeBlocked(filter = …)`** — now takes an optional `GroupFilter` so the "must be blocked if able" requirement can be projected onto a creature other than the ability's source (the equipped creature). `BlockPhaseManager` resolves it relative to the static's source (`attachedCreature()`/`source()`/`Specific`/`Battlefield` scopes).

First strike while attacking reuses `GrantKeyword` + a `ConditionalStaticAbility` gated on `EntityMatches(EquippedCreature, attacking)` (the AttachedTo grant path drops base-filter predicates in projection, so the gate can't live on the filter).

## Known limitation (documented)

A scoped source's own "when this creature dies" trigger fired by *itself* dying isn't doubled — post-death trigger detection no longer exposes the doubler's attachment. This is the same constraint the existing `AdditionalSourceTriggers` doubler has; the common case (another creature dying) is handled fully. The emblem-scope leg is inert today (no engine emblem carries a triggered ability) but is modelled and detector-ready.

## Tests

`TheMasamuneScenarioTest` (4 cases): first-strike gating (has it while attacking, not otherwise), equipped attacker must be blocked if able, death-trigger doubling (gain-2 fires twice → +4), and a no-Masamune control (+2). Full `:rules-engine` and `:mtg-sets` (lint + snapshot) suites pass; FIN card snapshot re-blessed (only The Masamune added). SDK reference updated for both primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)