### PR TITLE
Add Foundations cards: Perforating Artist, Valkyrie's Call, Dropkick Bomber

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DropkickBomber.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/DropkickBomber.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.GrantTriggeredAbilityEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeSelfEffect
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Dropkick Bomber
+ * {2}{R}
+ * Creature — Goblin Warrior
+ * 2/3
+ *
+ * Other Goblins you control get +1/+1.
+ * {R}: Until end of turn, another target Goblin you control gains flying and "When this
+ * creature deals combat damage, sacrifice it."
+ *
+ * The anthem is a [ModifyStats] static over other Goblins you control (excludeSelf). The
+ * activated ability grants two things to another target Goblin until end of turn: flying
+ * ([Effects.GrantKeyword]) and a granted triggered ability ([GrantTriggeredAbilityEffect])
+ * whose SELF-bound combat-damage trigger (to any recipient — player or creature) sacrifices
+ * the creature it was granted to ([SacrificeSelfEffect] resolves against the trigger's own
+ * source). "Another target" excludes Dropkick Bomber itself via [TargetFilter.excludeSelf].
+ */
+val DropkickBomber = card("Dropkick Bomber") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Warrior"
+    power = 2
+    toughness = 3
+    oracleText = "Other Goblins you control get +1/+1.\n" +
+        "{R}: Until end of turn, another target Goblin you control gains flying and \"When this " +
+        "creature deals combat damage, sacrifice it.\""
+
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(
+                GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN).youControl(),
+                excludeSelf = true
+            )
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{R}")
+        val goblin = target(
+            "another target Goblin you control",
+            TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.withSubtype(Subtype.GOBLIN).youControl(),
+                    excludeSelf = true
+                )
+            )
+        )
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.FLYING, goblin, Duration.EndOfTurn),
+            GrantTriggeredAbilityEffect(
+                ability = TriggeredAbility.create(
+                    trigger = Triggers.dealsDamage(
+                        damageType = DamageType.Combat,
+                        recipient = RecipientFilter.Any,
+                        binding = TriggerBinding.SELF
+                    ).event,
+                    binding = TriggerBinding.SELF,
+                    effect = SacrificeSelfEffect,
+                    descriptionOverride = "When this creature deals combat damage, sacrifice it."
+                ),
+                target = goblin,
+                duration = Duration.EndOfTurn
+            )
+        )
+        description = "Until end of turn, another target Goblin you control gains flying and " +
+            "\"When this creature deals combat damage, sacrifice it.\""
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "537"
+        artist = "Quintin Gleim"
+        flavorText = "\"I've always enjoyed kicking stuff, so this was an ideal career opportunity.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/4/b44f758e-716a-408e-96d4-b58403591c2a.jpg?1782688798"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PerforatingArtist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/PerforatingArtist.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.costs.PayCost
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.PayOrSufferEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Perforating Artist
+ * {1}{B}{R}
+ * Creature — Devil
+ * 3/2
+ *
+ * Deathtouch
+ * Raid — At the beginning of your end step, if you attacked this turn, each opponent
+ * loses 3 life unless that player sacrifices a nonland permanent of their choice or
+ * discards a card.
+ *
+ * Raid (ability word, CR 207.2c — flavor only) is the intervening-if
+ * [Conditions.YouAttackedThisTurn] on the end-step trigger (Rule 603.4). The payoff is
+ * per-opponent: [Effects.ForEachPlayer] over [Player.EachOpponent] rebinds the body's
+ * controller to each opponent, so [EffectTarget.Controller] inside resolves to *that*
+ * opponent. Each opponent independently faces a [PayOrSufferEffect] — pay by choosing to
+ * sacrifice a nonland permanent or discard a card ([PayCost.Choice]), else lose 3 life.
+ * This mirrors Starseer Mentor's punisher, widened from "target opponent" to "each opponent".
+ */
+val PerforatingArtist = card("Perforating Artist") {
+    manaCost = "{1}{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Creature — Devil"
+    power = 3
+    toughness = 2
+    oracleText = "Deathtouch\nRaid — At the beginning of your end step, if you attacked this turn, " +
+        "each opponent loses 3 life unless that player sacrifices a nonland permanent of their choice " +
+        "or discards a card."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouAttackedThisTurn
+        effect = Effects.ForEachPlayer(
+            Player.EachOpponent,
+            listOf(
+                PayOrSufferEffect(
+                    cost = Costs.pay.Choice(
+                        listOf(
+                            Costs.pay.Sacrifice(filter = GameObjectFilter.Nonland),
+                            Costs.pay.Discard()
+                        )
+                    ),
+                    suffer = LoseLifeEffect(
+                        amount = DynamicAmount.Fixed(3),
+                        target = EffectTarget.Controller
+                    ),
+                    player = EffectTarget.Controller
+                )
+            )
+        )
+        description = "Raid — At the beginning of your end step, if you attacked this turn, each " +
+            "opponent loses 3 life unless that player sacrifices a nonland permanent of their choice " +
+            "or discards a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "124"
+        artist = "Arif Wijaya"
+        flavorText = "The first three rows of the audience are marketed as the \"slash zone.\""
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/72980409-53f0-43c1-965e-06f22e7bb608.jpg?1782689158"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ValkyriesCall.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/ValkyriesCall.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Valkyrie's Call
+ * {3}{W}{W}
+ * Enchantment
+ *
+ * Whenever a nontoken, non-Angel creature you control dies, return that card to the
+ * battlefield under its owner's control with a +1/+1 counter on it. It has flying and
+ * is an Angel in addition to its other types.
+ *
+ * Modeled on the Vraska, the Silencer template: a filtered leaves-the-battlefield trigger
+ * ([Triggers.leavesBattlefield] to [Zone.GRAVEYARD], ANY binding) whose filter restricts to
+ * nontoken, non-Angel creatures the controller controls. [EffectTarget.TriggeringEntity] is
+ * the dying card, now in the graveyard; [Effects.Move] returns it to the battlefield (under
+ * its owner's control — the reanimation default), then a +1/+1 counter and two
+ * [Duration.Permanent] continuous grants (Angel creature type + flying) apply to that
+ * returned object for as long as it remains on the battlefield (CR 611.2b — the effect has
+ * no duration and modifies the object created by the resolution).
+ */
+val ValkyriesCall = card("Valkyrie's Call") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment"
+    oracleText = "Whenever a nontoken, non-Angel creature you control dies, return that card to " +
+        "the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is " +
+        "an Angel in addition to its other types."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.nontoken().youControl().notSubtype(Subtype.ANGEL),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.Composite(
+            // Return that card to the battlefield under its owner's control.
+            Effects.Move(EffectTarget.TriggeringEntity, Zone.BATTLEFIELD),
+            // ... with a +1/+1 counter on it.
+            Effects.AddCounters("+1/+1", 1, EffectTarget.TriggeringEntity),
+            // It has flying and is an Angel in addition to its other types.
+            Effects.AddCreatureType("Angel", EffectTarget.TriggeringEntity, Duration.Permanent),
+            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.TriggeringEntity, Duration.Permanent)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "27"
+        artist = "Scott Murphy"
+        flavorText = "\"Welcome, worthy one.\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/e/0e1f1ff2-fa8f-4d38-b631-2d6e08e614c8.jpg?1782689241"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -1912,6 +1912,93 @@
     ]
 }
 
