### PR TITLE
Add Foundations cards: Linden, Ingenious Leonin, Kalastria Highborn

### DIFF
--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/LindenTheSteadfastQueen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/eld/cards/LindenTheSteadfastQueen.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.eld.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Linden, the Steadfast Queen
+ * {W}{W}{W}
+ * Legendary Creature — Human Noble
+ * 3/3
+ * Vigilance (Attacking doesn't cause this creature to tap.)
+ * Whenever a white creature you control attacks, you gain 1 life.
+ *
+ * Canonical printing lives in Throne of Eldraine (the earliest real-expansion printing); the
+ * Foundations release is a [com.wingedsheep.sdk.model.Printing] row (see
+ * `mtg-sets/.../definitions/fdn/cards/LindenTheSteadfastQueenReprint.kt`).
+ *
+ * The attack trigger fires once per qualifying attacker via [TriggerBinding.ANY] over a white
+ * creature you control — Linden is herself a white creature, so she counts when she attacks.
+ */
+val LindenTheSteadfastQueen = card("Linden, the Steadfast Queen") {
+    manaCost = "{W}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Legendary Creature — Human Noble"
+    power = 3
+    toughness = 3
+    oracleText = "Vigilance (Attacking doesn't cause this creature to tap.)\n" +
+        "Whenever a white creature you control attacks, you gain 1 life."
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.attacks(
+            filter = GameObjectFilter.Creature.withColor(Color.WHITE).youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.GainLife(1)
+        description = "Whenever a white creature you control attacks, you gain 1 life."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "20"
+        artist = "Ryan Pancoast"
+        flavorText = "\"Until my last breath, I will defend the realm.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/a/fa3ab467-be97-4b84-a73d-b03484d06b97.jpg?1782707922"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/IngeniousLeoninReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/IngeniousLeoninReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Ingenious Leonin reprint in Foundations. Canonical CardDefinition lives in the Jumpstart 2022
+ * set's `cards/` package; this file contributes only presentation data.
+ */
+val IngeniousLeoninReprint = Printing(
+    oracleId = "99853d2e-2223-4c05-bbd7-0a746f8f810d",
+    name = "Ingenious Leonin",
+    setCode = "FDN",
+    collectorNumber = "495",
+    scryfallId = "ea566679-4202-4076-9314-142241485f6e",
+    artist = "Eric Deschamps",
+    imageUri = "https://cards.scryfall.io/normal/front/e/a/ea566679-4202-4076-9314-142241485f6e.jpg?1782688835",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KalastriaHighbornReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/KalastriaHighbornReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kalastria Highborn reprint in Foundations. Canonical CardDefinition lives in the Worldwake set's
+ * `cards/` package; this file contributes only presentation data.
+ */
+val KalastriaHighbornReprint = Printing(
+    oracleId = "77e319da-d782-4258-bf0e-626755e5adc9",
+    name = "Kalastria Highborn",
+    setCode = "FDN",
+    collectorNumber = "607",
+    scryfallId = "1a52f6ef-7759-4be3-8b80-a57e9d6ae386",
+    artist = "D. Alexander Gregory",
+    imageUri = "https://cards.scryfall.io/normal/front/1/a/1a52f6ef-7759-4be3-8b80-a57e9d6ae386.jpg?1782688738",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/LindenTheSteadfastQueenReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/LindenTheSteadfastQueenReprint.kt
@@ -1,0 +1,20 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Linden, the Steadfast Queen reprint in Foundations. Canonical CardDefinition lives in the
+ * Throne of Eldraine set's `cards/` package; this file contributes only presentation data.
+ */
+val LindenTheSteadfastQueenReprint = Printing(
+    oracleId = "dbc56f3b-83b3-41c8-a8ae-d3774fe6ee01",
+    name = "Linden, the Steadfast Queen",
+    setCode = "FDN",
+    collectorNumber = "577",
+    scryfallId = "0dcd0898-db3d-44ec-9d56-a1b558da90f4",
+    artist = "Ryan Pancoast",
+    imageUri = "https://cards.scryfall.io/normal/front/0/d/0dcd0898-db3d-44ec-9d56-a1b558da90f4.jpg?1782688763",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.RARE,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IngeniousLeonin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/j22/cards/IngeniousLeonin.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.mtg.sets.definitions.j22.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Ingenious Leonin
+ * {4}{W}
+ * Creature — Cat Soldier
+ * 4/4
+ * {3}{W}: Put a +1/+1 counter on another target attacking creature you control. If that creature
+ *   is a Cat, it gains first strike until end of turn.
+ *
+ * Canonical printing lives in Jumpstart 2022 (the earliest real printing); Foundations is a
+ * [com.wingedsheep.sdk.model.Printing] row (see `.../definitions/fdn/cards/IngeniousLeoninReprint.kt`).
+ *
+ * The activated ability always adds the counter; the first-strike grant is a resolution-time state
+ * test ([ConditionalEffect], lowering to `Gate.WhenCondition`) on the chosen target being a Cat —
+ * [Conditions.TargetMatchesFilter] reads the same target index the counter landed on.
+ */
+val IngeniousLeonin = card("Ingenious Leonin") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "{3}{W}: Put a +1/+1 counter on another target attacking creature you control. " +
+        "If that creature is a Cat, it gains first strike until end of turn. (It deals combat " +
+        "damage before creatures without first strike.)"
+
+    activatedAbility {
+        cost = Costs.Mana("{3}{W}")
+        val t = target(
+            "target",
+            TargetCreature(filter = TargetFilter.Creature.attacking().youControl().other()),
+        )
+        effect = Effects.Composite(
+            listOf(
+                Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t),
+                ConditionalEffect(
+                    condition = Conditions.TargetMatchesFilter(
+                        GameObjectFilter.Creature.withSubtype("Cat"),
+                    ),
+                    effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, t),
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "5"
+        artist = "Eric Deschamps"
+        flavorText = "Leonin claws were already deadly weapons of natural evolution before he " +
+            "improved upon them."
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c6fd0bf-3f02-46f3-9c9a-931eab190584.jpg?1782699361"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/KalastriaHighborn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/wwk/cards/KalastriaHighborn.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.wwk.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kalastria Highborn
+ * {B}{B}
+ * Creature — Vampire Shaman
+ * 2/2
+ * Whenever this creature or another Vampire you control dies, you may pay {B}. If you do,
+ *   target player loses 2 life and you gain 2 life.
+ *
+ * Canonical printing lives in Worldwake (the earliest real printing); Foundations is a
+ * [com.wingedsheep.sdk.model.Printing] row (see `.../definitions/fdn/cards/KalastriaHighbornReprint.kt`).
+ *
+ * "This creature or another Vampire you control" is exactly "a Vampire you control" — the source is
+ * itself a Vampire — so the trigger is a Vampire-filtered dies event with [TriggerBinding.ANY], which
+ * fires off the source's own death via last-known information. The target player is chosen when the
+ * ability goes on the stack; the {B} payment is the resolution-time gate ([MayPayManaEffect]) for the
+ * drain.
+ */
+val KalastriaHighborn = card("Kalastria Highborn") {
+    manaCost = "{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Shaman"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature or another Vampire you control dies, you may pay {B}. " +
+        "If you do, target player loses 2 life and you gain 2 life."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype("Vampire").youControl(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY,
+        )
+        val player = target("target player", Targets.Player)
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{B}"),
+            effect = Effects.Composite(
+                Effects.LoseLife(2, player),
+                Effects.GainLife(2, EffectTarget.Controller),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "59"
+        artist = "D. Alexander Gregory"
+        flavorText = "Each of Malakir's great families boasts a contingent of nulls appropriate " +
+            "to its rank in society."
+        imageUri = "https://cards.scryfall.io/normal/front/f/1/f1efd1dd-903c-47a0-b746-5571a3ea1755.jpg?1782715561"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/ELD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/ELD.json
@@ -186,6 +186,51 @@
     "colorIdentityOverride": []
 }
 
+// Linden, the Steadfast Queen
+{
+    "name": "Linden, the Steadfast Queen",
+    "manaCost": "{W}{W}{W}",
+    "typeLine": "Legendary Creature — Human Noble",
+    "oracleText": "Vigilance (Attacking doesn't cause this creature to tap.)\nWhenever a white creature you control attacks, you gain 1 life.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "filter": "creature white ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "Whenever a white creature you control attacks, you gain 1 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "20",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "flavorText": "\"Until my last breath, I will defend the realm.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/a/fa3ab467-be97-4b84-a73d-b03484d06b97.jpg?1782707922"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Raging Redcap
 {
     "name": "Raging Redcap",

--- a/mtg-sets/src/test/resources/snapshots/cards/J22.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/J22.json
@@ -1,3 +1,85 @@
+// Ingenious Leonin
+{
+    "name": "Ingenious Leonin",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Cat Soldier",
+    "oracleText": "{3}{W}: Put a +1/+1 counter on another target attacking creature you control. If that creature is a Cat, it gains first strike until end of turn. (It deals combat damage before creatures without first strike.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "creature Cat"
+                                }
+                            },
+                            "then": {
+                                "type": "GrantKeyword",
+                                "keyword": "FIRST_STRIKE",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature attacking ctrl:you",
+                            "excludeSelf": true
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "5",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Deschamps",
+        "flavorText": "Leonin claws were already deadly weapons of natural evolution before he improved upon them.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c6fd0bf-3f02-46f3-9c9a-931eab190584.jpg?1782699361"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Mild-Mannered Librarian
 {
     "name": "Mild-Mannered Librarian",

--- a/mtg-sets/src/test/resources/snapshots/cards/WWK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/WWK.json
@@ -118,6 +118,79 @@
     ]
 }
 
+// Kalastria Highborn
+{
+    "name": "Kalastria Highborn",
+    "manaCost": "{B}{B}",
+    "typeLine": "Creature — Vampire Shaman",
+    "oracleText": "Whenever this creature or another Vampire you control dies, you may pay {B}. If you do, target player loses 2 life and you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Vampire ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{B}"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target player"
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            }
+                        ]
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetPlayer",
+                    "id": "target player"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "RARE",
+        "artist": "D. Alexander Gregory",
+        "flavorText": "Each of Malakir's great families boasts a contingent of nulls appropriate to its rank in society.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/1/f1efd1dd-903c-47a0-b746-5571a3ea1755.jpg?1782715561"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Pilgrim's Eye
 {
     "name": "Pilgrim's Eye",

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IngeniousLeoninScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IngeniousLeoninScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.j22.cards.IngeniousLeonin
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ingenious Leonin (J22, reprinted in FDN) — {4}{W} Creature — Cat Soldier, 4/4.
+ *
+ * "{3}{W}: Put a +1/+1 counter on another target attacking creature you control. If that creature
+ *  is a Cat, it gains first strike until end of turn."
+ *
+ * The counter always lands; the first-strike grant is gated on the chosen target being a Cat. These
+ * tests pin both halves: a Cat attacker ends up +1/+1 *and* first striking, a non-Cat attacker gets
+ * only the counter, and the ability can't target a non-attacking creature.
+ */
+class IngeniousLeoninScenarioTest : FunSpec({
+
+    val catAttacker = card("Test Cat Attacker") {
+        manaCost = "{1}{W}"
+        typeLine = "Creature — Cat"
+        power = 2
+        toughness = 2
+    }
+    val dogAttacker = card("Test Dog Attacker") {
+        manaCost = "{1}{W}"
+        typeLine = "Creature — Dog"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(IngeniousLeonin, catAttacker, dogAttacker))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            bothPass()
+            guard++
+        }
+    }
+
+    /** Put Leonin + [attackerCard] into play, declare [attackerCard] as an attacker, and return its id. */
+    fun GameTestDriver.setUpAttacker(attackerCard: String): Pair<EntityId, EntityId> {
+        val me = activePlayer!!
+        val opponent = getOpponent(me)
+        val leonin = putCreatureOnBattlefield(me, "Ingenious Leonin")
+        val attacker = putCreatureOnBattlefield(me, attackerCard)
+        removeSummoningSickness(leonin)
+        removeSummoningSickness(attacker)
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        declareAttackers(me, listOf(attacker), opponent)
+        giveMana(me, Color.WHITE, 4)
+        return leonin to attacker
+    }
+
+    fun GameTestDriver.activateLeonin(leonin: EntityId, target: EntityId) {
+        val abilityId = IngeniousLeonin.activatedAbilities[0].id
+        submitSuccess(
+            ActivateAbility(
+                playerId = activePlayer!!,
+                sourceId = leonin,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(target)),
+            ),
+        )
+        resolveStack()
+    }
+
+    test("targeting a Cat attacker: +1/+1 counter and first strike") {
+        val driver = createDriver()
+        val (leonin, cat) = driver.setUpAttacker("Test Cat Attacker")
+
+        driver.activateLeonin(leonin, cat)
+
+        driver.state.projectedState.getPower(cat) shouldBe 3
+        driver.state.projectedState.getToughness(cat) shouldBe 3
+        driver.state.projectedState.hasKeyword(cat, Keyword.FIRST_STRIKE) shouldBe true
+    }
+
+    test("targeting a non-Cat attacker: +1/+1 counter but no first strike") {
+        val driver = createDriver()
+        val (leonin, dog) = driver.setUpAttacker("Test Dog Attacker")
+
+        driver.activateLeonin(leonin, dog)
+
+        driver.state.projectedState.getPower(dog) shouldBe 3
+        driver.state.projectedState.getToughness(dog) shouldBe 3
+        driver.state.projectedState.hasKeyword(dog, Keyword.FIRST_STRIKE) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KalastriaHighbornScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KalastriaHighbornScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.wwk.cards.KalastriaHighborn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kalastria Highborn (WWK, reprinted in FDN) — {B}{B} Creature — Vampire Shaman, 2/2.
+ *
+ * "Whenever this creature or another Vampire you control dies, you may pay {B}. If you do, target
+ *  player loses 2 life and you gain 2 life."
+ *
+ * Proves: another Vampire dying + paying {B} drains the chosen player and gains you 2; the source's
+ * own death also triggers (the "this creature or" clause); declining the {B} does nothing; and a
+ * non-Vampire creature dying doesn't trigger at all.
+ */
+class KalastriaHighbornScenarioTest : FunSpec({
+
+    val vampireToken = card("Test Vampire Ally") {
+        manaCost = "{B}"
+        typeLine = "Creature — Vampire"
+        power = 1
+        toughness = 1
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(KalastriaHighborn, vampireToken))
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Resolve the stack, answering Kalastria's trigger: pick [targetPlayer], then accept/decline the
+     * {B} may-pay per [pay] (auto-tapping mana sources when asked).
+     */
+    fun GameTestDriver.resolveTrigger(targetPlayer: EntityId, pay: Boolean) {
+        var guard = 0
+        while ((stackSize > 0 || state.pendingDecision != null) && guard < 40) {
+            when (val pending = state.pendingDecision) {
+                is ChooseTargetsDecision -> submitTargetSelection(pending.playerId, listOf(targetPlayer))
+                is YesNoDecision -> submitYesNo(pending.playerId, pay)
+                is SelectManaSourcesDecision -> submitManaAutoPayOrDecline(pending.playerId, true)
+                else -> bothPass()
+            }
+            guard++
+        }
+    }
+
+    /** Opponent kills [victim] with a Lightning Bolt so it dies to a real death event. */
+    fun GameTestDriver.boltToDeath(victim: EntityId) {
+        val you = activePlayer!!
+        val opponent = getOpponent(you)
+        giveMana(opponent, Color.RED, 1)
+        val bolt = putCardInHand(opponent, "Lightning Bolt")
+        passPriority(you)
+        castSpellWithTargets(opponent, bolt, listOf(ChosenTarget.Permanent(victim))).error shouldBe null
+    }
+
+    test("another Vampire dying + paying {B} drains the chosen player and gains you 2") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youBefore = driver.getLifeTotal(you)
+        val oppBefore = driver.getLifeTotal(opponent)
+
+        driver.putCreatureOnBattlefield(you, "Kalastria Highborn")
+        val ally = driver.putCreatureOnBattlefield(you, "Test Vampire Ally")
+        driver.giveMana(you, Color.BLACK, 1) // to pay the {B}
+
+        driver.boltToDeath(ally)
+        driver.resolveTrigger(targetPlayer = opponent, pay = true)
+
+        driver.getLifeTotal(opponent) shouldBe (oppBefore - 2)
+        driver.getLifeTotal(you) shouldBe (youBefore + 2)
+    }
+
+    test("Kalastria's own death also triggers the drain") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youBefore = driver.getLifeTotal(you)
+        val oppBefore = driver.getLifeTotal(opponent)
+
+        val highborn = driver.putCreatureOnBattlefield(you, "Kalastria Highborn")
+        driver.giveMana(you, Color.BLACK, 1)
+
+        driver.boltToDeath(highborn)
+        driver.resolveTrigger(targetPlayer = opponent, pay = true)
+
+        driver.getLifeTotal(opponent) shouldBe (oppBefore - 2)
+        driver.getLifeTotal(you) shouldBe (youBefore + 2)
+    }
+
+    test("declining the {B} does nothing") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youBefore = driver.getLifeTotal(you)
+        val oppBefore = driver.getLifeTotal(opponent)
+
+        driver.putCreatureOnBattlefield(you, "Kalastria Highborn")
+        val ally = driver.putCreatureOnBattlefield(you, "Test Vampire Ally")
+
+        driver.boltToDeath(ally)
+        driver.resolveTrigger(targetPlayer = opponent, pay = false)
+
+        driver.getLifeTotal(opponent) shouldBe oppBefore
+        driver.getLifeTotal(you) shouldBe youBefore
+    }
+
+    test("a non-Vampire creature dying does not trigger") {
+        val driver = createDriver()
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+        val youBefore = driver.getLifeTotal(you)
+        val oppBefore = driver.getLifeTotal(opponent)
+
+        driver.putCreatureOnBattlefield(you, "Kalastria Highborn")
+        val bears = driver.putCreatureOnBattlefield(you, "Grizzly Bears") // non-Vampire
+        driver.giveMana(you, Color.BLACK, 1)
+
+        driver.boltToDeath(bears)
+        // No trigger should be waiting — just let the stack settle.
+        var guard = 0
+        while (driver.stackSize > 0 && guard < 20) { driver.bothPass(); guard++ }
+
+        driver.getLifeTotal(opponent) shouldBe oppBefore
+        driver.getLifeTotal(you) shouldBe youBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LindenTheSteadfastQueenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LindenTheSteadfastQueenScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.eld.cards.LindenTheSteadfastQueen
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Linden, the Steadfast Queen (ELD, reprinted in FDN) — {W}{W}{W} Legendary Creature — Human Noble, 3/3.
+ *
+ * - Vigilance.
+ * - "Whenever a white creature you control attacks, you gain 1 life."
+ *
+ * The trigger uses [com.wingedsheep.sdk.scripting.TriggerBinding.ANY] over a white-creature-you-control
+ * filter, so it fires once per qualifying attacker — including Linden herself, who is white. These tests
+ * pin: a white attacker gains 1 life, a non-white attacker gains nothing, and multiple white attackers
+ * (Linden + another) each add a point.
+ */
+class LindenTheSteadfastQueenScenarioTest : FunSpec({
+
+    val whiteBear = card("Test White Bear") {
+        manaCost = "{1}{W}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+    val greenBear = card("Test Green Bear") {
+        manaCost = "{1}{G}"
+        typeLine = "Creature — Bear"
+        power = 2
+        toughness = 2
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(LindenTheSteadfastQueen, whiteBear, greenBear))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        return driver
+    }
+
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard < 50) {
+            bothPass()
+            guard++
+        }
+    }
+
+    fun GameTestDriver.attackWith(attackers: List<EntityId>) {
+        val me = activePlayer!!
+        val opponent = getOpponent(me)
+        passPriorityUntil(Step.DECLARE_ATTACKERS)
+        declareAttackers(me, attackers, opponent)
+        resolveStack()
+    }
+
+    test("Linden has vigilance") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val linden = driver.putCreatureOnBattlefield(me, "Linden, the Steadfast Queen")
+        driver.state.projectedState.hasKeyword(linden, Keyword.VIGILANCE) shouldBe true
+    }
+
+    test("attacking with a white creature you control gains 1 life") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val bear = driver.putCreatureOnBattlefield(me, "Test White Bear")
+        driver.removeSummoningSickness(bear)
+        driver.putCreatureOnBattlefield(me, "Linden, the Steadfast Queen") // Linden stays back
+
+        val before = driver.getLifeTotal(me)
+        driver.attackWith(listOf(bear))
+        driver.getLifeTotal(me) shouldBe before + 1
+    }
+
+    test("attacking with a non-white creature you control gains no life") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val bear = driver.putCreatureOnBattlefield(me, "Test Green Bear")
+        driver.removeSummoningSickness(bear)
+        driver.putCreatureOnBattlefield(me, "Linden, the Steadfast Queen")
+
+        val before = driver.getLifeTotal(me)
+        driver.attackWith(listOf(bear))
+        driver.getLifeTotal(me) shouldBe before
+    }
+
+    test("Linden and another white creature attacking each add 1 life") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val linden = driver.putCreatureOnBattlefield(me, "Linden, the Steadfast Queen")
+        val bear = driver.putCreatureOnBattlefield(me, "Test White Bear")
+        driver.removeSummoningSickness(linden)
+        driver.removeSummoningSickness(bear)
+
+        val before = driver.getLifeTotal(me)
+        driver.attackWith(listOf(linden, bear))
+        driver.getLifeTotal(me) shouldBe before + 2
+    }
+})


### PR DESCRIPTION
Implements a handful of Foundations (FDN) reprints. Each canonical `CardDefinition` lives in the card's **earliest** real printing with a `Printing` row in Foundations (validated by `just check-card-printing`); no new SDK/engine types were needed — all three compose existing primitives.

## Cards

| Card | Canonical set | FDN # | Mechanic |
|------|---------------|-------|----------|
| **Linden, the Steadfast Queen** | ELD | 577 | Vigilance + `Triggers.attacks` (ANY binding, white-creature-you-control filter) → `GainLife(1)` per attacker |
| **Ingenious Leonin** | J22 | 495 | `{3}{W}`: `+1/+1` counter on another target attacking creature you control; `ConditionalEffect` gated on `Conditions.TargetMatchesFilter(Cat)` grants first strike EOT |
| **Kalastria Highborn** | WWK | 607 | Vampire-filtered `leavesBattlefield` dies trigger (source's own death counts) wrapped in `MayPayManaEffect({B})` → target player loses 2, you gain 2 |

## Tests
- New Kotest scenario tests for all three (`rules-engine`) — cover the happy path plus edge cases: non-matching attacker/creature filters, "may" decline, and the source's own death.
- `CardDefinitionSnapshotTest` re-blessed; the golden diff adds only these three cards (ELD/J22/WWK).
- `just build` green.

## Notes
Originally considered Garna, Bloodfist of Keld but dropped it — its "draw a card if it *was attacking*" requires a new engine condition (last-known attacking state of a dead creature), which is `add-feature` territory rather than `add-card`. Swapped in Kalastria Highborn, fully covered by existing primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)