### PR TITLE
Add Foundations cards: High Fae Trickster, Electroduplicate, Niv-Mizzet, Visionary

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/Electroduplicate.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/Electroduplicate.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Electroduplicate
+ * {2}{R}
+ * Sorcery
+ * Create a token that's a copy of target creature you control, except it has haste and
+ * "At the beginning of the end step, sacrifice this token."
+ * Flashback {2}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)
+ *
+ * Red's aggressive cousin of Self-Reflection: the copy clause layers `addedKeywords = HASTE`
+ * and the "sacrifice at the next end step" delayed trigger (`sacrificeAtStep = END`, any player's
+ * end step — the token dies before it can attack again) onto [Effects.CreateTokenCopyOfTarget].
+ */
+val Electroduplicate = card("Electroduplicate") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Create a token that's a copy of target creature you control, except it has haste and " +
+        "\"At the beginning of the end step, sacrifice this token.\"\n" +
+        "Flashback {2}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)"
+
+    spell {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.CreateTokenCopyOfTarget(
+            creature,
+            addedKeywords = setOf(Keyword.HASTE),
+            sacrificeAtStep = Step.END
+        )
+    }
+    keywordAbility(KeywordAbility.flashback("{2}{R}{R}"))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "85"
+        artist = "Warren Mahy"
+        flavorText = "The dragon roared and the storm thundered back."
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/abb06b1c-5d4e-49b9-9c4a-e60ab656a257.jpg?1782689192"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HighFaeTrickster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/HighFaeTrickster.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantFlashToSpellType
+
+/**
+ * High Fae Trickster
+ * {3}{U}
+ * Creature — Faerie Wizard
+ * 4/2
+ * Flash (You may cast this spell any time you could cast an instant.)
+ * Flying
+ * You may cast spells as though they had flash.
+ *
+ * The third line is a [GrantFlashToSpellType] static over every spell the controller casts
+ * (`GameObjectFilter.Any`, `controllerOnly = true`) — the unrestricted, you-only sibling of
+ * Valley Floodcaller's noncreature-only grant.
+ */
+val HighFaeTrickster = card("High Fae Trickster") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Faerie Wizard"
+    power = 4
+    toughness = 2
+    oracleText = "Flash (You may cast this spell any time you could cast an instant.)\n" +
+        "Flying\n" +
+        "You may cast spells as though they had flash."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    staticAbility {
+        ability = GrantFlashToSpellType(
+            filter = GameObjectFilter.Any,
+            controllerOnly = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "40"
+        artist = "Justyna Dura"
+        flavorText = "To the High Fae, spells that take a human years to master come as easily as breathing."
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f1b93ea-1ec1-4010-9343-765742f5088b.jpg?1782689229"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/NivMizzetVisionary.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/NivMizzetVisionary.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.NoMaximumHandSize
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.events.DamageType
+import com.wingedsheep.sdk.scripting.events.RecipientFilter
+import com.wingedsheep.sdk.scripting.values.ContextPropertyKey
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Niv-Mizzet, Visionary
+ * {4}{U}{R}
+ * Legendary Creature — Dragon Wizard
+ * 5/5
+ * Flying
+ * You have no maximum hand size.
+ * Whenever a source you control deals noncombat damage to an opponent, you draw that many cards.
+ *
+ * "A source you control" is modelled the same way as Twinflame Tyrant — a `DealsDamageEvent`
+ * whose `sourceFilter` is `GameObjectFilter.Any.youControl()`, restricted here to noncombat
+ * damage aimed at an opponent. The draw count reads the triggering damage amount via
+ * [ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT] ("draw that many cards").
+ */
+val NivMizzetVisionary = card("Niv-Mizzet, Visionary") {
+    manaCost = "{4}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Dragon Wizard"
+    power = 5
+    toughness = 5
+    oracleText = "Flying\n" +
+        "You have no maximum hand size.\n" +
+        "Whenever a source you control deals noncombat damage to an opponent, you draw that many cards."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = NoMaximumHandSize
+    }
+
+    triggeredAbility {
+        trigger = Triggers.dealsDamage(
+            damageType = DamageType.NonCombat,
+            recipient = RecipientFilter.Opponent,
+            sourceFilter = GameObjectFilter.Any.youControl(),
+            binding = TriggerBinding.ANY
+        )
+        effect = Effects.DrawCards(DynamicAmount.ContextProperty(ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT))
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "123"
+        artist = "Dan Murayama Scott"
+        flavorText = "Ravnica's sharpest mind and its biggest ego."
+        imageUri = "https://cards.scryfall.io/normal/front/7/a/7a69a618-d588-4745-8ede-0ff0a9f356f1.jpg?1782689159"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -2039,6 +2039,55 @@
     ]
 }
 
+// Electroduplicate
+{
+    "name": "Electroduplicate",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Create a token that's a copy of target creature you control, except it has haste and \"At the beginning of the end step, sacrifice this token.\"\nFlashback {2}{R}{R} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
+    "keywords": [
+        "FLASHBACK"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Flashback",
+            "cost": "{2}{R}{R}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "CreateTokenCopyOfTarget",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature you control"
+            },
+            "addedKeywords": [
+                "HASTE"
+            ],
+            "sacrificeAtStep": "END"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature ctrl:you"
+                },
+                "id": "target creature you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "85",
+        "rarity": "RARE",
+        "artist": "Warren Mahy",
+        "flavorText": "The dragon roared and the storm thundered back.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/abb06b1c-5d4e-49b9-9c4a-e60ab656a257.jpg?1782689192"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Elementalist Adept
 {
     "name": "Elementalist Adept",
@@ -3375,6 +3424,41 @@
     ]
 }
 