+// Dropkick Bomber
+{
+    "name": "Dropkick Bomber",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Other Goblins you control get +1/+1.\n{R}: Until end of turn, another target Goblin you control gains flying and \"When this creature deals combat damage, sacrifice it.\"",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{R}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "another target Goblin you control"
+                            }
+                        },
+                        {
+                            "type": "GrantTriggeredAbility",
+                            "ability": {
+                                "id": "ability_2",
+                                "trigger": {
+                                    "type": "DealsDamageEvent",
+                                    "damageType": "DamageCombat"
+                                },
+                                "effect": "SacrificeSelf",
+                                "descriptionOverride": "When this creature deals combat damage, sacrifice it."
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "another target Goblin you control"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Goblin ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "another target Goblin you control"
+                    }
+                ],
+                "descriptionOverride": "Until end of turn, another target Goblin you control gains flying and \"When this creature deals combat damage, sacrifice it.\""
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1,
+                "filter": {
+                    "baseFilter": "creature Goblin ctrl:you",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "537",
+        "rarity": "RARE",
+        "artist": "Quintin Gleim",
+        "flavorText": "\"I've always enjoyed kicking stuff, so this was an ideal career opportunity.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/4/b44f758e-716a-408e-96d4-b58403591c2a.jpg?1782688798"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Eager Trufflesnout
 {
     "name": "Eager Trufflesnout",
@@ -4555,6 +4642,92 @@
     ]
 }
 
