### PR TITLE
Add 20 The Lost Caverns of Ixalan cards + basic-land art variants

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -261,7 +261,7 @@
 - [ ] Thousand Moons Crackshot
 - [ ] Thousand Moons Infantry
 - [ ] Thousand Moons Smithy
-- [ ] Thrashing Brontodon
+- [x] Thrashing Brontodon
 - [ ] Threefold Thunderhulk
 - [ ] Throne of the Grim Captain
 - [ ] Tinker's Tote

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 87 / 286
+**Implemented:** 91 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -173,7 +173,7 @@
 - [ ] Ojer Pakpatiq, Deepest Epoch
 - [ ] Ojer Taq, Deepest Foundation
 - [x] Oltec Archaeologists
-- [ ] Oltec Cloud Guard
+- [x] Oltec Cloud Guard
 - [x] Orazca Puzzle-Door
 - [ ] Oteclan Landmark
 - [ ] Out of Air

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -90,7 +90,7 @@
 - [ ] Echo of Dusk
 - [ ] Echoing Deeps
 - [ ] Enterprising Scallywag
-- [ ] Envoy of Okinec Ahau
+- [x] Envoy of Okinec Ahau
 - [ ] Etali's Favor
 - [ ] Explorer's Cache
 - [ ] Fabrication Foundry

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -217,7 +217,7 @@
 - [x] Scampering Surveyor
 - [x] Screaming Phantom
 - [ ] Scytheclaw Raptor
-- [ ] Seeker of Sunlight
+- [x] Seeker of Sunlight
 - [x] Seismic Monstrosaur
 - [x] Self-Reflection
 - [x] Sentinel of the Nameless City

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 72 / 286
+**Implemented:** 81 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -44,7 +44,7 @@
 - [ ] Captain Storm, Cosmium Raider
 - [x] Captivating Cave
 - [x] Careening Mine Cart
-- [ ] Cartographer's Companion
+- [x] Cartographer's Companion
 - [ ] Cavern Stomper
 - [x] Cavern of Souls
 - [ ] Cavernous Maw

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -70,7 +70,7 @@
 - [x] Dead Weight
 - [x] Deathcap Marionette
 - [ ] Deconstruction Hammer
-- [ ] Deep Goblin Skulltaker
+- [x] Deep Goblin Skulltaker
 - [x] Deep-Cavern Bat
 - [ ] Deepfathom Echo
 - [ ] Deeproot Pilgrimage

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -194,7 +194,7 @@
 - [ ] Queen's Bay Paladin
 - [x] Quicksand Whirlpool
 - [ ] Quintorius Kand
