### PR TITLE
Add Zenos yae Galvus // Shinryu, Transcendent Rival to Final Fantasy

### DIFF
--- a/backlog/fin-engine-gaps.md
+++ b/backlog/fin-engine-gaps.md
@@ -465,5 +465,15 @@ stale on both:
     accrues lore each turn. Previously such tokens were inert. Tested by `TokenCopyOfSagaEntryScenarioTest`
     (generally) and `TerraMagicalAdeptScenarioTest` (via the card). Covered by `TerraMagicalAdeptScenarioTest`
     (ETB mill-take, Trance transform, chapter copy with/without the Saga lore prompt).
-- Remaining missing FIN cards (5): Emet-Selch, Unsundered; Esper Origins; Gogo, Master of Mimicry;
-  Ultima, Origin of Oblivion; Zenos yae Galvus — all still `add-feature` scope (see Tier-3 above).
+- **Zenos yae Galvus // Shinryu, Transcendent Rival — DONE.** Front's "My First Friend" ETB is an
+  optional `target(CreatureOpponentControls, optional = true)` + `ForEachInGroup(AllCreatures
+  .other().otherThanTarget(), ModifyStats(-2,-2))` (the -2/-2 still resolves when no creature is
+  chosen, per the ruling), plus a persistent reflexive delayed trigger (`Triggers.LeavesBattlefield`
+  + `watchedTarget` + new `DelayedTriggerExpiry.Never`) that transforms Zenos when the chosen
+  creature leaves. Shinryu's win-rider uses the new `Triggers.AnyPlayerLosesGame`
+  (`EventPattern.PlayerLostGameEvent` → engine `PlayerLostEvent`) gated by the new
+  `Conditions.TriggeringPlayerIs(Player.ChosenOpponent)` + `Effects.WinGame()`. Also fixed
+  `TriggerMatcher.filterByTriggerCondition` to thread `triggeringPlayerId` into the intervening-if
+  context (previously null). Covered by `ZenosYaeGalvusScenarioTest` (incl. a 3-player win-con pod).
+- Remaining missing FIN cards (4): Emet-Selch, Unsundered; Esper Origins; Gogo, Master of Mimicry;
+  Ultima, Origin of Oblivion — all still `add-feature` scope (see Tier-3 above).

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -3107,6 +3107,7 @@ Triggers.youCastSpell(
 - `AnyPlayerLosesLife` — anyone loses life.
 - `AnOpponentLosesLife` — an opponent loses life (fires per opponent life-loss event; read the amount via `ContextPropertyKey.TRIGGER_LIFE_LOST`). Bloodthirsty Conqueror; Kefka, Ruler of Ruin (pair with `triggerCondition = Conditions.IsYourTurn` for "during your turn").
 - `YouGainOrLoseLife` — combined life-change.
+- `AnyPlayerLosesGame` — a player loses the game (CR 104.3; backed by `EventPattern.PlayerLostGameEvent`, matched against the engine's `PlayerLostEvent`). Fires for every player's loss; `Player.TriggeringPlayer` inside the effect is the loser. Narrow to one player with a `triggerCondition` — Shinryu, Transcendent Rival's "When the chosen player loses the game, you win the game" uses `triggerCondition = Conditions.TriggeringPlayerIs(Player.ChosenOpponent)` + `Effects.WinGame()`.
 
 ### The Ring
 
@@ -3322,6 +3323,14 @@ Dominant back faces that "stay" instead self-exile on their final chapter, dodgi
     control on your next attack). With `fireOnce = false` (default) it fires on every matching event
     until expiry (double-strike combat damage). One-shot consumption happens when the trigger goes
     on the stack (`TriggerProcessor`), so a second matching event the same turn won't re-fire it.
+  - `expiry` — when the resident delayed trigger is removed. `DelayedTriggerExpiry.EndOfTurn`
+    (default) drops it in the end-of-turn cleanup ("this turn" riders). `DelayedTriggerExpiry.Never`
+    keeps it across turns until it fires (pair with `fireOnce = true`) or the game ends — for
+    watch-a-permanent-until-it-leaves reflexive triggers that aren't turn-scoped, e.g. Zenos yae
+    Galvus's "When the chosen creature leaves the battlefield, transform Zenos yae Galvus"
+    (`trigger = Triggers.LeavesBattlefield, watchedTarget = <chosen>, fireOnce = true,
+    expiry = DelayedTriggerExpiry.Never`). `EffectTarget.Self` inside the effect resolves to the
+    delayed trigger's source (the permanent that created it).
   - `targetRequirement = <TargetRequirement>` — a target chosen **each time** the delayed trigger
     fires, exposed to `effect` as `EffectTarget.ContextTarget`. Use for delayed triggers whose payoff
     targets: Rediscover the Way chapter III installs
@@ -4743,6 +4752,11 @@ answer it and would silently return `false`.
   the dedicated check for "any target" effects with a player-only follow-up. Used by Sonic Shrieker
   ("If a player is dealt damage this way, they discard a card"); pair with
   `EffectTarget.ContextTarget(index)` to make that same player the subject of the follow-up.
+- `TriggeringPlayerIs(player)` — the player who triggered this ability equals another resolved
+  `Player` reference. Narrows a broad "whenever a player …" trigger to one player without a bespoke
+  event filter; both sides resolve through the shared player resolver. Shinryu, Transcendent Rival
+  gates "When the chosen player loses the game, you win the game" with
+  `triggerCondition = TriggeringPlayerIs(Player.ChosenOpponent)` on `Triggers.AnyPlayerLosesGame`.
 - `TargetIsCreatureCard(targetIndex = 0)` — the context target is a creature *card*, tested by the
   underlying card's printed types rather than projected state. Unlike `TargetMatchesFilter(Creature)`
   (which reads projection, where a face-down permanent always projects as a typeless 2/2 Creature),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Conditions.kt
@@ -457,6 +457,14 @@ object Conditions {
         com.wingedsheep.sdk.scripting.conditions.TargetIsPlayer(targetIndex)
 
     /**
+     * The player who triggered this ability is [player]. Narrows a broad "whenever a player …"
+     * trigger to a specific player — e.g. Shinryu, Transcendent Rival gates "When the chosen
+     * player loses the game, you win the game" with `TriggeringPlayerIs(Player.ChosenOpponent)`.
+     */
+    fun TriggeringPlayerIs(player: Player): ConditionInterface =
+        com.wingedsheep.sdk.scripting.conditions.TriggeringPlayerIs(player)
+
+    /**
      * If the context target at [targetIndex] is a tapped battlefield permanent. Branch on a
      * target's tapped state at resolution — e.g. Shackle Slinger's "If it's tapped, put a stun
      * counter on it. Otherwise, tap it."

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -1572,6 +1572,18 @@ object Triggers {
     )
 
     /**
+     * Whenever a player loses the game (CR 104.3). Fires for every player's loss; pair with a
+     * `triggerCondition` to narrow to a specific player (e.g. Shinryu, Transcendent Rival's
+     * "When the chosen player loses the game, you win the game" gates on
+     * [com.wingedsheep.sdk.dsl.Conditions.TriggeringPlayerIs]`(Player.ChosenOpponent)`).
+     * `Player.TriggeringPlayer` inside the effect resolves to the player who lost.
+     */
+    val AnyPlayerLosesGame: TriggerSpec = TriggerSpec(
+        event = PlayerLostGameEvent(Player.Each),
+        binding = TriggerBinding.ANY
+    )
+
+    /**
      * Whenever an opponent loses life. Fires once per life-loss event of any opponent
      * (CR "whenever" per-event templating). The lost amount is exposed via
      * [com.wingedsheep.sdk.scripting.values.ContextPropertyKey.TRIGGER_LIFE_LOST].

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -347,6 +347,24 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
     }
 
     /**
+     * When a player loses the game (CR 104.3 — life 0, drawing from an empty library, poison,
+     * commander damage, or a "loses the game" effect). Fires from the engine's `PlayerLostEvent`,
+     * which is emitted by the state-based-action / turn-based checks when a player loses.
+     *
+     * Use [player] to filter which player's loss is relevant (default [Player.Each] — any player).
+     * For "when the chosen player loses the game" (Shinryu, Transcendent Rival) pair
+     * [Player.Each] with a `triggerCondition` comparing the triggering player to the source's
+     * chosen opponent, so `Player.TriggeringPlayer` inside the effect resolves to the loser.
+     */
+    @SerialName("PlayerLostGameEvent")
+    @Serializable
+    data class PlayerLostGameEvent(
+        val player: Player = Player.Each
+    ) : EventPattern {
+        override val description: String = "${player.description} loses the game"
+    }
+
+    /**
      * Whenever the Ring tempts a player (CR 701.54d). Fires after the temptee completes
      * the "the Ring tempts you" action, even if some or all of it was impossible.
      * Used by cards with "Whenever the Ring tempts you, ...".

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/conditions/GenericConditions.kt
@@ -13,6 +13,24 @@ import kotlinx.serialization.Serializable
 // =============================================================================
 
 /**
+ * Condition: "the player who triggered this ability is [player]".
+ *
+ * Compares the triggering player (the one carried in the trigger context — e.g. the player who
+ * lost the game, gained life, cast the spell) against another resolved player reference. Used to
+ * narrow a broad "whenever a player does X" trigger to a specific player without a bespoke event
+ * filter: Shinryu, Transcendent Rival gates "When the chosen player loses the game, you win the
+ * game" as `triggerCondition = TriggeringPlayerIs(Player.ChosenOpponent)`. Both sides resolve via
+ * the engine's shared player resolver, so any [Player] reference works on the right-hand side.
+ */
+@SerialName("TriggeringPlayerIs")
+@Serializable
+data class TriggeringPlayerIs(
+    val player: Player
+) : Condition {
+    override val description: String = "if the triggering player is ${player.description}"
+}
+
+/**
  * Condition: "if a card in the named collection matches [filter]"
  * Checks whether any entity in a stored pipeline collection matches the given filter.
  * Used for "if you did X this way" patterns where the card selected/milled/returned

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/CompositeEffects.kt
@@ -723,6 +723,18 @@ sealed interface DelayedTriggerExpiry {
     @SerialName("DelayedTriggerExpiry.EndOfTurn")
     @Serializable
     data object EndOfTurn : DelayedTriggerExpiry
+
+    /**
+     * Never expire on a turn boundary — the delayed trigger persists across turns until it
+     * fires (pair with `fireOnce = true`) or the game ends. Models watch-a-permanent-until-it-
+     * leaves reflexive triggers that aren't scoped to the current turn, e.g. Zenos yae Galvus's
+     * "When the chosen creature leaves the battlefield, transform Zenos yae Galvus." The
+     * end-of-turn cleanup only removes [EndOfTurn] triggers, so a [Never] trigger is retained
+     * automatically; a `fireOnce` trigger is still consumed the first time it fires.
+     */
+    @SerialName("DelayedTriggerExpiry.Never")
+    @Serializable
+    data object Never : DelayedTriggerExpiry
 }
 
 /**

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZenosYaeGalvus.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/ZenosYaeGalvus.kt
@@ -1,0 +1,162 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.CreateDelayedTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.DelayedTriggerExpiry
+import com.wingedsheep.sdk.scripting.effects.ModifyStatsEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Zenos yae Galvus // Shinryu, Transcendent Rival (Final Fantasy #127)
+ * {3}{B}{B} — Legendary Creature — Human Noble Warrior 4/4
+ * //  — Legendary Creature — Dragon 8/8 (Flying)
+ *
+ * Front — Zenos yae Galvus:
+ *   My First Friend — When Zenos yae Galvus enters, choose a creature an opponent controls. Until
+ *   end of turn, creatures other than Zenos yae Galvus and the chosen creature get -2/-2.
+ *   When the chosen creature leaves the battlefield, transform Zenos yae Galvus.
+ *
+ * Back — Shinryu, Transcendent Rival:
+ *   Flying
+ *   As this creature transforms into Shinryu, choose an opponent.
+ *   Burning Chains — When the chosen player loses the game, you win the game.
+ *
+ * Modeling notes:
+ *  - "choose a creature an opponent controls" is a non-targeting choice. Per the card's ruling,
+ *    when you *can't* choose one (opponents control no creatures) the -2/-2 still resolves for
+ *    every other creature. A mandatory target would remove the whole triggered ability from the
+ *    stack in that case (CR 603.3c), so we model the choice as an **optional** target: the -2/-2
+ *    `ForEachInGroup` runs regardless, and only the delayed transform-watch is created when a
+ *    creature was actually chosen. (The one divergence from a true non-targeting choice — the
+ *    engine has no "choose one if able" primitive — is that a player could decline while an
+ *    opponent creature exists, and hexproof creatures can't be chosen.)
+ *  - The -2/-2 is a one-shot [ModifyStatsEffect] applied to `AllCreatures.other().otherThanTarget()`
+ *    — every creature except the source (Zenos) and the chosen target — mirroring Infest.
+ *  - "When the chosen creature leaves the battlefield, transform Zenos" is a reflexive delayed
+ *    trigger scoped to the chosen creature ([Triggers.LeavesBattlefield] + `watchedTarget`). It
+ *    must survive across turns until that creature leaves, so it uses [DelayedTriggerExpiry.Never]
+ *    with `fireOnce` (the end-of-turn cleanup only removes EndOfTurn triggers). `EffectTarget.Self`
+ *    resolves to the delayed trigger's source — Zenos — when it fires.
+ *  - The back's win condition is a broad [Triggers.AnyPlayerLosesGame] gated to the chosen player
+ *    via `triggerCondition = TriggeringPlayerIs(Player.ChosenOpponent)`; [Effects.ChooseOpponent]
+ *    (on [Triggers.TransformsToBack]) stores that opponent, and only an actual transform sets it.
+ */
+
+private val ShinryuTranscendentRival = card("Shinryu, Transcendent Rival") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Dragon"
+    oracleText = "Flying\n" +
+        "As this creature transforms into Shinryu, choose an opponent.\n" +
+        "Burning Chains — When the chosen player loses the game, you win the game."
+    power = 8
+    toughness = 8
+
+    keywords(Keyword.FLYING)
+
+    // As this creature transforms into Shinryu, choose an opponent.
+    triggeredAbility {
+        trigger = Triggers.TransformsToBack
+        effect = Effects.ChooseOpponent("Choose an opponent")
+        description = "As this creature transforms into Shinryu, choose an opponent."
+    }
+
+    // Burning Chains — When the chosen player loses the game, you win the game.
+    triggeredAbility {
+        trigger = Triggers.AnyPlayerLosesGame
+        triggerCondition = Conditions.TriggeringPlayerIs(Player.ChosenOpponent)
+        effect = Effects.WinGame(
+            message = "Shinryu, Transcendent Rival — the chosen player lost the game"
+        )
+        description = "Burning Chains — When the chosen player loses the game, you win the game."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Alexander Mokhov"
+        imageUri = "https://cards.scryfall.io/normal/back/b/6/b65ffce4-bb58-418a-9bad-81533a5f2ba2.jpg?1782686503"
+    }
+}
+
+private val ZenosYaeGalvusFront = card("Zenos yae Galvus") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Legendary Creature — Human Noble Warrior"
+    oracleText = "My First Friend — When Zenos yae Galvus enters, choose a creature an opponent " +
+        "controls. Until end of turn, creatures other than Zenos yae Galvus and the chosen " +
+        "creature get -2/-2.\n" +
+        "When the chosen creature leaves the battlefield, transform Zenos yae Galvus."
+    power = 4
+    toughness = 4
+
+    // My First Friend — When Zenos enters, choose a creature an opponent controls (optional so the
+    // rider still resolves when opponents control none). Give every other creature -2/-2 until end
+    // of turn, then, if a creature was chosen, set up the transform-watch on it.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val chosen = target(
+            "creature an opponent controls",
+            TargetPermanent(filter = TargetFilter.CreatureOpponentControls, optional = true)
+        )
+        effect = Effects.Composite(
+            Effects.ForEachInGroup(
+                filter = GroupFilter.AllCreatures.other().otherThanTarget(),
+                effect = ModifyStatsEffect(-2, -2, EffectTarget.Self)
+            ),
+            ConditionalEffect(
+                condition = Conditions.EntityMatches(
+                    EffectTarget.ContextTarget(0),
+                    GameObjectFilter.Creature
+                ),
+                effect = CreateDelayedTriggerEffect(
+                    trigger = Triggers.LeavesBattlefield,
+                    watchedTarget = chosen,
+                    fireOnce = true,
+                    expiry = DelayedTriggerExpiry.Never,
+                    effect = TransformEffect(EffectTarget.Self)
+                )
+            )
+        )
+        description = "My First Friend — When Zenos yae Galvus enters, choose a creature an " +
+            "opponent controls. Until end of turn, creatures other than Zenos yae Galvus and the " +
+            "chosen creature get -2/-2. When the chosen creature leaves the battlefield, transform " +
+            "Zenos yae Galvus."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "127"
+        artist = "Alexander Mokhov"
+        imageUri = "https://cards.scryfall.io/normal/front/b/6/b65ffce4-bb58-418a-9bad-81533a5f2ba2.jpg?1782686503"
+        ruling(
+            "2025-06-06",
+            "In the case where you can't choose a creature an opponent controls for Zenos's first " +
+                "ability (probably because your opponents control no creatures), other creatures " +
+                "will still get -2/-2 until end of turn when Zenos's first ability resolves."
+        )
+        ruling(
+            "2025-06-06",
+            "If this card somehow enters the battlefield with its back face up, it didn't " +
+                "transform, so you won't choose an opponent."
+        )
+    }
+}
+
+val ZenosYaeGalvus: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = ZenosYaeGalvusFront,
+    backFace = ShinryuTranscendentRival,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -25913,6 +25913,164 @@
     ]
 }
 
