### PR TITLE
Add Foundations cards: Dictate of Kruphix, Demolition Field, Maelstrom Pulse, Eaten Alive

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/DemolitionField.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/bro/cards/DemolitionField.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.bro.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Demolition Field
+ * Land
+ * {T}: Add {C}.
+ * {2}, {T}, Sacrifice this land: Destroy target nonbasic land an opponent controls. That land's
+ * controller may search their library for a basic land card, put it onto the battlefield, then
+ * shuffle. You may search your library for a basic land card, put it onto the battlefield, then
+ * shuffle.
+ *
+ * "That land's controller" is [Player.ControllerOf] the destroyed land — resolved after the land
+ * dies, so in the normal case (an opponent controlling their own land) it reads the graveyard
+ * card's owner, which is that same player. Their optional basic-land fetch runs under
+ * [Effects.ForEachPlayer], which rebinds `Player.You` inside the search to that player; the
+ * controller's own optional fetch follows as a plain `Player.You` search.
+ */
+val DemolitionField = card("Demolition Field") {
+    manaCost = ""
+    colorIdentity = ""
+    typeLine = "Land"
+    oracleText = "{T}: Add {C}.\n" +
+        "{2}, {T}, Sacrifice this land: Destroy target nonbasic land an opponent controls. " +
+        "That land's controller may search their library for a basic land card, put it onto the " +
+        "battlefield, then shuffle. You may search your library for a basic land card, put it onto " +
+        "the battlefield, then shuffle."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddColorlessMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap, Costs.SacrificeSelf)
+        val land = target(
+            "target nonbasic land an opponent controls",
+            TargetPermanent(filter = TargetFilter.NonbasicLand.opponentControls())
+        )
+        effect = Effects.Destroy(land) then
+            Effects.ForEachPlayer(
+                Player.ControllerOf("the destroyed land"),
+                listOf(
+                    MayEffect(
+                        Patterns.Library.searchLibrary(
+                            filter = GameObjectFilter.BasicLand,
+                            count = 1,
+                            destination = SearchDestination.BATTLEFIELD
+                        )
+                    )
+                )
+            ) then
+            MayEffect(
+                Patterns.Library.searchLibrary(
+                    filter = GameObjectFilter.BasicLand,
+                    count = 1,
+                    destination = SearchDestination.BATTLEFIELD
+                )
+            )
+        description = "{2}, {T}, Sacrifice this land: Destroy target nonbasic land an opponent " +
+            "controls. That land's controller may search their library for a basic land card, put " +
+            "it onto the battlefield, then shuffle. You may search your library for a basic land " +
+            "card, put it onto the battlefield, then shuffle."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "260"
+        artist = "Kamila Szutenberg"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d9c88546-13c9-4d7e-a618-cb2ccd1dbc0f.jpg?1782699688"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DemolitionFieldReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DemolitionFieldReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Demolition Field reprint in FDN. Canonical CardDefinition lives in its earliest set (BRO).
+ */
+val DemolitionFieldReprint = Printing(
+    oracleId = "93953926-a644-49bb-9b5a-4c8f19114c7e",
+    name = "Demolition Field",
+    setCode = "FDN",
+    collectorNumber = "687",
+    scryfallId = "0c7e51b6-4898-4632-b39c-3ce438caa882",
+    artist = "Kamila Szutenberg",
+    imageUri = "https://cards.scryfall.io/normal/front/0/c/0c7e51b6-4898-4632-b39c-3ce438caa882.jpg?1782688670",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DictateOfKruphixReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DictateOfKruphixReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Dictate of Kruphix reprint in FDN. Canonical CardDefinition lives in its earliest set (JOU).
+ */
+val DictateOfKruphixReprint = Printing(
+    oracleId = "be74a4c1-d569-4203-b28a-3e2ac6a82990",
+    name = "Dictate of Kruphix",
+    setCode = "FDN",
+    collectorNumber = "587",
+    scryfallId = "b5e4087b-e692-4eb2-bb59-ff2a001d6dd4",
+    artist = "Daarken",
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b5e4087b-e692-4eb2-bb59-ff2a001d6dd4.jpg?1782688755",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/EatenAliveReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/EatenAliveReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eaten Alive reprint in FDN. Canonical CardDefinition lives in its earliest set (MID).
+ */
+val EatenAliveReprint = Printing(
+    oracleId = "d437ecc2-2fd3-4ad3-b23e-217f55e58dae",
+    name = "Eaten Alive",
+    setCode = "FDN",
+    collectorNumber = "172",
+    scryfallId = "1c4f7b20-b2a8-498c-8c36-dc296863b0b9",
+    artist = "Nicholas Gregory",
+    imageUri = "https://cards.scryfall.io/normal/front/1/c/1c4f7b20-b2a8-498c-8c36-dc296863b0b9.jpg?1782689117",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MaelstromPulseReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/MaelstromPulseReprint.kt
@@ -1,0 +1,19 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Maelstrom Pulse reprint in FDN. Canonical CardDefinition lives in its earliest set (ARB).
+ */
+val MaelstromPulseReprint = Printing(
+    oracleId = "95ce305f-34bc-4d6d-b7ba-ffd4b2a25336",
+    name = "Maelstrom Pulse",
+    setCode = "FDN",
+    collectorNumber = "661",
+    scryfallId = "019e8d47-a086-4e9f-8130-8c3b2dc50179",
+    artist = "John Avon",
+    imageUri = "https://cards.scryfall.io/normal/front/0/1/019e8d47-a086-4e9f-8130-8c3b2dc50179.jpg?1782688691",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/DictateOfKruphix.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/jou/cards/DictateOfKruphix.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.jou.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Dictate of Kruphix
+ * {1}{U}{U}
+ * Enchantment
+ * Flash
+ * At the beginning of each player's draw step, that player draws an additional card.
+ *
+ * The additional draw is a triggered ability (not a replacement), fired on every player's
+ * draw step. [Player.TriggeringPlayer] resolves to the player whose draw step it is (the
+ * active player of that step), matching the "that player" wording — see Collapsing Borders
+ * for the same each-player step-trigger shape.
+ */
+val DictateOfKruphix = card("Dictate of Kruphix") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment"
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "At the beginning of each player's draw step, that player draws an additional card."
+
+    keywords(Keyword.FLASH)
+
+    triggeredAbility {
+        trigger = Triggers.phase(Step.DRAW, Player.Each)
+        effect = Effects.DrawCards(1, EffectTarget.PlayerRef(Player.TriggeringPlayer))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "37"
+        artist = "Daarken"
+        flavorText = "\"Knowledge is cruel. It will break your heart and test your allegiances. " +
+            "Are you certain you want this curse?\""
+        imageUri = "https://cards.scryfall.io/normal/front/e/8/e8e7916c-f39a-48a0-a47d-7e83ebf028fa.jpg?1782713429"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/BRO.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BRO.json
@@ -143,6 +143,178 @@
     ]
 }
 
+// Demolition Field
+{
+    "name": "Demolition Field",
+    "manaCost": "",
+    "typeLine": "Land",
+    "oracleText": "{T}: Add {C}.\n{2}, {T}, Sacrifice this land: Destroy target nonbasic land an opponent controls. That land's controller may search their library for a basic land card, put it onto the battlefield, then shuffle. You may search your library for a basic land card, put it onto the battlefield, then shuffle.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddColorlessMana",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target nonbasic land an opponent controls"
+                            },
+                            "destination": "Graveyard",
+                            "byDestruction": true
+                        },
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Players",
+                                "players": {
+                                    "type": "ControllerOf",
+                                    "targetDescription": "the destroyed land"
+                                }
+                            },
+                            "body": {
+                                "type": "Gated",
+                                "gate": "Gate.MayDecide",
+                                "then": {
+                                    "type": "Composite",
+                                    "effects": [
+                                        {
+                                            "type": "GatherCards",
+                                            "source": {
+                                                "type": "FromZone",
+                                                "zone": "Library",
+                                                "filter": "basicland"
+                                            },
+                                            "storeAs": "searchable"
+                                        },
+                                        {
+                                            "type": "SelectFromCollection",
+                                            "from": "searchable",
+                                            "selection": {
+                                                "type": "ChooseUpTo",
+                                                "count": {
+                                                    "type": "Fixed",
+                                                    "amount": 1
+                                                }
+                                            },
+                                            "storeSelected": "found"
+                                        },
+                                        {
+                                            "type": "MoveCollection",
+                                            "from": "found",
+                                            "destination": {
+                                                "type": "ToZone",
+                                                "zone": "Battlefield"
+                                            }
+                                        },
+                                        "ShuffleLibrary",
+                                        "EmitLibrarySearchedEvent"
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Library",
+                                            "filter": "basicland"
+                                        },
+                                        "storeAs": "searchable"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "searchable",
+                                        "selection": {
+                                            "type": "ChooseUpTo",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "found"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "found",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Battlefield"
+                                        }
+                                    },
+                                    "ShuffleLibrary",
+                                    "EmitLibrarySearchedEvent"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsLand",
+                                    {
+                                        "type": "Not",
+                                        "predicate": "IsBasicLand"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByOpponent"
+                            }
+                        },
+                        "id": "target nonbasic land an opponent controls"
+                    }
+                ],
+                "descriptionOverride": "{2}, {T}, Sacrifice this land: Destroy target nonbasic land an opponent controls. That land's controller may search their library for a basic land card, put it onto the battlefield, then shuffle. You may search your library for a basic land card, put it onto the battlefield, then shuffle."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "rarity": "UNCOMMON",
+        "artist": "Kamila Szutenberg",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d9c88546-13c9-4d7e-a618-cb2ccd1dbc0f.jpg?1782699688"
+    },
+    "colorIdentityOverride": []
+}
+
 // Flow of Knowledge
 {
     "name": "Flow of Knowledge",

--- a/mtg-sets/src/test/resources/snapshots/cards/JOU.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/JOU.json
@@ -66,6 +66,51 @@
     ]
 }
 
