### PR TITLE
Add Foundations cards: Midnight Snack, Bloodthirsty Conqueror, Goblin Negotiation

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3092,6 +3092,7 @@ Triggers.youCastSpell(
 - `AnyPlayerGainsLife` — anyone gains life.
 - `YouLoseLife` — you lose any life.
 - `AnyPlayerLosesLife` — anyone loses life.
+- `AnOpponentLosesLife` — an opponent loses life (fires per opponent life-loss event; read the amount via `ContextPropertyKey.TRIGGER_LIFE_LOST`). Bloodthirsty Conqueror.
 - `YouGainOrLoseLife` — combined life-change.
 
 ### The Ring

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1571,6 +1571,17 @@ object Triggers {
     )
 
     /**
+     * Whenever an opponent loses life. Fires once per life-loss event of any opponent
+     * (CR "whenever" per-event templating). The lost amount is exposed via
+     * [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.TRIGGER_LIFE_LOST].
+     * Used by cards like Bloodthirsty Conqueror.
+     */
+    val AnOpponentLosesLife: TriggerSpec = TriggerSpec(
+        event = LifeLossEvent(Player.EachOpponent),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * Whenever you gain or lose life.
      * Used for cards like Moonstone Harbinger.
      */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BloodthirstyConqueror.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BloodthirstyConqueror.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Bloodthirsty Conqueror
+ * {3}{B}{B}
+ * Creature — Vampire Knight
+ * 5/5
+ *
+ * Flying, deathtouch
+ * Whenever an opponent loses life, you gain that much life. (Damage causes loss of life.)
+ *
+ * The trigger fires once per opponent life-loss event ([Triggers.AnOpponentLosesLife]); the
+ * amount lost is read from that event via [ContextPropertyKey.TRIGGER_LIFE_LOST] so you gain
+ * exactly that much.
+ */
+val BloodthirstyConqueror = card("Bloodthirsty Conqueror") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Knight"
+    power = 5
+    toughness = 5
+    oracleText = "Flying, deathtouch\n" +
+        "Whenever an opponent loses life, you gain that much life. (Damage causes loss of life.)"
+
+    keywords(Keyword.FLYING, Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.AnOpponentLosesLife
+        effect = Effects.GainLife(DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_LIFE_LOST))
+        description = "Whenever an opponent loses life, you gain that much life."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "58"
+        artist = "Dmitry Burmak"
+        flavorText = "\"This town swims with such exquisite blood. I will take every drop for my own.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/e/ce860ed4-a5bd-4347-9eab-dd716ea84db1.jpg?1782689215"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GoblinNegotiation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GoblinNegotiation.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Goblin Negotiation
+ * {X}{R}{R}
+ * Sorcery
+ *
+ * Goblin Negotiation deals X damage to target creature. Create a number of 1/1 red Goblin
+ * creature tokens equal to the amount of excess damage dealt to that creature this way.
+ *
+ * Composed from existing atoms (mirrors Hell to Pay): [Effects.DealXDamage] deals X to the target
+ * and marks the damage, then [Effects.CreateToken] reads the post-damage excess via
+ * `EntityProperty(EntityReference.Target(0), ExcessMarkedDamage)` — `max(0, marked − toughness)`
+ * (CR 120.4a). CompositeEffect resolves its steps sequentially with no interleaved SBA pass, so
+ * the marked damage in scope at the second step is exactly the X this spell just dealt.
+ */
+val GoblinNegotiation = card("Goblin Negotiation") {
+    manaCost = "{X}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Goblin Negotiation deals X damage to target creature. Create a number of 1/1 " +
+        "red Goblin creature tokens equal to the amount of excess damage dealt to that creature this way."
+
+    spell {
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.DealXDamage(creature),
+            Effects.CreateToken(
+                count = DynamicAmount.EntityProperty(
+                    EntityReference.Target(0),
+                    EntityNumericProperty.ExcessMarkedDamage
+                ),
+                power = 1,
+                toughness = 1,
+                colors = setOf(Color.RED),
+                creatureTypes = setOf("Goblin"),
+                imageUri = "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1782727474"
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "88"
+        artist = "Svetlin Velinov"
+        flavorText = "Either you pay for Krenko's \"protection\" or you pay to replace your stall. Either way, you pay."
+        imageUri = "https://cards.scryfall.io/normal/front/f/2/f2016585-e26c-4d13-b09f-af6383c192f7.jpg?1782689188"
+
+        ruling("2024-11-15", "Excess damage is the amount of damage dealt to the creature beyond what was needed to be lethal. Damage already marked on the creature and any damage that would be prevented are taken into account.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MidnightSnack.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MidnightSnack.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Midnight Snack
+ * {2}{B}
+ * Enchantment
+ *
+ * Raid — At the beginning of your end step, if you attacked this turn, create a Food token.
+ * ({2}, {T}, Sacrifice this token: You gain 3 life.)
+ * {2}{B}, Sacrifice this enchantment: Target opponent loses X life, where X is the amount of
+ * life you gained this turn.
+ *
+ * "Raid" is an ability word (no rules meaning); the actual gate is the intervening-if condition
+ * that you attacked this turn, evaluated both when the trigger would be put on the stack and
+ * again on resolution ([Conditions.YouAttackedThisTurn]). The drain reads the LIFE_GAINED turn
+ * tracker via [DynamicAmounts.lifeGainedThisTurn] — if you gained no life this turn, X = 0.
+ */
+val MidnightSnack = card("Midnight Snack") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Raid — At the beginning of your end step, if you attacked this turn, create a " +
+        "Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n" +
+        "{2}{B}, Sacrifice this enchantment: Target opponent loses X life, where X is the amount " +
+        "of life you gained this turn."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouAttackedThisTurn
+        effect = Effects.CreateFood()
+        description = "At the beginning of your end step, if you attacked this turn, create a Food token."
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{B}"),
+            Costs.SacrificeSelf
+        )
+        val opponent = target("target opponent", Targets.Opponent)
+        effect = Effects.LoseLife(DynamicAmounts.lifeGainedThisTurn(), opponent)
+        description = "Target opponent loses X life, where X is the amount of life you gained this turn."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "65"
+        artist = "Kai Carpenter"
+        imageUri = "https://cards.scryfall.io/normal/front/c/9/c9b7543f-2a45-4db6-b560-d15507a58c91.jpg?1782689208"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -806,6 +806,52 @@
     ]
 }
 
+// Bloodthirsty Conqueror
+{
+    "name": "Bloodthirsty Conqueror",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Vampire Knight",
+    "oracleText": "Flying, deathtouch\nWhenever an opponent loses life, you gain that much life. (Damage causes loss of life.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING",
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "LifeLossEvent",
+                    "player": "EachOpponent"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_LIFE_LOST"
+                    }
+                },
+                "descriptionOverride": "Whenever an opponent loses life, you gain that much life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "58",
+        "rarity": "MYTHIC",
+        "artist": "Dmitry Burmak",
+        "flavorText": "\"This town swims with such exquisite blood. I will take every drop for my own.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/e/ce860ed4-a5bd-4347-9eab-dd716ea84db1.jpg?1782689215"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Boltwave
 {
     "name": "Boltwave",
@@ -2672,6 +2718,71 @@
     ]
 }
 
+// Goblin Negotiation
+{
+    "name": "Goblin Negotiation",
+    "manaCost": "{X}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Goblin Negotiation deals X damage to target creature. Create a number of 1/1 red Goblin creature tokens equal to the amount of excess damage dealt to that creature this way.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": "XValue",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "ExcessMarkedDamage"
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Goblin"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/7/0/70f8a1de-cd4c-4afa-bf03-0245d375d42e.jpg?1782727474"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "UNCOMMON",
+        "artist": "Svetlin Velinov",
+        "flavorText": "Either you pay for Krenko's \"protection\" or you pay to replace your stall. Either way, you pay.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/2/f2016585-e26c-4d13-b09f-af6383c192f7.jpg?1782689188",
+        "rulings": [
+            {
+                "date": "2024-11-15",
+                "text": "Excess damage is the amount of damage dealt to the creature beyond what was needed to be lethal. Damage already marked on the creature and any damage that would be prevented are taken into account."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Goblin Surprise
 {
     "name": "Goblin Surprise",
@@ -3969,6 +4080,90 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Midnight Snack
+{
+    "name": "Midnight Snack",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Raid — At the beginning of your end step, if you attacked this turn, create a Food token. (It's an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\n{2}{B}, Sacrifice this enchantment: Target opponent loses X life, where X is the amount of life you gained this turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Food"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "PLAYER_ATTACKED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, if you attacked this turn, create a Food token."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target opponent"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetOpponent",
+                        "id": "target opponent"
+                    }
+                ],
+                "descriptionOverride": "Target opponent loses X life, where X is the amount of life you gained this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "65",
+        "rarity": "UNCOMMON",
+        "artist": "Kai Carpenter",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/9/c9b7543f-2a45-4db6-b560-d15507a58c91.jpg?1782689208"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodthirstyConquerorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodthirstyConquerorScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.BloodthirstyConqueror
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Bloodthirsty Conqueror {3}{B}{B} — Creature — Vampire Knight 5/5
+ *   Flying, deathtouch
+ *   Whenever an opponent loses life, you gain that much life.
+ *
+ * Proves the new [com.wingedsheep.sdk.dsl.Triggers.AnOpponentLosesLife] trigger fires on both
+ * combat and non-combat life loss, and that the controller gains exactly the amount lost.
+ */
+class BloodthirstyConquerorScenarioTest : FunSpec({
+
+    // A cheap instant that makes each opponent lose 2 life — a non-combat life-loss source.
+    val DrainTwo = CardDefinition.instant(
+        name = "Drain Two",
+        manaCost = ManaCost.parse("{B}"),
+        oracleText = "Each opponent loses 2 life.",
+        script = CardScript.spell(
+            effect = LoseLifeEffect(
+                amount = DynamicAmount.Fixed(2),
+                target = EffectTarget.PlayerRef(Player.EachOpponent)
+            )
+        )
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(BloodthirstyConqueror, DrainTwo))
+        return driver
+    }
+
+    test("combat damage: opponent loses 5, you gain 5") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val conqueror = driver.putCreatureOnBattlefield(you, "Bloodthirsty Conqueror")
+        driver.removeSummoningSickness(conqueror)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(conqueror), defendingPlayer = opponent).error shouldBe null
+
+        // No blockers (opponent has none) — resolve combat damage, then the life-gain trigger.
+        driver.passPriorityUntil(Step.COMBAT_DAMAGE)
+        driver.bothPass() // combat damage: opponent 20 -> 15
+        driver.bothPass() // resolve "you gain that much life"
+
+        driver.assertLifeTotal(opponent, 15)
+        driver.assertLifeTotal(you, 25)
+    }
+
+    test("non-combat life loss: opponent loses 2, you gain exactly 2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(you, "Bloodthirsty Conqueror")
+
+        val spell = driver.putCardInHand(you, "Drain Two")
+        driver.giveMana(you, Color.BLACK, 1)
+        driver.castSpell(you, spell).isSuccess shouldBe true
+        driver.bothPass() // resolve Drain Two: opponent 20 -> 18
+        driver.bothPass() // resolve the life-gain trigger
+
+        driver.assertLifeTotal(opponent, 18)
+        driver.assertLifeTotal(you, 22)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinNegotiationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinNegotiationScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.GoblinNegotiation
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Goblin Negotiation (FDN) — {X}{R}{R} Sorcery.
+ *
+ * "Goblin Negotiation deals X damage to target creature. Create a number of 1/1 red Goblin
+ *  creature tokens equal to the amount of excess damage dealt to that creature this way."
+ *
+ * Mirrors Hell to Pay: excess = max(0, marked − toughness), read via
+ * [com.wingedsheep.sdk.scripting.values.EntityNumericProperty.ExcessMarkedDamage] in the same
+ * composite resolution — one Goblin per point of overkill.
+ */
+class GoblinNegotiationScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + GoblinNegotiation)
+        return driver
+    }
+
+    fun goblinCount(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).count { entityId ->
+            driver.state.getEntity(entityId)?.get<CardComponent>()?.name == "Goblin Token"
+        }
+
+    test("X=5 to a 2/2 → 3 excess → 3 Goblins, and the creature dies") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2
+
+        val spell = driver.putCardInHand(player, "Goblin Negotiation")
+        driver.giveMana(player, Color.RED, 2)  // {R}{R}
+        driver.giveColorlessMana(player, 5)     // X = 5
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+                xValue = 5
+            )
+        )
+        driver.bothPass()
+
+        // 5 damage to toughness 2 → 3 excess → 3 Goblins.
+        goblinCount(driver, player) shouldBe 3
+        driver.findPermanent(opponent, "Black Creature") shouldBe null
+    }
+
+    test("X exactly lethal (X=2 to a 2/2) → no excess → no Goblins") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = driver.putCreatureOnBattlefield(opponent, "Black Creature") // 2/2
+
+        val spell = driver.putCardInHand(player, "Goblin Negotiation")
+        driver.giveMana(player, Color.RED, 2)
+        driver.giveColorlessMana(player, 2)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = spell,
+                targets = listOf(ChosenTarget.Permanent(victim)),
+                xValue = 2
+            )
+        )
+        driver.bothPass()
+
+        goblinCount(driver, player) shouldBe 0
+        driver.findPermanent(opponent, "Black Creature") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MidnightSnackScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MidnightSnackScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.MidnightSnack
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Midnight Snack {2}{B} — Enchantment
+ *   Raid — At the beginning of your end step, if you attacked this turn, create a Food token.
+ *   {2}{B}, Sacrifice this enchantment: Target opponent loses X life, where X is the amount of
+ *   life you gained this turn.
+ *
+ * Proves the Raid intervening-"if" gates the Food creation, and that the sacrifice drain reads the
+ * LIFE_GAINED turn tracker (X = life gained this turn).
+ */
+class MidnightSnackScenarioTest : FunSpec({
+
+    // A cheap instant that gains 4 life — seeds the LIFE_GAINED turn tracker for the drain test.
+    val GainFourLife = CardDefinition.instant(
+        name = "Gain Four Life",
+        manaCost = ManaCost.parse("{W}"),
+        oracleText = "You gain 4 life.",
+        script = CardScript.spell(effect = GainLifeEffect(4))
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(MidnightSnack, GainFourLife) + PredefinedTokens.Food)
+        return driver
+    }
+
+    fun foodCount(driver: GameTestDriver, playerId: EntityId): Int =
+        driver.state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).count { entityId ->
+            driver.state.getEntity(entityId)?.get<CardComponent>()?.name == "Food"
+        }
+
+    test("raid active: attacked this turn → Food token at end step") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(you, "Midnight Snack")
+        val attacker = driver.putCreatureOnBattlefield(you, "Grizzly Bears")
+        driver.removeSummoningSickness(attacker)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(attacker), defendingPlayer = opponent).error shouldBe null
+
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass() // resolve the end-step raid trigger
+
+        foodCount(driver, you) shouldBe 1
+    }
+
+    test("no attack this turn: raid does nothing") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(you, "Midnight Snack")
+
+        driver.passPriorityUntil(Step.END)
+        var safety = 0
+        while (driver.stackSize > 0 && safety < 10) {
+            driver.bothPass()
+            safety++
+        }
+
+        foodCount(driver, you) shouldBe 0
+    }
+
+    test("drain: sacrifice makes target opponent lose X = life gained this turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val snack = driver.putPermanentOnBattlefield(you, "Midnight Snack")
+
+        // Gain 4 life this turn so the drain's X = 4.
+        val gain = driver.putCardInHand(you, "Gain Four Life")
+        driver.giveMana(you, Color.WHITE, 1)
+        driver.castSpell(you, gain).isSuccess shouldBe true
+        driver.bothPass()
+        driver.assertLifeTotal(you, 24)
+
+        // Activate: {2}{B}, Sacrifice this enchantment: target opponent loses 4.
+        val abilityId = MidnightSnack.activatedAbilities.first().id
+        driver.giveMana(you, Color.BLACK, 3)
+        driver.submit(
+            ActivateAbility(
+                playerId = you,
+                sourceId = snack,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Player(opponent))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass() // resolve the drain
+
+        driver.findPermanent(you, "Midnight Snack") shouldBe null // sacrificed
+        driver.assertLifeTotal(opponent, 16) // lost 4
+        driver.assertLifeTotal(you, 24)      // unchanged
+    }
+})