-- [ ] Rampaging Ceratops
+- [x] Rampaging Ceratops
 - [x] Rampaging Spiketail
 - [ ] Ray of Ruin
 - [ ] Relic's Roar

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -1,0 +1,291 @@
+# The Lost Caverns of Ixalan (LCI) - Card Checklist
+
+**Set Size:** 286 booster cards (excluding basic lands and tokens)
+**Release Date:** November 17, 2023
+**Implemented:** 72 / 286
+- [x] Abrade
+- [ ] Abuelo's Awakening
+- [x] Abuelo, Ancestral Echo
+- [ ] Abyssal Gorestalker
+- [ ] Aclazotz, Deepest Betrayal
+- [x] Acolyte of Aclazotz
+- [x] Acrobatic Leap
+- [ ] Adaptive Gemguard
+- [ ] Akal Pakal, First Among Equals
+- [ ] Akawalli, the Seething Tower
+- [ ] Amalia Benavides Aguirre
+- [x] Ancestors' Aid
+- [x] Ancestral Reminiscence
+- [ ] Anim Pakal, Thousandth Moon
+- [ ] Another Chance
+- [ ] Armored Kincaller
+- [x] Attentive Sunscribe
+- [x] Bartolomé del Presidio
+- [ ] Basking Capybara
+- [ ] Bat Colony
+- [ ] Bedrock Tortoise
+- [ ] Belligerent Yearling
+- [x] Bitter Triumph
+- [x] Bloodletter of Aclazotz
+- [ ] Bloodthorn Flail
+- [ ] Bonehoard Dracosaur
+- [ ] Brackish Blunder
+- [ ] Braided Net
+- [ ] Brass's Tunnel-Grinder
+- [ ] Brazen Blademaster
+- [ ] Breeches, Eager Pillager
+- [x] Bringer of the Last Gift
+- [ ] Broodrage Mycoid
+- [ ] Buried Treasure
+- [ ] Burning Sun Cavalry
+- [ ] Calamitous Cave-In
+- [ ] Canonized in Blood
+- [ ] Caparocti Sunborn
+- [ ] Captain Storm, Cosmium Raider
+- [x] Captivating Cave
+- [x] Careening Mine Cart
+- [ ] Cartographer's Companion
+- [ ] Cavern Stomper
+- [x] Cavern of Souls
+- [ ] Cavernous Maw
+- [ ] Cenote Scout
+- [x] Chart a Course
+- [ ] Child of the Volcano
+- [ ] Chimil, the Inner Sun
+- [x] Chupacabra Echo
+- [ ] Clay-Fired Bricks
+- [ ] Coati Scavenger
+- [x] Cogwork Wrestler
+- [x] Colossadactyl
+- [x] Compass Gnome
+- [x] Confounding Riddle
+- [ ] Contested Game Ball
+- [ ] Corpses of the Lost
+- [x] Cosmium Blast
+- [ ] Cosmium Confluence
+- [ ] Council of Echoes
+- [ ] Curator of Sun's Creation
+- [ ] Daring Discovery
+- [ ] Dauntless Dismantler
+- [x] Dead Weight
+- [x] Deathcap Marionette
+- [ ] Deconstruction Hammer
+- [ ] Deep Goblin Skulltaker
+- [x] Deep-Cavern Bat
+- [ ] Deepfathom Echo
+- [ ] Deeproot Pilgrimage
+- [ ] Defossilize
+- [ ] Diamond Pick-Axe
+- [ ] Didact Echo
+- [ ] Digsite Conservator
+- [x] Dinotomaton
+- [ ] Dire Flail
+- [x] Disruptor Wanderglyph
+- [ ] Disturbed Slumber
+- [ ] Dowsing Device
+- [ ] Dreadmaw's Ire
+- [x] Dusk Rose Reliquary
+- [ ] Earthshaker Dreadmaw
+- [ ] Eaten by Piranhas
+- [ ] Echo of Dusk
+- [ ] Echoing Deeps
+- [ ] Enterprising Scallywag
+- [ ] Envoy of Okinec Ahau
+- [ ] Etali's Favor
+- [ ] Explorer's Cache
+- [ ] Fabrication Foundry
+- [x] Family Reunion
+- [ ] Fanatical Offering
+- [x] Forgotten Monument
+- [ ] Frilled Cave-Wurm
+- [ ] Fungal Fortitude
+- [ ] Gargantuan Leech
+- [ ] Geological Appraiser
+- [ ] Get Lost
+- [x] Ghalta, Stampede Tyrant
+- [x] Gishath, Sun's Avatar
+- [ ] Glimpse the Core
+- [ ] Glorifier of Suffering
+- [ ] Glowcap Lantern
+- [ ] Goblin Tomb Raider
+- [ ] Goldfury Strider
+- [ ] Grasping Shadows
+- [x] Greedy Freebooter
+- [ ] Growing Rites of Itlimoc
+- [ ] Guardian of the Great Door
+- [ ] Helping Hand
+- [x] Hermitic Nautilus
+- [ ] Hidden Cataract
+- [ ] Hidden Courtyard
+- [ ] Hidden Necropolis
+- [ ] Hidden Nursery
+- [ ] Hidden Volcano
+- [ ] Hit the Mother Lode
+- [x] Hotfoot Gnome
+- [x] Hoverstone Pilgrim
+- [x] Huatli's Final Strike
+- [ ] Huatli, Poet of Unity
+- [ ] Hulking Raptor
+- [ ] Hunter's Blowgun
+- [ ] Hurl into History
+- [ ] Idol of the Deep King
+- [ ] In the Presence of Ages
+- [ ] Inti, Seneschal of the Sun
+- [ ] Intrepid Paleontologist
+- [ ] Inverted Iceberg
+- [x] Ironpaw Aspirant
+- [ ] Itzquinth, Firstborn of Gishath
+- [ ] Ixalli's Lorekeeper
+- [ ] Jade Seedstones
+- [ ] Jadelight Spelunker
+- [ ] Join the Dead
+- [ ] Kaslem's Stonetree
+- [ ] Kellan, Daring Traveler
+- [ ] Kinjalli's Dawnrunner
+- [ ] Kitesail Larcenist
+- [ ] Kutzil's Flanker
+- [ ] Kutzil, Malamet Exemplar
+- [ ] Lodestone Needle
+- [ ] Magmatic Galleon
+- [ ] Malamet Battle Glyph
+- [x] Malamet Brawler
+- [x] Malamet Scythe
+- [ ] Malamet Veteran
+- [x] Malamet War Scribe
+- [x] Malcolm, Alluring Scoundrel
+- [ ] Malicious Eclipse
+- [x] Marauding Brinefang
+- [ ] Market Gnome
+- [ ] Master's Guide-Mural
+- [ ] Matzalantli, the Great Door
+- [x] Mephitic Draught
+- [ ] Merfolk Cave-Diver
+- [x] Might of the Ancestors
+- [ ] Miner's Guidewing
+- [x] Mineshaft Spider
+- [x] Mischievous Pup
+- [ ] Molten Collapse
+- [ ] Nicanzil, Current Conductor
+- [x] Nurturing Bristleback
+- [ ] Oaken Siren
+- [ ] Ojer Axonil, Deepest Might
+- [ ] Ojer Kaslem, Deepest Growth
+- [ ] Ojer Pakpatiq, Deepest Epoch
+- [ ] Ojer Taq, Deepest Foundation
+- [x] Oltec Archaeologists
+- [ ] Oltec Cloud Guard
+- [x] Orazca Puzzle-Door
+- [ ] Oteclan Landmark
+- [ ] Out of Air
+- [ ] Over the Edge
+- [x] Palani's Hatcher
+- [x] Panicked Altisaur
+- [ ] Pathfinding Axejaw
+- [ ] Petrify
+- [ ] Pirate Hat
+- [ ] Pit of Offerings
+- [x] Plundering Pirate
+- [ ] Poetic Ingenuity
+- [x] Poison Dart Frog
+- [ ] Preacher of the Schism
+- [ ] Primordial Gnawer
+- [x] Promising Vein
+- [ ] Pugnacious Hammerskull
+- [ ] Queen's Bay Paladin
+- [x] Quicksand Whirlpool
+- [ ] Quintorius Kand
+- [ ] Rampaging Ceratops
+- [x] Rampaging Spiketail
+- [ ] Ray of Ruin
+- [ ] Relic's Roar
+- [ ] Resplendent Angel
+- [ ] Restless Anchorage
+- [ ] Restless Prairie
+- [ ] Restless Reef
+- [ ] Restless Ridgeline
+- [ ] Restless Vents
+- [ ] River Herald Guide
+- [ ] River Herald Scout
+- [ ] Roaming Throne
+- [x] Ruin-Lurker Bat
+- [ ] Rumbling Rockslide
+- [x] Runaway Boulder
+- [ ] Sage of Days
+- [x] Saheeli's Lattice
+- [ ] Saheeli, the Sun's Brilliance
+- [ ] Sanguine Evangelist
+- [x] Scampering Surveyor
+- [ ] Screaming Phantom
+- [ ] Scytheclaw Raptor
+- [ ] Seeker of Sunlight
+- [x] Seismic Monstrosaur
+- [x] Self-Reflection
+- [x] Sentinel of the Nameless City
+- [ ] Shipwreck Sentry
+- [ ] Sinuous Benthisaur
+- [ ] Skullcap Snail
+- [x] Soaring Sandwing
+- [ ] Song of Stupefaction
+- [ ] Sorcerous Spyglass
+- [x] Soulcoil Viper
+- [ ] Souls of the Lost
+- [ ] Sovereign Okinec Ahau
+- [ ] Spelunking
+- [ ] Spring-Loaded Sawblades
+- [ ] Spyglass Siren
+- [ ] Squirming Emergence
+- [x] Staggering Size
+- [ ] Stalactite Stalker
+- [ ] Starving Revenant
+- [x] Staunch Crewmate
+- [ ] Stinging Cave Crawler
+- [ ] Subterranean Schooner
+- [ ] Sunbird Standard
+- [ ] Sunfire Torch
+- [ ] Sunken Citadel
+- [ ] Sunshot Militia
+- [ ] Swashbuckler's Whip
+- [ ] Synapse Necromage
+- [ ] Tarrian's Journal
+- [ ] Tarrian's Soulcleaver
+- [ ] Tectonic Hazard
+- [ ] Tendril of the Mycotyrant
+- [x] Terror Tide
+- [ ] The Ancient One
+- [ ] The Belligerent
+- [ ] The Enigma Jewel
+- [ ] The Everflowing Well
+- [ ] The Millennium Calendar
+- [ ] The Mycotyrant
+- [ ] The Skullspore Nexus
+- [ ] Thousand Moons Crackshot
+- [ ] Thousand Moons Infantry
+- [ ] Thousand Moons Smithy
+- [ ] Thrashing Brontodon
+- [ ] Threefold Thunderhulk
+- [ ] Throne of the Grim Captain
+- [ ] Tinker's Tote
+- [ ] Tishana's Tidebinder
+- [ ] Tithing Blade
+- [ ] Treasure Map
+- [ ] Triumphant Chomp
+- [ ] Trumpeting Carnosaur
+- [ ] Twists and Turns
+- [ ] Uchbenbak, the Great Mistake
+- [ ] Unlucky Drop
+- [ ] Unstable Glyphbridge
+- [x] Vanguard of the Rose
+- [ ] Visage of Dread
+- [x] Vito's Inquisitor
+- [ ] Vito, Fanatic of Aclazotz
+- [ ] Volatile Fault
+- [x] Volatile Wanderglyph
+- [ ] Wail of the Forgotten
+- [ ] Walk with the Ancestors
+- [ ] Warden of the Inner Sky
+- [ ] Waterlogged Hulk
+- [ ] Waterwind Scout
+- [x] Waylaying Pirates
+- [ ] Zoetic Glyph
+- [ ] Zoyowa Lava-Tongue
+- [ ] Zoyowa's Justice

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -89,7 +89,7 @@
 - [ ] Eaten by Piranhas
 - [ ] Echo of Dusk
 - [ ] Echoing Deeps