+// Perforating Artist
+{
+    "name": "Perforating Artist",
+    "manaCost": "{1}{B}{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "Deathtouch\nRaid — At the beginning of your end step, if you attacked this turn, each opponent loses 3 life unless that player sacrifices a nonland permanent of their choice or discards a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "EachOpponent"
+                    },
+                    "body": {
+                        "type": "PayOrSuffer",
+                        "cost": {
+                            "type": "Choice",
+                            "options": [
+                                {
+                                    "type": "PayAtom",
+                                    "atom": {
+                                        "type": "AtomSacrifice",
+                                        "filter": "nonland"
+                                    }
+                                },
+                                {
+                                    "type": "PayAtom",
+                                    "atom": "AtomDiscard"
+                                }
+                            ]
+                        },
+                        "suffer": {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 3
+                            },
+                            "target": "Controller"
+                        }
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "PLAYER_ATTACKED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Raid — At the beginning of your end step, if you attacked this turn, each opponent loses 3 life unless that player sacrifices a nonland permanent of their choice or discards a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "124",
+        "rarity": "UNCOMMON",
+        "artist": "Arif Wijaya",
+        "flavorText": "The first three rows of the audience are marketed as the \"slash zone.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/72980409-53f0-43c1-965e-06f22e7bb608.jpg?1782689158"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Preposterous Proportions
 {
     "name": "Preposterous Proportions",
@@ -6631,6 +6804,75 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Valkyrie's Call
+{
+    "name": "Valkyrie's Call",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever a nontoken, non-Angel creature you control dies, return that card to the battlefield under its owner's control with a +1/+1 counter on it. It has flying and is an Angel in addition to its other types.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            "IsNontoken",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Angel"
+                            }
+                        ],
+                        "controllerPredicate": "ControlledByYou"
+                    },
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "TriggeringEntity",
+                            "destination": "Battlefield"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "TriggeringEntity"
+                        },
+                        {
+                            "type": "AddCreatureType",
+                            "subtype": "Angel",
+                            "target": "TriggeringEntity"
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "FLYING",
+                            "target": "TriggeringEntity",
+                            "duration": "Permanent"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "MYTHIC",
+        "artist": "Scott Murphy",
+        "flavorText": "\"Welcome, worthy one.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/e/0e1f1ff2-fa8f-4d38-b631-2d6e08e614c8.jpg?1782689241"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DropkickBomberScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DropkickBomberScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.DropkickBomber
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Dropkick Bomber (FDN) — {2}{R} Creature — Goblin Warrior 2/3.
+ *
+ * "Other Goblins you control get +1/+1." The activated ability (grant flying + a temporary
+ * combat-damage-sacrifice trigger) reuses proven grant primitives; this test pins the anthem's
+ * projection: other Goblins are buffed, Dropkick Bomber itself is not (excludeSelf).
+ */
+class DropkickBomberScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + DropkickBomber)
+        return driver
+    }
+
+    test("Dropkick Bomber buffs other Goblins you control but not itself") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bomber = driver.putCreatureOnBattlefield(player, "Dropkick Bomber")
+        val goblin = driver.putCreatureOnBattlefield(player, "Goblin Guide") // base 2/1 Goblin
+
+        val projected = projector.project(driver.state)
+        // Other Goblin gets +1/+1: 2/1 -> 3/2.
+        projected.getPower(goblin) shouldBe 3
+        projected.getToughness(goblin) shouldBe 2
+        // Dropkick Bomber does not buff itself (excludeSelf).
+        projected.getPower(bomber) shouldBe 2
+        projected.getToughness(bomber) shouldBe 3
+    }
+
+    test("the anthem does not buff a Goblin an opponent controls") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putCreatureOnBattlefield(player, "Dropkick Bomber")
+        val enemyGoblin = driver.putCreatureOnBattlefield(opponent, "Goblin Guide")
+
+        val projected = projector.project(driver.state)
+        // "Goblins you control" — the opponent's Goblin is unaffected.
+        projected.getPower(enemyGoblin) shouldBe 2
+        projected.getToughness(enemyGoblin) shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PerforatingArtistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PerforatingArtistScenarioTest.kt
@@ -1,0 +1,122 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.PerforatingArtist
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Perforating Artist (FDN) — {1}{B}{R} Creature — Devil 3/2.
+ *
+ * Deathtouch. Raid — At the beginning of your end step, if you attacked this turn, each opponent
+ * loses 3 life unless that player sacrifices a nonland permanent of their choice or discards a card.
+ *
+ * Exercises the raid intervening-if gate (no attack → no trigger), and the per-opponent punisher:
+ * the opponent may discard to avoid the loss, or take 3 life loss.
+ */
+class PerforatingArtistScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + PerforatingArtist)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun GameTestDriver.advanceToMyEndStep() {
+        var guard = 0
+        while (currentStep != Step.END && guard++ < 60) {
+            if (state.stack.isNotEmpty() || pendingDecision != null) bothPass() else passPriorityUntil(Step.END)
+        }
+    }
+
+    test("Raid gate: without attacking, the end-step trigger does nothing") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        driver.putCreatureOnBattlefield(me, "Perforating Artist")
+        val oppLifeBefore = driver.getLifeTotal(opp)
+
+        driver.advanceToMyEndStep()
+
+        // No attack this turn → intervening-if fails → no decision, no life loss.
+        driver.pendingDecision shouldBe null
+        driver.getLifeTotal(opp) shouldBe oppLifeBefore
+    }
+
+    test("after attacking, an opponent who discards avoids losing life") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val artist = driver.putCreatureOnBattlefield(me, "Perforating Artist")
+        driver.removeSummoningSickness(artist)
+        // Opponent has no nonland permanents; give a card so discard is the sole avoidance option.
+        driver.putCardInHand(opp, "Lightning Bolt")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(artist), opp)
+        driver.advanceToMyEndStep()
+
+        var lifeAtDecision = -1
+        var discarded = false
+        var guard = 0
+        while (guard++ < 30) {
+            when (val pd = driver.pendingDecision) {
+                is ChooseOptionDecision -> {
+                    if (lifeAtDecision < 0) lifeAtDecision = driver.getLifeTotal(opp)
+                    val discardIdx = pd.options.indexOfFirst { it.contains("Discard", ignoreCase = true) }
+                    driver.submitDecision(opp, OptionChosenResponse(pd.id, discardIdx))
+                }
+                is SelectCardsDecision -> {
+                    driver.submitCardSelection(opp, pd.options.take(1))
+                    discarded = true
+                }
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        discarded shouldBe true
+        // Discarded to pay → no life lost to the punisher.
+        driver.getLifeTotal(opp) shouldBe lifeAtDecision
+    }
+
+    test("after attacking, an opponent who declines loses 3 life") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        val artist = driver.putCreatureOnBattlefield(me, "Perforating Artist")
+        driver.removeSummoningSickness(artist)
+        driver.putCardInHand(opp, "Lightning Bolt")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(artist), opp)
+        driver.advanceToMyEndStep()
+
+        var lifeAtDecision = -1
+        var guard = 0
+        while (guard++ < 30) {
+            when (val pd = driver.pendingDecision) {
+                is ChooseOptionDecision -> {
+                    if (lifeAtDecision < 0) lifeAtDecision = driver.getLifeTotal(opp)
+                    // The suffer option ("loses 3 life") is always appended last.
+                    driver.submitDecision(opp, OptionChosenResponse(pd.id, pd.options.lastIndex))
+                }
+                is SelectCardsDecision -> driver.submitCardSelection(opp, pd.options.take(1))
+                else -> if (driver.state.stack.isNotEmpty()) driver.bothPass() else break
+            }
+        }
+
+        // Declined the cost → lost 3 life to the punisher.
+        driver.getLifeTotal(opp) shouldBe lifeAtDecision - 3
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValkyriesCallScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ValkyriesCallScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.ValkyriesCall
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Valkyrie's Call (FDN) — {3}{W}{W} Enchantment.
+ *
+ * Whenever a nontoken, non-Angel creature you control dies, return that card to the
+ * battlefield under its owner's control with a +1/+1 counter on it. It has flying and is
+ * an Angel in addition to its other types.
+ */
+class ValkyriesCallScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + ValkyriesCall)
+        return driver
+    }
+
+    test("a nontoken creature you control that dies returns as a 4/4 flying Angel with a +1/+1 counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Valkyrie's Call")
+        driver.putCreatureOnBattlefield(player, "Centaur Courser") // 3/3 nontoken, not an Angel
+
+        // Kill your own Centaur Courser with Lightning Bolt.
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        val courser = driver.findPermanent(player, "Centaur Courser")!!
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, listOf(courser))
+        driver.bothPass() // resolve Bolt → Courser dies → Valkyrie's Call trigger goes on the stack
+        driver.bothPass() // resolve the trigger → Courser returns transformed
+
+        // No longer in the graveyard...
+        driver.getGraveyard(player).mapNotNull { driver.getCardName(it) } shouldNotContain "Centaur Courser"
+
+        // ...back on the battlefield under its owner's control, transformed.
+        val returned = driver.findPermanent(player, "Centaur Courser")!!
+        val projected = projector.project(driver.state)
+        projected.getPower(returned) shouldBe 4      // 3 + the +1/+1 counter
+        projected.getToughness(returned) shouldBe 4
+        projected.hasKeyword(returned, Keyword.FLYING) shouldBe true
+        projected.hasSubtype(returned, "Angel") shouldBe true
+        // The original Centaur subtype is retained ("in addition to its other types").
+        projected.hasSubtype(returned, "Centaur") shouldBe true
+
+        driver.state.getEntity(returned)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+    }
+
+    test("an opponent's creature dying does not trigger Valkyrie's Call") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Valkyrie's Call")
+        driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        val courser = driver.findPermanent(opponent, "Centaur Courser")!!
+        driver.giveMana(player, Color.RED, 1)
+        driver.castSpell(player, bolt, listOf(courser))
+        driver.bothPass()
+        driver.bothPass()
+
+        // "creature you control" — the opponent's creature stays dead.
+        driver.getGraveyard(opponent).mapNotNull { driver.getCardName(it) } shouldContain "Centaur Courser"
+        driver.findPermanent(opponent, "Centaur Courser") shouldBe null
+        driver.findPermanent(player, "Centaur Courser") shouldBe null
+    }
+})


