### PR TITLE
Add Emet-Selch, Unsundered to Final Fantasy

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/EmetSelchUnsundered.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fin/cards/EmetSelchUnsundered.kt
@@ -1,0 +1,164 @@
+package com.wingedsheep.mtg.sets.definitions.fin.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.MayCastFromGraveyard
+import com.wingedsheep.sdk.scripting.MayPlayLandsFromGraveyard
+import com.wingedsheep.sdk.scripting.RedirectZoneChange
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.TransformEffect
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Emet-Selch, Unsundered // Hades, Sorcerer of Eld — Final Fantasy #218
+ * {1}{U}{B} · Legendary Creature — Elder Wizard 2/4
+ * // Legendary Creature — Avatar 6/6
+ *
+ * Front — Emet-Selch, Unsundered:
+ *   Vigilance
+ *   Whenever Emet-Selch enters or attacks, draw a card, then discard a card.
+ *   At the beginning of your upkeep, if there are fourteen or more cards in your graveyard,
+ *   you may transform Emet-Selch.
+ *
+ * Back — Hades, Sorcerer of Eld:
+ *   Vigilance
+ *   Echo of the Lost — During your turn, you may play cards from your graveyard.
+ *   If a card or token would be put into your graveyard from anywhere, exile it instead.
+ *
+ * "Enters or attacks" is two distinct trigger conditions, so the loot is modelled as two
+ * triggered abilities (`EntersBattlefield` + self `Attacks`), each running the standard
+ * draw-then-discard [Patterns.Hand.loot]. The upkeep transform is an intervening-"if" trigger
+ * ([triggerCondition]) — per the ruling, the fourteen-card graveyard check is evaluated both when
+ * the ability would trigger and again as it resolves — wrapped in [MayEffect] for the optional
+ * "you may transform" and flipping the permanent in place with [TransformEffect].
+ *
+ * Hades' back face reuses the Yawgmoth's Agenda shape: [MayPlayLandsFromGraveyard] (land-play
+ * timing already enforces "during your turn") + [MayCastFromGraveyard] gated to your turn covers
+ * "play cards from your graveyard", and a [RedirectZoneChange] to exile catches every card or
+ * token you own that would hit your graveyard from anywhere.
+ */
+private val HadesSorcererOfEld = card("Hades, Sorcerer of Eld") {
+    manaCost = ""
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Avatar"
+    oracleText = "Vigilance\n" +
+        "Echo of the Lost — During your turn, you may play cards from your graveyard.\n" +
+        "If a card or token would be put into your graveyard from anywhere, exile it instead."
+    power = 6
+    toughness = 6
+    keywords(Keyword.VIGILANCE)
+
+    // Echo of the Lost — During your turn, you may play cards from your graveyard.
+    // Lands: normal land-play timing already restricts this to your own turn.
+    staticAbility {
+        ability = MayPlayLandsFromGraveyard
+    }
+    // Spells: gated to your turn so instants from the graveyard can't be cast on opponents' turns.
+    staticAbility {
+        ability = MayCastFromGraveyard(filter = GameObjectFilter.Nonland, duringYourTurnOnly = true)
+    }
+
+    // If a card or token would be put into your graveyard from anywhere, exile it instead.
+    replacementEffect(
+        RedirectZoneChange(
+            newDestination = Zone.EXILE,
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter(
+                    controllerPredicate = ControllerPredicate.OwnedByYou
+                ),
+                to = Zone.GRAVEYARD
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "218"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/back/7/5/75cf4eb8-33e7-4dfc-b890-a7e3b5c1b9d5.jpg?1782686432"
+        ruling(
+            "2025-06-06",
+            "While you control Hades, Sorcerer of Eld, abilities that trigger whenever a permanent " +
+                "you own is put into your graveyard from the battlefield (for example, \"When this " +
+                "creature dies . . .\") won't trigger."
+        )
+        ruling(
+            "2025-06-06",
+            "If you discard a card while you control Hades, Sorcerer of Eld, abilities that function " +
+                "when a card is discarded (such as madness) still work, even though that card never " +
+                "reaches your graveyard. Spells or abilities that check the characteristics of a " +
+                "discarded card can find that card in exile."
+        )
+        ruling(
+            "2025-06-06",
+            "You pay all costs and follow all timing rules for cards played with the permission " +
+                "granted by Hades, Sorcerer of Eld's second ability."
+        )
+    }
+}
+
+private val EmetSelchUnsunderedFront = card("Emet-Selch, Unsundered") {
+    manaCost = "{1}{U}{B}"
+    colorIdentity = "UB"
+    typeLine = "Legendary Creature — Elder Wizard"
+    oracleText = "Vigilance\n" +
+        "Whenever Emet-Selch enters or attacks, draw a card, then discard a card.\n" +
+        "At the beginning of your upkeep, if there are fourteen or more cards in your graveyard, " +
+        "you may transform Emet-Selch."
+    power = 2
+    toughness = 4
+    keywords(Keyword.VIGILANCE)
+
+    // Whenever Emet-Selch enters or attacks, draw a card, then discard a card.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Hand.loot()
+    }
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Hand.loot()
+    }
+
+    // At the beginning of your upkeep, if there are fourteen or more cards in your graveyard,
+    // you may transform Emet-Selch. Intervening "if" — checked at trigger time and again on
+    // resolution.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        triggerCondition = Conditions.CardsInGraveyardAtLeast(14)
+        effect = MayEffect(TransformEffect(EffectTarget.Self))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "218"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/front/7/5/75cf4eb8-33e7-4dfc-b890-a7e3b5c1b9d5.jpg?1782686432"
+        ruling(
+            "2025-06-06",
+            "Emet-Selch's last ability checks your graveyard at the moment it would trigger to see " +
+                "if you have fourteen or more cards in your graveyard. If you don't, the ability " +
+                "won't trigger at all. If it does trigger, the ability will check again as it tries " +
+                "to resolve. If you don't have fourteen or more cards in your graveyard at that " +
+                "time, the ability won't resolve and none of its effects will happen."
+        )
+        ruling(
+            "2025-06-06",
+            "The mana value of a nonmodal double-faced card is the mana value of its front face, " +
+                "no matter which face is up."
+        )
+    }
+}
+
+val EmetSelchUnsundered: CardDefinition = CardDefinition.doubleFacedCreature(
+    frontFace = EmetSelchUnsunderedFront,
+    backFace = HadesSorcererOfEld,
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/FIN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FIN.json
@@ -5897,6 +5897,234 @@
     "colorIdentityOverride": []
 }
 
