### PR TITLE
Fire ETB triggers dropped by the legend rule on the decision path

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/decision/SubmitDecisionHandler.kt
@@ -102,12 +102,42 @@ class SubmitDecisionHandler(
 
             // Check SBAs after continuation completes
             if (result.isSuccess && !result.isPaused) {
+                // Detect triggers from the resumed resolution's events BEFORE SBAs run, so an
+                // enters-the-battlefield trigger on a permanent that an SBA immediately removes —
+                // e.g. the legend rule putting a just-entered duplicate legendary into the
+                // graveyard, or a Gishath/Ghalta chain that puts a second copy onto the
+                // battlefield — is still queued (CR 603.6a: the ability triggers the moment the
+                // permanent enters; the SBA that removes it happens afterward). Mirrors
+                // PassPriorityHandler.resolveTopOfStack, which handles the non-decision path.
+                // Skipped when the resumed chain already ran detection on its own emitted events
+                // (see the post-SBA note below).
+                val preSbaTriggers = if (result.triggersAlreadyProcessed) {
+                    emptyList()
+                } else {
+                    triggerDetector.detectTriggers(result.state, result.events)
+                }
+
+                val preSbaStackSize = result.state.continuationStack.size
                 val sbaResult = sbaChecker.checkAndApply(result.state)
 
-                // If SBA needs player input (e.g., legend rule), return paused
+                // If SBA needs player input (e.g., legend rule), return paused — but first queue
+                // preSbaTriggers beneath the SBA's continuation frames so they fire after the SBA
+                // decision resolves, instead of being silently dropped.
                 if (sbaResult.isPaused) {
+                    var pausedState = sbaResult.state
+                    if (preSbaTriggers.isNotEmpty()) {
+                        val pendingTriggers = PendingTriggersContinuation(
+                            decisionId = "submit-sba-deferred-triggers-${java.util.UUID.randomUUID()}",
+                            remainingTriggers = preSbaTriggers
+                        )
+                        val stack = pausedState.continuationStack
+                        val newStack = stack.subList(0, preSbaStackSize) +
+                            pendingTriggers +
+                            stack.subList(preSbaStackSize, stack.size)
+                        pausedState = pausedState.copy(continuationStack = newStack)
+                    }
                     return ExecutionResult.paused(
-                        sbaResult.state,
+                        pausedState,
                         sbaResult.pendingDecision!!,
                         listOf(submittedEvent) + result.events + sbaResult.events
                     )
@@ -119,17 +149,19 @@ class SubmitDecisionHandler(
                     return ExecutionResult.success(sbaResult.newState, combinedEvents)
                 }
 
-                // Process triggers. When the resumed chain re-entered an action handler
-                // that already ran detection on its own emitted events (e.g.,
-                // `CastSpellHandler` re-entered via `finalizeModalCast` after a cast-time
-                // mode picker), skip those events here — re-detecting would double-queue
-                // battlefield triggers like Riku of Many Paths.
-                val eventsToDetect = if (result.triggersAlreadyProcessed) {
+                // Detect the remaining triggers on the post-SBA state: the submitted decision and
+                // any SBA events (e.g. death triggers). The resumed resolution's own events were
+                // already captured pre-SBA above. When the resumed chain re-entered an action
+                // handler that already ran detection on its own emitted events (e.g.,
+                // `CastSpellHandler` re-entered via `finalizeModalCast` after a cast-time mode
+                // picker), preSbaTriggers is empty and re-detecting result.events would
+                // double-queue battlefield triggers like Riku of Many Paths — so those are
+                // deliberately excluded here.
+                val postSbaTriggers = triggerDetector.detectTriggers(
+                    sbaResult.newState,
                     listOf(submittedEvent) + sbaResult.events
-                } else {
-                    combinedEvents
-                }
-                val triggers = triggerDetector.detectTriggers(sbaResult.newState, eventsToDetect)
+                )
+                val triggers = preSbaTriggers + postSbaTriggers
                 if (triggers.isNotEmpty()) {
                     val triggerResult = triggerProcessor.processTriggers(sbaResult.newState, triggers)
 
@@ -157,7 +189,7 @@ class SubmitDecisionHandler(
             // The chain paused (or errored). When paused, events emitted during the
             // chain (e.g., BecomesTargetEvent from putting a triggered ability on the
             // stack mid-chain) may fire additional triggers (e.g., Valiant) that the
-            // success path's trigger-detection at line 108 would catch — but the paused
+            // success branch's trigger-detection above would catch — but the paused
             // path returns before reaching it, so those triggers would be lost.
             // Detect them here and queue as a PendingTriggersContinuation BENEATH the frames
             // this resume left in flight, so they fire only after the whole in-flight resolution

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhaltaStampedeTyrantLegendRuleTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GhaltaStampedeTyrantLegendRuleTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression test for a decision-path enters-the-battlefield / legend-rule ordering bug.
+ *
+ * Ghalta, Stampede Tyrant (LCI) — {5}{G}{G}{G} Legendary Creature — Elder Dinosaur 12/12
+ *   Trample
+ *   When Ghalta enters, put any number of creature cards from your hand onto the battlefield.
+ *
+ * Scenario: cast Ghalta A. Its ETB (a decision-driven "put creatures from your hand" effect) puts a
+ * second Ghalta B onto the battlefield. Ghalta B duplicates the legendary already present, so the
+ * legend rule (state-based action, CR 704.5j) immediately puts one copy into the graveyard. Per
+ * CR 603.6a the ability triggers the moment Ghalta B enters — before the legend-rule SBA removes it —
+ * so Ghalta B's own ETB must still fire and let the player put a further creature onto the
+ * battlefield.
+ *
+ * Before the fix, the entering-and-putting happened while resuming the ETB's "choose creatures"
+ * decision ([com.wingedsheep.engine.handlers.actions.decision.SubmitDecisionHandler]), whose success
+ * path checked SBAs *before* detecting the resolution's triggers — and, on the SBA pause, never
+ * detected them at all — dropping Ghalta B's ETB entirely.
+ * [com.wingedsheep.engine.handlers.actions.priority.PassPriorityHandler] already handled the
+ * non-decision path correctly (detect pre-SBA, defer beneath the legend-rule continuation); this
+ * test pins the decision path to the same behaviour.
+ */
+class GhaltaStampedeTyrantLegendRuleTest : ScenarioTestBase() {
+    init {
+        test("a just-entered duplicate Ghalta's ETB still fires even though the legend rule removes it") {
+            val game = scenario()
+                .withPlayers("Alice", "Bob")
+                .withLandsOnBattlefield(1, "Forest", 8)
+                .withCardsInHand(1, "Ghalta, Stampede Tyrant", 2)
+                .withCardInHand(1, "Grizzly Bears")
+                .withActivePlayer(1)
+                .withPriorityPlayer(1)
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .build()
+
+            // Cast the first Ghalta.
+            game.castSpell(1, "Ghalta, Stampede Tyrant").error shouldBe null
+            if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+
+            // Resolve the spell and its ETB trigger; resolution pauses on the ETB's
+            // "choose any number of creature cards from your hand" decision.
+            game.resolveStack()
+            game.hasPendingDecision() shouldBe true
+
+            // Capture the first Ghalta now, while it is the only copy on the battlefield.
+            val firstGhalta = game.findPermanent("Ghalta, Stampede Tyrant")
+            firstGhalta shouldNotBe null
+
+            // Ghalta A's ETB: put ONLY the second Ghalta from hand onto the battlefield, keeping
+            // Grizzly Bears in hand as the payload for Ghalta B's own ETB.
+            val secondGhaltaInHand = game.findCardsInHand(1, "Ghalta, Stampede Tyrant").first()
+            game.selectCards(listOf(secondGhaltaInHand)).error shouldBe null
+
+            // Two Ghaltas are now on the battlefield → the legend rule pauses for a choice.
+            game.hasPendingDecision() shouldBe true
+
+            // Keep the first (older) Ghalta; the just-entered duplicate is put into the graveyard.
+            game.selectCards(listOf(firstGhalta!!)).error shouldBe null
+
+            // The removed Ghalta's ETB must still fire. Resolve until it pauses on its own
+            // "choose creatures from your hand" decision.
+            if (!game.hasPendingDecision()) game.resolveStack()
+            game.hasPendingDecision() shouldBe true
+
+            // Put Grizzly Bears onto the battlefield via the dead Ghalta's ETB.
+            val bears = game.findCardsInHand(1, "Grizzly Bears").first()
+            game.selectCards(listOf(bears)).error shouldBe null
+            game.resolveStack()
+
+            // Proof the ETB fired: Grizzly Bears is on the battlefield, exactly one Ghalta remains,
+            // and the duplicate is in the graveyard.
+            game.isOnBattlefield("Grizzly Bears") shouldBe true
+            game.findPermanents("Ghalta, Stampede Tyrant").size shouldBe 1
+            game.isInGraveyard(1, "Ghalta, Stampede Tyrant") shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
## Problem

An enters-the-battlefield trigger on a permanent that a state-based action immediately removes was being **silently dropped** — but only on the decision-resume path.

Concretely: cast Ghalta, Stampede Tyrant. Its ETB ("put any number of creature cards from your hand onto the battlefield") is a decision-driven effect. If it puts a *second* Ghalta onto the battlefield, the legend rule (SBA, CR 704.5j) immediately moves one copy to the graveyard. Per CR 603.6a the duplicate's ability triggers the moment it enters — *before* the legend-rule SBA removes it — so its own ETB must still fire. It didn't.

## Cause

`SubmitDecisionHandler` (the decision-resume path) checked SBAs *before* detecting the resumed resolution's triggers, and on an SBA pause returned without ever detecting them. `PassPriorityHandler.resolveTopOfStack` (the non-decision path) already handled this correctly — detect pre-SBA, defer beneath the legend-rule continuation.

## Fix

Bring `SubmitDecisionHandler` in line with `PassPriorityHandler`:

- Detect the resumed resolution's triggers on the **pre-SBA** state (`result.events`), so ETB triggers on a permanent an SBA is about to remove are captured (CR 603.6a).
- On an SBA pause, queue those triggers as a `PendingTriggersContinuation` inserted **beneath** the SBA's continuation frames, so they fire after the legend-rule decision resolves instead of being dropped.
- Post-SBA detection now covers only the submitted decision + SBA events; the resumed resolution's own events are no longer re-detected there, so the `triggersAlreadyProcessed` modal-cast guard (Riku of Many Paths) still prevents double-queueing.

## Test

`GhaltaStampedeTyrantLegendRuleTest` — casts Ghalta A, uses its ETB to put Ghalta B onto the battlefield, keeps the older Ghalta under the legend rule, and asserts the *removed* Ghalta B's ETB still fires (Grizzly Bears reaches the battlefield). Also asserts exactly one Ghalta survives and the duplicate is in the graveyard.

Regression-checked: `LegendRuleTest`, `ModalCastTimeModeTest`, `ModalCastTimeDeferredTargetsTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
