### PR TITLE
Add Foundations cards: Twinblade Paladin, Goblin Smuggler, Brineborn Cutthroat

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BrinebornCutthroatReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/BrinebornCutthroatReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brineborn Cutthroat reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in M20's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BrinebornCutthroatReprint = Printing(
+    oracleId = "916cb70f-3b06-48ed-972d-75f805aa0892",
+    name = "Brineborn Cutthroat",
+    setCode = "FDN",
+    collectorNumber = "152",
+    scryfallId = "acf7aafb-931f-49e5-8691-eab8cb34b05e",
+    artist = "Caio Monteiro",
+    imageUri = "https://cards.scryfall.io/normal/front/a/c/acf7aafb-931f-49e5-8691-eab8cb34b05e.jpg?1782689135",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GoblinSmugglerReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GoblinSmugglerReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Goblin Smuggler reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in M20's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val GoblinSmugglerReprint = Printing(
+    oracleId = "eae15f7d-1f6e-4dfc-afea-7698b93cd145",
+    name = "Goblin Smuggler",
+    setCode = "FDN",
+    collectorNumber = "540",
+    scryfallId = "5837ccf1-9bac-4afb-bcc9-82c5f3c0e8e2",
+    artist = "Milivoj Ćeran",
+    imageUri = "https://cards.scryfall.io/normal/front/5/8/5837ccf1-9bac-4afb-bcc9-82c5f3c0e8e2.jpg?1782688794",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TwinbladePaladinReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TwinbladePaladinReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Twinblade Paladin reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in M20's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * FDN-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val TwinbladePaladinReprint = Printing(
+    oracleId = "d373dc71-5196-43a0-8cc5-67e2a591aad0",
+    name = "Twinblade Paladin",
+    setCode = "FDN",
+    collectorNumber = "503",
+    scryfallId = "5cd9e73d-de8d-486f-bbbd-a2f5d3f8f686",
+    artist = "Jana Schirmer",
+    imageUri = "https://cards.scryfall.io/normal/front/5/c/5cd9e73d-de8d-486f-bbbd-a2f5d3f8f686.jpg?1782688827",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BrinebornCutthroatReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/BrinebornCutthroatReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Brineborn Cutthroat reprint in Jumpstart 2022.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in M20's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * J22-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val BrinebornCutthroatReprint = Printing(
+    oracleId = "916cb70f-3b06-48ed-972d-75f805aa0892",
+    name = "Brineborn Cutthroat",
+    setCode = "J22",
+    collectorNumber = "278",
+    scryfallId = "9021592a-1170-4e8e-a9bd-3086bbc0d435",
+    artist = "Caio Monteiro",
+    imageUri = "https://cards.scryfall.io/normal/front/9/0/9021592a-1170-4e8e-a9bd-3086bbc0d435.jpg?1782699188",
+    releaseDate = "2022-12-02",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BrinebornCutthroat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/BrinebornCutthroat.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Brineborn Cutthroat
+ * {1}{U}
+ * Creature — Merfolk Pirate
+ * 2/1
+ *
+ * Flash
+ * Whenever you cast a spell during an opponent's turn, put a +1/+1 counter on this creature.
+ *
+ * The grow trigger uses [Triggers.YouCastSpell] gated by [Conditions.IsNotYourTurn] as a
+ * fire-time trigger condition, so it only fires for spells cast on a turn that isn't the
+ * controller's — the "during an opponent's turn" rider. Flash lets it be cast at instant
+ * speed to enable those responses in the first place.
+ *
+ * Canonical printing: Core Set 2020 (earliest real printing). Reprinted in Jumpstart 2022
+ * (J22 #278) and Foundations (FDN #152).
+ */
+val BrinebornCutthroat = card("Brineborn Cutthroat") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Pirate"
+    power = 2
+    toughness = 1
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Whenever you cast a spell during an opponent's turn, put a +1/+1 counter on this creature."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.YouCastSpell
+        triggerCondition = Conditions.IsNotYourTurn
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever you cast a spell during an opponent's turn, put a +1/+1 counter on this creature."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "50"
+        artist = "Caio Monteiro"
+        flavorText = "\"I always attack from where their spyglasses can't see.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/8/0857765f-afd7-418a-a93b-c0bd1b1f037e.jpg?1782708357"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GoblinSmuggler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/GoblinSmuggler.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Goblin Smuggler
+ * {2}{R}
+ * Creature — Goblin Rogue
+ * 2/2
+ *
+ * Haste
+ * {T}: Another target creature with power 2 or less can't be blocked this turn.
+ *
+ * The activated ability taps the source and grants [AbilityFlag.CANT_BE_BLOCKED] (default
+ * end-of-turn duration) to a chosen creature. "Another target creature with power 2 or less"
+ * is [TargetFilter.Creature] narrowed by `powerAtMost(2)` and `.other()` (excludes the source);
+ * the source-exclusion is enforced by the legal-target enumerator.
+ *
+ * Canonical printing: Core Set 2020 (earliest real printing). Reprinted in Foundations (FDN #540).
+ */
+val GoblinSmuggler = card("Goblin Smuggler") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Rogue"
+    power = 2
+    toughness = 2
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\n" +
+        "{T}: Another target creature with power 2 or less can't be blocked this turn."
+    keywords(Keyword.HASTE)
+
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature.powerAtMost(2).other()))
+        effect = Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, t)
+        description = "Another target creature with power 2 or less can't be blocked this turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "144"
+        artist = "Dan Murayama Scott"
+        flavorText = "\"I am but a humble traveler. I have no taste for sneakery nor thiefiness.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/5/95dc1a65-271c-455a-ae0c-f652444a53ac.jpg?1782708292"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/TwinbladePaladin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/m20/cards/TwinbladePaladin.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.m20.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Twinblade Paladin
+ * {3}{W}
+ * Creature — Human Knight
+ * 3/3
+ *
+ * Whenever you gain life, put a +1/+1 counter on this creature.
+ * As long as you have 25 or more life, this creature has double strike.
+ *
+ * The grow trigger uses [Triggers.YouGainLife] (fires once per life-gain event) placing a
+ * single +1/+1 counter on the source. The double-strike buff is a conditional [staticAbility]
+ * gated on [Conditions.LifeAtLeast] (25) granting [Keyword.DOUBLE_STRIKE] to the source; it is
+ * projected through the layer system so it turns on and off as the controller's life crosses 25.
+ *
+ * Canonical printing: Core Set 2020 (earliest real printing). Reprinted in Foundations (FDN #503).
+ */
+val TwinbladePaladin = card("Twinblade Paladin") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 3
+    toughness = 3
+    oracleText = "Whenever you gain life, put a +1/+1 counter on this creature.\n" +
+        "As long as you have 25 or more life, this creature has double strike. " +
+        "(It deals both first-strike and regular combat damage.)"
+
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        description = "Whenever you gain life, put a +1/+1 counter on this creature."
+    }
+
+    staticAbility {
+        condition = Conditions.LifeAtLeast(25)
+        ability = GrantKeyword(Keyword.DOUBLE_STRIKE, Filters.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "285"
+        artist = "Jana Schirmer"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/6397d426-00e0-44da-b23c-44ccea65f5aa.jpg?1782708196"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/M20.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/M20.json
@@ -57,6 +57,48 @@
     ]
 }
 