-- [ ] Enterprising Scallywag
+- [x] Enterprising Scallywag
 - [x] Envoy of Okinec Ahau
 - [ ] Etali's Favor
 - [ ] Explorer's Cache

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 81 / 286
+**Implemented:** 87 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -232,7 +232,7 @@
 - [ ] Sovereign Okinec Ahau
 - [ ] Spelunking
 - [ ] Spring-Loaded Sawblades
-- [ ] Spyglass Siren
+- [x] Spyglass Siren
 - [ ] Squirming Emergence
 - [x] Staggering Size
 - [ ] Stalactite Stalker

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -85,7 +85,7 @@
 - [ ] Dowsing Device
 - [ ] Dreadmaw's Ire
 - [x] Dusk Rose Reliquary
-- [ ] Earthshaker Dreadmaw
+- [x] Earthshaker Dreadmaw
 - [ ] Eaten by Piranhas
 - [ ] Echo of Dusk
 - [ ] Echoing Deeps

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -205,7 +205,7 @@
 - [ ] Restless Ridgeline
 - [ ] Restless Vents
 - [ ] River Herald Guide
-- [ ] River Herald Scout
+- [x] River Herald Scout
 - [ ] Roaming Throne
 - [x] Ruin-Lurker Bat
 - [ ] Rumbling Rockslide

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -284,7 +284,7 @@
 - [ ] Walk with the Ancestors
 - [ ] Warden of the Inner Sky
 - [ ] Waterlogged Hulk
-- [ ] Waterwind Scout
+- [x] Waterwind Scout
 - [x] Waylaying Pirates
 - [ ] Zoetic Glyph
 - [ ] Zoyowa Lava-Tongue

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -215,7 +215,7 @@
 - [ ] Saheeli, the Sun's Brilliance
 - [ ] Sanguine Evangelist
 - [x] Scampering Surveyor
-- [ ] Screaming Phantom
+- [x] Screaming Phantom
 - [ ] Scytheclaw Raptor
 - [ ] Seeker of Sunlight
 - [x] Seismic Monstrosaur

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -208,7 +208,7 @@
 - [x] River Herald Scout
 - [ ] Roaming Throne
 - [x] Ruin-Lurker Bat
-- [ ] Rumbling Rockslide
+- [x] Rumbling Rockslide
 - [x] Runaway Boulder
 - [ ] Sage of Days
 - [x] Saheeli's Lattice

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -48,7 +48,7 @@
 - [ ] Cavern Stomper
 - [x] Cavern of Souls
 - [ ] Cavernous Maw
-- [ ] Cenote Scout
+- [x] Cenote Scout
 - [x] Chart a Course
 - [ ] Child of the Volcano
 - [ ] Chimil, the Inner Sun

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -161,7 +161,7 @@
 - [x] Mephitic Draught
 - [ ] Merfolk Cave-Diver
 - [x] Might of the Ancestors
-- [ ] Miner's Guidewing
+- [x] Miner's Guidewing
 - [x] Mineshaft Spider
 - [x] Mischievous Pup
 - [ ] Molten Collapse

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -204,7 +204,7 @@
 - [ ] Restless Reef
 - [ ] Restless Ridgeline
 - [ ] Restless Vents
-- [ ] River Herald Guide
+- [x] River Herald Guide
 - [x] River Herald Scout
 - [ ] Roaming Throne
 - [x] Ruin-Lurker Bat

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -180,7 +180,7 @@
 - [ ] Over the Edge
 - [x] Palani's Hatcher
 - [x] Panicked Altisaur
-- [ ] Pathfinding Axejaw
+- [x] Pathfinding Axejaw
 - [ ] Petrify
 - [ ] Pirate Hat
 - [ ] Pit of Offerings

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -141,7 +141,7 @@
 - [ ] Join the Dead
 - [ ] Kaslem's Stonetree
 - [ ] Kellan, Daring Traveler
-- [ ] Kinjalli's Dawnrunner
+- [x] Kinjalli's Dawnrunner
 - [ ] Kitesail Larcenist
 - [ ] Kutzil's Flanker
 - [ ] Kutzil, Malamet Exemplar

