### PR TITLE
Add Foundations cards: Twinflame Tyrant, Homunculus Horde, Sphinx of Forgotten Lore

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HomunculusHorde.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HomunculusHorde.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Homunculus Horde
+ * {3}{U}
+ * Creature — Homunculus
+ * 2/2
+ *
+ * Whenever you draw your second card each turn, create a token that's a copy of this creature.
+ *
+ * The draw trigger uses [Triggers.NthCardDrawn] (n = 2), the shared "your Nth card each turn"
+ * detector that fires exactly once per turn when your second card is drawn. The payoff is a copy
+ * of this permanent via [Effects.CreateTokenCopyOfSelf]. The token copies the printed
+ * characteristics (including this ability), so it can snowball if it too draws a second card.
+ */
+val HomunculusHorde = card("Homunculus Horde") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Homunculus"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever you draw your second card each turn, create a token that's a copy of this creature."
+
+    triggeredAbility {
+        trigger = Triggers.NthCardDrawn(2)
+        effect = Effects.CreateTokenCopyOfSelf()
+        description = "Whenever you draw your second card each turn, create a token that's a copy of this creature."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "41"
+        artist = "Adrián Rodríguez Pérez"
+        flavorText = "\"That is why you triple-check all decimals when commissioning a new batch of homunculi!\"\n—Trigori, Azorius senator"
+        imageUri = "https://cards.scryfall.io/normal/front/4/7/470c4d03-340a-4e0e-a59f-f19d05497785.jpg?1782689229"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SphinxOfForgottenLore.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/SphinxOfForgottenLore.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sphinx of Forgotten Lore
+ * {2}{U}{U}
+ * Creature — Sphinx
+ * 3/3
+ *
+ * Flash
+ * Flying
+ * Whenever this creature attacks, target instant or sorcery card in your graveyard gains
+ * flashback until end of turn. The flashback cost is equal to that card's mana cost.
+ *
+ * The attack trigger grants Flashback (CR 702.34) at runtime via [Effects.GrantFlashback], whose
+ * cost defaults to the targeted card's own mana cost (the "flashback cost is equal to that card's
+ * mana cost" clause). The cast-from-graveyard enumerator, cast handler, and stack resolver honor
+ * the granted flashback exactly like a printed one through the shared `FlashbackGrants` resolver;
+ * the grant expires during the cleanup step. Same pattern as Archmage's Newt, keyed off the
+ * attack event rather than combat damage.
+ */
+val SphinxOfForgottenLore = card("Sphinx of Forgotten Lore") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Sphinx"
+    power = 3
+    toughness = 3
+    oracleText = "Flash\nFlying\n" +
+        "Whenever this creature attacks, target instant or sorcery card in your graveyard gains " +
+        "flashback until end of turn. The flashback cost is equal to that card's mana cost. " +
+        "(You may cast that card from your graveyard for its flashback cost. Then exile it.)"
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        target = TargetObject(
+            filter = TargetFilter.InstantOrSorceryInGraveyard.ownedByYou()
+        )
+        effect = Effects.GrantFlashback(EffectTarget.ContextTarget(0))
+        description = "Whenever this creature attacks, target instant or sorcery card in your " +
+            "graveyard gains flashback until end of turn. The flashback cost is equal to that " +
+            "card's mana cost."
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "51"
+        artist = "Dmitry Burmak"
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/af6e46b8-62ed-4bca-ba38-a821f225b59f.jpg?1782689220"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TwinflameTyrant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/TwinflameTyrant.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.DoubleDamage
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.events.SourceFilter
+
+/**
+ * Twinflame Tyrant
+ * {3}{R}{R}
+ * Creature — Dragon
+ * 3/5
+ *
+ * Flying
+ * If a source you control would deal damage to an opponent or a permanent an opponent
+ * controls, it deals double that damage instead.
+ *
+ * The doubling is a [DoubleDamage] damage-amount replacement (CR 616), scoped by an
+ * [EventPattern.DamageEvent] whose source is "any source you control" and whose recipient is
+ * [RecipientFilter.OpponentOrPermanentTheyControl] ("an opponent or a permanent an opponent
+ * controls" — the same recipient shape used by Fated Firepower). Combat and noncombat damage
+ * alike double, matching the unrestricted "deal damage" wording.
+ */
+val TwinflameTyrant = card("Twinflame Tyrant") {
+    manaCost = "{3}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dragon"
+    power = 3
+    toughness = 5
+    oracleText = "Flying\n" +
+        "If a source you control would deal damage to an opponent or a permanent an opponent " +
+        "controls, it deals double that damage instead."
+
+    keywords(Keyword.FLYING)
+
+    replacementEffect(
+        DoubleDamage(
+            appliesTo = EventPattern.DamageEvent(
+                source = SourceFilter.Matching(GameObjectFilter.Any.youControl()),
+                recipient = RecipientFilter.OpponentOrPermanentTheyControl,
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "97"
+        artist = "Xabi Gaztelua"
+        flavorText = "\"Job only paid enough for one head. I'm out.\"\n—Peren, veteran mercenary"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1eb34f51-0bd2-43c3-af95-2ce8dabcc7bb.jpg?1782689182"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -3411,6 +3411,42 @@
     ]
 }
 
+// Homunculus Horde
+{
+    "name": "Homunculus Horde",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Homunculus",
+    "oracleText": "Whenever you draw your second card each turn, create a token that's a copy of this creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "NthCardDrawnEvent",
+                    "nthCard": 2
+                },
+                "binding": "ANY",
+                "effect": "CreateTokenCopyOfSource",
+                "descriptionOverride": "Whenever you draw your second card each turn, create a token that's a copy of this creature."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "rarity": "RARE",
+        "artist": "Adrián Rodríguez Pérez",
+        "flavorText": "\"That is why you triple-check all decimals when commissioning a new batch of homunculi!\"\n—Trigori, Azorius senator",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/7/470c4d03-340a-4e0e-a59f-f19d05497785.jpg?1782689229"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Hungry Ghoul
 {
     "name": "Hungry Ghoul",
@@ -5678,6 +5714,54 @@
     ]
 }
 
+// Sphinx of Forgotten Lore
+{
+    "name": "Sphinx of Forgotten Lore",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Sphinx",
+    "oracleText": "Flash\nFlying\nWhenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "GrantFlashback",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "instant|sorcery own:you",
+                        "zone": "Graveyard"
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to that card's mana cost."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "MYTHIC",
+        "artist": "Dmitry Burmak",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/af6e46b8-62ed-4bca-ba38-a821f225b59f.jpg?1782689220"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Spinner of Souls
 {
     "name": "Spinner of Souls",
@@ -6463,6 +6547,46 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Twinflame Tyrant
+{
+    "name": "Twinflame Tyrant",
+    "manaCost": "{3}{R}{R}",
+    "typeLine": "Creature — Dragon",
+    "oracleText": "Flying\nIf a source you control would deal damage to an opponent or a permanent an opponent controls, it deals double that damage instead.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "replacementEffects": [
+            {
+                "type": "DoubleDamage",
+                "appliesTo": {
+                    "type": "DamageEvent",
+                    "recipient": "OpponentOrPermanentTheyControl",
+                    "source": {
+                        "type": "SourceMatching",
+                        "filter": "ctrl:you"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "97",
+        "rarity": "MYTHIC",
+        "artist": "Xabi Gaztelua",
+        "flavorText": "\"Job only paid enough for one head. I'm out.\"\n—Peren, veteran mercenary",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1eb34f51-0bd2-43c3-af95-2ce8dabcc7bb.jpg?1782689182"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 


### PR DESCRIPTION
## Summary

Implements a handful of **Foundations (FDN)** cards, all FDN-original and all composed
purely from existing, already-tested SDK primitives — **no new engine features**.

| Card | Cost | P/T | What it does | Built from |
|------|------|-----|--------------|------------|
| **Twinflame Tyrant** | {3}{R}{R} | 3/5 Dragon | Flying; a source you control deals double damage to an opponent or a permanent they control | `DoubleDamage` replacement + `DamageEvent(source=YouControl, recipient=OpponentOrPermanentTheyControl)` — the Fated Firepower recipient shape |
| **Homunculus Horde** | {3}{U} | 2/2 | Whenever you draw your second card each turn, create a token copy of it | `Triggers.NthCardDrawn(2)` + `Effects.CreateTokenCopyOfSelf()` (Mischievous Mystic's trigger) |
| **Sphinx of Forgotten Lore** | {2}{U}{U} | 3/3 Sphinx | Flash, Flying; on attack, target instant/sorcery in your graveyard gains flashback (= its mana cost) | `Triggers.Attacks` + `Effects.GrantFlashback` (Archmage's Newt pattern, keyed off the attack event) |

FDN implementation status: **207 → 210** of 262.

## Card selection rationale

Started from the FDN missing list and deliberately picked cards whose **earliest real
printing is FDN itself** (so the canonical `CardDefinition` lives in FDN, no set
scaffolding) and whose mechanics **compose from existing primitives**. Dropped candidates
that would have needed feature work: Angel of Finality (canonical belongs in unscaffolded
C13), Blasphemous Edict (conditional self-alternative cost — `SelfAlternativeCost` has no
condition field), and Valkyrie's Call / Infernal Vessel (persistent "becomes a type in
addition to its other types" on a returned permanent).

## Testing

- `just build` — green (full suite).
- Card snapshot re-blessed; `git diff` on `FDN.json` shows **only** the three new cards
  added, no unrelated card trees moved (confirms no shared SDK behavior changed).
- `CardLintTest` and `CardDefinitionSnapshotTest` pass.
- `just check-card-printing` confirms all three canonicals sit in FDN (earliest real printing).
- No new scenario tests: each card reuses primitives already covered by their reference
  cards (Gratuitous Violence / Fated Firepower, Mischievous Mystic, Archmage's Newt).
- Verified all fields (cost, type, P/T, oracle text, rarity, collector number, artist,
  image URI HTTP 200) against Scryfall per-printing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)