+// Brineborn Cutthroat
+{
+    "name": "Brineborn Cutthroat",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Pirate",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nWhenever you cast a spell during an opponent's turn, put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "SpellCastEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": "IsNotYourTurn",
+                "descriptionOverride": "Whenever you cast a spell during an opponent's turn, put a +1/+1 counter on this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "50",
+        "rarity": "UNCOMMON",
+        "artist": "Caio Monteiro",
+        "flavorText": "\"I always attack from where their spyglasses can't see.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/8/0857765f-afd7-418a-a93b-c0bd1b1f037e.jpg?1782708357"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Devout Decree
 {
     "name": "Devout Decree",
@@ -184,6 +226,57 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Goblin Smuggler
+{
+    "name": "Goblin Smuggler",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Rogue",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\n{T}: Another target creature with power 2 or less can't be blocked this turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "CANT_BE_BLOCKED",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature pow<=2",
+                            "excludeSelf": true
+                        },
+                        "id": "target"
+                    }
+                ],
+                "descriptionOverride": "Another target creature with power 2 or less can't be blocked this turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "144",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "\"I am but a humble traveler. I have no taste for sneakery nor thiefiness.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/5/95dc1a65-271c-455a-ae0c-f652444a53ac.jpg?1782708292"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -536,6 +629,68 @@
         "artist": "Cristi Balanescu",
         "flavorText": "The strength of the one is the strength of the many.",
         "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd7d6112-ffb2-41d8-98ed-1a7b22841dfd.jpg"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Twinblade Paladin