--- a/backlog/sets/the-lost-caverns-of-ixalan/mechanics.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/mechanics.md
@@ -1,0 +1,47 @@
+# The Lost Caverns of Ixalan (LCI) — Mechanics
+
+Counts are over the 286 booster cards (excluding basic lands), by front-face + back-face
+oracle text. "Unimpl" = not yet implemented as of this document (72 cards done).
+
+Engine-support column reflects whether the SDK/rules-engine already models the mechanic
+(so cards using *only* supported mechanics need **no backend change** — pure `add-card` work).
+
+## Set mechanics
+
+| Mechanic | Total | Unimpl | Engine support | Notes |
+|----------|------:|-------:|----------------|-------|
+| **Explore** | 25 | 24 | ✅ `ExploreEffect` | Creature reveals top card; land → hand, nonland → +1/+1 counter + may mill. |
+| **Discover N** | 11 | 11 | ❌ **NOT supported** | No SDK type exists (no effect / dynamic amount / condition). **Needs `add-feature`** — all 11 cards blocked until then. |
+| **Craft** | 19 | 19 | ✅ `Craft*` + DFC transform | Activate from battlefield (exile materials), transform to back face. All Craft cards are DFCs. |
+| **Descend (4 / 8 / fathomless)** | 28 | 27 | ✅ `descended` tracking | Cares about permanent cards in your graveyard; "descend N" / "fathomless descent". |
+| **Map token** | 7 | 6 | ✅ `MapToken` | Artifact token; `{1}, {T}, Sacrifice: target creature you control explores.` |
+| **Transform / DFC** | 35 | 35 | ✅ `TransformEffects` | Includes Craft backs, MDFC lands (front spell // back land), god // land flips. |
+| **Treasure** | 16 | 12 | ✅ Treasure token | Standard artifact token, sac for one mana of any color. |
+| **Vehicle / Crew** | 6 | 5 | ✅ Crew | Standard vehicles. |
+| **Cave (land subtype)** | 12 | 10 | ✅ (subtype only) | New land subtype; some cards care "you control a Cave". |
+| **Finality counter** | 5 | 4 | ✅ finality counters | -1/-1-ish removal-on-death counter; used by a few cards. |
+
+## Evergreen / returning keywords present
+
+Flying (25), Trample (14), Vigilance (10), Ward (9), Menace (6), Lifelink (5), Deathtouch (4),
+Haste (4), Reach (4), First strike (2), Double strike (1), Flash (12), Defender (1),
+Indestructible (1), Hexproof (1). Plus Equip (12), Cycling / typecycling / landcycling (13),
+Mill (12), Scry (11), Surveil (1), Enchant (7), Fight (1). **All engine-supported.**
+
+## Backend-change assessment
+
+Every headline LCI mechanic **except Discover** is already modelled by the engine (72 LCI cards,
+including a Craft DFC — `SaheelisLattice.kt` — are implemented). Therefore **most remaining cards
+are pure `add-card` authoring**. The known backend gap:
+
+- **Discover N (11 cards)** — no SDK primitive exists. Needs `add-feature` (a `DiscoverEffect`
+  modelling "exile from top until nonland MV ≤ N; cast free or hand; rest to bottom random").
+  Until then every Discover card is blocked, e.g. Primordial Gnawer, Geological Appraiser,
+  Daring Discovery, Chimil the Inner Sun, Hurl into History, Walk with the Ancestors.
+
+Beyond that, individual cards may need `add-feature` for a novel one-off ability — flagged
+per-card during implementation. The 214 unimplemented cards break down as 179 single-faced + 35 DFCs.
+
+Implementation order: single-faced cards using only supported mechanics first (explore / Map /
+discover / standard effects), then DFCs (Craft, MDFC lands, god flips), deferring any card that
+turns out to need a new SDK primitive.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/LostCavernsOfIxalanSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/LostCavernsOfIxalanSet.kt
@@ -26,5 +26,9 @@ object LostCavernsOfIxalanSet : MtgSet {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.lci.cards"
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CartographersCompanion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CartographersCompanion.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cartographer's Companion — {3}
+ * Artifact Creature — Gnome
+ * 2/1
+ * When this creature enters, create a Map token.
+ */
+val CartographersCompanion = card("Cartographer's Companion") {
+    manaCost = "{3}"
+    typeLine = "Artifact Creature — Gnome"
+    oracleText = "When this creature enters, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")"
+    power = 2
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMapToken()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "248"
+        artist = "Chuck Lukacs"
+        flavorText = "Ever since the Fomori's attempt long ago to extinguish Chimil's light, the Oltec have taken extensive measures to never get lost in the Core."
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbd8115e-4cb3-49b6-b74f-8fcfa28c6404.jpg?1782694413"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CenoteScout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CenoteScout.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cenote Scout — {G}
+ * Creature — Merfolk Scout
+ * 1/1
+ * When this creature enters, it explores.
+ */
+val CenoteScout = card("Cenote Scout") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Scout"
+    oracleText = "When this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)"
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Explore(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "178"
+        artist = "Caroline Gariba"
+        flavorText = "\"If you're afraid to dive into the unknown, how will you ever find anything new?\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4ce4b7bc-636b-4723-a7c1-2c859f333492.jpg?1782694467"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeepGoblinSkulltaker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeepGoblinSkulltaker.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deep Goblin Skulltaker — {2}{B}
+ * Creature — Goblin Warrior
+ * 2/2
+ * Menace
+ * At the beginning of your end step, if you descended this turn, put a +1/+1 counter on this creature.
+ */
+val DeepGoblinSkulltaker = card("Deep Goblin Skulltaker") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Goblin Warrior"
+    oracleText = "Menace\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on this creature. (You descended if a permanent card was put into your graveyard from anywhere.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouDescendedThisTurn()
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "101"
+        artist = "Cristi Balanescu"
+        flavorText = "\"Go away! I found it first!\""
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0b24bb7c-6b34-48b6-af94-f312ebdbb759.jpg?1782694530"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EarthshakerDreadmaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EarthshakerDreadmaw.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Earthshaker Dreadmaw — {4}{G}{G}
+ * Creature — Dinosaur
+ * 6/6
+ * Trample
+ * When this creature enters, draw a card for each other Dinosaur you control.
+ */
+val EarthshakerDreadmaw = card("Earthshaker Dreadmaw") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "Trample\nWhen this creature enters, draw a card for each other Dinosaur you control."
+    power = 6
+    toughness = 6
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(
+            DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Creature.withSubtype("Dinosaur"),
+                aggregation = Aggregation.COUNT,
+                excludeSelf = true,
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "183"
+        artist = "Jesper Ejsing"
+        flavorText = "\"I suggest we leave this cavern for someone else to conquer.\" —Amalia, master cartographer"
+        imageUri = "https://cards.scryfall.io/normal/front/c/d/cdcbba6f-aa54-44be-a3b0-f712fa8bd5ad.jpg?1782694463"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EnterprisingScallywag.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EnterprisingScallywag.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Enterprising Scallywag — {1}{R}
+ * Creature — Goblin Pirate
+ * 2/2
+ * At the beginning of your end step, if you descended this turn, create a Treasure token.
+ */
+val EnterprisingScallywag = card("Enterprising Scallywag") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Goblin Pirate"
+    oracleText = "At the beginning of your end step, if you descended this turn, create a Treasure token. (You descended if a permanent card was put into your graveyard from anywhere.)"
+    power = 2
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouDescendedThisTurn()
+        effect = Effects.CreateTreasure()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "148"
+        artist = "Denman Rooke"
+        flavorText = "\"He would've wanted me to have it!\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/44420f52-2ed8-4f81-93e4-5decc77bed01.jpg?1782694491"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EnvoyOfOkinecAhau.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EnvoyOfOkinecAhau.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Envoy of Okinec Ahau — {2}{W}
+ * Creature — Cat Advisor
+ * 3/3
+ * {4}{W}: Create a 1/1 colorless Gnome artifact creature token.
+ */
+val EnvoyOfOkinecAhau = card("Envoy of Okinec Ahau") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Cat Advisor"
+    oracleText = "{4}{W}: Create a 1/1 colorless Gnome artifact creature token."
+    power = 3
+    toughness = 3
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{W}")
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Gnome"),
+            artifactToken = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Zoltan Boros"
+        flavorText = "Though wary of each other at first, the Malamet and the Oltec found a common enemy in the mycoids. They began to share glyph knowledge and other crafting secrets."
+        imageUri = "https://cards.scryfall.io/normal/front/9/6/96de0741-9270-4118-bb8e-f3480c75a582.jpg?1782694605"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/KinjallisDawnrunner.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/KinjallisDawnrunner.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kinjalli's Dawnrunner — {2}{W}
+ * Creature — Human Scout
+ * 1/1
+ * Double strike
+ * When this creature enters, it explores.
+ */
+val KinjallisDawnrunner = card("Kinjalli's Dawnrunner") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Scout"
+    oracleText = "Double strike\nWhen this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.DOUBLE_STRIKE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Explore(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "19"
+        artist = "Arash Radkia"
+        imageUri = "https://cards.scryfall.io/normal/front/f/c/fc4c527c-6963-47f4-bcad-841d06bb2211.jpg?1782694597"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/LostCavernsOfIxalanBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/LostCavernsOfIxalanBasicLands.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * The Lost Caverns of Ixalan Basic Lands
+ *
+ * One art variant of each basic land type, collector numbers 287-291.
+ */
+
+val LciPlains287 = basicLand("Plains") {
+    collectorNumber = "287"
+    artist = "Olga Tereshenko"
+    imageUri = "https://cards.scryfall.io/normal/front/b/5/b5453630-bfff-4403-a9a9-49f1534e1d42.jpg?1782694382"
+}
+
+val LciIsland288 = basicLand("Island") {
+    collectorNumber = "288"
+    artist = "WFlemming Illustration"
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/338e5b63-1fee-4a7c-af9b-483d383f79b7.jpg?1782694382"
+}
+
+val LciSwamp289 = basicLand("Swamp") {
+    collectorNumber = "289"
+    artist = "Elektrodeko"
+    imageUri = "https://cards.scryfall.io/normal/front/a/8/a825ac86-d642-42fd-b6aa-94aa804907d9.jpg?1782694382"
+}
+
+val LciMountain290 = basicLand("Mountain") {
+    collectorNumber = "290"
+    artist = "BEMOCS"
+    imageUri = "https://cards.scryfall.io/normal/front/7/c/7cb82fdb-5090-45c0-ae67-4846667c8625.jpg?1782694381"
+}
+
+val LciForest291 = basicLand("Forest") {
+    collectorNumber = "291"
+    artist = "Matteo Bassini"
+    imageUri = "https://cards.scryfall.io/normal/front/8/c/8c13cafb-3078-4856-a5b0-c38aace8a34a.jpg?1782694380"
+}
+
+/**
+ * All The Lost Caverns of Ixalan basic land variants.
+ */
+val LostCavernsOfIxalanBasicLands = listOf(
+    LciPlains287,
+    LciIsland288,
+    LciSwamp289,
+    LciMountain290,
+    LciForest291,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MinersGuidewing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MinersGuidewing.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Miner's Guidewing — {W}
+ * Creature — Bird
+ * 1/1
+ * Flying, vigilance
+ * When this creature dies, target creature you control explores.
+ */
+val MinersGuidewing = card("Miner's Guidewing") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Bird"
+    oracleText = "Flying, vigilance\nWhen this creature dies, target creature you control explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        val t = target("target creature you control", TargetCreature(filter = TargetFilter.CreatureYouControl))
+        effect = Effects.Explore(t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Allen Douglas"
+        imageUri = "https://cards.scryfall.io/normal/front/9/0/9048cd9d-df3f-4705-a5f4-e5b09760c631.jpg?1782694591"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OltecCloudGuard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OltecCloudGuard.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Oltec Cloud Guard — {3}{W}
+ * Creature — Human Soldier
+ * 3/2
+ * Flying
+ * When this creature enters, create a 1/1 colorless Gnome artifact creature token.
+ */
+val OltecCloudGuard = card("Oltec Cloud Guard") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Flying\nWhen this creature enters, create a 1/1 colorless Gnome artifact creature token."
+    power = 3
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Gnome"),
+            artifactToken = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "28"
+        artist = "Evyn Fong"
+        flavorText = "Many Oltec youth dream of one day joining the elite bat-riding cavalry of the Thousand Moons military force."
+        imageUri = "https://cards.scryfall.io/normal/front/0/2/02d68a38-2e0b-401b-b67d-a55e2af5b18d.jpg?1782694589"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PathfindingAxejaw.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PathfindingAxejaw.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Pathfinding Axejaw — {3}{G}
+ * Creature — Dinosaur
+ * 4/3
+ * When this creature enters, it explores.
+ */
+val PathfindingAxejaw = card("Pathfinding Axejaw") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "When this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)"
+    power = 4
+    toughness = 3
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Explore(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "206"
+        artist = "Raoul Vitale"
+        flavorText = "When you don't know what dangers you'll face, bring the biggest danger with you."
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f619075-ca5d-4e09-bd84-31e6b61eaa7e.jpg?1782694444"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RampagingCeratops.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RampagingCeratops.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByFewerThan
+
+/**
+ * Rampaging Ceratops — {4}{R}
+ * Creature — Dinosaur
+ * 5/4
+ * This creature can't be blocked except by three or more creatures.
+ */
+val RampagingCeratops = card("Rampaging Ceratops") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur"
+    oracleText = "This creature can't be blocked except by three or more creatures."
+    power = 5
+    toughness = 4
+
+    staticAbility {
+        ability = CantBeBlockedByFewerThan(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "162"
+        artist = "Nicholas Gregory"
+        flavorText = "Anticipating tight spaces and trivial fauna, the first Dusk Legion expeditions were small, mobile, and lightly armored. Hundreds of casualties later, they started sending plate-clad platoons."
+        imageUri = "https://cards.scryfall.io/normal/front/8/b/8bab3f8f-cb06-466d-a35d-0b5e1a2b524c.jpg?1782694479"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RiverHeraldGuide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RiverHeraldGuide.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * River Herald Guide — {2}{G}
+ * Creature — Merfolk Scout
+ * 3/1
+ * Vigilance
+ * When this creature enters, it explores.
+ */
+val RiverHeraldGuide = card("River Herald Guide") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Scout"
+    oracleText = "Vigilance\nWhen this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)"
+    power = 3
+    toughness = 1
+
+    keywords(Keyword.VIGILANCE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Explore(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "209"
+        artist = "David Astruga"
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9ea7e323-f329-4928-b25a-c0b44c5ac058.jpg?1782694442"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RiverHeraldScout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RiverHeraldScout.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * River Herald Scout — {1}{U}
+ * Creature — Merfolk Scout
+ * 1/2
+ * When this creature enters, it explores.
+ */
+val RiverHeraldScout = card("River Herald Scout") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Scout"
+    oracleText = "When this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)"
+    power = 1
+    toughness = 2
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Explore(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "72"
+        artist = "Josu Hernaiz"
+        flavorText = "\"Don't worry, little swimmers. I'm here for the ruins, not you.\""
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8ae8ab66-5840-4b2e-bd4e-94ead0c79b61.jpg?1782694553"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RumblingRockslide.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/RumblingRockslide.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Rumbling Rockslide — {3}{R}
+ * Sorcery
+ * Rumbling Rockslide deals damage to target creature equal to the number of lands you control.
+ */
+val RumblingRockslide = card("Rumbling Rockslide") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Rumbling Rockslide deals damage to target creature equal to the number of lands you control."
+
+    spell {
+        val t = target("target creature", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.DealDamage(
+            amount = DynamicAmount.Count(
+                player = Player.You,
+                zone = Zone.BATTLEFIELD,
+                filter = GameObjectFilter.Land,
+            ),
+            target = t,
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "163"
+        artist = "Johann Bodin"
+        flavorText = "Sometimes an expedition reaches a natural conclusion. Sometimes it all just comes crashing down."
+        imageUri = "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg?1782694478"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ScreamingPhantom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ScreamingPhantom.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Screaming Phantom — {2}{B}
+ * Creature — Spirit
+ * 2/2
+ * Flying
+ * Whenever this creature attacks, mill a card.
+ */
+val ScreamingPhantom = card("Screaming Phantom") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\nWhenever this creature attacks, mill a card. (Put the top card of your library into your graveyard.)"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Patterns.Library.mill(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "118"
+        artist = "Halil Ural"
+        flavorText = "After a slow death in darkness, she flies into a rage at the slightest glimpse of light."
+        imageUri = "https://cards.scryfall.io/normal/front/b/c/bc2f3efb-1526-48c0-842a-374af63ea467.jpg?1782694518"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SeekerOfSunlight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SeekerOfSunlight.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Seeker of Sunlight — {G}
+ * Creature — Merfolk Scout
+ * 1/1
+ * {2}{G}: This creature explores. Activate only as a sorcery.
+ */
+val SeekerOfSunlight = card("Seeker of Sunlight") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Scout"
+    oracleText = "{2}{G}: This creature explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)"
+    power = 1
+    toughness = 1
+
+    activatedAbility {
+        cost = Costs.Mana("{2}{G}")
+        timing = TimingRule.SorcerySpeed
+        effect = Effects.Explore(EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "210"
+        artist = "Randy Vargas"
+        flavorText = "\"We weren't fleeing a broken world. We were running toward paradise!\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/f/ffcdb10f-4bad-4f89-8e7c-daa5c0c69230.jpg?1782694440"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SpyglassSiren.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SpyglassSiren.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Spyglass Siren — {U}
+ * Creature — Siren Pirate
+ * 1/1
+ * Flying
+ * When this creature enters, create a Map token.
+ */
+val SpyglassSiren = card("Spyglass Siren") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Siren Pirate"
+    oracleText = "Flying\nWhen this creature enters, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")"
+    power = 1
+    toughness = 1
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMapToken()
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "78"
+        artist = "David Astruga"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/41e54343-95e5-4dc4-9f18-e4a415fe5e0a.jpg?1782694547"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThrashingBrontodonReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThrashingBrontodonReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Thrashing Brontodon reprint in LCI.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types, P/T) lives in
+ * RIX's `cards/` package (the card's earliest real printing). This file contributes only
+ * the LCI-specific presentation row — set, collector number, art — picked up automatically
+ * by `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ThrashingBrontodonReprint = Printing(
+    oracleId = "60bc63dc-ac9f-4a2f-aef5-c90d0aa31553",
+    name = "Thrashing Brontodon",
+    setCode = "LCI",
+    collectorNumber = "216",
+    artist = "Randy Vargas",
+    imageUri = "https://cards.scryfall.io/normal/front/d/5/d52ef7c1-dacb-4204-b64e-5fa3ae3b1ace.jpg?1782694436",
+    releaseDate = "2023-11-17",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/WaterwindScout.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/WaterwindScout.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Waterwind Scout — {2}{U}
+ * Creature — Merfolk Scout
+ * 2/2
+ * Flying
+ * When this creature enters, create a Map token.
+ */
+val WaterwindScout = card("Waterwind Scout") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Merfolk Scout"
+    oracleText = "Flying\nWhen this creature enters, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")"
+    power = 2
+    toughness = 2
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateMapToken()
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Alix Branwyn"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a7738fb-0a1b-4010-b8c0-e1129739c765.jpg?1782694543"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2960,6 +2960,51 @@
     ]
 }
 
+// Oltec Cloud Guard
+{
+    "name": "Oltec Cloud Guard",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Flying\nWhen this creature enters, create a 1/1 colorless Gnome artifact creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Gnome"
+                    ],
+                    "artifactToken": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "28",
+        "artist": "Evyn Fong",
+        "flavorText": "Many Oltec youth dream of one day joining the elite bat-riding cavalry of the Thousand Moons military force.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/2/02d68a38-2e0b-401b-b67d-a55e2af5b18d.jpg?1782694589"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Orazca Puzzle-Door
 {
     "name": "Orazca Puzzle-Door",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -742,6 +742,39 @@
     "colorIdentityOverride": []
 }
 
+// Cartographer's Companion
+{
+    "name": "Cartographer's Companion",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Gnome",
+    "oracleText": "When this creature enters, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Map"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "248",
+        "artist": "Chuck Lukacs",
+        "flavorText": "Ever since the Fomori's attempt long ago to extinguish Chimil's light, the Oltec have taken extensive measures to never get lost in the Core.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbd8115e-4cb3-49b6-b74f-8fcfa28c6404.jpg?1782694413"
+    }
+}
+
 // Cenote Scout
 {
     "name": "Cenote Scout",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1564,6 +1564,51 @@
     ]
 }
 
+// Envoy of Okinec Ahau
+{
+    "name": "Envoy of Okinec Ahau",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Cat Advisor",
+    "oracleText": "{4}{W}: Create a 1/1 colorless Gnome artifact creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Gnome"
+                    ],
+                    "artifactToken": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Zoltan Boros",
+        "flavorText": "Though wary of each other at first, the Malamet and the Oltec found a common enemy in the mycoids. They began to share glyph knowledge and other crafting secrets.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/6/96de0741-9270-4118-bb8e-f3480c75a582.jpg?1782694605"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Family Reunion
 {
     "name": "Family Reunion",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3951,6 +3951,46 @@
     ]
 }
 
+// Seeker of Sunlight
+{
+    "name": "Seeker of Sunlight",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Merfolk Scout",
+    "oracleText": "{2}{G}: This creature explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Explore",
+                    "target": "Self"
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "210",
+        "artist": "Randy Vargas",
+        "flavorText": "\"We weren't fleeing a broken world. We were running toward paradise!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/f/ffcdb10f-4bad-4f89-8e7c-daa5c0c69230.jpg?1782694440"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Seismic Monstrosaur
 {
     "name": "Seismic Monstrosaur",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1564,6 +1564,51 @@
     ]
 }
 
+// Earthshaker Dreadmaw
+{
+    "name": "Earthshaker Dreadmaw",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Trample\nWhen this creature enters, draw a card for each other Dinosaur you control.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Dinosaur",
+                        "excludeSelf": true
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "183",
+        "rarity": "UNCOMMON",
+        "artist": "Jesper Ejsing",
+        "flavorText": "\"I suggest we leave this cavern for someone else to conquer.\" —Amalia, master cartographer",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/d/cdcbba6f-aa54-44be-a3b0-f712fa8bd5ad.jpg?1782694463"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Envoy of Okinec Ahau
 {
     "name": "Envoy of Okinec Ahau",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1257,6 +1257,61 @@
     ]
 }
 
+// Deep Goblin Skulltaker
+{
+    "name": "Deep Goblin Skulltaker",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Goblin Warrior",
+    "oracleText": "Menace\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on this creature. (You descended if a permanent card was put into your graveyard from anywhere.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "101",
+        "artist": "Cristi Balanescu",
+        "flavorText": "\"Go away! I found it first!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0b24bb7c-6b34-48b6-af94-f312ebdbb759.jpg?1782694530"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Deep-Cavern Bat
 {
     "name": "Deep-Cavern Bat",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -4141,6 +4141,45 @@
     ]
 }
 
+// Spyglass Siren
+{
+    "name": "Spyglass Siren",
+    "manaCost": "{U}",
+    "typeLine": "Creature — Siren Pirate",
+    "oracleText": "Flying\nWhen this creature enters, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Map"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "rarity": "UNCOMMON",
+        "artist": "David Astruga",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/41e54343-95e5-4dc4-9f18-e4a415fe5e0a.jpg?1782694547"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Staggering Size
 {
     "name": "Staggering Size",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1664,6 +1664,57 @@
     ]
 }
 
+// Enterprising Scallywag
+{
+    "name": "Enterprising Scallywag",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Goblin Pirate",
+    "oracleText": "At the beginning of your end step, if you descended this turn, create a Treasure token. (You descended if a permanent card was put into your graveyard from anywhere.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "148",
+        "rarity": "UNCOMMON",
+        "artist": "Denman Rooke",
+        "flavorText": "\"He would've wanted me to have it!\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/44420f52-2ed8-4f81-93e4-5decc77bed01.jpg?1782694491"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Envoy of Okinec Ahau
 {
     "name": "Envoy of Okinec Ahau",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3400,6 +3400,36 @@
     ]
 }
 
+// Rampaging Ceratops
+{
+    "name": "Rampaging Ceratops",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "This creature can't be blocked except by three or more creatures.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantBeBlockedByFewerThan",
+                "minBlockers": 3
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "162",
+        "rarity": "UNCOMMON",
+        "artist": "Nicholas Gregory",
+        "flavorText": "Anticipating tight spaces and trivial fauna, the first Dusk Legion expeditions were small, mobile, and lightly armored. Hundreds of casualties later, they started sending plate-clad platoons.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/b/8bab3f8f-cb06-466d-a35d-0b5e1a2b524c.jpg?1782694479"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Rampaging Spiketail
 {
     "name": "Rampaging Spiketail",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -4581,6 +4581,44 @@
     ]
 }
 
+// Waterwind Scout
+{
+    "name": "Waterwind Scout",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Merfolk Scout",
+    "oracleText": "Flying\nWhen this creature enters, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Map"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Alix Branwyn",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a7738fb-0a1b-4010-b8c0-e1129739c765.jpg?1782694543"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Waylaying Pirates
 {
     "name": "Waylaying Pirates",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3286,6 +3286,42 @@
     ]
 }
 
+// River Herald Scout
+{
+    "name": "River Herald Scout",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Merfolk Scout",
+    "oracleText": "When this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Explore",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "72",
+        "artist": "Josu Hernaiz",
+        "flavorText": "\"Don't worry, little swimmers. I'm here for the ruins, not you.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8ae8ab66-5840-4b2e-bd4e-94ead0c79b61.jpg?1782694553"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ruin-Lurker Bat
 {
     "name": "Ruin-Lurker Bat",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3844,6 +3844,63 @@
     "colorIdentityOverride": []
 }
 
+// Screaming Phantom
+{
+    "name": "Screaming Phantom",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nWhenever this creature attacks, mill a card. (Put the top card of your library into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "118",
+        "artist": "Halil Ural",
+        "flavorText": "After a slow death in darkness, she flies into a rage at the slightest glimpse of light.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/c/bc2f3efb-1526-48c0-842a-374af63ea467.jpg?1782694518"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Seismic Monstrosaur
 {
     "name": "Seismic Monstrosaur",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3699,6 +3699,47 @@
     ]
 }
 
+// Rumbling Rockslide
+{
+    "name": "Rumbling Rockslide",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Rumbling Rockslide deals damage to target creature equal to the number of lands you control.",
+    "script": {
+        "spellEffect": {
+            "type": "DealDamage",
+            "amount": {
+                "type": "Count",
+                "player": "You",
+                "zone": "Battlefield",
+                "filter": "land"
+            },
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature"
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "163",
+        "artist": "Johann Bodin",
+        "flavorText": "Sometimes an expedition reaches a natural conclusion. Sometimes it all just comes crashing down.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/f/4f06b53f-ec82-4d7f-bee3-6ca04583f023.jpg?1782694478"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Runaway Boulder
 {
     "name": "Runaway Boulder",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3392,6 +3392,44 @@
     ]
 }
 
+// River Herald Guide
+{
+    "name": "River Herald Guide",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Merfolk Scout",
+    "oracleText": "Vigilance\nWhen this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Explore",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "209",
+        "artist": "David Astruga",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9ea7e323-f329-4928-b25a-c0b44c5ac058.jpg?1782694442"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // River Herald Scout
 {
     "name": "River Herald Scout",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3020,6 +3020,42 @@
     ]
 }
 
+// Pathfinding Axejaw
+{
+    "name": "Pathfinding Axejaw",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "When this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Explore",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "artist": "Raoul Vitale",
+        "flavorText": "When you don't know what dangers you'll face, bring the biggest danger with you.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f619075-ca5d-4e09-bd84-31e6b61eaa7e.jpg?1782694444"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Plundering Pirate
 {
     "name": "Plundering Pirate",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -742,6 +742,43 @@
     "colorIdentityOverride": []
 }
 
+// Cenote Scout
+{
+    "name": "Cenote Scout",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Merfolk Scout",
+    "oracleText": "When this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Explore",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "178",
+        "rarity": "UNCOMMON",
+        "artist": "Caroline Gariba",
+        "flavorText": "\"If you're afraid to dive into the unknown, how will you ever find anything new?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4ce4b7bc-636b-4723-a7c1-2c859f333492.jpg?1782694467"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Chupacabra Echo
 {
     "name": "Chupacabra Echo",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2631,6 +2631,56 @@
     ]
 }
 
+// Miner's Guidewing
+{
+    "name": "Miner's Guidewing",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Bird",
+    "oracleText": "Flying, vigilance\nWhen this creature dies, target creature you control explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Explore",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Allen Douglas",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/0/9048cd9d-df3f-4705-a5f4-e5b09760c631.jpg?1782694591"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Mineshaft Spider
 {
     "name": "Mineshaft Spider",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2086,6 +2086,45 @@
     ]
 }
 
+// Kinjalli's Dawnrunner
+{
+    "name": "Kinjalli's Dawnrunner",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Scout",
+    "oracleText": "Double strike\nWhen this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DOUBLE_STRIKE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Explore",
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "rarity": "UNCOMMON",
+        "artist": "Arash Radkia",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/c/fc4c527c-6963-47f4-bcad-841d06bb2211.jpg?1782694597"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Malamet Brawler
 {
     "name": "Malamet Brawler",


### PR DESCRIPTION
## The Lost Caverns of Ixalan — card batch (20 cards + basic-land art variants)

Adds 20 LCI cards plus the five LCI basic-land art variants (collector 287–291). Every
card composes existing, already-tested SDK primitives — **no new SDK types are introduced**.

### Cards

| Card | Cost | What it does | Primitive(s) |
|------|------|--------------|--------------|
| Cenote Scout | {G} | ETB explores | `Effects.Explore` |
| Kinjalli's Dawnrunner | {2}{W} | Double strike; ETB explores | `Effects.Explore` |
| Pathfinding Axejaw | {3}{G} | ETB explores | `Effects.Explore` |
| River Herald Guide | {2}{G} | Vigilance; ETB explores | `Effects.Explore` |
| River Herald Scout | {1}{U} | ETB explores | `Effects.Explore` |
| Seeker of Sunlight | {G} | {2}{G} sorcery-speed: explores | `Effects.Explore` + `TimingRule.SorcerySpeed` |
| Miner's Guidewing | {W} | Flying, vigilance; dies → target creature you control explores | `Triggers.Dies` + targeted `Effects.Explore` |
| Cartographer's Companion | {3} | Artifact Gnome; ETB creates a Map | `Effects.CreateMapToken` |
| Spyglass Siren | {U} | Flying; ETB creates a Map | `Effects.CreateMapToken` |
| Waterwind Scout | {2}{U} | Flying; ETB creates a Map | `Effects.CreateMapToken` |
| Oltec Cloud Guard | {3}{W} | Flying; ETB creates a colorless Gnome artifact token | `Effects.CreateToken` |
| Envoy of Okinec Ahau | {2}{W} | {4}{W}: create a colorless Gnome artifact token | `Effects.CreateToken` |
| Deep Goblin Skulltaker | {2}{B} | Menace; end step, if descended → +1/+1 counter | `Conditions.YouDescendedThisTurn` |
| Enterprising Scallywag | {1}{R} | End step, if descended → Treasure | `Conditions.YouDescendedThisTurn` + `Effects.CreateTreasure` |
| Screaming Phantom | {2}{B} | Flying; attacks → mill 1 | `Patterns.Library.mill` |
| Earthshaker Dreadmaw | {4}{G}{G} | Trample; ETB draw for each **other** Dinosaur | `DynamicAmount.AggregateBattlefield(excludeSelf=true)` |
| Rumbling Rockslide | {3}{R} | Sorcery: damage = lands you control | `DynamicAmount.Count` |
| Rampaging Ceratops | {4}{R} | Can't be blocked except by 3+ creatures | `CantBeBlockedByFewerThan(3)` |
| Thrashing Brontodon (LCI reprint) | — | `Printing(...)` row only; canonical stays in RIX | — |
| LCI basic lands (287–291) | — | Art variants | `basicLand` DSL |

### Notes

- **Thrashing Brontodon** is added as a `Printing(...)` row only — the canonical `card(...)`
  remains in RIX (the earliest real printing). No duplicate canonical.
- Gnome tokens are colorless as printed (`colors` omitted), artifact creatures.
- Basic lands wired via `MtgSet.basicLands` → `CardDiscovery.findBasicLandsIn(pkg, code)`.
- Backlog checklist header resynced to **91 / 286** implemented.
- `CardDefinitionSnapshotTest` golden (`LCI.json`) re-blessed to cover the new cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