+// High Fae Trickster
+{
+    "name": "High Fae Trickster",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Faerie Wizard",
+    "oracleText": "Flash (You may cast this spell any time you could cast an instant.)\nFlying\nYou may cast spells as though they had flash.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "GrantFlashToSpellType",
+                "filter": {},
+                "controllerOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "40",
+        "rarity": "RARE",
+        "artist": "Justyna Dura",
+        "flavorText": "To the High Fae, spells that take a human years to master come as easily as breathing.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f1b93ea-1ec1-4010-9343-765742f5088b.jpg?1782689229"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // High-Society Hunter
 {
     "name": "High-Society Hunter",
@@ -4529,6 +4613,56 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Niv-Mizzet, Visionary
+{
+    "name": "Niv-Mizzet, Visionary",
+    "manaCost": "{4}{U}{R}",
+    "typeLine": "Legendary Creature — Dragon Wizard",
+    "oracleText": "Flying\nYou have no maximum hand size.\nWhenever a source you control deals noncombat damage to an opponent, you draw that many cards.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageNonCombat",
+                    "recipient": "RecipientOpponent",
+                    "sourceFilter": "ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "ContextProperty",
+                        "key": "TRIGGER_DAMAGE_AMOUNT"
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            "NoMaximumHandSize"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "MYTHIC",
+        "artist": "Dan Murayama Scott",
+        "flavorText": "Ravnica's sharpest mind and its biggest ego.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/a/7a69a618-d588-4745-8ede-0ff0a9f356f1.jpg?1782689159"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElectroduplicateScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ElectroduplicateScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.Electroduplicate
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Electroduplicate (FDN #85) — {2}{R} Sorcery.
+ *
+ * "Create a token that's a copy of target creature you control, except it has haste and
+ * \"At the beginning of the end step, sacrifice this token.\" Flashback {2}{R}{R}."
+ *
+ * Red's sibling of Self-Reflection: the copy clause layers `addedKeywords = HASTE` plus a
+ * `sacrificeAtStep = END` delayed trigger onto [com.wingedsheep.sdk.dsl.Effects.CreateTokenCopyOfTarget].
+ */
+class ElectroduplicateScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun newDriver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(Electroduplicate)
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("creates a hasty copy that is sacrificed at the end step") {
+        val d = newDriver()
+        val p1 = d.player1
+
+        val original = d.putCreatureOnBattlefield(p1, "Centaur Courser") // 3/3
+        val spell = d.putCardInHand(p1, "Electroduplicate")
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 2)
+
+        d.castSpellWithTargets(p1, spell, listOf(ChosenTarget.Permanent(original))).error shouldBe null
+        d.bothPass()
+
+        // A token copy now exists alongside the original.
+        val creatures = d.getCreatures(p1)
+        creatures.size shouldBe 2
+        val token = creatures.first { it != original }
+
+        val projected = projector.project(d.state)
+        projected.hasKeyword(token, Keyword.HASTE) shouldBe true
+        projected.getPower(token) shouldBe 3
+        projected.getToughness(token) shouldBe 3
+
+        // At the beginning of the end step the token is sacrificed; the original survives.
+        d.passPriorityUntil(Step.END)
+        d.bothPass()
+        d.getCreatures(p1) shouldBe listOf(original)
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HighFaeTricksterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HighFaeTricksterScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.HighFaeTrickster
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * High Fae Trickster (FDN #40) — {3}{U} Creature — Faerie Wizard, 4/2.
+ *
+ * "Flash. Flying. You may cast spells as though they had flash."
+ *
+ * The third line is a `GrantFlashToSpellType` static over every spell its controller casts
+ * (`GameObjectFilter.Any`, `controllerOnly = true`). This exercises the static-ability path
+ * (the engine scans battlefield permanents for the grant when checking cast timing), distinct
+ * from the one-shot `GrantFlashToSpellsEffect` component.
+ */
+class HighFaeTricksterScenarioTest : FunSpec({
+
+    // A plain sorcery-speed creature to try to cast at instant speed.
+    val testBeast = CardDefinition.creature(
+        name = "Test Beast",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 2,
+        toughness = 2
+    )
+
+    fun newDriver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + testBeast)
+        d.registerCard(HighFaeTrickster)
+        d.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("baseline: without the grant a creature can't be cast during the end step") {
+        val d = newDriver()
+        val p1 = d.player1
+
+        val beast = d.putCardInHand(p1, "Test Beast")
+        d.passPriorityUntil(Step.END)
+        d.giveMana(p1, Color.GREEN, 1)
+        d.giveColorlessMana(p1, 1)
+
+        val result = d.submit(CastSpell(playerId = p1, cardId = beast, paymentStrategy = PaymentStrategy.FromPool))
+        result.isSuccess shouldBe false
+    }
+
+    test("High Fae Trickster lets its controller cast a creature at instant speed") {
+        val d = newDriver()
+        val p1 = d.player1
+
+        d.putCreatureOnBattlefield(p1, "High Fae Trickster")
+        val beast = d.putCardInHand(p1, "Test Beast")
+        d.passPriorityUntil(Step.END)
+        d.giveMana(p1, Color.GREEN, 1)
+        d.giveColorlessMana(p1, 1)
+
+        val result = d.submit(CastSpell(playerId = p1, cardId = beast, paymentStrategy = PaymentStrategy.FromPool))
+        result.isSuccess shouldBe true
+    }
+
+    test("opponents do not benefit from the grant") {
+        val d = newDriver()
+        val p1 = d.player1
+        val p2 = d.player2
+
+        d.putCreatureOnBattlefield(p1, "High Fae Trickster")
+        val beast = d.putCardInHand(p2, "Test Beast")
+        // Still p1's turn (end step) — p2 holds priority but has no flash permission.
+        d.passPriorityUntil(Step.END)
+        d.giveMana(p2, Color.GREEN, 1)
+        d.giveColorlessMana(p2, 1)
+
+        val result = d.submit(CastSpell(playerId = p2, cardId = beast, paymentStrategy = PaymentStrategy.FromPool))
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NivMizzetVisionaryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NivMizzetVisionaryScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.NivMizzetVisionary
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Niv-Mizzet, Visionary (FDN #123) — {4}{U}{R} Legendary Creature — Dragon Wizard, 5/5.
+ *
+ * "Flying. You have no maximum hand size. Whenever a source you control deals noncombat damage
+ * to an opponent, you draw that many cards."
+ *
+ * The trigger reuses Twinflame Tyrant's "a source you control" shape (`DealsDamageEvent` with
+ * `sourceFilter = GameObjectFilter.Any.youControl()`), scoped to noncombat damage at an opponent,
+ * and draws the triggering damage amount (`ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT`).
+ */
+class NivMizzetVisionaryScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(NivMizzetVisionary)
+        d.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return d
+    }
+
+    test("noncombat damage from a source you control draws that many cards") {
+        val d = newDriver()
+        val p1 = d.player1
+        val p2 = d.player2
+
+        d.putCreatureOnBattlefield(p1, "Niv-Mizzet, Visionary")
+        val bolt = d.putCardInHand(p1, "Lightning Bolt") // {R}: 3 damage to any target
+        d.giveMana(p1, Color.RED, 1)
+
+        val handBefore = d.getHandSize(p1)
+
+        // Cast Lightning Bolt at the opponent — 3 noncombat damage from a source you control.
+        d.castSpell(p1, bolt, targets = listOf(p2)).error shouldBe null
+        d.bothPass() // Lightning Bolt resolves, deals 3, Niv's trigger goes on the stack
+        d.bothPass() // Niv's trigger resolves, drawing 3
+
+        d.isPaused shouldBe false
+        d.getLifeTotal(p2) shouldBe 17
+        // -1 for the cast Lightning Bolt, +3 drawn by Niv-Mizzet.
+        d.getHandSize(p1) shouldBe handBefore - 1 + 3
+    }
+
+    test("noncombat damage to an opponent's creature does not trigger the draw") {
+        val d = newDriver()
+        val p1 = d.player1
+        val p2 = d.player2
+
+        d.putCreatureOnBattlefield(p1, "Niv-Mizzet, Visionary")
+        val victim = d.putCreatureOnBattlefield(p2, "Centaur Courser") // 3/3
+        val bolt = d.putCardInHand(p1, "Lightning Bolt")
+        d.giveMana(p1, Color.RED, 1)
+
+        val handBefore = d.getHandSize(p1)
+
+        // Damage to a permanent an opponent controls is not damage "to an opponent" (a player).
+        d.castSpell(p1, bolt, targets = listOf(victim)).error shouldBe null
+        d.bothPass()
+
+        d.isPaused shouldBe false
+        d.assertInGraveyard(p2, "Centaur Courser")
+        // Only the Lightning Bolt left the hand; Niv did not trigger.
+        d.getHandSize(p1) shouldBe handBefore - 1
+    }
+})


### PR DESCRIPTION
Adds three cards new to **Foundations (FDN)**, each composed entirely from existing SDK primitives — **no engine/SDK changes** (so no reference-doc update needed).

## Cards

| Card | Cost | Mechanic |
|------|------|----------|
| **High Fae Trickster** | {3}{U} 4/2 | Flash, Flying, + `GrantFlashToSpellType(GameObjectFilter.Any, controllerOnly = true)` — "you may cast spells as though they had flash" |
| **Electroduplicate** | {2}{R} Sorcery | `CreateTokenCopyOfTarget` with `addedKeywords = HASTE` and `sacrificeAtStep = END`, plus Flashback {2}{R}{R}. Red's sibling of Self-Reflection |
| **Niv-Mizzet, Visionary** | {4}{U}{R} 5/5 | Flying, `NoMaximumHandSize`, + "a source you control deals noncombat damage to an opponent → draw that many" (reuses Twinflame Tyrant's `sourceFilter = GameObjectFilter.Any.youControl()` shape with `ContextPropertyKey.TRIGGER_DAMAGE_AMOUNT`) |

All metadata (mana cost, P/T, oracle text, rarity, collector number, artist, flavor, image URI) verified against Scryfall for the FDN printing; all three are new to Foundations, so the canonical `CardDefinition` lives in FDN.

## Tests
- `HighFaeTricksterScenarioTest` — controller can cast a creature at instant speed; baseline (no permanent) and opponents cannot.
- `ElectroduplicateScenarioTest` — hasty token copy is created and sacrificed at the end step; original survives.
- `NivMizzetVisionaryScenarioTest` — noncombat damage to an opponent draws that many; noncombat damage to an opponent's *creature* does not.
- FDN card-definition snapshot golden re-blessed (only the three new cards added).

`just build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)