### PR TITLE
Defer tournament "Random Set" pick until game start

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/LobbyHandler.kt
@@ -558,20 +558,26 @@ class LobbyHandler(
             return
         }
 
-        // Validate all set codes
+        // Validate all set codes. Random-set placeholders (RANDOM_SET_CODE) are deferred — they're
+        // kept in the selection as-is and rolled to a concrete set at start (see resolveRandomSets).
         if (message.setCodes.isEmpty()) {
             sender.sendError(session, ErrorCode.INVALID_ACTION, "At least one set code is required")
             return
         }
-        val setConfigs = message.setCodes.mapNotNull { boosterGenerator.getSetConfig(it) }
-        if (setConfigs.size != message.setCodes.size) {
-            val invalidCodes = message.setCodes.filter { boosterGenerator.getSetConfig(it) == null }
+        val hasRandomSet = message.setCodes.any { TournamentLobby.isRandomSetCode(it) }
+        val concreteCodes = message.setCodes.filterNot { TournamentLobby.isRandomSetCode(it) }
+        val setConfigs = concreteCodes.mapNotNull { boosterGenerator.getSetConfig(it) }
+        if (setConfigs.size != concreteCodes.size) {
+            val invalidCodes = concreteCodes.filter { boosterGenerator.getSetConfig(it) == null }
             sender.sendError(session, ErrorCode.INVALID_ACTION, "Unknown set codes: ${invalidCodes.joinToString()}")
             return
         }
-        extensionOnlyError(setConfigs)?.let { error ->
-            sender.sendError(session, ErrorCode.INVALID_ACTION, error)
-            return
+        // A random slot always resolves to a regular set, so it satisfies the "needs a base set" rule.
+        if (!hasRandomSet) {
+            extensionOnlyError(setConfigs)?.let { error ->
+                sender.sendError(session, ErrorCode.INVALID_ACTION, error)
+                return
+            }
         }
 
         val token = sessionRegistry.getTokenByWsId(session.id)
@@ -642,7 +648,13 @@ class LobbyHandler(
             TournamentFormat.PREMADE_DECKS -> 0
         }
 
-        val codes = setConfigs.map { it.setCode }
+        // Preserve the selection order and any random placeholders; names line up index-for-index
+        // (placeholders show as "Random Set" until resolveRandomSets reveals them at start).
+        val codes = message.setCodes
+        val names = message.setCodes.map { code ->
+            if (TournamentLobby.isRandomSetCode(code)) TournamentLobby.RANDOM_SET_NAME
+            else boosterGenerator.getSetConfig(code)?.setName ?: code
+        }
         // Pick-2 is the default for Draft and Commander Draft — speeds the draft and matches the
         // paper Commander Legends template. Other formats stay at the lobby's pick-1 default.
         val initialPicksPerRound = when (format) {
@@ -651,7 +663,7 @@ class LobbyHandler(
         }
         val lobby = TournamentLobby(
             setCodes = codes,
-            setNames = setConfigs.map { it.setName },
+            setNames = names,
             boosterGenerator = boosterGenerator,
             format = format,
             boosterCount = boosterCount,
@@ -1169,6 +1181,11 @@ class LobbyHandler(
             sender.sendError(session, ErrorCode.INVALID_ACTION, "Need at least 2 players")
             return
         }
+
+        // Reveal any deferred "Random Set" placeholders now that the game is starting — the concrete
+        // sets stay hidden in the lobby until this moment (mirrors the Quick Game deferred roll). Done
+        // before the extension gate and pool generation so both see concrete, validated set codes.
+        lobby.resolveRandomSets()
 
         // Booster-based formats can't run on extension sets alone (Premade brings its own decks
         // and ignores the set selection). The lobby may hold an extension-only selection while

--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/lobby/TournamentLobby.kt
@@ -383,15 +383,46 @@ class TournamentLobby(
         if (state != LobbyState.WAITING_FOR_PLAYERS) return false
         if (newSetCodes.isEmpty()) return false
 
-        // Validate all set codes first
-        val configs = newSetCodes.map { code ->
-            boosterGenerator.getSetConfig(code) ?: return false
+        // Validate concrete codes; random placeholders are validated only when resolved at start.
+        val names = newSetCodes.map { code ->
+            if (isRandomSetCode(code)) RANDOM_SET_NAME
+            else (boosterGenerator.getSetConfig(code) ?: return false).setName
         }
 
-        setCodes = configs.map { it.setCode }
-        setNames = configs.map { it.setName }
+        setCodes = newSetCodes
+        setNames = names
         boosterDistribution = calculateDefaultDistribution(setCodes, boosterCount)
         return true
+    }
+
+    /**
+     * Reveal any deferred [RANDOM_SET_CODE] placeholders in [setCodes] by rolling a concrete set
+     * for each. Picks fully-implemented, non-extension sets that aren't already in the selection
+     * (and distinct from each other), then recomputes [setNames] and remaps [boosterDistribution]
+     * keys so any host-tuned per-set booster counts survive the reveal. No-op when there are no
+     * placeholders. Called once at tournament start (see LobbyHandler.handleStartTournamentLobby).
+     */
+    fun resolveRandomSets() {
+        if (setCodes.none { isRandomSetCode(it) }) return
+
+        val used = setCodes.filterNot { isRandomSetCode(it) }.toMutableSet()
+        val pool = boosterGenerator.availableSets.values
+            .filter { it.fullyImplemented && !it.extensionSet }
+            .map { it.setCode }
+
+        val placeholderToConcrete = HashMap<String, String>()
+        val resolved = setCodes.map { code ->
+            if (!isRandomSetCode(code)) return@map code
+            // Prefer an unused set; fall back to the whole pool only if it's exhausted.
+            val pick = pool.filterNot { it in used }.ifEmpty { pool }.randomOrNull() ?: return@map code
+            used.add(pick)
+            placeholderToConcrete[code] = pick
+            pick
+        }
+
+        setCodes = resolved
+        setNames = resolved.map { boosterGenerator.getSetConfig(it)?.setName ?: it }
+        boosterDistribution = boosterDistribution.mapKeys { (key, _) -> placeholderToConcrete[key] ?: key }
     }
 
     /**
@@ -1814,6 +1845,24 @@ class TournamentLobby(
     }
 
     companion object {
+        /**
+         * Sentinel set code for a deferred "Random Set" pick. A host can add one or more random
+         * slots to a lobby's pool; each stays hidden (displayed as [RANDOM_SET_NAME]) until the
+         * tournament starts, when [resolveRandomSets] rolls a concrete set. This mirrors the Quick
+         * Game deferred roll (QuickGameLobbyHandler resolves a null set code at game start).
+         *
+         * Multiple random slots use suffixed codes (`RANDOM`, `RANDOM-2`, …) so each is a distinct
+         * key in [setCodes] / [boosterDistribution] and resolves independently.
+         */
+        const val RANDOM_SET_CODE = "RANDOM"
+
+        /** Display name shown for an unresolved [RANDOM_SET_CODE] slot. */
+        const val RANDOM_SET_NAME = "Random Set"
+
+        /** True if [code] is an unresolved random-set placeholder (see [RANDOM_SET_CODE]). */
+        fun isRandomSetCode(code: String): Boolean =
+            code == RANDOM_SET_CODE || code.startsWith("$RANDOM_SET_CODE-")
+
         /**
          * Calculate a default booster distribution for the given sets and total booster count.
          * Distributes evenly with remainder going to the first sets.

--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/TournamentRandomSetTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/lobby/TournamentRandomSetTest.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.gameserver.lobby
+
+import com.wingedsheep.engine.limited.BoosterGenerator
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * The tournament lobby's "Random Set" pick is *deferred*: a host adds a [TournamentLobby.RANDOM_SET_CODE]
+ * placeholder that stays hidden (displayed as "Random Set") until the game starts, when
+ * [TournamentLobby.resolveRandomSets] rolls a concrete set. This pins that reveal contract — the pool
+ * must stay unresolved in the lobby and only concretise (avoiding extension/partial/duplicate sets) at
+ * start, mirroring the Quick Game deferred roll.
+ */
+class TournamentRandomSetTest : FunSpec({
+
+    fun setConfig(code: String, name: String, extension: Boolean = false, incomplete: Boolean = false) =
+        BoosterGenerator.SetConfig(
+            setCode = code,
+            setName = name,
+            cards = emptyList(),
+            basicLands = emptyList(),
+            incomplete = incomplete,
+            sealedSupported = !incomplete,
+            extensionSet = extension,
+        )
+
+    // Two regular complete sets, one extension set, one partial (incomplete) set.
+    val generator = BoosterGenerator(
+        mapOf(
+            "AAA" to setConfig("AAA", "Alpha Set"),
+            "BBB" to setConfig("BBB", "Beta Set"),
+            "EXT" to setConfig("EXT", "Extension Set", extension = true),
+            "PAR" to setConfig("PAR", "Partial Set", incomplete = true),
+        ),
+    )
+
+    fun lobby(setCodes: List<String>, setNames: List<String>, boosterCount: Int = 6) =
+        TournamentLobby(
+            setCodes = setCodes,
+            setNames = setNames,
+            boosterGenerator = generator,
+            boosterCount = boosterCount,
+            boosterDistribution = TournamentLobby.calculateDefaultDistribution(setCodes, boosterCount),
+        )
+
+    test("isRandomSetCode recognises the sentinel and suffixed variants, not real codes") {
+        TournamentLobby.isRandomSetCode("RANDOM") shouldBe true
+        TournamentLobby.isRandomSetCode("RANDOM-2") shouldBe true
+        TournamentLobby.isRandomSetCode("AAA") shouldBe false
+        TournamentLobby.isRandomSetCode("") shouldBe false
+    }
+
+    test("updateSets accepts a random placeholder and keeps it hidden as \"Random Set\"") {
+        val l = lobby(listOf("AAA"), listOf("Alpha Set"))
+        l.updateSets(listOf("AAA", "RANDOM")) shouldBe true
+        l.setCodes shouldContainExactly listOf("AAA", "RANDOM")
+        l.setNames shouldContainExactly listOf("Alpha Set", "Random Set")
+    }
+
+    test("updateSets still rejects an unknown concrete code") {
+        val l = lobby(listOf("AAA"), listOf("Alpha Set"))
+        l.updateSets(listOf("AAA", "ZZZ")) shouldBe false
+        // Selection unchanged on rejection.
+        l.setCodes shouldContainExactly listOf("AAA")
+    }
+
+    test("resolveRandomSets reveals a concrete complete set, never extension or partial") {
+        val l = lobby(listOf("RANDOM"), listOf("Random Set"))
+        l.resolveRandomSets()
+
+        l.setCodes.single() shouldNotBe "RANDOM"
+        (l.setCodes.single() in setOf("AAA", "BBB")) shouldBe true
+        l.setCodes shouldNotContain "EXT"
+        l.setCodes shouldNotContain "PAR"
+        // Name lines up with the revealed code.
+        l.setNames.single() shouldBe generator.getSetConfig(l.setCodes.single())!!.setName
+    }
+
+    test("a random slot never duplicates an already-selected concrete set") {
+        // AAA is picked; the only other complete set is BBB, so the random slot must become BBB.
+        val l = lobby(listOf("AAA", "RANDOM"), listOf("Alpha Set", "Random Set"))
+        l.resolveRandomSets()
+        l.setCodes shouldContainExactly listOf("AAA", "BBB")
+    }
+
+    test("multiple random slots resolve to distinct sets") {
+        val l = lobby(listOf("RANDOM", "RANDOM-2"), listOf("Random Set", "Random Set"))
+        l.resolveRandomSets()
+        l.setCodes.toSet().size shouldBe 2
+        l.setCodes.toSet() shouldBe setOf("AAA", "BBB")
+    }
+
+    test("resolveRandomSets remaps the distribution key, preserving the host's booster count") {
+        // Host allocates 4 boosters to AAA and 2 to the random slot.
+        val l = lobby(listOf("AAA", "RANDOM"), listOf("Alpha Set", "Random Set"), boosterCount = 6)
+        l.boosterDistribution = mapOf("AAA" to 4, "RANDOM" to 2)
+        l.resolveRandomSets()
+
+        // Random slot resolved to BBB; its 2 boosters carry over to the concrete key.
+        l.boosterDistribution["AAA"] shouldBe 4
+        l.boosterDistribution["BBB"] shouldBe 2
+        l.boosterDistribution.containsKey("RANDOM") shouldBe false
+    }
+
+    test("resolveRandomSets is a no-op when there are no placeholders") {
+        val l = lobby(listOf("AAA", "BBB"), listOf("Alpha Set", "Beta Set"))
+        val before = l.setCodes.toList()
+        l.resolveRandomSets()
+        l.setCodes shouldContainExactly before
+    }
+})

--- a/web-client/src/components/ui/GameUI.tsx
+++ b/web-client/src/components/ui/GameUI.tsx
@@ -749,6 +749,15 @@ function WaitingForOpponent({
  * Targets 18 grids per draft (the canonical number).
  */
 /**
+ * Sentinel set code for a deferred "Random Set" pick in a tournament lobby. The concrete set stays
+ * hidden (shown as "Random Set") until the server rolls it at game start — mirrors the server's
+ * TournamentLobby.RANDOM_SET_CODE. Multiple random slots use suffixed codes (RANDOM, RANDOM-2, …).
+ */
+const RANDOM_SET_CODE = 'RANDOM'
+const isRandomSetCode = (code: string): boolean =>
+  code === RANDOM_SET_CODE || code.startsWith(`${RANDOM_SET_CODE}-`)
+
+/**
  * Lobby overlay for sealed lobbies.
  */
 function LobbyOverlay({
@@ -859,11 +868,17 @@ function LobbyOverlay({
   // (`SetPickerModal`, shared with the Quick Game lobby). The lobby itself only shows the
   // *selected* sets as compact chips, so its footprint stays small and stable no matter how many
   // sets exist in total or how many a host picks.
-  type AvailableSet = typeof lobbyState.settings.availableSets[number]
   const allSets = lobbyState.settings.availableSets
-  const selectedSets = lobbyState.settings.setCodes
-    .map((code) => allSets.find((s) => s.code === code))
-    .filter((s): s is AvailableSet => s != null)
+  // A selected-set chip is either a concrete set or a deferred "Random Set" placeholder that stays
+  // hidden until the server reveals it at game start (see addRandomSet / RANDOM_SET_CODE).
+  type SelectedSetChip = { code: string; name: string; partial: boolean; extensionSet: boolean; random: boolean }
+  const selectedSets: SelectedSetChip[] = lobbyState.settings.setCodes
+    .map((code): SelectedSetChip | null => {
+      if (isRandomSetCode(code)) return { code, name: 'Random Set', partial: false, extensionSet: false, random: true }
+      const s = allSets.find((x) => x.code === code)
+      return s ? { code, name: s.name, partial: s.partial ?? false, extensionSet: s.extensionSet ?? false, random: false } : null
+    })
+    .filter((s): s is SelectedSetChip => s != null)
 
   const toggleSet = (code: string) => {
     const isSelected = lobbyState.settings.setCodes.includes(code)
@@ -873,14 +888,13 @@ function LobbyOverlay({
     updateLobbySettings({ setCodes: newCodes })
   }
 
-  // "Random Set" in the picker: add one random complete, standalone set to the selection.
-  // Partial sets stay opt-in and extension sets can't anchor a pool, so neither is rolled.
+  // "Random Set" in the picker: add a deferred random slot. Unlike a concrete set it stays hidden
+  // (shown as "Random Set") until the server rolls a complete, non-extension set at game start.
+  // Suffixed codes keep multiple random slots distinct (RANDOM, RANDOM-2, …).
   const addRandomSet = () => {
-    const candidates = allSets.filter(
-      (s) => !s.partial && !s.extensionSet && !lobbyState.settings.setCodes.includes(s.code),
-    )
-    const pick = candidates[Math.floor(Math.random() * candidates.length)]
-    if (pick) updateLobbySettings({ setCodes: [...lobbyState.settings.setCodes, pick.code] })
+    const existing = lobbyState.settings.setCodes.filter(isRandomSetCode).length
+    const code = existing === 0 ? RANDOM_SET_CODE : `${RANDOM_SET_CODE}-${existing + 1}`
+    updateLobbySettings({ setCodes: [...lobbyState.settings.setCodes, code] })
   }
 
   return (
@@ -1233,13 +1247,17 @@ function LobbyOverlay({
                       <span
                         key={set.code}
                         className={`${styles.setChip} ${isAnyDraft ? styles.setChipDraft : ''} ${set.partial ? styles.setChipPartial : ''}`}
-                        title={set.partial
-                          ? `${set.name} — partial (reduced card pool)`
-                          : set.extensionSet
-                            ? `${set.name} — extension set (needs a regular set alongside)`
-                            : set.name}
+                        title={set.random
+                          ? 'Random Set — revealed when the game starts'
+                          : set.partial
+                            ? `${set.name} — partial (reduced card pool)`
+                            : set.extensionSet
+                              ? `${set.name} — extension set (needs a regular set alongside)`
+                              : set.name}
                       >
-                        <SetIcon code={set.code} className={styles.setChipIcon} />
+                        {set.random
+                          ? <span className={styles.setChipIcon} aria-hidden>🎲</span>
+                          : <SetIcon code={set.code} className={styles.setChipIcon} />}
                         <span className={styles.setChipName}>{set.name}</span>
                         <button
                           type="button"


### PR DESCRIPTION
## What

In a tournament lobby, the host's **"Random Set"** pick used to roll a concrete set in the browser at pick time, so the chosen set was revealed in the lobby immediately. This makes the pick **deferred and hidden**: the slot shows as 🎲 **"Random Set"** until the game starts, and only then resolves to a concrete set — mirroring the Quick Game deferred roll.

## How

A `RANDOM` sentinel in the lobby's `setCodes`:

- **Client** (`web-client/src/components/ui/GameUI.tsx`): `addRandomSet` adds a placeholder code (`RANDOM`, then `RANDOM-2`, … so multiple random slots stay distinct) instead of a real set. The set chip renders a 🎲 icon + "Random Set" (title: *"revealed when the game starts"*).
- **Server** (`TournamentLobby.kt`, `LobbyHandler.kt`):
  - `RANDOM_SET_CODE` / `RANDOM_SET_NAME` / `isRandomSetCode()` live in `TournamentLobby`'s companion.
  - Lobby create + `updateSets` validation tolerates placeholders (only concrete codes are checked; the extension-only gate is skipped when a random slot is present, since it always resolves to a regular set).
  - New `TournamentLobby.resolveRandomSets()` runs at the top of `handleStartTournamentLobby` — **before** the extension gate and pool generation — rolling a fully-implemented, non-extension set for each slot (avoiding already-selected and duplicate sets) and **remapping `boosterDistribution` keys** so host-tuned booster counts survive the reveal. Players then see the concrete sets via `SealedPoolGenerated`.

## Not touched

`createAiTournament` (dev endpoint, explicit codes) and the legacy `SealedSession` path — neither receives the random pick. Quick Game keeps its own nullable-`setCode` → `deckGenerator.randomSetCode()` pattern.

## Tests

`TournamentRandomSetTest` (8 cases): placeholder acceptance, unknown-code rejection, resolution avoiding extension/partial/duplicate sets, multiple distinct slots, distribution-key remap preserving booster counts, and the no-op case. `:game-server:compileKotlin` and `npm run typecheck` (client) both pass.

## Note

No lobby screenshot yet — the game server wasn't running locally (booting it holds the machine-global gradle lock). Happy to add a before/after of the "Random Set" chip if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)