+{
+    "name": "Twinblade Paladin",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Whenever you gain life, put a +1/+1 counter on this creature.\nAs long as you have 25 or more life, this creature has double strike. (It deals both first-strike and regular combat damage.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Whenever you gain life, put a +1/+1 counter on this creature."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DOUBLE_STRIKE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "LifeTotal",
+                        "player": "You"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 25
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "285",
+        "rarity": "UNCOMMON",
+        "artist": "Jana Schirmer",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/6397d426-00e0-44da-b23c-44ccea65f5aa.jpg?1782708196"
     },
     "colorIdentityOverride": [
         "WHITE"

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrinebornCutthroatScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrinebornCutthroatScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Brineborn Cutthroat ({1}{U}, 2/1 Merfolk Pirate, Flash).
+ *
+ * Whenever you cast a spell during an opponent's turn, put a +1/+1 counter on this creature.
+ *
+ * Verifies the [com.wingedsheep.sdk.dsl.Triggers.YouCastSpell] trigger gated by
+ * [com.wingedsheep.sdk.dsl.Conditions.IsNotYourTurn]: it grows only when its controller casts
+ * a spell on a turn that isn't theirs, and stays put for spells cast on their own turn.
+ */
+class BrinebornCutthroatScenarioTest : ScenarioTestBase() {
+
+    // A {0} instant used to represent "casting a spell". Flash-timed by nature (instant).
+    private val flashProbe = card("Flash Probe") {
+        manaCost = "{0}"
+        typeLine = "Instant"
+        oracleText = "You gain 1 life."
+        spell {
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    init {
+        cardRegistry.register(flashProbe)
+
+        context("Brineborn Cutthroat") {
+
+            test("grows when you cast a spell during an opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Brineborn Cutthroat")
+                    .withCardInHand(1, "Flash Probe")
+                    .withActivePlayer(2) // opponent's turn
+                    .withPriorityPlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cutthroat = game.findPermanent("Brineborn Cutthroat")!!
+                withClue("base 2/1 before casting") {
+                    game.state.projectedState.getPower(cutthroat) shouldBe 2
+                    game.state.projectedState.getToughness(cutthroat) shouldBe 1
+                }
+
+                game.castSpell(1, "Flash Probe").error shouldBe null
+                game.resolveStack()
+
+                withClue("casting on the opponent's turn adds a +1/+1 counter → 3/2") {
+                    game.state.projectedState.getPower(cutthroat) shouldBe 3
+                    game.state.projectedState.getToughness(cutthroat) shouldBe 2
+                }
+            }
+
+            test("does not grow when you cast a spell during your own turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Brineborn Cutthroat")
+                    .withCardInHand(1, "Flash Probe")
+                    .withActivePlayer(1) // your own turn
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cutthroat = game.findPermanent("Brineborn Cutthroat")!!
+
+                game.castSpell(1, "Flash Probe").error shouldBe null
+                game.resolveStack()
+
+                withClue("casting on your own turn does not trigger — stays 2/1") {
+                    game.state.projectedState.getPower(cutthroat) shouldBe 2
+                    game.state.projectedState.getToughness(cutthroat) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinSmugglerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinSmugglerScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.m20.cards.GoblinSmuggler
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Goblin Smuggler ({2}{R}, 2/2 Goblin Rogue, Haste).
+ *
+ * {T}: Another target creature with power 2 or less can't be blocked this turn.
+ *
+ * Verifies the tap-activated ability grants [AbilityFlag.CANT_BE_BLOCKED] to a legal target,
+ * that the power-2-or-less restriction rejects a bigger creature, and that "another" excludes
+ * the Smuggler itself.
+ */
+class GoblinSmugglerScenarioTest : ScenarioTestBase() {
+
+    private val abilityId = GoblinSmuggler.activatedAbilities.first().id
+
+    init {
+        context("Goblin Smuggler") {
+
+            test("grants can't-be-blocked to another creature with power 2 or less") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Goblin Smuggler", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val smuggler = game.findPermanent("Goblin Smuggler")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Grizzly Bears is not evasive before the ability") {
+                    game.state.projectedState.hasKeyword(bears, AbilityFlag.CANT_BE_BLOCKED) shouldBe false
+                }
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = smuggler,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("activating targeting a power-2 creature is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the targeted creature can't be blocked this turn") {
+                    game.state.projectedState.hasKeyword(bears, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+                }
+            }
+
+            test("legal targets are power-2-or-less creatures, excluding itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Goblin Smuggler", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // power 2 → eligible
+                    .withCardOnBattlefield(2, "Hill Giant") // power 3 → too big
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val smuggler = game.findPermanent("Goblin Smuggler")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val ability = game.getLegalActions(1).single { info ->
+                    val act = info.action
+                    act is ActivateAbility && act.sourceId == smuggler && act.abilityId == abilityId
+                }
+                val validTargets = ability.validTargets ?: emptyList()
+
+                withClue("power-2 Grizzly Bears is a legal target: $validTargets") {
+                    (bears in validTargets) shouldBe true
+                }
+                withClue("power-3 Hill Giant exceeds 'power 2 or less': $validTargets") {
+                    (giant in validTargets) shouldBe false
+                }
+                withClue("'another' excludes the Smuggler itself: $validTargets") {
+                    (smuggler in validTargets) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TwinbladePaladinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TwinbladePaladinScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Twinblade Paladin ({3}{W}, 3/3 Human Knight).
+ *
+ * - Whenever you gain life, put a +1/+1 counter on this creature.
+ * - As long as you have 25 or more life, this creature has double strike.
+ *
+ * Verifies the [com.wingedsheep.sdk.dsl.Triggers.YouGainLife] grow trigger and the
+ * [com.wingedsheep.sdk.dsl.Conditions.LifeAtLeast] (25) conditional double-strike static
+ * ability, which turns on and off as the controller's life crosses the threshold.
+ */
+class TwinbladePaladinScenarioTest : ScenarioTestBase() {
+
+    // A {0} sorcery that makes its controller gain 3 life — a clean way to fire a life-gain event.
+    private val gainThreeLife = card("Gain Three Life") {
+        manaCost = "{0}"
+        typeLine = "Sorcery"
+        oracleText = "You gain 3 life."
+        spell {
+            effect = Effects.GainLife(3)
+        }
+    }
+
+    init {
+        cardRegistry.register(gainThreeLife)
+
+        context("Twinblade Paladin") {
+
+            test("gaining life puts a +1/+1 counter on it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Twinblade Paladin")
+                    .withCardInHand(1, "Gain Three Life")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val paladin = game.findPermanent("Twinblade Paladin")!!
+                withClue("base 3/3 before any life gain") {
+                    game.state.projectedState.getPower(paladin) shouldBe 3
+                    game.state.projectedState.getToughness(paladin) shouldBe 3
+                }
+
+                game.castSpell(1, "Gain Three Life").error shouldBe null
+                game.resolveStack()
+
+                withClue("gaining 3 life → one +1/+1 counter → 4/4") {
+                    game.getLifeTotal(1) shouldBe 23
+                    game.state.projectedState.getPower(paladin) shouldBe 4
+                    game.state.projectedState.getToughness(paladin) shouldBe 4
+                }
+            }
+
+            test("no double strike below 25 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Twinblade Paladin")
+                    .withLifeTotal(1, 24)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val paladin = game.findPermanent("Twinblade Paladin")!!
+                withClue("24 life is below the 25-life threshold") {
+                    game.state.projectedState.hasKeyword(paladin, Keyword.DOUBLE_STRIKE) shouldBe false
+                }
+            }
+
+            test("double strike at 25 or more life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Twinblade Paladin")
+                    .withLifeTotal(1, 25)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val paladin = game.findPermanent("Twinblade Paladin")!!
+                withClue("25 life meets the threshold → double strike is granted") {
+                    game.state.projectedState.hasKeyword(paladin, Keyword.DOUBLE_STRIKE) shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements a handful of cards from **Foundations (FDN)** via the `add-card` skill. All three were first printed in **Core Set 2020**, so per the reprint rules the canonical `CardDefinition` lives in **M20** (earliest real printing) and the newer sets get `Printing` rows:

| Card | Canonical | Reprint rows |
|------|-----------|--------------|
| Twinblade Paladin `{3}{W}` 3/3 | M20 #285 | FDN #503 |
| Goblin Smuggler `{2}{R}` 2/2 | M20 #144 | FDN #540 |
| Brineborn Cutthroat `{1}{U}` 2/1 | M20 #50 | FDN #152, J22 #278 |

All three compose entirely from existing SDK primitives — **no engine/SDK changes**.

## Implementation notes

- **Twinblade Paladin** — `Triggers.YouGainLife` → `Effects.AddCounters(+1/+1)`; a `ConditionalStaticAbility` gated on `Conditions.LifeAtLeast(25)` grants `Keyword.DOUBLE_STRIKE`, projected so it toggles as life crosses the threshold.
- **Goblin Smuggler** — Haste; `{T}` activated ability grants `AbilityFlag.CANT_BE_BLOCKED` (end of turn) to `TargetFilter.Creature.powerAtMost(2).other()`. The "another" (source-exclusion) is enforced by the legal-target enumerator.
- **Brineborn Cutthroat** — Flash; `Triggers.YouCastSpell` with `triggerCondition = Conditions.IsNotYourTurn` puts a +1/+1 counter on it when you cast a spell on an opponent's turn.

## Tests

Scenario test per card (rules-engine):
- Twinblade: life-gain grows it; double strike off at 24 life / on at 25.
- Goblin Smuggler: grants can't-be-blocked; legal-target enumeration includes a power-2 creature and excludes both a power-3 creature and itself.
- Brineborn: grows on an opponent's-turn cast, no growth on your own turn.

Re-blessed the M20 card-snapshot golden (only the three new card trees added). `just build` green; `check-card-printing` clean for all three.