### PR TITLE
Add Terra, Magical Adept (FIN) + AddCountersUpTo + token-copy-of-Saga entry

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -441,3 +441,29 @@ stale on both:
   primitive is general: `firstFlipEachTurn = false` gives a plain "you win all coin flips". Covered by
   `EdgarKingOfFigaroScenarioTest` (forced first-flip win via The Gold Saucer, the once-per-turn gate,
   and the artifact-count ETB draw).
+
+## Implementation pass — 2026-07-05 (Terra, Magical Adept + two engine additions)
+
+- **Terra, Magical Adept // Esper Terra** — implemented (295/300). The front ETB (mill five, put up to
+  one enchantment milled this way into hand) and the Trance `ExileAndReturnTransformed` into the Esper
+  Terra Summon-Saga back are pure authoring (CacheGrab / Clive-Ifrit precedents). Chapter IV (`AddMana`
+  ×5 colors + `ExileAndReturnTransformed(FRONT)`) is authoring too; it exile-returns front face up before
+  the CR 714.4 final-chapter sacrifice applies, like the Dominant eikons. Two small, reusable engine
+  additions unblocked chapters I–III:
+  - **`AddCountersUpTo(counterType, max, target)`** (`Effects.AddCountersUpTo`) — the additive,
+    single-kind, player-chosen mirror of `RemoveAnyNumberOfCounters`: one `ChooseNumberDecision` (0..max),
+    then placement through the normal `AddCounters` chokepoint (honors placement replacements + Saga
+    chapter triggers). Chapter I–III's "if it's a Saga, put up to three lore counters on it" composes as
+    `ConditionalEffect(CollectionContainsMatch(CREATED_TOKENS, Enchantment.withSubtype(SAGA)),
+    AddCountersUpTo(LORE, 3, PipelineTarget(CREATED_TOKENS)))`. mtgish bridge: `UptoNumberCountersOfTypeOnPermanent`
+    → `AddCountersUpTo` (capability-only; player-choice shape stays SCAFFOLD). Tested by
+    `AddCountersUpToScenarioTest`.
+  - **Token copies of a Saga now enter as Sagas (CR 714.2b/714.3a)** — the `CreateTokenCopyOf*` executors
+    (target/source/chosen/equipped) route through the shared `ZoneMovementUtils.applySagaEntryIfNeeded`
+    hook (`BattlefieldEntry.place`, the ad-hoc insertion path, skips enters-with-counters setup), so a
+    token copy of a Saga gains a `SagaComponent`, its on-enter lore counter (chapter I triggers), and
+    accrues lore each turn. Previously such tokens were inert. Tested by `TokenCopyOfSagaEntryScenarioTest`
+    (generally) and `TerraMagicalAdeptScenarioTest` (via the card). Covered by `TerraMagicalAdeptScenarioTest`
+    (ETB mill-take, Trance transform, chapter copy with/without the Saga lore prompt).
+- Remaining missing FIN cards (5): Emet-Selch, Unsundered; Esper Origins; Gogo, Master of Mimicry;
+  Ultima, Origin of Oblivion; Zenos yae Galvus — all still `add-feature` scope (see Tier-3 above).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -654,6 +654,14 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 
 - `AddCounters(type, count, target)` — add N counters of `type`.
 - `AddDynamicCounters(type, amount, target)` — count is computed at resolution.