+// Zenos yae Galvus
+{
+    "name": "Zenos yae Galvus",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Legendary Creature — Human Noble Warrior",
+    "oracleText": "My First Friend — When Zenos yae Galvus enters, choose a creature an opponent controls. Until end of turn, creatures other than Zenos yae Galvus and the chosen creature get -2/-2.\nWhen the chosen creature leaves the battlefield, transform Zenos yae Galvus.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ForEach",
+                            "space": {
+                                "type": "IterationSpace.Group",
+                                "filter": {
+                                    "baseFilter": "creature",
+                                    "excludeSelf": true,
+                                    "excludeTarget": true
+                                }
+                            },
+                            "body": {
+                                "type": "ModifyStats",
+                                "powerModifier": {
+                                    "type": "Fixed",
+                                    "amount": -2
+                                },
+                                "toughnessModifier": {
+                                    "type": "Fixed",
+                                    "amount": -2
+                                },
+                                "target": "Self"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "creature"
+                                }
+                            },
+                            "then": {
+                                "type": "CreateDelayedTrigger",
+                                "effect": "Transform",
+                                "trigger": {
+                                    "event": {
+                                        "type": "ZoneChangeEvent",
+                                        "from": "Battlefield"
+                                    }
+                                },
+                                "watchedTarget": {
+                                    "type": "BoundVariable",
+                                    "name": "creature an opponent controls"
+                                },
+                                "expiry": "DelayedTriggerExpiry.Never",
+                                "fireOnce": true
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature ctrl:opponent"
+                    },
+                    "id": "creature an opponent controls"
+                },
+                "descriptionOverride": "My First Friend — When Zenos yae Galvus enters, choose a creature an opponent controls. Until end of turn, creatures other than Zenos yae Galvus and the chosen creature get -2/-2. When the chosen creature leaves the battlefield, transform Zenos yae Galvus."
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Shinryu, Transcendent Rival",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Dragon",
+        "oracleText": "Flying\nAs this creature transforms into Shinryu, choose an opponent.\nBurning Chains — When the chosen player loses the game, you win the game.",
+        "creatureStats": {
+            "power": 8,
+            "toughness": 8
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_2",
+                    "trigger": {
+                        "type": "TransformEvent",
+                        "intoBackFace": true
+                    },
+                    "effect": "ChooseOpponentForSource",
+                    "descriptionOverride": "As this creature transforms into Shinryu, choose an opponent."
+                },
+                {
+                    "id": "ability_3",
+                    "trigger": "PlayerLostGameEvent",
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "WinGame",
+                        "message": "Shinryu, Transcendent Rival — the chosen player lost the game"
+                    },
+                    "triggerCondition": {
+                        "type": "TriggeringPlayerIs",
+                        "player": "ChosenOpponent"
+                    },
+                    "descriptionOverride": "Burning Chains — When the chosen player loses the game, you win the game."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "127",
+            "rarity": "RARE",
+            "artist": "Alexander Mokhov",
+            "imageUri": "https://cards.scryfall.io/normal/back/b/6/b65ffce4-bb58-418a-9bad-81533a5f2ba2.jpg?1782686503"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "127",
+        "rarity": "RARE",
+        "artist": "Alexander Mokhov",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/6/b65ffce4-bb58-418a-9bad-81533a5f2ba2.jpg?1782686503",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "In the case where you can't choose a creature an opponent controls for Zenos's first ability (probably because your opponents control no creatures), other creatures will still get -2/-2 until end of turn when Zenos's first ability resolves."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "If this card somehow enters the battlefield with its back face up, it didn't transform, so you won't choose an opponent."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Zidane, Tantalus Thief
 {
     "name": "Zidane, Tantalus Thief",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerContext.kt
@@ -204,6 +204,14 @@ data class TriggerContext(
                     xValueOfTriggeringSpell = event.xValue
                 )
                 is CardsDrawnEvent -> TriggerContext(triggeringPlayerId = event.playerId)
+                // A player losing the game: the loser is both the triggering player (so
+                // Player.TriggeringPlayer / a TriggeringPlayerIs condition resolves to them) and
+                // the triggering entity (players are entities). Shinryu, Transcendent Rival reads
+                // this to gate "when the chosen player loses the game, you win the game".
+                is com.wingedsheep.engine.core.PlayerLostEvent -> TriggerContext(
+                    triggeringEntityId = event.playerId,
+                    triggeringPlayerId = event.playerId
+                )
                 is com.wingedsheep.engine.core.ScriedEvent -> TriggerContext(
                     triggeringPlayerId = event.playerId,
                     scryCount = event.count

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerIndex.kt
@@ -81,6 +81,7 @@ enum class TriggerCategory {
     BECAME_SADDLED,
     BECOMES_ATTACHED,
     SAGA_CHAPTER_RESOLVED,
+    PLAYER_LOST,
 }
 
 /**
@@ -256,6 +257,7 @@ class TriggerIndex(
                 is SdkGameEvent.BecameSaddledEvent -> BECAME_SADDLED_LIST
                 is SdkGameEvent.BecomesAttachedEvent -> BECOMES_ATTACHED_LIST
                 is SdkGameEvent.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
+                is SdkGameEvent.PlayerLostGameEvent -> PLAYER_LOST_LIST
                 // These are handled by specialized detect methods, not the main loop
                 else -> emptyList()
             }
@@ -299,6 +301,7 @@ class TriggerIndex(
             is com.wingedsheep.engine.core.BecameSaddledEvent -> BECAME_SADDLED_LIST
             is com.wingedsheep.engine.core.PermanentAttachedEvent -> BECOMES_ATTACHED_LIST
             is com.wingedsheep.engine.core.SagaChapterResolvedEvent -> SAGA_CHAPTER_RESOLVED_LIST
+            is com.wingedsheep.engine.core.PlayerLostEvent -> PLAYER_LOST_LIST
             else -> emptyList()
         }
 
@@ -335,5 +338,6 @@ class TriggerIndex(
         private val BECAME_SADDLED_LIST = listOf(TriggerCategory.BECAME_SADDLED)
         private val BECOMES_ATTACHED_LIST = listOf(TriggerCategory.BECOMES_ATTACHED)
         private val SAGA_CHAPTER_RESOLVED_LIST = listOf(TriggerCategory.SAGA_CHAPTER_RESOLVED)
+        private val PLAYER_LOST_LIST = listOf(TriggerCategory.PLAYER_LOST)
     }
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -528,6 +528,10 @@ class TriggerMatcher(
                     event.oldLife != event.newLife &&
                     matchesPlayer(trigger.player, event.playerId, controllerId)
             }
+            is EventPattern.PlayerLostGameEvent -> {
+                event is com.wingedsheep.engine.core.PlayerLostEvent &&
+                    matchesPlayer(trigger.player, event.playerId, controllerId)
+            }
             is EventPattern.DiscardEvent -> {
                 event is CardsDiscardedEvent &&
                     matchingDiscardCount(trigger, event, sourceId, controllerId, state) > 0
@@ -1503,6 +1507,7 @@ class TriggerMatcher(
                 sourceId = trigger.sourceId,
                 controllerId = trigger.controllerId,
                 triggeringEntityId = trigger.triggerContext.triggeringEntityId,
+                triggeringPlayerId = trigger.triggerContext.triggeringPlayerId,
                 triggerDamageAmount = trigger.triggerContext.damageAmount,
                 triggerCounterCount = trigger.triggerContext.counterCount,
                 triggerTotalCounterCount = trigger.triggerContext.totalCounterCount,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/ConditionEvaluator.kt
@@ -130,6 +130,7 @@ import com.wingedsheep.sdk.scripting.conditions.PermanentTypeEnteredBattlefieldT
 import com.wingedsheep.sdk.scripting.conditions.PlayerCastSpellsThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerCommittedCrimeThisTurn
 import com.wingedsheep.sdk.scripting.conditions.PlayerHasCitysBlessing
+import com.wingedsheep.sdk.scripting.conditions.TriggeringPlayerIs
 import com.wingedsheep.sdk.scripting.conditions.RingHasTemptedPlayerAtLeast
 import com.wingedsheep.sdk.scripting.conditions.CreatureDiedThisTurnCondition
 import com.wingedsheep.sdk.scripting.conditions.ControlledCreatureDiedThisTurnCondition
@@ -366,6 +367,12 @@ class ConditionEvaluator(
                 count > 0
             }
             is PlayerHasCitysBlessing -> evaluateHasCitysBlessingCtx(state, condition, ctx)
+
+            is TriggeringPlayerIs -> {
+                val triggeringPlayer = resolvePlayer(state, Player.TriggeringPlayer, ctx)
+                val expected = resolvePlayer(state, condition.player, ctx)
+                triggeringPlayer != null && expected != null && triggeringPlayer == expected
+            }
 
             is RingHasTemptedPlayerAtLeast -> {
                 val playerId = resolvePlayer(state, condition.player, ctx)

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZenosYaeGalvusScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ZenosYaeGalvusScenarioTest.kt
@@ -1,0 +1,285 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.GameConfig
+import com.wingedsheep.engine.core.GameInitializer
+import com.wingedsheep.engine.core.PassPriority
+import com.wingedsheep.engine.core.PlayerConfig
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.registry.CardRegistry
+import com.wingedsheep.engine.state.components.battlefield.CastChoicesComponent
+import com.wingedsheep.engine.state.components.battlefield.ChoiceValue
+import com.wingedsheep.engine.state.components.battlefield.chosenOpponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fin.cards.ZenosYaeGalvus
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.ChoiceSlot
+import com.wingedsheep.sdk.scripting.references.Player
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Zenos yae Galvus // Shinryu, Transcendent Rival (FIN #127).
+ *
+ * Proves the card's assembly and the two engine primitives it introduced:
+ *  - The "My First Friend" ETB gives every creature except Zenos and the chosen creature -2/-2, and
+ *    still resolves the debuff when there is no opponent creature to choose (the printed ruling).
+ *  - "When the chosen creature leaves the battlefield, transform" is a persistent
+ *    ([DelayedTriggerExpiry.Never]) reflexive delayed trigger — it survives an end-of-turn cleanup
+ *    and fires only for the watched creature, then flips Zenos to its Shinryu back face.
+ *  - Shinryu's `Triggers.AnyPlayerLosesGame` + `Conditions.TriggeringPlayerIs(Player.ChosenOpponent)`
+ *    + `Effects.WinGame()` make you win when your chosen opponent loses — proven discriminatingly in
+ *    a 3-player pod (an unchosen opponent's loss does not win it for you).
+ */
+class ZenosYaeGalvusScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ZenosYaeGalvus))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        return driver
+    }
+
+    // Player 1 may not be active at game start (random turn order) — advance until it is.
+    fun GameTestDriver.advanceToPlayer1(targetStep: Step) {
+        passPriorityUntil(targetStep)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(targetStep)
+            safety++
+        }
+    }
+
+    fun faceName(driver: GameTestDriver, id: EntityId): String =
+        driver.state.getEntity(id)!!.get<CardComponent>()!!.name
+
+    /** Walk the stack + any decisions to rest, choosing [chosen] (or nothing) for Zenos's ETB. */
+    fun resolveWithChoice(driver: GameTestDriver, chosen: EntityId?) {
+        var guard = 0
+        while (guard++ < 40 && (driver.state.stack.isNotEmpty() || driver.isPaused)) {
+            val decision = driver.pendingDecision
+            if (driver.isPaused && decision is ChooseTargetsDecision) {
+                driver.submitTargetSelection(
+                    decision.playerId,
+                    if (chosen != null) listOf(chosen) else emptyList()
+                )
+            } else if (driver.isPaused) {
+                driver.autoResolveDecision()
+            } else {
+                driver.bothPass()
+            }
+        }
+    }
+
+    /** Cast Zenos from [me]'s hand (auto-paying) and resolve its ETB, choosing [chosen]. */
+    fun castZenos(driver: GameTestDriver, me: EntityId, chosen: EntityId?): EntityId {
+        val card = driver.putCardInHand(me, "Zenos yae Galvus")
+        driver.giveMana(me, Color.BLACK, 5) // {3}{B}{B}
+        driver.castSpell(me, card).isSuccess shouldBe true
+        resolveWithChoice(driver, chosen)
+        return driver.findPermanent(me, "Zenos yae Galvus")
+            ?: driver.findPermanent(me, "Shinryu, Transcendent Rival")!!
+    }
+
+    /** Kill [victim] with a Lightning Bolt from [caster] via the real event pipeline, then settle. */
+    fun killWithBolt(driver: GameTestDriver, caster: EntityId, victim: EntityId) {
+        val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+        driver.giveMana(caster, Color.RED, 1)
+        driver.castSpell(caster, bolt, targets = listOf(victim)).isSuccess shouldBe true
+        var guard = 0
+        while (guard++ < 40 && (driver.state.stack.isNotEmpty() || driver.isPaused)) {
+            if (driver.isPaused) driver.autoResolveDecision() else driver.bothPass()
+        }
+    }
+
+    test("My First Friend gives -2/-2 to every creature except Zenos and the chosen creature") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val myBear = driver.putCreatureOnBattlefield(me, "Centaur Courser")   // 3/3 -> 1/1
+        val chosen = driver.putCreatureOnBattlefield(opp, "Centaur Courser")  // 3/3, excluded
+        val other = driver.putCreatureOnBattlefield(opp, "Centaur Courser")   // 3/3 -> 1/1
+
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val zenos = castZenos(driver, me, chosen)
+
+        val projected = projector.project(driver.state)
+        // Zenos itself is excluded (excludeSelf).
+        projected.getPower(zenos) shouldBe 4
+        projected.getToughness(zenos) shouldBe 4
+        // The chosen creature is excluded (excludeTarget).
+        projected.getPower(chosen) shouldBe 3
+        projected.getToughness(chosen) shouldBe 3
+        // Every other creature — mine and the opponent's — took -2/-2.
+        projected.getPower(myBear) shouldBe 1
+        projected.getToughness(myBear) shouldBe 1
+        projected.getPower(other) shouldBe 1
+        projected.getToughness(other) shouldBe 1
+    }
+
+    test("with no creature to choose, the other creatures still get -2/-2 (printed ruling)") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        val myBear = driver.putCreatureOnBattlefield(me, "Centaur Courser") // 3/3 -> 1/1
+        // The opponent controls no creatures — nothing to choose.
+
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val zenos = castZenos(driver, me, null)
+
+        val projected = projector.project(driver.state)
+        projected.getPower(zenos) shouldBe 4
+        projected.getPower(myBear) shouldBe 1
+        projected.getToughness(myBear) shouldBe 1
+    }
+
+    test("transforms into Shinryu when the chosen creature leaves — surviving an end-of-turn cleanup") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val chosen = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val zenos = castZenos(driver, me, chosen)
+        faceName(driver, zenos) shouldBe "Zenos yae Galvus"
+
+        // Cross two turn boundaries so the reflexive delayed trigger survives cleanup (Never expiry),
+        // and priority returns to me at a main phase to cast the removal.
+        driver.passPriorityUntil(Step.END)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.passPriorityUntil(Step.END)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        faceName(driver, zenos) shouldBe "Zenos yae Galvus"
+
+        // The chosen creature leaves → transform Zenos. Two full turns have passed, so it is my
+        // turn again and I have priority to cast the removal.
+        driver.activePlayer shouldBe me
+        killWithBolt(driver, me, chosen)
+        faceName(driver, zenos) shouldBe "Shinryu, Transcendent Rival"
+        // Transforming into Shinryu chose the sole opponent.
+        driver.state.getEntity(zenos)!!.chosenOpponent() shouldBe opp
+    }
+
+    test("a different creature leaving does not transform Zenos") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val chosen = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+        val other = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        driver.advanceToPlayer1(Step.PRECOMBAT_MAIN)
+        val zenos = castZenos(driver, me, chosen)
+
+        // Kill the creature that was NOT chosen — the watch is scoped to the chosen creature only.
+        killWithBolt(driver, me, other)
+        faceName(driver, zenos) shouldBe "Zenos yae Galvus"
+    }
+
+    test("Shinryu: when the chosen player loses the game, you win — even with another opponent alive") {
+        // A single-faced stand-in carrying Shinryu's win trigger, so a 3-player pod can be built
+        // directly (the transform + ChooseOpponent path is covered by the 2-player tests above).
+        val watcher = card("Chosen Doom Watcher") {
+            manaCost = "{B}"
+            colorIdentity = "B"
+            typeLine = "Creature — Human"
+            power = 1
+            toughness = 1
+            triggeredAbility {
+                trigger = Triggers.AnyPlayerLosesGame
+                triggerCondition = Conditions.TriggeringPlayerIs(Player.ChosenOpponent)
+                effect = Effects.WinGame()
+            }
+        }
+
+        fun runPod(chosenOpponentIndex: Int): Pair<GameTestDriver, List<EntityId>> {
+            val registry = CardRegistry()
+            (TestCards.all + watcher).forEach { registry.register(it) }
+            val deck = Deck(cards = List(40) { "Centaur Courser" })
+            val init = GameInitializer(registry).initializeGame(
+                GameConfig(
+                    players = (1..3).map { PlayerConfig("Player $it", deck, 20) },
+                    skipMulligans = true,
+                    startingPlayerIndex = 0
+                )
+            )
+            val driver = GameTestDriver()
+            driver.registerCards(TestCards.all + watcher)
+            driver.replaceState(init.state)
+
+            val p1 = init.playerIds[0]
+            val chronicler = driver.putCreatureOnBattlefield(p1, "Chosen Doom Watcher")
+            driver.addComponent(
+                chronicler,
+                CastChoicesComponent(
+                    chosen = mapOf(
+                        ChoiceSlot.OPPONENT to ChoiceValue.EntityChoice(init.playerIds[chosenOpponentIndex])
+                    )
+                )
+            )
+            // The fresh state starts in the untap step; advance to a main phase so priority passing
+            // runs state-based actions normally.
+            var g = 0
+            while (g++ < 40 && driver.state.step != Step.PRECOMBAT_MAIN) {
+                val pid = driver.state.priorityPlayerId ?: break
+                if (!driver.submit(PassPriority(pid)).isSuccess) break
+            }
+            return driver to init.playerIds
+        }
+
+        // Pass priority (for whoever holds it) up to a bounded cap. Passing priority runs
+        // state-based actions (marking the 0-life player lost → PlayerLostEvent) and detects the
+        // resulting triggers, then lets the "you win the game" trigger be placed and resolve. Stops
+        // as soon as the game ends, staying early in the turn (never reaching a combat declaration).
+        fun settle(driver: GameTestDriver, passes: Int) {
+            var guard = 0
+            while (guard++ < passes && !driver.state.gameOver) {
+                if (driver.isPaused) {
+                    driver.autoResolveDecision()
+                } else {
+                    val pid = driver.state.priorityPlayerId ?: break
+                    driver.submit(PassPriority(pid))
+                }
+            }
+        }
+
+        // Deal lethal to [victim] with a Lightning Bolt cast by whoever holds priority, then settle.
+        // Resolving the bolt runs the post-resolution state-based-action sweep (marking the 0-life
+        // player lost → PlayerLostEvent), which the priority pipeline feeds to trigger detection.
+        fun boltToDeath(driver: GameTestDriver, victim: EntityId) {
+            driver.replaceState(driver.state.withLifeTotal(victim, 2))
+            val caster = driver.state.priorityPlayerId!!
+            val bolt = driver.putCardInHand(caster, "Lightning Bolt")
+            driver.giveMana(caster, Color.RED, 1)
+            driver.castSpell(caster, bolt, targets = listOf(victim)).isSuccess shouldBe true
+            settle(driver, passes = 12)
+        }
+
+        // Chosen opponent = Player 2. Player 2 loses → Shinryu's controller (Player 1) wins, even
+        // though Player 3 is still in the game.
+        val (winDriver, winPlayers) = runPod(chosenOpponentIndex = 1)
+        boltToDeath(winDriver, winPlayers[1])
+        winDriver.state.gameOver shouldBe true
+        winDriver.state.winnerId shouldBe winPlayers[0]
+
+        // Control: chosen opponent = Player 3, but Player 2 loses. The trigger does not fire, so the
+        // game continues with Players 1 and 3 — no free win.
+        val (contDriver, contPlayers) = runPod(chosenOpponentIndex = 2)
+        boltToDeath(contDriver, contPlayers[1])
+        contDriver.state.gameOver shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Zenos yae Galvus // Shinryu, Transcendent Rival** (FIN #127), one of the last unimplemented Final Fantasy cards, along with three small, reusable engine additions and a latent-bug fix. FIN goes 295 → 296 / 300.

This is a single, complex transforming legendary DFC — per the "pick fewer if complex" guidance, it's implemented thoroughly rather than shipping several shallow cards. The remaining 4 missing FIN cards (Emet-Selch, Esper Origins, Gogo, Ultima) each still need their own `add-feature`-scope work.

## Card behavior

**Front — Zenos yae Galvus (4/4):** *My First Friend* — When Zenos enters, choose a creature an opponent controls; until end of turn, creatures other than Zenos and the chosen creature get -2/-2. When the chosen creature leaves the battlefield, transform Zenos.

**Back — Shinryu, Transcendent Rival (8/8, flying):** As it transforms into Shinryu, choose an opponent. When the chosen player loses the game, you win the game.

Modeling notes:
- The choice is an **optional** target so the -2/-2 still resolves when opponents control no creatures (per the printed ruling); a required target would remove the whole ability from the stack.
- "When the chosen creature leaves" is a persistent reflexive delayed trigger scoped to the chosen creature — it must survive end-of-turn cleanup, hence the new `Never` expiry.

## Engine / SDK additions (all general-purpose, documented in `card-sdk-language-reference.md`)

- **`DelayedTriggerExpiry.Never`** — a watched delayed trigger that persists across turns until it fires (the end-of-turn cleanup only removes `EndOfTurn` triggers).
- **`EventPattern.PlayerLostGameEvent` + `Triggers.AnyPlayerLosesGame`** — "when a player loses the game", wired through `TriggerIndex` (new `PLAYER_LOST` category), `TriggerMatcher`, and `TriggerContext.fromEvent` (mapping the engine's existing `PlayerLostEvent`; the loser becomes the triggering player).
- **`Conditions.TriggeringPlayerIs(player)`** — compares the triggering player against any resolved `Player` reference; used to gate the win-rider on `Player.ChosenOpponent`.

## Fix

`TriggerMatcher.filterByTriggerCondition` now threads `triggeringPlayerId` into the intervening-if `EffectContext`, so a `triggerCondition` can reference `Player.TriggeringPlayer` (it was always `null` there before — a latent bug for any player-referencing intervening-if).

## Tests

`ZenosYaeGalvusScenarioTest` covers:
- -2/-2 hits every creature **except** Zenos and the chosen creature;
- the no-legal-choice ruling (debuff still applies);
- transform when the chosen creature leaves, **surviving an end-of-turn cleanup** (`Never` expiry);
- a different creature leaving does **not** transform;
- a discriminating **3-player** win-condition pod (the chosen opponent's loss wins the game for you while another opponent survives; an unchosen opponent's loss does not).

Full `just test` passes (no regressions from the shared `TriggerMatcher` change); FIN snapshot golden re-blessed (additive only); `just check-card-printing "Zenos yae Galvus"` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)