### PR DESCRIPTION
## Summary

Implements a handful of **Foundations (FDN)** cards. All three are pure compositions of existing SDK primitives — **no new engine mechanics, effects, keywords, or SDK types** — so the SDK reference needs no changes.

I deliberately kept the handful to three: two candidates I scoped out (**Blasphemous Edict**, a condition-gated self-alternative-cost, and **Banner of Kinship**, a brand-new counter type spanning five layers) are genuine `add-feature` work rather than card authoring, and **Angel of Finality** would have required scaffolding Commander 2013 (its earliest printing) — all left for follow-ups.

## Cards

| Card | Mechanics | Reuses |
|------|-----------|--------|
| **Perforating Artist** `{1}{B}{R}` | Deathtouch + Raid end-step trigger: each opponent loses 3 life unless they sacrifice a nonland permanent or discard a card | `ForEachPlayer(EachOpponent)` + `PayOrSuffer(Choice)` (Starseer Mentor punisher, widened to each opponent) + `YouAttackedThisTurn` gate (Storm Fleet Spy) |
| **Valkyrie's Call** `{3}{W}{W}` | Whenever a nontoken, non-Angel creature you control dies, return it with a +1/+1 counter as a flying Angel | Filtered `leavesBattlefield` → `Move(TriggeringEntity)` + `AddCounters` + Permanent-duration `AddCreatureType`/`GrantKeyword` (Vraska, the Silencer template) |
| **Dropkick Bomber** `{2}{R}` | Goblin anthem + `{R}`: another target Goblin gains flying and a temporary combat-damage self-sacrifice trigger | `ModifyStats` lord (excludeSelf) + `GrantKeyword` + `GrantTriggeredAbility` (Commando Raid) |

## Testing

- **Scenario tests** for all three, each proven end-to-end:
  - Perforating Artist: raid gate (no attack → no trigger), discard-to-avoid, and decline-loses-3-life.
  - Valkyrie's Call: dying creature returns as a 4/4 flying Angel (retaining Centaur) with a +1/+1 counter; a creature you *don't* control does not trigger it.
  - Dropkick Bomber: anthem buffs other Goblins you control (2/1 → 3/2) but not itself, and not opponents' Goblins.
- FDN card snapshot re-blessed (diff = only the three new cards).
- `CardLintTest` + `CardDefinitionSnapshotTest` green; full `just build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)