+- `AddCountersUpTo(type, max, target)` — the effect's controller **chooses** how many (0 up to `max`, a
+  `DynamicAmount` so "up to X" works) counters of `type` to put on the target, via one `ChooseNumberDecision`
+  at resolution. The additive, single-kind mirror of `RemoveAnyNumberOfCounters` / `RemoveCountersUpTo`;
+  placement goes through the normal `AddCounters` chokepoint, so counter-placement replacements (Hardened
+  Scales) and downstream triggers (Saga chapter abilities off lore counters) fire. No-op when the target
+  can't receive counters or `max` ≤ 0; choosing 0 places none. Esper Terra's "if it's a Saga, put up to three
+  lore counters on it" = `ConditionalEffect(CollectionContainsMatch(CREATED_TOKENS, Enchantment.withSubtype(SAGA)),
+  AddCountersUpTo(Counters.LORE, 3, PipelineTarget(CREATED_TOKENS)))`.
 - **Stat counters and the layer system.** Counters whose `type` is a P/T stat counter modify power/toughness in
   layer 7c (CR 613.4c) via `EffectApplicator.applyCounters`. The symmetric pair is `Counters.PLUS_ONE_PLUS_ONE` /
   `Counters.MINUS_ONE_MINUS_ONE`; the asymmetric counters `Counters.PLUS_ONE_PLUS_ZERO` (`+1/+0`),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -23,6 +23,7 @@ import com.wingedsheep.sdk.scripting.effects.AddCardTypeEffect
 import com.wingedsheep.sdk.scripting.effects.CantBeRegeneratedEffect
 import com.wingedsheep.sdk.scripting.effects.OpenLifeBidEffect
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.AddCountersUpToEffect
 import com.wingedsheep.sdk.scripting.effects.AddDynamicCountersEffect
 import com.wingedsheep.sdk.scripting.effects.MoveAllLastKnownCountersEffect
 import com.wingedsheep.sdk.scripting.effects.AddSubtypeEffect
@@ -1441,6 +1442,18 @@ object Effects {
      */
     fun AddDynamicCounters(counterType: String, amount: DynamicAmount, target: EffectTarget): Effect =
         AddDynamicCountersEffect(counterType, amount, target)
+
+    /**
+     * Put a player-chosen number (0 up to [max]) of a single kind of counter on a target.
+     * "Put up to N [counterType] counters on target" — the additive mirror of
+     * [Effects.RemoveCountersUpTo] / [RemoveAnyNumberOfCountersEffect].
+     */
+    fun AddCountersUpTo(counterType: String, max: Int, target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
+        AddCountersUpToEffect(counterType, DynamicAmount.Fixed(max), target)
+
+    /** [AddCountersUpTo] with a dynamic ceiling ("put up to X counters"). */
+    fun AddCountersUpTo(counterType: String, max: DynamicAmount, target: EffectTarget = EffectTarget.ContextTarget(0)): Effect =
+        AddCountersUpToEffect(counterType, max, target)
 
     /**
      * Put every counter that was on the triggering source onto a target.

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CounterEffects.kt
@@ -46,6 +46,33 @@ data class AddDynamicCountersEffect(
 }
 
 /**
+ * Put a player-chosen number (0 up to [max]) of a single kind of counter on a target.
+ * "Put up to three lore counters on it." (Esper Terra) — "Put up to two +1/+1 counters on
+ * target creature."
+ *
+ * The additive, single-kind mirror of [RemoveAnyNumberOfCountersEffect]: at resolution the
+ * executor prompts the effect's controller with one `ChooseNumberDecision` (0..[max], evaluated
+ * once at resolution) and then places that many [counterType] counters on the target through the
+ * standard counter-placement chokepoint — so counter-placement replacement effects (Hardened
+ * Scales) and downstream triggers (Saga chapter abilities off lore counters) fire normally.
+ * No-op when the target can't receive counters or [max] resolves to <= 0. Choosing 0 places none.
+ *
+ * @property counterType Which counter kind to place (e.g. [com.wingedsheep.sdk.core.Counters.LORE]).
+ * @property max Ceiling on the controller's choice (a [DynamicAmount] so "up to X" is expressible).
+ * @property target The permanent to put counters on.
+ */
+@SerialName("AddCountersUpTo")
+@Serializable
+data class AddCountersUpToEffect(
+    val counterType: String,
+    val max: DynamicAmount,
+    val target: EffectTarget = EffectTarget.ContextTarget(0)
+) : Effect {
+    override val description: String =
+        "Put up to ${max.description} $counterType counter${if (max is DynamicAmount.Fixed && max.amount == 1) "" else "s"} on ${target.description}"
+}
+
+/**
  * Put all counters that were on the triggering source onto a target.
  * "When this creature dies, put its counters on target creature you control."
  *

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TerraMagicalAdept.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/TerraMagicalAdept.kt
@@ -1,0 +1,183 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CREATED_TOKENS
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.ReturnFace
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Terra, Magical Adept // Esper Terra (Final Fantasy #245)
+ * {1}{R}{G} — Legendary Creature — Human Wizard Warrior 4/2
+ * //  — Legendary Enchantment Creature — Saga Wizard 6/6 (Flying)
+ *
+ * Front — Terra, Magical Adept:
+ *   When Terra enters, mill five cards. Put up to one enchantment card milled this way into your hand.
+ *   Trance — {4}{R}{G}, {T}: Exile Terra, then return it to the battlefield transformed under its
+ *   owner's control. Activate only as a sorcery.
+ *
+ * Back — Esper Terra (a Summon-style Saga creature):
+ *   (As this Saga enters and after your draw step, add a lore counter.)
+ *   I, II, III — Create a token that's a copy of target nonlegendary enchantment you control. It gains
+ *   haste. If it's a Saga, put up to three lore counters on it. Sacrifice it at the beginning of your
+ *   next end step.
+ *   IV — Add {W}{W}, {U}{U}, {B}{B}, {R}{R}, and {G}{G}. Exile Esper Terra, then return it to the
+ *   battlefield (front face up).
+ *
+ * The chapter I–III copy is composed from atoms: `CreateTokenCopyOfTarget` (haste via addedKeywords,
+ * sacrifice at the controller's next end step via sacrificeAtStep) publishes the token into
+ * `CREATED_TOKENS`; a `ConditionalEffect` gated on that collection containing a Saga then runs
+ * `AddCountersUpTo(LORE, 3, …)` so the controller may advance the copied Saga's chapters. Chapter IV
+ * exile-returns Esper Terra front face up before the CR 714.4 final-chapter sacrifice applies (the
+ * chapter is on the stack when lore reaches four, and on resolution the permanent is no longer a Saga),
+ * mirroring the Dominant eikon backs — so no sacrifice-opt-out flag is needed.
+ *
+ * A token copy of a Saga made by chapter I–III enters as a Saga with CR 714.2b's on-enter lore counter
+ * (its chapter I triggers) — the token-copy executors route through the shared
+ * `ZoneMovementUtils.applySagaEntryIfNeeded` Saga-entry hook, so the "put up to three lore counters"
+ * clause stacks on top of that starting counter.
+ */
+
+// Shared chapter I–III effect, parameterized on the chosen target enchantment.
+private fun copyChapterEffect(chosen: EffectTarget): Effect = Effects.Composite(
+    Effects.CreateTokenCopyOfTarget(
+        target = chosen,
+        addedKeywords = setOf(Keyword.HASTE),
+        // "Sacrifice it at the beginning of your next end step."
+        sacrificeAtStep = Step.END,
+        sacrificeOnlyOnControllersTurn = true,
+    ),
+    // "If it's a Saga, put up to three lore counters on it." The created token is in CREATED_TOKENS;
+    // gate on it being a Saga, then let the controller choose 0..3 lore counters (advancing its
+    // chapters). Copying a non-Saga enchantment offers no lore prompt.
+    ConditionalEffect(
+        condition = Conditions.CollectionContainsMatch(
+            CREATED_TOKENS,
+            GameObjectFilter.Enchantment.withSubtype(Subtype.SAGA),
+        ),
+        effect = Effects.AddCountersUpTo(Counters.LORE, 3, EffectTarget.PipelineTarget(CREATED_TOKENS, 0)),
+    ),
+)
+
+private val EsperTerra = card("Esper Terra") {
+    manaCost = ""
+    colorIdentity = "WUBRG"
+    typeLine = "Legendary Enchantment Creature — Saga Wizard"
+    oracleText = "(As this Saga enters and after your draw step, add a lore counter.)\n" +
+        "I, II, III — Create a token that's a copy of target nonlegendary enchantment you control. " +
+        "It gains haste. If it's a Saga, put up to three lore counters on it. Sacrifice it at the " +
+        "beginning of your next end step.\n" +
+        "IV — Add {W}{W}, {U}{U}, {B}{B}, {R}{R}, and {G}{G}. Exile Esper Terra, then return it to " +
+        "the battlefield (front face up)."
+    power = 6
+    toughness = 6
+    keywords(Keyword.FLYING)
+
+    // I, II, III — copy a nonlegendary enchantment you control.
+    for (chapter in 1..3) {
+        sagaChapter(chapter) {
+            val enchantment = target(
+                "enchantment",
+                TargetObject(filter = TargetFilter.Enchantment.youControl().nonlegendary()),
+            )
+            effect = copyChapterEffect(enchantment)
+        }
+    }
+
+    // IV — Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, then exile Esper Terra and return it front face up.
+    sagaChapter(4) {
+        effect = Effects.Composite(
+            Effects.AddMana(Color.WHITE, 2),
+            Effects.AddMana(Color.BLUE, 2),
+            Effects.AddMana(Color.BLACK, 2),
+            Effects.AddMana(Color.RED, 2),
+            Effects.AddMana(Color.GREEN, 2),
+            Effects.ExileAndReturnTransformed(EffectTarget.Self, ReturnFace.FRONT),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "245"
+        artist = "Clare Wong"
+        imageUri = "https://cards.scryfall.io/normal/back/f/b/fbd447aa-588d-4c4d-925e-a7d3bdf6a65c.jpg?1782686407"
+        ruling("2025-06-06", "Esper Terra's fourth chapter ability isn't a mana ability. It uses the stack and can be responded to.")
+        ruling("2025-06-06", "The token copies exactly what was printed on the original enchantment. It doesn't copy counters, Auras/Equipment, or non-copy effects. If the copied enchantment has {X} in its mana cost, X is 0.")
+    }
+}
+
+private val TerraMagicalAdeptFront = card("Terra, Magical Adept") {
+    manaCost = "{1}{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Human Wizard Warrior"
+    oracleText = "When Terra enters, mill five cards. Put up to one enchantment card milled this way " +
+        "into your hand.\n" +
+        "Trance — {4}{R}{G}, {T}: Exile Terra, then return it to the battlefield transformed under " +
+        "its owner's control. Activate only as a sorcery."
+    power = 4
+    toughness = 2
+
+    // When Terra enters, mill five cards. Put up to one enchantment card milled this way into hand.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.mill(5),
+            SelectFromCollectionEffect(
+                from = "milled",
+                selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                filter = GameObjectFilter.Enchantment,
+                storeSelected = "selected",
+                showAllCards = true,
+                prompt = "You may put an enchantment card milled this way into your hand",
+                selectedLabel = "Put in hand",
+                remainderLabel = "Leave in graveyard",
+            ),
+            MoveCollectionEffect(
+                from = "selected",
+                destination = CardDestination.ToZone(Zone.HAND),
+            ),
+        )
+    }
+
+    // Trance — {4}{R}{G}, {T}: Exile Terra, then return it transformed. Activate only as a sorcery.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{R}{G}"), Costs.Tap)
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.ExileAndReturnTransformed()
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "245"
+        artist = "Clare Wong"
+        imageUri = "https://cards.scryfall.io/normal/front/f/b/fbd447aa-588d-4c4d-925e-a7d3bdf6a65c.jpg?1782686407"
+    }
+}
+
+val TerraMagicalAdept: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = TerraMagicalAdeptFront,
+    backFace = EsperTerra,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -20721,6 +20721,374 @@
     ]
 }
 
+// Terra, Magical Adept
+{
+    "name": "Terra, Magical Adept",
+    "manaCost": "{1}{R}{G}",
+    "typeLine": "Legendary Creature — Human Wizard Warrior",
+    "oracleText": "When Terra enters, mill five cards. Put up to one enchantment card milled this way into your hand.\nTrance — {4}{R}{G}, {T}: Exile Terra, then return it to the battlefield transformed under its owner's control. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 5
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "milled",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "enchantment",
+                            "storeSelected": "selected",
+                            "prompt": "You may put an enchantment card milled this way into your hand",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Leave in graveyard",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "selected",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}{G}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": "ExileAndReturnTransformed",
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Esper Terra",
+        "manaCost": "",
+        "typeLine": "Legendary Enchantment Creature — Saga Wizard",
+        "oracleText": "(As this Saga enters and after your draw step, add a lore counter.)\nI, II, III — Create a token that's a copy of target nonlegendary enchantment you control. It gains haste. If it's a Saga, put up to three lore counters on it. Sacrifice it at the beginning of your next end step.\nIV — Add {W}{W}, {U}{U}, {B}{B}, {R}{R}, and {G}{G}. Exile Esper Terra, then return it to the battlefield (front face up).",
+        "creatureStats": {
+            "power": 6,
+            "toughness": 6
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "sagaChapters": [
+                {
+                    "chapter": 1,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "CreateTokenCopyOfTarget",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "enchantment"
+                                },
+                                "addedKeywords": [
+                                    "HASTE"
+                                ],
+                                "sacrificeAtStep": "END",
+                                "sacrificeOnlyOnControllersTurn": true
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "CollectionContainsMatch",
+                                        "collection": "createdTokens",
+                                        "filter": "enchantment Saga"
+                                    }
+                                },
+                                "then": {
+                                    "type": "AddCountersUpTo",
+                                    "counterType": "lore",
+                                    "max": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    },
+                                    "target": {
+                                        "type": "PipelineTarget",
+                                        "collectionName": "createdTokens"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsEnchantment",
+                                    "IsNonlegendary"
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "enchantment"
+                    }
+                },
+                {
+                    "chapter": 2,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "CreateTokenCopyOfTarget",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "enchantment"
+                                },
+                                "addedKeywords": [
+                                    "HASTE"
+                                ],
+                                "sacrificeAtStep": "END",
+                                "sacrificeOnlyOnControllersTurn": true
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "CollectionContainsMatch",
+                                        "collection": "createdTokens",
+                                        "filter": "enchantment Saga"
+                                    }
+                                },
+                                "then": {
+                                    "type": "AddCountersUpTo",
+                                    "counterType": "lore",
+                                    "max": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    },
+                                    "target": {
+                                        "type": "PipelineTarget",
+                                        "collectionName": "createdTokens"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsEnchantment",
+                                    "IsNonlegendary"
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "enchantment"
+                    }
+                },
+                {
+                    "chapter": 3,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "CreateTokenCopyOfTarget",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "enchantment"
+                                },
+                                "addedKeywords": [
+                                    "HASTE"
+                                ],
+                                "sacrificeAtStep": "END",
+                                "sacrificeOnlyOnControllersTurn": true
+                            },
+                            {
+                                "type": "Gated",
+                                "gate": {
+                                    "type": "Gate.WhenCondition",
+                                    "condition": {
+                                        "type": "CollectionContainsMatch",
+                                        "collection": "createdTokens",
+                                        "filter": "enchantment Saga"
+                                    }
+                                },
+                                "then": {
+                                    "type": "AddCountersUpTo",
+                                    "counterType": "lore",
+                                    "max": {
+                                        "type": "Fixed",
+                                        "amount": 3
+                                    },
+                                    "target": {
+                                        "type": "PipelineTarget",
+                                        "collectionName": "createdTokens"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsEnchantment",
+                                    "IsNonlegendary"
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "enchantment"
+                    }
+                },
+                {
+                    "chapter": 4,
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddMana",
+                                "color": "WHITE",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "AddMana",
+                                "color": "BLUE",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "AddMana",
+                                "color": "BLACK",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "AddMana",
+                                "color": "RED",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "AddMana",
+                                "color": "GREEN",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            {
+                                "type": "ExileAndReturnTransformed",
+                                "returnAs": "FRONT"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "245",
+            "rarity": "MYTHIC",
+            "artist": "Clare Wong",
+            "imageUri": "https://cards.scryfall.io/normal/back/f/b/fbd447aa-588d-4c4d-925e-a7d3bdf6a65c.jpg?1782686407",
+            "rulings": [
+                {
+                    "date": "2025-06-06",
+                    "text": "Esper Terra's fourth chapter ability isn't a mana ability. It uses the stack and can be responded to."
+                },
+                {
+                    "date": "2025-06-06",
+                    "text": "The token copies exactly what was printed on the original enchantment. It doesn't copy counters, Auras/Equipment, or non-copy effects. If the copied enchantment has {X} in its mana cost, X is 0."
+                }
+            ]
+        },
+        "colorIdentityOverride": [
+            "WHITE",
+            "BLUE",
+            "BLACK",
+            "RED",
+            "GREEN"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "245",
+        "rarity": "MYTHIC",
+        "artist": "Clare Wong",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/b/fbd447aa-588d-4c4d-925e-a7d3bdf6a65c.jpg?1782686407"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
 // The Crystal's Chosen
 {
     "name": "The Crystal's Chosen",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -46,6 +46,12 @@ internal fun BridgeBuilder.manaCountersAndState() {
     envelope("PutCounters", "put-counter envelope — the real action is the nested _PutCountersAction variant")
     // "Put a / N +1/+1 (or keyword) counter(s) on <permanent>" -> AddCounters / AddDynamicCounters.
     effects("ACounterOfTypeOnPermanent", "NumberCountersOfTypeOnPermanent", tag = "AddCounters", note = UNIVERSAL)
+    // "Put up to N counters of a type on <permanent>" (Esper Terra's lore chapters) -> AddCountersUpTo,
+    // the additive/player-chosen mirror of the RemoveAnyNumberOfCounters family. Capability-only: the
+    // put-up-to-N shape is a value-selection prompt the emitter declines to render (-> SCAFFOLD), per
+    // the module's "chosen values" policy.
+    effect("UptoNumberCountersOfTypeOnPermanent", "AddCountersUpTo",
+        "put up to N counters of a type on a permanent — player chooses 0..N (Esper Terra)")
     // "Put a / N counter(s) on each <filter>" — the mass form, ForEachInGroup(AddCounters) over the
     // recovered group filter or the just-created tokens (Bounding Felidar, Germination Practicum).
     composed("ACounterOfTypeOnEachPermanent", "ForEachInGroup(AddCounters) over a group filter",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/CardSpecificContinuations.kt
@@ -186,6 +186,26 @@ data class RemoveAnyNumberOfCountersContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the controller picks how many counters (0..max) to put on a target, for
+ * `AddCountersUpToEffect` ("Put up to N [counterType] counters on target" — Esper Terra's lore
+ * chapters). The chosen count is placed through the standard `AddCountersEffect` path so
+ * counter-placement replacements and downstream (Saga chapter) triggers fire. Choosing 0 is a no-op.
+ *
+ * @property targetId The permanent to put counters on
+ * @property controllerId The player who made the choice
+ * @property counterType The counter kind to place
+ * @property sourceId Source emitting the effect (for the placement context)
+ */
+@Serializable
+data class AddCountersUpToContinuation(
+    override val decisionId: String,
+    val targetId: EntityId,
+    val controllerId: EntityId,
+    val counterType: String,
+    val sourceId: EntityId?
+) : ContinuationFrame
+
+/**
  * Resume after the controller picks how many counters of one kind to move from a
  * [sourceId] permanent onto a [destinationId] permanent. The executor for
  * `MoveChosenCountersToTargetEffect` issues one decision per counter kind on the source;

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -271,6 +271,7 @@ val engineSerializersModule = SerializersModule {
         subclass(TypecycleSearchContinuation::class)
         subclass(DistributeCountersContinuation::class)
         subclass(RemoveAnyNumberOfCountersContinuation::class)
+        subclass(AddCountersUpToContinuation::class)
         subclass(MoveChosenCountersToTargetContinuation::class)
         subclass(ProliferateContinuation::class)
         subclass(RingTemptContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -30,6 +30,7 @@ class MiscContinuationResumer(
         resumer(CopyActivatedAbilityTargetContinuation::class, ::resumeCopyActivatedAbilityTarget),
         resumer(DistributeCountersContinuation::class, ::resumeDistributeCounters),
         resumer(RemoveAnyNumberOfCountersContinuation::class, ::resumeRemoveAnyNumberOfCounters),
+        resumer(AddCountersUpToContinuation::class, ::resumeAddCountersUpTo),
         resumer(ConvertCountersToTokensContinuation::class, ::resumeConvertCountersToTokens),
         resumer(MoveChosenCountersToTargetContinuation::class, ::resumeMoveChosenCountersToTarget),
         resumer(ProliferateContinuation::class, ::resumeProliferate),
@@ -110,6 +111,41 @@ class MiscContinuationResumer(
         if (!stackResult.isSuccess) return stackResult
 
         return checkForMore(stackResult.newState, stackResult.events)
+    }
+
+    private fun resumeAddCountersUpTo(
+        state: GameState,
+        continuation: AddCountersUpToContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is NumberChosenResponse) {
+            return ExecutionResult.error(state, "Expected number chosen response for AddCountersUpTo")
+        }
+
+        val chosen = response.number
+        if (chosen <= 0) {
+            return checkForMore(state, emptyList())
+        }
+
+        // Place the chosen counters through the standard AddCountersEffect path so
+        // counter-placement replacement effects and downstream (Saga chapter) triggers fire.
+        val addEffect = com.wingedsheep.sdk.scripting.effects.AddCountersEffect(
+            counterType = continuation.counterType,
+            count = chosen,
+            target = com.wingedsheep.sdk.scripting.targets.EffectTarget.SpecificEntity(continuation.targetId)
+        )
+        val addContext = EffectContext(
+            sourceId = continuation.sourceId,
+            controllerId = continuation.controllerId,
+        )
+        val result = services.effectExecutorRegistry.execute(state, addEffect, addContext).toExecutionResult()
+
+        if (result.isPaused) {
+            return result
+        }
+
+        return checkForMore(result.state, result.events.toList())
     }
 
     private fun resumeDrawUpTo(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/PermanentExecutors.kt
@@ -117,6 +117,7 @@ class PermanentExecutors(
         // counters
         AddCountersExecutor(),
         AddDynamicCountersExecutor(),
+        com.wingedsheep.engine.handlers.effects.permanent.counters.AddCountersUpToExecutor(),
         MoveAllLastKnownCountersExecutor(),
         AddCountersToCollectionExecutor(),
         DoubleCountersExecutor(),

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersUpToExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/AddCountersUpToExecutor.kt
@@ -1,0 +1,92 @@
+package com.wingedsheep.engine.handlers.effects.permanent.counters
+
+import com.wingedsheep.engine.core.AddCountersUpToContinuation
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.DecisionContext
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DecisionRequestedEvent
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.scripting.effects.AddCountersUpToEffect
+import java.util.UUID
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [AddCountersUpToEffect].
+ *
+ * "Put up to N [counterType] counters on target" — the additive, single-kind mirror of
+ * [RemoveAnyNumberOfCountersExecutor]. Evaluates the [AddCountersUpToEffect.max] ceiling once,
+ * then prompts the controller with a single [ChooseNumberDecision] (0..max). On resume
+ * ([AddCountersUpToContinuation]) the chosen number of counters is placed through the standard
+ * `AddCountersEffect` path, so counter-placement replacement effects (Hardened Scales) and any
+ * downstream triggers (Saga chapter abilities off lore counters) fire normally.
+ *
+ * No-op — no prompt — when the target is gone, can't receive counters, or the ceiling resolves
+ * to <= 0.
+ */
+class AddCountersUpToExecutor(
+    private val amountEvaluator: DynamicAmountEvaluator = DynamicAmountEvaluator()
+) : EffectExecutor<AddCountersUpToEffect> {
+
+    override val effectType: KClass<AddCountersUpToEffect> = AddCountersUpToEffect::class
+
+    override fun execute(
+        state: GameState,
+        effect: AddCountersUpToEffect,
+        context: EffectContext
+    ): EffectResult {
+        val targetId = context.resolveTarget(effect.target, state)
+            ?: return EffectResult.success(state, emptyList())
+
+        if (!state.projectedState.canReceiveCounters(targetId)) {
+            return EffectResult.success(state, emptyList())
+        }
+
+        val max = amountEvaluator.evaluate(state, effect.max, context)
+        if (max <= 0) return EffectResult.success(state, emptyList())
+
+        val targetName = state.getEntity(targetId)?.get<CardComponent>()?.name ?: ""
+        val sourceName = context.sourceId?.let { state.getEntity(it)?.get<CardComponent>()?.name }
+
+        val decisionId = UUID.randomUUID().toString()
+        val decision = ChooseNumberDecision(
+            id = decisionId,
+            playerId = context.controllerId,
+            prompt = "Put how many ${effect.counterType} counters on $targetName? (0-$max)",
+            context = DecisionContext(
+                sourceId = context.sourceId,
+                sourceName = sourceName,
+                phase = DecisionPhase.RESOLUTION
+            ),
+            minValue = 0,
+            maxValue = max
+        )
+
+        val continuation = AddCountersUpToContinuation(
+            decisionId = decisionId,
+            targetId = targetId,
+            controllerId = context.controllerId,
+            counterType = effect.counterType,
+            sourceId = context.sourceId
+        )
+
+        val newState = state
+            .withPendingDecision(decision)
+            .pushContinuation(continuation)
+
+        val events = listOf(
+            DecisionRequestedEvent(
+                decisionId = decisionId,
+                playerId = context.controllerId,
+                decisionType = "CHOOSE_NUMBER",
+                prompt = decision.prompt
+            )
+        )
+
+        return EffectResult.paused(newState, decision, events)
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
@@ -156,7 +156,13 @@ class CreateTokenCopyOfChosenPermanentExecutor(
                 newState, tokenId, controllerId
             )
 
-            return EffectResult.success(stateWithCounters, listOf(event) + counterEvents)
+            // CR 714.2b/714.3a: a token copy of a Saga enters as a Saga with its on-enter lore
+            // counter. BattlefieldEntry.place skips enters-with-counters setup, so apply the shared
+            // Saga-entry helper (as the standard moveToZone pipeline does). No-op for non-Sagas.
+            val (sagaState, sagaEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .applySagaEntryIfNeeded(stateWithCounters, tokenId)
+
+            return EffectResult.success(sagaState, listOf(event) + counterEvents + sagaEvents)
         }
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
@@ -123,6 +123,12 @@ class CreateTokenCopyOfEquippedCreatureExecutor(
             )
         )
 
-        return EffectResult.success(newState, events)
+        // CR 714.2b/714.3a: if the copied permanent is a Saga (e.g. an Enchantment Creature — Saga),
+        // the token enters as a Saga with its on-enter lore counter. BattlefieldEntry.place skips
+        // enters-with-counters setup, so apply the shared Saga-entry helper. No-op for non-Sagas.
+        val (sagaState, sagaEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+            .applySagaEntryIfNeeded(newState, tokenId)
+
+        return EffectResult.success(sagaState, events + sagaEvents)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -142,6 +142,14 @@ class CreateTokenCopyOfSourceExecutor(
             )
             newState = nextState
             counterEvents.addAll(events)
+
+            // CR 714.2b/714.3a: a token copy of a Saga enters as a Saga and gets its on-enter lore
+            // counter. BattlefieldEntry.place skips enters-with-counters setup, so apply the shared
+            // Saga-entry helper (as the standard moveToZone pipeline does). No-op for non-Sagas.
+            val (sagaState, sagaEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .applySagaEntryIfNeeded(newState, tokenId)
+            newState = sagaState
+            counterEvents.addAll(sagaEvents)
         }
 
         // If exileAtStep is set, create delayed triggers to exile each created token

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -212,6 +212,15 @@ class CreateTokenCopyOfTargetExecutor(
                     ownerId = controllerId
                 )
             )
+
+            // CR 714.2b/714.3a: a token copy of a Saga enters as a Saga and gets its on-enter lore
+            // counter (chapter I then triggers). BattlefieldEntry.place is the ad-hoc insertion path
+            // and intentionally skips enters-with-counters setup, so apply the shared Saga-entry
+            // helper here — the same one the standard moveToZone pipeline uses. No-op for non-Sagas.
+            val (sagaState, sagaEvents) = com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+                .applySagaEntryIfNeeded(newState, tokenId)
+            newState = sagaState
+            events.addAll(sagaEvents)
         }
 
         // If sacrificeAtStep is set, create a delayed trigger to sacrifice each created token

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AddCountersUpToScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AddCountersUpToScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Feature test for [com.wingedsheep.sdk.scripting.effects.AddCountersUpToEffect] — "Put up to N
+ * counters on target", the additive/player-chosen mirror of `RemoveAnyNumberOfCounters`. Driven
+ * through an inline instant that puts up to three +1/+1 counters on target creature.
+ *
+ * Proves: the single `ChooseNumberDecision` is capped at the effect's max; the chosen count is
+ * placed; choosing 0 is a no-op; and the count clamps to the effect's ceiling regardless of board
+ * state. (The Saga-lore composition — gate on `CollectionContainsMatch(SAGA)` then
+ * `AddCountersUpTo(LORE, 3, …)` advancing a copied Saga's chapters — is proven end-to-end by
+ * `TerraMagicalAdeptScenarioTest`.)
+ */
+class AddCountersUpToScenarioTest : ScenarioTestBase() {
+
+    private val empowerment = card("Test Empowerment") {
+        manaCost = "{1}{G}"
+        colorIdentity = "G"
+        typeLine = "Instant"
+        oracleText = "Put up to three +1/+1 counters on target creature."
+        spell {
+            target = Targets.Creature
+            effect = Effects.AddCountersUpTo(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.ContextTarget(0))
+        }
+    }
+
+    private fun count(game: TestGame, id: EntityId, type: CounterType): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(type) ?: 0
+
+    init {
+        cardRegistry.register(empowerment)
+
+        context("AddCountersUpTo — put up to N counters (player chooses)") {
+
+            test("prompt is capped at the effect's max, and the chosen count is placed") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Test Empowerment")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Test Empowerment", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("A single ChooseNumber prompt, capped at the effect's max of 3") {
+                    (decision is ChooseNumberDecision) shouldBe true
+                    (decision as ChooseNumberDecision).minValue shouldBe 0
+                    decision.maxValue shouldBe 3
+                }
+                game.chooseNumber(2).error shouldBe null
+
+                withClue("Two +1/+1 counters were placed") {
+                    count(game, bears, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+            }
+
+            test("choosing 0 places no counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Test Empowerment")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Test Empowerment", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                (game.getPendingDecision() as ChooseNumberDecision).maxValue shouldBe 3
+                game.chooseNumber(0).error shouldBe null
+
+                withClue("No counters placed when the controller chooses 0") {
+                    count(game, bears, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 0
+                }
+            }
+
+            test("the full max may be chosen") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Test Empowerment")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Test Empowerment", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                game.chooseNumber(3).error shouldBe null
+
+                withClue("All three counters placed") {
+                    count(game, bears, CounterType.PLUS_ONE_PLUS_ONE) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TerraMagicalAdeptScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TerraMagicalAdeptScenarioTest.kt
@@ -1,0 +1,232 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.SagaComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.TerraMagicalAdept
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Terra, Magical Adept // Esper Terra (FIN #245).
+ *
+ * Exercises the card end-to-end: the front ETB mill-five-take-an-enchantment; the Trance
+ * exile-and-return-transformed into the Summon-Saga back (a new object, fresh lore); and — the
+ * point of the accompanying engine work — Esper Terra's chapter I–III copy, where the "if it's a
+ * Saga, put up to three lore counters on it" clause is composed as
+ * `ConditionalEffect(CollectionContainsMatch(CREATED_TOKENS, Saga), AddCountersUpTo(LORE, 3, …))`.
+ */
+class TerraMagicalAdeptScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A plain nonlegendary enchantment — the "copy target that is NOT a Saga" case (no lore prompt).
+    val testSigil = card("Test Sigil") {
+        manaCost = "{1}"
+        colorIdentity = ""
+        typeLine = "Enchantment"
+        oracleText = ""
+    }
+
+    // A nonlegendary Saga with five benign (no-target) chapters — the "copy target that IS a Saga"
+    // case. Five chapters so putting up to three extra lore on a token copy (which enters with one)
+    // never reaches the final chapter and self-sacrifices mid-test.
+    val testChronicle = card("Test Chronicle") {
+        manaCost = "{2}"
+        colorIdentity = ""
+        typeLine = "Enchantment — Saga"
+        oracleText = "I, II, III, IV, V — You gain 1 life."
+        for (n in 1..5) sagaChapter(n) { effect = Effects.GainLife(1) }
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun clearBenignDecisions(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 20 && driver.isPaused) {
+            when (val decision = driver.pendingDecision) {
+                is YesNoDecision ->
+                    driver.submitDecision(decision.playerId, YesNoResponse(decision.id, false))
+                is ChooseTargetsDecision -> {
+                    val chosen = decision.targetRequirements.associate { req ->
+                        req.index to decision.legalTargets[req.index].orEmpty().take(req.minTargets)
+                    }
+                    driver.submitDecision(decision.playerId, TargetsResponse(decision.id, chosen))
+                }
+                else -> driver.autoResolveDecision()
+            }
+        }
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TerraMagicalAdept, testSigil, testChronicle))
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun tokenCopies(driver: GameTestDriver, player: EntityId, name: String): List<EntityId> =
+        driver.state.getZone(player, Zone.BATTLEFIELD).filter { id ->
+            val c = driver.state.getEntity(id) ?: return@filter false
+            c.get<CardComponent>()?.name == name && c.get<TokenComponent>() != null
+        }
+
+    // Cast Terra; on ETB resolution, either select the milled enchantment [takeMilled] into hand or
+    // decline. Returns Terra's entity id.
+    fun castTerra(driver: GameTestDriver, player: EntityId, takeMilled: EntityId? = null): EntityId {
+        val terra = driver.putCardInHand(player, "Terra, Magical Adept")
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 1)
+        driver.castSpell(player, terra)
+        driver.bothPass()
+        resolveStack(driver)
+        // ETB "put up to one enchantment milled this way into your hand" — a card-selection prompt.
+        if (driver.isPaused) {
+            val decisionId = driver.pendingDecision!!.id
+            driver.submitDecision(player, CardsSelectedResponse(decisionId, listOfNotNull(takeMilled)))
+        }
+        resolveStack(driver)
+        clearBenignDecisions(driver)
+        return driver.findPermanent(player, "Terra, Magical Adept")!!
+    }
+
+    fun trance(driver: GameTestDriver, player: EntityId, terra: EntityId) {
+        driver.removeSummoningSickness(terra)
+        driver.giveMana(player, Color.RED, 1)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 4)
+        val abilityId = TerraMagicalAdept.activatedAbilities.first().id
+        driver.submit(ActivateAbility(playerId = player, sourceId = terra, abilityId = abilityId))
+            .isSuccess shouldBe true
+        driver.bothPass()
+    }
+
+    test("front ETB mills five and may put an enchantment milled this way into hand") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        // Seed a plain enchantment on top of the library so it is among the five milled.
+        val sigil = driver.putCardOnTopOfLibrary(active, "Test Sigil")
+
+        castTerra(driver, active, takeMilled = sigil)
+
+        driver.state.getZone(active, Zone.HAND) shouldContain sigil
+        // Five cards left the top of the library (the enchantment then moved on to the hand).
+        driver.state.getZone(active, Zone.GRAVEYARD).size shouldBeGreaterThanOrEqual 4
+        driver.findPermanent(active, "Terra, Magical Adept") shouldNotBe null
+    }
+
+    test("Trance exiles Terra and returns it transformed as Esper Terra — a 6/6 flying Saga, fresh lore") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val terra = castTerra(driver, active)
+
+        trance(driver, active, terra)
+        clearBenignDecisions(driver) // no nonlegendary enchantment to copy -> chapter I has no target
+        resolveStack(driver)
+        clearBenignDecisions(driver)
+
+        val container = driver.state.getEntity(terra)!!
+        container.get<CardComponent>()!!.name shouldBe "Esper Terra"
+        val projected = projector.project(driver.state)
+        projected.isCreature(terra) shouldBe true
+        projected.hasType(terra, "Saga") shouldBe true
+        projected.getPower(terra) shouldBe 6
+        projected.getToughness(terra) shouldBe 6
+        projected.hasKeyword(terra, Keyword.FLYING) shouldBe true
+        container.get<SagaComponent>() shouldNotBe null
+        container.get<CountersComponent>()!!.getCount(CounterType.LORE) shouldBe 1
+    }
+
+    test("chapter I copying a non-Saga enchantment makes a haste token and offers no lore prompt") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val terra = castTerra(driver, active)
+        driver.putPermanentOnBattlefield(active, "Test Sigil")
+
+        trance(driver, active, terra)
+        // Chapter I triggers on transform; target the (only) nonlegendary enchantment we control.
+        var guard = 0
+        while (guard++ < 15 && driver.isPaused) {
+            val decision = driver.pendingDecision
+            // A lore ChooseNumber must NOT appear for a non-Saga copy.
+            (decision is ChooseNumberDecision) shouldBe false
+            clearBenignDecisions(driver)
+            resolveStack(driver)
+        }
+        resolveStack(driver)
+
+        val tokens = tokenCopies(driver, active, "Test Sigil")
+        tokens.size shouldBe 1
+        projector.project(driver.state).hasKeyword(tokens.first(), Keyword.HASTE).shouldBeTrue()
+    }
+
+    test("chapter I copying a Saga offers 'up to three lore counters' and places the chosen count") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val terra = castTerra(driver, active)
+        driver.putPermanentOnBattlefield(active, "Test Chronicle")
+
+        trance(driver, active, terra)
+
+        // Resolve everything up to (and including) the lore ChooseNumber prompt, which proves the
+        // Saga gate + AddCountersUpTo composition fired. Answer it with 3.
+        var sawLorePrompt = false
+        var guard = 0
+        while (guard++ < 25 && driver.isPaused) {
+            when (val decision = driver.pendingDecision) {
+                is ChooseNumberDecision -> {
+                    decision.maxValue shouldBe 3
+                    sawLorePrompt = true
+                    driver.submitDecision(decision.playerId, NumberChosenResponse(decision.id, 3))
+                }
+                is ChooseTargetsDecision -> {
+                    // Target the Saga we control for the copy.
+                    val chosen = decision.targetRequirements.associate { req ->
+                        req.index to decision.legalTargets[req.index].orEmpty().take(1)
+                    }
+                    driver.submitDecision(decision.playerId, TargetsResponse(decision.id, chosen))
+                }
+                else -> clearBenignDecisions(driver)
+            }
+            resolveStack(driver)
+        }
+
+        sawLorePrompt.shouldBeTrue()
+        val tokens = tokenCopies(driver, active, "Test Chronicle")
+        tokens.size shouldBe 1
+        // The token copy entered as a Saga with CR 714.2b's on-enter lore counter (1); the
+        // AddCountersUpTo composition then placed the three chosen lore counters — total 4.
+        driver.state.getEntity(tokens.first())!!.get<CountersComponent>()!!
+            .getCount(CounterType.LORE) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TokenCopyOfSagaEntryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TokenCopyOfSagaEntryScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.SagaComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * CR 714.2b / 714.3a: a token that's a copy of a Saga enters the battlefield **as a Saga** — it
+ * gains a [SagaComponent], gets its on-enter lore counter, and its chapter I ability triggers; lore
+ * then accrues on the controller's following turns like any other Saga.
+ *
+ * The ad-hoc token-creation path (`BattlefieldEntry.place`) does not run the enters-with-counters /
+ * Saga-entry setup that the standard `moveToZone` pipeline does, so the token-copy executors call the
+ * shared [com.wingedsheep.engine.handlers.effects.ZoneMovementUtils.applySagaEntryIfNeeded] hook
+ * themselves. This test proves that generally (not through any one card), driven by a plain
+ * "create a token that's a copy of target enchantment you control" instant.
+ */
+class TokenCopyOfSagaEntryScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A nonlegendary Saga whose chapters gain life — a visible signal that each chapter triggered.
+    val chronicle = card("Test Chronicle") {
+        manaCost = "{2}"
+        colorIdentity = ""
+        typeLine = "Enchantment — Saga"
+        oracleText = "I, II, III, IV, V — You gain 1 life."
+        for (n in 1..5) sagaChapter(n) { effect = Effects.GainLife(1) }
+    }
+
+    // "Create a token that's a copy of target enchantment you control." — a generic copy maker.
+    val echo = card("Test Echo") {
+        manaCost = "{2}{U}"
+        colorIdentity = "U"
+        typeLine = "Instant"
+        oracleText = "Create a token that's a copy of target enchantment you control."
+        spell {
+            target = Targets.Enchantment
+            effect = Effects.CreateTokenCopyOfTarget(EffectTarget.ContextTarget(0))
+        }
+    }
+
+    fun resolveStack(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 40 && driver.state.stack.isNotEmpty() && !driver.isPaused) driver.bothPass()
+    }
+
+    fun clearBenignDecisions(driver: GameTestDriver) {
+        var guard = 0
+        while (guard++ < 20 && driver.isPaused) driver.autoResolveDecision()
+    }
+
+    fun advanceToNextTurnMain(driver: GameTestDriver) {
+        driver.passPriorityUntil(Step.END, maxPasses = 300)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)
+        clearBenignDecisions(driver)
+        resolveStack(driver)
+        clearBenignDecisions(driver)
+    }
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(chronicle, echo))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun tokenCopy(driver: GameTestDriver, player: EntityId, name: String): EntityId? =
+        driver.state.getZone(player, Zone.BATTLEFIELD).firstOrNull { id ->
+            val c = driver.state.getEntity(id) ?: return@firstOrNull false
+            c.get<CardComponent>()?.name == name && c.get<TokenComponent>() != null
+        }
+
+    test("a token copy of a Saga enters with a SagaComponent, one lore counter, and chapter I fires") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val source = driver.putPermanentOnBattlefield(active, "Test Chronicle")
+        val lifeBefore = driver.getLifeTotal(active)
+
+        val echoCard = driver.putCardInHand(active, "Test Echo")
+        driver.giveMana(active, Color.BLUE, 1)
+        driver.giveColorlessMana(active, 2)
+        driver.castSpell(active, echoCard, targets = listOf(source))
+        driver.bothPass()
+        resolveStack(driver)
+        clearBenignDecisions(driver) // resolve the copied Saga's chapter I (gain 1 life)
+        resolveStack(driver)
+
+        val token = tokenCopy(driver, active, "Test Chronicle")
+        token shouldNotBe null
+        val container = driver.state.getEntity(token!!)!!
+        container.get<SagaComponent>() shouldNotBe null
+        container.get<CountersComponent>()!!.getCount(CounterType.LORE) shouldBe 1
+        projector.project(driver.state).hasType(token, "Saga") shouldBe true
+
+        val lifeAfter = driver.getLifeTotal(active)
+        // Chapter I of the token copy triggered and resolved (gained 1 life). The original on the
+        // battlefield was placed directly (no chapter trigger), so the +1 is the token's chapter I.
+        lifeAfter shouldBe lifeBefore + 1
+    }
+
+    test("a token copy of a Saga accrues lore on the controller's next turn (chapter II triggers)") {
+        val driver = newDriver()
+        val active = driver.activePlayer!!
+        val source = driver.putPermanentOnBattlefield(active, "Test Chronicle")
+
+        val echoCard = driver.putCardInHand(active, "Test Echo")
+        driver.giveMana(active, Color.BLUE, 1)
+        driver.giveColorlessMana(active, 2)
+        driver.castSpell(active, echoCard, targets = listOf(source))
+        driver.bothPass()
+        resolveStack(driver)
+        clearBenignDecisions(driver)
+        resolveStack(driver)
+
+        val token = tokenCopy(driver, active, "Test Chronicle")!!
+        driver.state.getEntity(token)!!.get<CountersComponent>()!!.getCount(CounterType.LORE) shouldBe 1
+
+        advanceToNextTurnMain(driver) // opponent's turn
+        advanceToNextTurnMain(driver) // controller's next turn -> draw step adds a lore counter
+
+        driver.state.getEntity(token)!!.get<CountersComponent>()!!
+            .getCount(CounterType.LORE) shouldBe 2
+    }
+})


### PR DESCRIPTION
Implements **Terra, Magical Adept // Esper Terra** (Final Fantasy #245), one of the last remaining FIN cards, plus the two small reusable engine additions it needed. FIN is now 295/300.

## The card

Front **Terra, Magical Adept** `{1}{R}{G}` 4/2 — ETB "mill five, put up to one enchantment card milled this way into your hand" (CacheGrab gather→mill→select→to-hand pattern); *Trance* activated ability exile-and-returns it transformed into the back.

Back **Esper Terra** — a Summon-Saga creature (6/6, Flying):
- **I, II, III** — create a haste token copy of target nonlegendary enchantment you control, sacrificed at your next end step, and *if it's a Saga* put up to three lore counters on it.
- **IV** — add `{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}`, then exile-and-return front face up (before the CR 714.4 final-chapter sacrifice, like the Dominant eikons).

## Engine additions (each general + tested)

**1. `AddCountersUpTo(counterType, max, target)`** — the additive, single-kind, player-chosen mirror of `RemoveAnyNumberOfCounters`. One `ChooseNumberDecision` (0..max), then placement through the normal `AddCounters` chokepoint (honors placement replacements + Saga chapter triggers). "Put up to N counters on target" is a very common MTG template that was missing. The Saga clause composes as `ConditionalEffect(CollectionContainsMatch(CREATED_TOKENS, Enchantment.withSubtype(SAGA)), AddCountersUpTo(LORE, 3, PipelineTarget(CREATED_TOKENS)))`. mtgish bridge maps `UptoNumberCountersOfTypeOnPermanent` → `AddCountersUpTo`.

**2. Token copies of Sagas now enter as Sagas (CR 714.2b/714.3a).** The `CreateTokenCopyOf*` executors place tokens via `BattlefieldEntry.place` (the ad-hoc path that skips enters-with-counters/Saga-entry setup), so a token copy of a Saga was previously inert — no `SagaComponent`, no on-enter lore counter, no chapter triggers, no lore accrual. All four copy executors (target/source/chosen/equipped) now route through the shared `ZoneMovementUtils.applySagaEntryIfNeeded` hook, matching the standard `moveToZone` pipeline. No-op for non-Sagas.

## Tests
- `AddCountersUpToScenarioTest` — prompt capped at max, chosen count placed, choosing 0 is a no-op, full max.
- `TokenCopyOfSagaEntryScenarioTest` — a token copy of a Saga enters with a `SagaComponent` + one lore counter (chapter I fires) and accrues lore next turn (chapter II).
- `TerraMagicalAdeptScenarioTest` — front ETB mill-take, Trance transform to the 6/6 flying Saga, chapter copy of a non-Saga (haste token, no lore prompt) vs a Saga (up-to-3 lore prompt, count placed → total 4).

Full `rules-engine` suite, `mtg-sets` snapshot + lint, and `mtgish-tooling` compile all green. `docs/card-sdk-language-reference.md` updated for `AddCountersUpTo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)