+// Dictate of Kruphix
+{
+    "name": "Dictate of Kruphix",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Enchantment",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nAt the beginning of each player's draw step, that player draws an additional card.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "DRAW",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "TriggeringPlayer"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "rarity": "RARE",
+        "artist": "Daarken",
+        "flavorText": "\"Knowledge is cruel. It will break your heart and test your allegiances. Are you certain you want this curse?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/8/e8e7916c-f39a-48a0-a47d-7e83ebf028fa.jpg?1782713429"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Heroes' Bane
 {
     "name": "Heroes' Bane",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DemolitionFieldScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DemolitionFieldScenarioTest.kt
@@ -1,0 +1,104 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Demolition Field (BRO #260, reprinted FDN #687).
+ *
+ * "{T}: Add {C}.
+ *  {2}, {T}, Sacrifice this land: Destroy target nonbasic land an opponent controls. That land's
+ *  controller may search their library for a basic land card, put it onto the battlefield, then
+ *  shuffle. You may search your library for a basic land card, put it onto the battlefield, then
+ *  shuffle."
+ *
+ * Verifies the whole chain: the targeted nonbasic land dies, *its controller* (the opponent, via
+ * [Player.ControllerOf]) fetches a basic onto the battlefield, and the activating player fetches
+ * one too.
+ */
+class DemolitionFieldScenarioTest : ScenarioTestBase() {
+
+    private fun forestsControlledBy(game: TestGame, playerId: EntityId): Int =
+        game.state.getBattlefield(playerId).count { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == "Forest"
+        }
+
+    init {
+        context("Demolition Field") {
+
+            test("destroys the opponent's nonbasic land; both its controller and you fetch a basic") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Demolition Field")
+                    // Two Forests to pay the {2} in the sacrifice ability's cost.
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    // The opponent's nonbasic land is the target.
+                    .withCardOnBattlefield(2, "Strip Mine")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                // Both libraries hold only basics, so any search selection is a basic land.
+                repeat(6) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(6) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                val p1 = game.player1Id
+                val p2 = game.player2Id
+                withClue("Precondition: opponent controls no Forests yet") {
+                    forestsControlledBy(game, p2) shouldBe 0
+                }
+                val p1ForestsBefore = forestsControlledBy(game, p1)
+
+                val field = game.findPermanent("Demolition Field")!!
+                val stripMine = game.findPermanent("Strip Mine")!!
+                val sacAbilityId = cardRegistry.getCard("Demolition Field")!!.script.activatedAbilities[1].id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = p1,
+                        sourceId = field,
+                        abilityId = sacAbilityId,
+                        targets = listOf(ChosenTarget.Permanent(stripMine)),
+                    )
+                )
+                withClue("Activating the sacrifice ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                // Drive the two optional basic-land searches (opponent first, then the controller).
+                var guard = 0
+                while (game.hasPendingDecision() && guard++ < 12) {
+                    when (val d = game.getPendingDecision()) {
+                        is YesNoDecision -> game.answerYesNo(true)
+                        is SelectCardsDecision -> game.selectCards(listOf(d.options.first()))
+                        else -> game.skipSelection()
+                    }
+                    game.resolveStack()
+                }
+
+                withClue("Demolition Field sacrificed itself as a cost") {
+                    game.isInGraveyard(1, "Demolition Field") shouldBe true
+                }
+                withClue("The targeted Strip Mine was destroyed") {
+                    game.isInGraveyard(2, "Strip Mine") shouldBe true
+                    game.isOnBattlefield("Strip Mine") shouldBe false
+                }
+                withClue("The destroyed land's controller (the opponent) fetched a basic onto the battlefield") {
+                    forestsControlledBy(game, p2) shouldBe 1
+                }
+                withClue("The activating player also fetched a basic onto the battlefield") {
+                    forestsControlledBy(game, p1) shouldBe p1ForestsBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DictateOfKruphixScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DictateOfKruphixScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Dictate of Kruphix (JOU #37, reprinted FDN #587).
+ *
+ * {1}{U}{U} Enchantment — Flash
+ * "At the beginning of each player's draw step, that player draws an additional card."
+ *
+ * Verifies the "each player" scope: both the controller and the opponent draw an extra
+ * card on their own draw step (the additional draw goes to [Player.TriggeringPlayer], the
+ * player whose draw step it is).
+ */
+class DictateOfKruphixScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dictate of Kruphix") {
+
+            test("each player draws an extra card on their own draw step") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Dictate of Kruphix")
+                    // Start on the opponent's turn so the first draw step we reach is a
+                    // regular (non-first-turn) draw step for the controller.
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(20) { builder = builder.withCardInLibrary(1, "Forest") }
+                repeat(20) { builder = builder.withCardInLibrary(2, "Forest") }
+                val game = builder.build()
+
+                // --- Controller's draw step (player 1) ---
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+                val p1BeforeDraw = game.handSize(1)
+
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+                withClue("Controller draws the turn-based card + Dictate's additional card (+2)") {
+                    game.handSize(1) shouldBe p1BeforeDraw + 2
+                }
+
+                // --- Opponent's draw step (player 2) ---
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+                val p2BeforeDraw = game.handSize(2)
+
+                game.passUntilPhase(Phase.BEGINNING, Step.DRAW)
+                game.resolveStack()
+                withClue("Opponent also draws the turn-based card + Dictate's additional card (+2)") {
+                    game.handSize(2) shouldBe p2BeforeDraw + 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A handful of Foundations (FDN) cards, composed entirely from existing SDK primitives (no engine changes).

| Card | Canonical | FDN | Notes |
|------|-----------|-----|-------|
| **Dictate of Kruphix** | JOU (earliest) | reprint row | Flash enchantment. `Triggers.phase(Step.DRAW, Player.Each)` → `Effects.DrawCards(1, PlayerRef(TriggeringPlayer))` so each player draws an extra card on **their own** draw step. |
| **Demolition Field** | BRO (earliest) | reprint row | Land. Mana ability + `{2},{T},Sac`: destroy target nonbasic land an opponent controls, then that land's controller (`Player.ControllerOf`, via `ForEachPlayer`) and you each **may** fetch a basic onto the battlefield. |
| **Maelstrom Pulse** | ARB (existing) | reprint row | Canonical already implemented — FDN `Printing(...)` row only. |
| **Eaten Alive** | MID (existing) | reprint row | Canonical already implemented — FDN `Printing(...)` row only. |

## Rules fidelity notes

- Dictate's extra draw is a triggered ability (not a replacement), firing on every player's draw step; the drawing player is the active player of that step (`TriggeringPlayer`).
- Demolition Field's "that land's controller" is resolved after the land is destroyed; in the normal case (an opponent controlling their own land) `ControllerOf` reads the graveyard card's owner, which is that same player. Both fetches are optional (`MayEffect`) and put the basic onto the battlefield untapped, matching oracle text.

## Testing

- `DictateOfKruphixScenarioTest` — both the controller and the opponent draw an extra card on their own draw step. ✅
- `DemolitionFieldScenarioTest` — the targeted nonbasic land dies, its controller (the opponent) fetches a basic, and the activating player fetches one too. ✅
- `just test-server` + full `:mtg-sets:test` net (lint, snapshot, facade-boundary, multi-printing, discovery) pass.
- Card snapshot goldens re-blessed for JOU and BRO (only the two new canonical cards added; no other card trees changed).

## Deliberately skipped

- **Blasphemous Edict** — its "pay {B} rather than mana cost **if there are 13+ creatures**" is a *condition-gated* self-alternative cost; `SelfAlternativeCost` has no condition field, so a faithful implementation needs a new SDK/engine capability (add-feature territory), not pure card authoring. Left out to keep this an add-card-only handful.

## Pre-existing, unrelated

`check-card-printing` reports missing `Printing(...)` rows for Maelstrom Pulse (`blc`) and Eaten Alive (`j22`) — those boosters list the cards but predate reprint rows. Independent of this change and in other sets, so left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)