+// Emet-Selch, Unsundered
+{
+    "name": "Emet-Selch, Unsundered",
+    "manaCost": "{1}{U}{B}",
+    "typeLine": "Legendary Creature — Elder Wizard",
+    "oracleText": "Vigilance\nWhenever Emet-Selch enters or attacks, draw a card, then discard a card.\nAt the beginning of your upkeep, if there are fourteen or more cards in your graveyard, you may transform Emet-Selch.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        },
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "discarded",
+                                    "prompt": "Choose 1 card to discard"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "discarded",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    },
+                                    "moveType": "Discard"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_3",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": "Transform"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 14
+                    }
+                }
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Hades, Sorcerer of Eld",
+        "manaCost": "",
+        "typeLine": "Legendary Creature — Avatar",
+        "oracleText": "Vigilance\nEcho of the Lost — During your turn, you may play cards from your graveyard.\nIf a card or token would be put into your graveyard from anywhere, exile it instead.",
+        "creatureStats": {
+            "power": 6,
+            "toughness": 6
+        },
+        "keywords": [
+            "VIGILANCE"
+        ],
+        "script": {
+            "staticAbilities": [
+                "MayPlayLandsFromGraveyard",
+                {
+                    "type": "MayCastFromGraveyard",
+                    "filter": "nonland",
+                    "duringYourTurnOnly": true
+                }
+            ],
+            "replacementEffects": [
+                {
+                    "type": "RedirectZoneChange",
+                    "newDestination": "Exile",
+                    "appliesTo": {
+                        "type": "ZoneChangeEvent",
+                        "filter": "own:you",
+                        "to": "Graveyard"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "218",
+            "rarity": "MYTHIC",
+            "artist": "Néstor Ossandón Leal",
+            "imageUri": "https://cards.scryfall.io/normal/back/7/5/75cf4eb8-33e7-4dfc-b890-a7e3b5c1b9d5.jpg?1782686432",
+            "rulings": [
+                {
+                    "date": "2025-06-06",
+                    "text": "While you control Hades, Sorcerer of Eld, abilities that trigger whenever a permanent you own is put into your graveyard from the battlefield (for example, \"When this creature dies . . .\") won't trigger."
+                },
+                {
+                    "date": "2025-06-06",
+                    "text": "If you discard a card while you control Hades, Sorcerer of Eld, abilities that function when a card is discarded (such as madness) still work, even though that card never reaches your graveyard. Spells or abilities that check the characteristics of a discarded card can find that card in exile."
+                },
+                {
+                    "date": "2025-06-06",
+                    "text": "You pay all costs and follow all timing rules for cards played with the permission granted by Hades, Sorcerer of Eld's second ability."
+                }
+            ]
+        },
+        "colorIdentityOverride": [
+            "BLUE",
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "rarity": "MYTHIC",
+        "artist": "Néstor Ossandón Leal",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/5/75cf4eb8-33e7-4dfc-b890-a7e3b5c1b9d5.jpg?1782686432",
+        "rulings": [
+            {
+                "date": "2025-06-06",
+                "text": "Emet-Selch's last ability checks your graveyard at the moment it would trigger to see if you have fourteen or more cards in your graveyard. If you don't, the ability won't trigger at all. If it does trigger, the ability will check again as it tries to resolve. If you don't have fourteen or more cards in your graveyard at that time, the ability won't resolve and none of its effects will happen."
+            },
+            {
+                "date": "2025-06-06",
+                "text": "The mana value of a nonmodal double-faced card is the mana value of its front face, no matter which face is up."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "BLACK"
+    ]
+}
+
 // Ether
 {
     "name": "Ether",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmetSelchUnsunderedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EmetSelchUnsunderedScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Emet-Selch, Unsundered // Hades, Sorcerer of Eld (FIN #218).
+ *
+ * Covers the assembled behaviour:
+ *  - The upkeep intervening-"if" transform: with fourteen or more cards in your graveyard the
+ *    "you may transform" ability triggers and, on yes, flips to Hades; with only thirteen it never
+ *    triggers (so no decision is offered and it stays Emet-Selch).
+ *  - Hades' back-face replacement: a card you own that would be put into your graveyard from
+ *    anywhere is exiled instead.
+ */
+class EmetSelchUnsunderedScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), skipMulligans = true, startingPlayer = 0)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Pass whole turns until it is [player]'s own upkeep. */
+    fun advanceToUpkeepOf(driver: GameTestDriver, player: EntityId) {
+        var guard = 0
+        while (guard++ < 6) {
+            driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+            if (driver.activePlayer == player) break
+            // Already at an upkeep: step out of it so the next call advances to the following one.
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 200)
+        }
+        driver.activePlayer shouldBe player
+    }
+
+    /** Resolve the stack until a yes/no ("may") decision is pending, or the stack empties. */
+    fun resolveUntilMayDecision(driver: GameTestDriver) {
+        var guard = 0
+        while (driver.pendingDecision !is YesNoDecision && guard++ < 40) {
+            if (driver.state.stack.isNotEmpty() || driver.isPaused) driver.bothPass() else break
+        }
+    }
+
+    test("upkeep: with fourteen cards in your graveyard you may transform into Hades") {
+        val driver = createDriver()
+        val you = driver.player1
+
+        val emet = driver.putCreatureOnBattlefield(you, "Emet-Selch, Unsundered")
+        repeat(14) { driver.putCardInGraveyard(you, "Swamp") }
+
+        advanceToUpkeepOf(driver, you)
+        resolveUntilMayDecision(driver)
+
+        // The intervening-"if" is satisfied, so the "you may transform" ability is offered.
+        val may = driver.pendingDecision
+        (may is YesNoDecision) shouldBe true
+        driver.submitYesNo(you, true)
+
+        driver.state.getEntity(emet)!!.get<CardComponent>()!!.name shouldBe "Hades, Sorcerer of Eld"
+    }
+
+    test("upkeep: with only thirteen cards the transform never triggers") {
+        val driver = createDriver()
+        val you = driver.player1
+
+        val emet = driver.putCreatureOnBattlefield(you, "Emet-Selch, Unsundered")
+        repeat(13) { driver.putCardInGraveyard(you, "Swamp") }
+
+        advanceToUpkeepOf(driver, you)
+        resolveUntilMayDecision(driver)
+
+        // Intervening-"if" fails at trigger time → no ability, no decision, still the front face.
+        (driver.pendingDecision is YesNoDecision) shouldBe false
+        driver.state.getEntity(emet)!!.get<CardComponent>()!!.name shouldBe "Emet-Selch, Unsundered"
+    }
+
+    test("back face: a creature you own that would die is exiled instead of hitting the graveyard") {
+        val driver = createDriver()
+        val you = driver.player1
+
+        // Flip Emet-Selch to Hades via the upkeep transform.
+        val emet = driver.putCreatureOnBattlefield(you, "Emet-Selch, Unsundered")
+        repeat(14) { driver.putCardInGraveyard(you, "Swamp") }
+        advanceToUpkeepOf(driver, you)
+        resolveUntilMayDecision(driver)
+        driver.submitYesNo(you, true)
+        driver.state.getEntity(emet)!!.get<CardComponent>()!!.name shouldBe "Hades, Sorcerer of Eld"
+
+        // A 1/1 you control, killed by your own Lightning Bolt, should be exiled — not put into
+        // your graveyard — by Hades' replacement effect.
+        val lion = driver.putCreatureOnBattlefield(you, "Savannah Lions")
+        val bolt = driver.putCardInHand(you, "Lightning Bolt")
+        driver.giveMana(you, Color.RED, 1)
+        driver.castSpell(you, bolt, listOf(lion)).isSuccess shouldBe true
+        var g = 0
+        while (driver.state.stack.isNotEmpty() && g++ < 20) driver.bothPass()
+
+        driver.getExile(you).contains(lion) shouldBe true
+        driver.getGraveyard(you).contains(lion) shouldBe false
+    }
+})