### PR DESCRIPTION
Implements a handful of **Foundations (FDN)** cards, each FDN-original (canonical `CardDefinition` lives directly in `fdn`). All three compose from existing SDK primitives, plus one small reusable trigger facade.

## Cards

| Card | Cost | What it does |
|------|------|--------------|
| **Midnight Snack** | `{2}{B}` Enchantment | Raid — at your end step, if you attacked, create a Food. `{2}{B}`, sac: target opponent loses X = life you gained this turn. |
| **Bloodthirsty Conqueror** | `{3}{B}{B}` 5/5 Vampire Knight | Flying, deathtouch. Whenever an opponent loses life, you gain that much life. |
| **Goblin Negotiation** | `{X}{R}{R}` Sorcery | X damage to target creature; create 1/1 red Goblins equal to the *excess* damage. |

## Implementation notes

- **Midnight Snack** — `Triggers.YourEndStep` + intervening-if `Conditions.YouAttackedThisTurn` (Raid) → `Effects.CreateFood`; activated ability with `SacrificeSelf` cost drains `DynamicAmounts.lifeGainedThisTurn()` (LIFE_GAINED tracker).
- **Bloodthirsty Conqueror** — adds a reusable **`Triggers.AnOpponentLosesLife`** facade (`LifeLossEvent(EachOpponent)`, already matched by `TriggerMatcher`); gains life read from `ContextPropertyKey.TRIGGER_LIFE_LOST`.
- **Goblin Negotiation** — mirrors Hell to Pay: `Effects.DealXDamage` then `Effects.CreateToken(count = ExcessMarkedDamage read)` in one composite resolution. No new engine work.

## Tests
- `BloodthirstyConquerorScenarioTest` — combat + non-combat life loss, exact amount gained.
- `GoblinNegotiationScenarioTest` — 5→2/2 gives 3 Goblins; exactly-lethal gives none.
- `MidnightSnackScenarioTest` — raid gate (attack vs no attack), Food creation, and the sacrifice drain.
- SDK reference (`AnOpponentLosesLife`) and the FDN card snapshot golden updated. `just build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)