### PR DESCRIPTION
## Summary

Implements **Emet-Selch, Unsundered // Hades, Sorcerer of Eld** (FIN #218), one of the four remaining unimplemented Final Fantasy cards. Built entirely from existing SDK primitives — no engine/SDK changes.

### Front — Emet-Selch, Unsundered ({1}{U}{B}, Legendary Creature — Elder Wizard, 2/4)
- **Vigilance**
- *Whenever Emet-Selch enters or attacks, draw a card, then discard a card.* — two triggered abilities (`EntersBattlefield` + self `Attacks`) each running `Patterns.Hand.loot()`, since "enters or attacks" is two distinct trigger conditions.
- *At the beginning of your upkeep, if there are fourteen or more cards in your graveyard, you may transform Emet-Selch.* — an intervening-"if" upkeep trigger (`triggerCondition = Conditions.CardsInGraveyardAtLeast(14)`, checked at trigger time **and** resolution per the ruling) wrapping `MayEffect(TransformEffect(Self))`.

### Back — Hades, Sorcerer of Eld (Legendary Creature — Avatar, 6/6)
- **Vigilance**
- *Echo of the Lost — During your turn, you may play cards from your graveyard.* — `MayPlayLandsFromGraveyard` (land-play timing already enforces "your turn") + `MayCastFromGraveyard(Nonland, duringYourTurnOnly = true)`.
- *If a card or token would be put into your graveyard from anywhere, exile it instead.* — a `RedirectZoneChange` to exile for anything you own headed to your graveyard (the Yawgmoth's Agenda shape).

## Tests
`EmetSelchUnsunderedScenarioTest` (rules-engine):
- Upkeep transform fires with 14 cards in graveyard (may → yes → flips to Hades).
- Upkeep transform never triggers with only 13 (intervening-if fails, stays Emet-Selch).
- Back-face replacement: a creature you own killed by your own Lightning Bolt is exiled, not put into your graveyard.

Also re-blessed the FIN `CardDefinitionSnapshotTest` golden (purely additive). `CardLintTest` and `check-card-printing` pass; canonical placement verified in the earliest (only) printing, FIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)