### PR TITLE
Add 5 Lost Caverns of Ixalan cards (batch 1)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 95 / 286
+**Implemented:** 96 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -117,7 +117,7 @@
 - [x] Hermitic Nautilus
 - [x] Hidden Cataract
 - [x] Hidden Courtyard
-- [ ] Hidden Necropolis
+- [x] Hidden Necropolis
 - [ ] Hidden Nursery
 - [ ] Hidden Volcano
 - [ ] Hit the Mother Lode

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 101 / 286
+**Implemented:** 102 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -127,7 +127,7 @@
 - [ ] Huatli, Poet of Unity
 - [ ] Hulking Raptor
 - [ ] Hunter's Blowgun
-- [ ] Hurl into History
+- [x] Hurl into History
 - [ ] Idol of the Deep King
 - [ ] In the Presence of Ages
 - [ ] Inti, Seneschal of the Sun

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 109 / 286
+**Implemented:** 110 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -77,7 +77,7 @@
 - [ ] Defossilize
 - [ ] Diamond Pick-Axe
 - [ ] Didact Echo
-- [ ] Digsite Conservator
+- [x] Digsite Conservator
 - [x] Dinotomaton
 - [ ] Dire Flail
 - [x] Disruptor Wanderglyph

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 104 / 286
+**Implemented:** 105 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -100,7 +100,7 @@
 - [ ] Frilled Cave-Wurm
 - [ ] Fungal Fortitude
 - [ ] Gargantuan Leech
-- [ ] Geological Appraiser
+- [x] Geological Appraiser
 - [ ] Get Lost
 - [x] Ghalta, Stampede Tyrant
 - [x] Gishath, Sun's Avatar

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 93 / 286
+**Implemented:** 94 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -115,7 +115,7 @@
 - [ ] Guardian of the Great Door
 - [ ] Helping Hand
 - [x] Hermitic Nautilus
-- [ ] Hidden Cataract
+- [x] Hidden Cataract
 - [ ] Hidden Courtyard
 - [ ] Hidden Necropolis
 - [ ] Hidden Nursery

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,21 +2,21 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 111 / 286
+**Implemented:** 116 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
-- [ ] Abyssal Gorestalker
+- [x] Abyssal Gorestalker
 - [ ] Aclazotz, Deepest Betrayal
 - [x] Acolyte of Aclazotz
 - [x] Acrobatic Leap
-- [ ] Adaptive Gemguard
-- [ ] Akal Pakal, First Among Equals
+- [x] Adaptive Gemguard
+- [x] Akal Pakal, First Among Equals
 - [ ] Akawalli, the Seething Tower
-- [ ] Amalia Benavides Aguirre
+- [x] Amalia Benavides Aguirre
 - [x] Ancestors' Aid
 - [x] Ancestral Reminiscence
-- [ ] Anim Pakal, Thousandth Moon
+- [x] Anim Pakal, Thousandth Moon
 - [ ] Another Chance
 - [ ] Armored Kincaller
 - [x] Attentive Sunscribe

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 106 / 286
+**Implemented:** 107 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -91,7 +91,7 @@
 - [ ] Echoing Deeps
 - [x] Enterprising Scallywag
 - [x] Envoy of Okinec Ahau
-- [ ] Etali's Favor
+- [x] Etali's Favor
 - [ ] Explorer's Cache
 - [ ] Fabrication Foundry
 - [x] Family Reunion

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 96 / 286
+**Implemented:** 97 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -118,7 +118,7 @@
 - [x] Hidden Cataract
 - [x] Hidden Courtyard
 - [x] Hidden Necropolis
-- [ ] Hidden Nursery
+- [x] Hidden Nursery
 - [ ] Hidden Volcano
 - [ ] Hit the Mother Lode
 - [x] Hotfoot Gnome

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 91 / 286
+**Implemented:** 92 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -65,7 +65,7 @@
 - [ ] Cosmium Confluence
 - [ ] Council of Echoes
 - [ ] Curator of Sun's Creation
-- [ ] Daring Discovery
+- [x] Daring Discovery
 - [ ] Dauntless Dismantler
 - [x] Dead Weight
 - [x] Deathcap Marionette

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 103 / 286
+**Implemented:** 104 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -188,7 +188,7 @@
 - [ ] Poetic Ingenuity
 - [x] Poison Dart Frog
 - [ ] Preacher of the Schism
-- [ ] Primordial Gnawer
+- [x] Primordial Gnawer
 - [x] Promising Vein
 - [ ] Pugnacious Hammerskull
 - [ ] Queen's Bay Paladin

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 107 / 286
+**Implemented:** 108 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -51,7 +51,7 @@
 - [x] Cenote Scout
 - [x] Chart a Course
 - [ ] Child of the Volcano
-- [ ] Chimil, the Inner Sun
+- [x] Chimil, the Inner Sun
 - [x] Chupacabra Echo
 - [ ] Clay-Fired Bricks
 - [ ] Coati Scavenger

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 94 / 286
+**Implemented:** 95 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -116,7 +116,7 @@
 - [ ] Helping Hand
 - [x] Hermitic Nautilus
 - [x] Hidden Cataract
-- [ ] Hidden Courtyard
+- [x] Hidden Courtyard
 - [ ] Hidden Necropolis
 - [ ] Hidden Nursery
 - [ ] Hidden Volcano

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 110 / 286
+**Implemented:** 111 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -40,7 +40,7 @@
 - [ ] Burning Sun Cavalry
 - [ ] Calamitous Cave-In
 - [ ] Canonized in Blood
-- [ ] Caparocti Sunborn
+- [x] Caparocti Sunborn
 - [ ] Captain Storm, Cosmium Raider
 - [x] Captivating Cave
 - [x] Careening Mine Cart

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 105 / 286
+**Implemented:** 106 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -269,7 +269,7 @@
 - [ ] Tithing Blade
 - [ ] Treasure Map
 - [ ] Triumphant Chomp
-- [ ] Trumpeting Carnosaur
+- [x] Trumpeting Carnosaur
 - [ ] Twists and Turns
 - [ ] Uchbenbak, the Great Mistake
 - [ ] Unlucky Drop

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 92 / 286
+**Implemented:** 93 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -281,7 +281,7 @@
 - [ ] Volatile Fault
 - [x] Volatile Wanderglyph
 - [ ] Wail of the Forgotten
-- [ ] Walk with the Ancestors
+- [x] Walk with the Ancestors
 - [ ] Warden of the Inner Sky
 - [ ] Waterlogged Hulk
 - [x] Waterwind Scout

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 100 / 286
+**Implemented:** 101 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -244,7 +244,7 @@
 - [ ] Sunfire Torch
 - [ ] Sunken Citadel
 - [ ] Sunshot Militia
-- [ ] Swashbuckler's Whip
+- [x] Swashbuckler's Whip
 - [ ] Synapse Necromage
 - [ ] Tarrian's Journal
 - [ ] Tarrian's Soulcleaver

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 98 / 286
+**Implemented:** 99 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -120,7 +120,7 @@
 - [x] Hidden Necropolis
 - [x] Hidden Nursery
 - [x] Hidden Volcano
-- [ ] Hit the Mother Lode
+- [x] Hit the Mother Lode
 - [x] Hotfoot Gnome
 - [x] Hoverstone Pilgrim
 - [x] Huatli's Final Strike

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 102 / 286
+**Implemented:** 103 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -193,7 +193,7 @@
 - [ ] Pugnacious Hammerskull
 - [ ] Queen's Bay Paladin
 - [x] Quicksand Whirlpool
-- [ ] Quintorius Kand
+- [x] Quintorius Kand
 - [x] Rampaging Ceratops
 - [x] Rampaging Spiketail
 - [ ] Ray of Ruin

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 108 / 286
+**Implemented:** 109 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -286,6 +286,6 @@
 - [ ] Waterlogged Hulk
 - [x] Waterwind Scout
 - [x] Waylaying Pirates
-- [ ] Zoetic Glyph
+- [x] Zoetic Glyph
 - [ ] Zoyowa Lava-Tongue
 - [ ] Zoyowa's Justice

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 99 / 286
+**Implemented:** 100 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -36,7 +36,7 @@
 - [ ] Breeches, Eager Pillager
 - [x] Bringer of the Last Gift
 - [ ] Broodrage Mycoid
-- [ ] Buried Treasure
+- [x] Buried Treasure
 - [ ] Burning Sun Cavalry
 - [ ] Calamitous Cave-In
 - [ ] Canonized in Blood

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 97 / 286
+**Implemented:** 98 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -119,7 +119,7 @@
 - [x] Hidden Courtyard
 - [x] Hidden Necropolis
 - [x] Hidden Nursery
-- [ ] Hidden Volcano
+- [x] Hidden Volcano
 - [ ] Hit the Mother Lode
 - [x] Hotfoot Gnome
 - [x] Hoverstone Pilgrim

--- a/backlog/sets/the-lost-caverns-of-ixalan/mechanics.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/mechanics.md
@@ -1,7 +1,9 @@
 # The Lost Caverns of Ixalan (LCI) — Mechanics
 
 Counts are over the 286 booster cards (excluding basic lands), by front-face + back-face
-oracle text. "Unimpl" = not yet implemented as of this document (72 cards done).
+oracle text. "Unimpl" = not yet implemented as of this document (111 cards done). The Discover
+row is freshly recounted; the other per-mechanic Unimpl counts predate the latest card batch
+and are approximate.
 
 Engine-support column reflects whether the SDK/rules-engine already models the mechanic
 (so cards using *only* supported mechanics need **no backend change** — pure `add-card` work).
@@ -11,7 +13,7 @@ Engine-support column reflects whether the SDK/rules-engine already models the m
 | Mechanic | Total | Unimpl | Engine support | Notes |
 |----------|------:|-------:|----------------|-------|
 | **Explore** | 25 | 24 | ✅ `ExploreEffect` | Creature reveals top card; land → hand, nonland → +1/+1 counter + may mill. |
-| **Discover N** | 11 | 11 | ❌ **NOT supported** | No SDK type exists (no effect / dynamic amount / condition). **Needs `add-feature`** — all 11 cards blocked until then. |
+| **Discover N** | 19 | 0 | ✅ `DiscoverEffect` | Exile from top until nonland MV ≤ N; cast free or to hand; rest bottomed random (CR 701.57). Fixed or dynamic threshold + optional discovered-card follow-up. All 19 discover cards implemented. |
 | **Craft** | 19 | 19 | ✅ `Craft*` + DFC transform | Activate from battlefield (exile materials), transform to back face. All Craft cards are DFCs. |
 | **Descend (4 / 8 / fathomless)** | 28 | 27 | ✅ `descended` tracking | Cares about permanent cards in your graveyard; "descend N" / "fathomless descent". |
 | **Map token** | 7 | 6 | ✅ `MapToken` | Artifact token; `{1}, {T}, Sacrifice: target creature you control explores.` |
@@ -30,17 +32,20 @@ Mill (12), Scry (11), Surveil (1), Enchant (7), Fight (1). **All engine-supporte
 
 ## Backend-change assessment
 
-Every headline LCI mechanic **except Discover** is already modelled by the engine (72 LCI cards,
-including a Craft DFC — `SaheelisLattice.kt` — are implemented). Therefore **most remaining cards
-are pure `add-card` authoring**. The known backend gap:
+Every headline LCI mechanic is now modelled by the engine (111 LCI cards, including a Craft DFC
+— `SaheelisLattice.kt` — are implemented). Therefore **the remaining cards are pure `add-card`
+authoring** unless an individual card needs a novel one-off ability. The former backend gap is
+closed:
 
-- **Discover N (11 cards)** — no SDK primitive exists. Needs `add-feature` (a `DiscoverEffect`
-  modelling "exile from top until nonland MV ≤ N; cast free or hand; rest to bottom random").
-  Until then every Discover card is blocked, e.g. Primordial Gnawer, Geological Appraiser,
-  Daring Discovery, Chimil the Inner Sun, Hurl into History, Walk with the Ancestors.
+- **Discover N (19 cards)** — ✅ implemented via `DiscoverEffect` (`Effects.Discover(N)`, CR 701.57):
+  exile from the top until a nonland card with mana value ≤ N; cast it free or put it into hand;
+  bottom the rest at random. Supports a dynamic threshold (Hurl into History — X = the countered
+  spell's mana value) and a follow-up keyed on the discovered card (Hit the Mother Lode's Treasures).
+  All 19 discover cards are done, e.g. Primordial Gnawer, Geological Appraiser, Daring Discovery,
+  Quintorius Kand, Hurl into History, Walk with the Ancestors.
 
 Beyond that, individual cards may need `add-feature` for a novel one-off ability — flagged
-per-card during implementation. The 214 unimplemented cards break down as 179 single-faced + 35 DFCs.
+per-card during implementation. 175 cards remain unimplemented.
 
 Implementation order: single-faced cards using only supported mechanics first (explore / Map /
 discover / standard effects), then DFCs (Craft, MDFC lands, god flips), deferring any card that

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -594,6 +594,18 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
 - `Effects.Cascade` — CR 702.85a (`CascadeEffect`). Exile from the top of the controller's library
   until a nonland card with mana value **strictly less than** the triggering spell's is exiled,
   offer to cast it for free, bottom-randomize every exiled card that isn't cast.
+- `Effects.Discover(amount, storeDiscoveredAs?, thenEffect?)` — Discover N, CR 701.57 (`DiscoverEffect`).
+  Exile from the top of the controller's library until a nonland card with mana value **≤ N** is exiled
+  (the "discovered card"), then present a two-option prompt: **cast it for free** or **put it into your
+  hand** (if the cast can't initiate, it falls back to hand); bottom-randomize the rest. `amount` is an
+  `Int` (fixed, "Discover 4/5/10") or a `DynamicAmount` ("Discover X, where X is that spell's mana value"
+  — **Hurl into History**, pass `EntityProperty(Target(0), ManaValue)`). Differs from `Cascade` on three
+  axes: explicit threshold (not the triggering spell's MV), ≤ vs strict <, and the non-cast branch keeps
+  the card (hand) rather than bottoming it — hence a distinct primitive. Set `storeDiscoveredAs` to publish
+  the discovered card's id to a pipeline collection and `thenEffect` to resolve a follow-up **only when a
+  card was discovered** (CR 701.57c); the follow-up runs after the cast/hand step and can read the
+  discovered card — e.g. **Hit the Mother Lode** (`Effects.Discover(10, storeDiscoveredAs = "discovered",
+  thenEffect = Effects.CreateTreasure(count = IfPositive(Subtract(Fixed(10), StoredCardManaValue("discovered"))), tapped = true))`).
 - `RevealAndMayCastFromLibraryEffect(count, maxManaValue, player?)` — Sunbird's Invocation
   shape. Reveal top `count` cards of `player`'s library, present a `SELECT_CARDS` prompt over
   the revealed nonland cards with mana value ≤ `maxManaValue` (player picks 0 or 1), free-cast

--- a/manual-scenarios/cards/g/geological-appraiser-discover.json
+++ b/manual-scenarios/cards/g/geological-appraiser-discover.json
@@ -1,0 +1,31 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Geological Appraiser"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Geological Appraiser", "Mountain", "Compass Gnome", "Island", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
+}

--- a/manual-scenarios/sets/lci/cards-a-1.json
+++ b/manual-scenarios/sets/lci/cards-a-1.json
@@ -1,0 +1,55 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Abyssal Gorestalker",
+      "Adaptive Gemguard",
+      "Akal Pakal, First Among Equals",
+      "Amalia Benavides Aguirre",
+      "Anim Pakal, Thousandth Moon"
+    ],
+    "battlefield": [
+      {"name": "Aang, the Last Airbender", "summoningSickness": false},
+      {"name": "Adelbert Steiner", "summoningSickness": false},
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Swamp", "Island", "Plains", "Swamp", "Island", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Grizzly Bears", "summoningSickness": false},
+      {"name": "Grizzly Bears", "summoningSickness": false}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains", "Plains", "Plains", "Plains", "Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "mode": "SELF"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -1283,6 +1283,35 @@ object Effects {
      */
     val Cascade: Effect = com.wingedsheep.sdk.scripting.effects.CascadeEffect
 
+    /**
+     * Discover N (CR 701.57). Exile from the top of your library until a nonland card
+     * with mana value [amount] or less is exiled; cast it for free or put it into your
+     * hand; bottom the rest in a random order. Fixed-threshold form ("Discover 4/5/10").
+     *
+     * @param storeDiscoveredAs publish the discovered card to this pipeline collection.
+     * @param thenEffect resolved after the discover, only if a card was discovered
+     *   (Hit the Mother Lode's "…create Treasure tokens equal to the difference").
+     */
+    fun Discover(
+        amount: Int,
+        storeDiscoveredAs: String? = null,
+        thenEffect: Effect? = null,
+    ): Effect = com.wingedsheep.sdk.scripting.effects.DiscoverEffect(
+        DynamicAmount.Fixed(amount), storeDiscoveredAs, thenEffect
+    )
+
+    /**
+     * Discover N with a dynamic threshold ("Discover X, where X is that spell's mana
+     * value" — Hurl into History). See the fixed-threshold overload for the parameters.
+     */
+    fun Discover(
+        amount: DynamicAmount,
+        storeDiscoveredAs: String? = null,
+        thenEffect: Effect? = null,
+    ): Effect = com.wingedsheep.sdk.scripting.effects.DiscoverEffect(
+        amount, storeDiscoveredAs, thenEffect
+    )
+
     // =========================================================================
     // Stat Modification Effects
     // =========================================================================

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/LibraryEffects.kt
@@ -359,3 +359,39 @@ data object CascadeEffect : Effect {
             "mana cost. Put the exiled cards on the bottom in a random order."
 }
 
+/**
+ * Discover N (CR 701.57). Exile cards from the top of the controller's library
+ * until a nonland card with mana value [amount] **or less** is exiled — the
+ * "discovered card" (CR 701.57c). The controller may cast that card without paying
+ * its mana cost; if they don't (or can't), it is put into their hand. The remaining
+ * exiled cards go on the bottom of the library in a random order.
+ *
+ * Differs from [CascadeEffect] on three axes, which is why it's its own primitive
+ * rather than a parameter on cascade:
+ *  - **Threshold source**: an explicit [amount] (fixed for "Discover 4/5/10", or a
+ *    [DynamicAmount] for "Discover X, where X is that spell's mana value" — Hurl into
+ *    History), instead of the triggering spell's mana value.
+ *  - **Comparison**: mana value *≤ N*, not strictly less-than.
+ *  - **Non-cast branch**: the discovered card is kept (put into hand), never bottomed.
+ *
+ * @property amount The threshold N.
+ * @property storeDiscoveredAs When set, the discovered card's entity id is published
+ *   to this pipeline collection before [thenEffect] runs, so the follow-up can read it
+ *   (e.g. its mana value via [com.wingedsheep.sdk.scripting.values.DynamicAmount.StoredCardManaValue]).
+ * @property thenEffect Optional effect resolved immediately after the discover
+ *   completes, and **only when a card was actually discovered** (CR 701.57c — no
+ *   discovered card means no follow-up). Used for "Discover 10. If the discovered
+ *   card's mana value is less than 10, create that many fewer than ten tapped Treasure
+ *   tokens" (Hit the Mother Lode). Runs after the discovered card is cast / put into
+ *   hand, so it may reference the discovered card via [storeDiscoveredAs].
+ */
+@SerialName("Discover")
+@Serializable
+data class DiscoverEffect(
+    val amount: DynamicAmount,
+    val storeDiscoveredAs: String? = null,
+    val thenEffect: Effect? = null,
+) : Effect {
+    override val description: String = "Discover ${amount.description}"
+}
+

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/serialization/CardLinter.kt
@@ -170,6 +170,7 @@ object CardLinter {
         put("FilterCollection" to "storeMatching", write(Space.COLLECTION))
         put("FilterCollection" to "storeNonMatching", write(Space.COLLECTION))
         put("ExileLibraryUntilManaValue" to "storeAs", write(Space.COLLECTION))
+        put("Discover" to "storeDiscoveredAs", write(Space.COLLECTION))
         put("CopyCardIntoCollection" to "storeAs", write(Space.COLLECTION))
         put("CopyCollectionIntoCollection" to "storeAs", write(Space.COLLECTION))
         put("CastFromCollectionWithoutPayingCost" to "storeCastTo", write(Space.COLLECTION))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AbyssalGorestalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AbyssalGorestalker.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ForEachPlayerEffect
+import com.wingedsheep.sdk.scripting.effects.ForceSacrificeEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Abyssal Gorestalker
+ * {4}{B}{B}
+ * Creature — Horror
+ * 6/6
+ *
+ * When this creature enters, each player sacrifices two creatures of their choice.
+ *
+ * Implemented as an ETB triggered ability using [ForEachPlayerEffect] over [Player.Each].
+ * Inside the loop, [EffectTarget.Controller] is rebound to the currently iterated player
+ * (CR 701.21), so each player independently chooses which two of their own creatures to
+ * sacrifice. When a player controls fewer than two creatures the [ForceSacrificeExecutor]
+ * auto-sacrifices all valid candidates without prompting (sacrifices as many as possible).
+ */
+val AbyssalGorestalker = card("Abyssal Gorestalker") {
+    manaCost = "{4}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Horror"
+    power = 6
+    toughness = 6
+    oracleText = "When this creature enters, each player sacrifices two creatures of their choice."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ForEachPlayerEffect(
+            players = Player.Each,
+            effects = listOf(
+                ForceSacrificeEffect(
+                    filter = GameObjectFilter.Creature,
+                    count = 2,
+                    target = EffectTarget.Controller
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "87"
+        artist = "Maxime Minard"
+        imageUri = "https://cards.scryfall.io/normal/front/a/5/a559f77f-1f10-475b-9361-7f297d50f254.jpg?1782694541"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AdaptiveGemguard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AdaptiveGemguard.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Adaptive Gemguard
+ * {3}{W}
+ * Artifact Creature — Gnome
+ * 3/3
+ * Tap two untapped artifacts and/or creatures you control: Put a +1/+1 counter on this creature.
+ * Activate only as a sorcery.
+ *
+ * The activation cost is "tap two untapped artifacts and/or creatures you control" (no "other"
+ * restriction — Adaptive Gemguard itself can be tapped as one of the two).  This is modelled with
+ * [Costs.TapPermanents] (the atomic `CostAtom.TapPermanents` primitive), which is exactly the right
+ * shape for "tap N untapped permanents matching a filter as an ability cost".
+ */
+val AdaptiveGemguard = card("Adaptive Gemguard") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Gnome"
+    power = 3
+    toughness = 3
+    oracleText = "Tap two untapped artifacts and/or creatures you control: Put a +1/+1 counter on this creature. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(
+            count = 2,
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature,
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "3"
+        artist = "Anthony Devine"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83c91e24-b7e8-4040-80cb-d1b375002c10.jpg?1782694608"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AkalPakal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AkalPakal.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Akal Pakal, First Among Equals
+ * {2}{U}
+ * Legendary Creature — Human Advisor
+ * 1/5
+ * At the beginning of each player's end step, if an artifact entered the battlefield under your
+ * control this turn, look at the top two cards of your library. Put one of them into your hand
+ * and the other into your graveyard.
+ *
+ * The trigger fires at the beginning of EACH player's end step (not just your own), but the
+ * intervening-if condition is always scoped to the source's controller ("under your control").
+ * Rule 603.4 requires the condition to be true both at trigger time and at resolution.
+ */
+val AkalPakal = card("Akal Pakal, First Among Equals") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Legendary Creature — Human Advisor"
+    power = 1
+    toughness = 5
+    oracleText = "At the beginning of each player's end step, if an artifact entered the battlefield under your control this turn, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard."
+
+    triggeredAbility {
+        trigger = Triggers.EachEndStep
+        triggerCondition = Conditions.ArtifactEnteredBattlefieldThisTurn
+        effect = Patterns.Library.lookAtTopAndKeep(count = 2, keepCount = 1)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "44"
+        artist = "Ryan Pancoast"
+        imageUri = "https://cards.scryfall.io/normal/front/a/b/ab9f6a1b-8467-4584-affd-8c71d3e34d2f.jpg?1782694575"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AmaliaBenavidesAguirre.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AmaliaBenavidesAguirre.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.effects.WardCost
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Amalia Benavides Aguirre — {W}{B}
+ * Legendary Creature — Vampire Scout
+ * 2/2
+ *
+ * Ward—Pay 3 life.
+ * Whenever you gain life, Amalia Benavides Aguirre explores. Then destroy all other
+ * creatures if its power is exactly 20.
+ *
+ * Implementation notes:
+ *
+ * **Ward—Pay 3 life:** `KeywordAbility.Ward(WardCost.Life(3))`. When an opponent
+ * targets Amalia, they must pay 3 life or the spell/ability is countered (CR 702.21).
+ *
+ * **YouGainLife trigger:** Fires once per life-gain event (`Triggers.YouGainLife`).
+ * The triggered effect is a sequential `Composite`:
+ *
+ * 1. `Effects.Explore(EffectTarget.Self)` — Amalia explores (CR 701.44): reveal the top
+ *    card of your library; a land goes to your hand (no counter); a nonland puts a +1/+1
+ *    counter on Amalia and gives the controller the option to put the card in the graveyard.
+ *
+ * 2. `ConditionalEffect(Conditions.SourceMatches(GameObjectFilter.Creature.power(20)), ...)` —
+ *    AFTER explore completes, check Amalia's projected power. If exactly 20, destroy all
+ *    other creatures. `Patterns.Group.destroyAll(GroupFilter(GameObjectFilter.Creature,
+ *    excludeSelf = true))` gathers every creature on the battlefield except the source
+ *    (Amalia) and destroys each.
+ *
+ * Ordering is rules-faithful: explore runs first and may change Amalia's power via a
+ * +1/+1 counter; the power-20 check reads the post-explore projected power.
+ */
+val AmaliaBenavidesAguirre = card("Amalia Benavides Aguirre") {
+    manaCost = "{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Legendary Creature — Vampire Scout"
+    oracleText = "Ward—Pay 3 life.\n" +
+        "Whenever you gain life, Amalia Benavides Aguirre explores. Then destroy all other " +
+        "creatures if its power is exactly 20. (To have this creature explore, reveal the top " +
+        "card of your library. Put that card into your hand if it's a land. Otherwise, put a " +
+        "+1/+1 counter on this creature, then put the card back or put it into your graveyard.)"
+    power = 2
+    toughness = 2
+
+    // Ward—Pay 3 life (CR 702.21a): whenever an opponent targets this creature, they must
+    // pay 3 life or their spell/ability is countered.
+    keywordAbility(KeywordAbility.Ward(WardCost.Life(3)))
+
+    // Whenever you gain life, Amalia explores, then wipe if power == 20.
+    triggeredAbility {
+        trigger = Triggers.YouGainLife
+        effect = Effects.Composite(listOf(
+            // Step 1: Amalia explores. Reveal top card; land → hand (no counter, no pause);
+            // nonland → +1/+1 counter on Amalia, then optional graveyard decision.
+            Effects.Explore(EffectTarget.Self),
+            // Step 2: After explore, check Amalia's projected power. If exactly 20, destroy
+            // all other creatures (excludeSelf = true excludes Amalia as the source).
+            ConditionalEffect(
+                condition = Conditions.SourceMatches(GameObjectFilter.Creature.power(20)),
+                effect = Patterns.Group.destroyAll(GroupFilter(GameObjectFilter.Creature, excludeSelf = true))
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "221"
+        artist = "Alix Branwyn"
+        imageUri = "https://cards.scryfall.io/normal/front/9/a/9acf80a5-f2ca-45b4-aca8-fbc690e35401.jpg?1782694434"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AnimPakal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AnimPakal.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Anim Pakal, Thousandth Moon
+ * {1}{R}{W}
+ * Legendary Creature — Human Soldier
+ * 1/2
+ *
+ * Whenever you attack with one or more non-Gnome creatures, put a +1/+1 counter on Anim Pakal,
+ * then create X 1/1 colorless Gnome artifact creature tokens that are tapped and attacking, where
+ * X is the number of +1/+1 counters on Anim Pakal.
+ *
+ * Implementation notes:
+ * - Trigger: [Triggers.YouAttackWithFilter] over [GameObjectFilter.Creature.notSubtype(Subtype.GNOME)]
+ *   fires whenever you attack with at least one non-Gnome creature. Anim Pakal need not be
+ *   attacking herself, but since she is a Human Soldier (not a Gnome) her presence in the attack
+ *   alone satisfies the condition.
+ * - The effect is a sequential [Effects.Composite]:
+ *   1. [Effects.AddCounters] puts a +1/+1 counter on Anim Pakal ([EffectTarget.Self]).
+ *   2. [CreateTokenEffect] reads [DynamicAmounts.countersOnSelf] with [CounterTypeFilter.PlusOnePlusOne]
+ *      at resolution time — after step 1 has already incremented the count — so the token count
+ *      always equals the total +1/+1 counters on Anim Pakal at the moment tokens are created.
+ * - Tokens are 1/1 colorless Gnome artifact creature tokens: no color set, `artifactToken = true`,
+ *   `creatureTypes = setOf("Gnome")`, `tapped = true`, `attacking = true`.
+ * - No imageUri for the Gnome token: no Gnome token entry was found in the local LCI Scryfall dump.
+ */
+val AnimPakal = card("Anim Pakal, Thousandth Moon") {
+    manaCost = "{1}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 1
+    toughness = 2
+    oracleText = "Whenever you attack with one or more non-Gnome creatures, put a +1/+1 counter on Anim Pakal, then create X 1/1 colorless Gnome artifact creature tokens that are tapped and attacking, where X is the number of +1/+1 counters on Anim Pakal."
+
+    triggeredAbility {
+        trigger = Triggers.YouAttackWithFilter(GameObjectFilter.Creature.notSubtype(Subtype.GNOME))
+        effect = Effects.Composite(
+            // Step 1: put a +1/+1 counter on Anim Pakal.
+            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+            // Step 2: create X tapped-and-attacking 1/1 colorless Gnome artifact creature tokens,
+            // where X = +1/+1 counters on Anim Pakal — evaluated after step 1.
+            CreateTokenEffect(
+                count = DynamicAmounts.countersOnSelf(CounterTypeFilter.PlusOnePlusOne),
+                power = 1,
+                toughness = 1,
+                colors = emptySet(),
+                creatureTypes = setOf("Gnome"),
+                tapped = true,
+                attacking = true,
+                artifactToken = true
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "223"
+        artist = "Chris Rahn"
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/868856b7-8875-43c1-8249-0f8fb2c8319b.jpg?1782694432"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BuriedTreasure.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BuriedTreasure.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Buried Treasure
+ * {2}
+ * Artifact — Treasure
+ * {T}, Sacrifice this artifact: Add one mana of any color.
+ * {5}, Exile this card from your graveyard: Discover 5. Activate only as a sorcery.
+ */
+val BuriedTreasure = card("Buried Treasure") {
+    manaCost = "{2}"
+    typeLine = "Artifact — Treasure"
+    oracleText = "{T}, Sacrifice this artifact: Add one mana of any color.\n{5}, Exile this card from your graveyard: Discover 5. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}"), Costs.ExileSelf)
+        effect = Effects.Discover(5)
+        timing = TimingRule.SorcerySpeed
+        activateFromZone = Zone.GRAVEYARD
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "246"
+        artist = "Jarel Threat"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4c9c45b6-dedd-4481-a06a-c83ace2f18fa.jpg?1782694415"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CaparoctiSunborn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CaparoctiSunborn.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.TapUntapCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Caparocti Sunborn
+ * {2}{R}{W}
+ * Legendary Creature — Human Soldier
+ * 4/4
+ * Whenever Caparocti Sunborn attacks, you may tap two untapped artifacts and/or creatures you
+ * control. If you do, discover 3.
+ *
+ * "You may tap two … If you do" is an [OptionalCostEffect] whose payable cost is the
+ * Gather → Select-exactly-2 → Tap pipeline (same shape as Aziza, Mage Tower Captain).
+ */
+val CaparoctiSunborn = card("Caparocti Sunborn") {
+    manaCost = "{2}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Creature — Human Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Whenever Caparocti Sunborn attacks, you may tap two untapped artifacts and/or creatures you control. If you do, discover 3."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val tapCost = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.ControlledPermanents(
+                        player = Player.You,
+                        filter = (GameObjectFilter.Artifact or GameObjectFilter.Creature).untapped(),
+                    ),
+                    storeAs = "caparoctiTapPool",
+                ),
+                SelectFromCollectionEffect(
+                    from = "caparoctiTapPool",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                    storeSelected = "caparoctiToTap",
+                    prompt = "Tap two untapped artifacts and/or creatures you control",
+                    useTargetingUI = true,
+                ),
+                TapUntapCollectionEffect("caparoctiToTap", tap = true),
+            ),
+        )
+        effect = OptionalCostEffect(
+            cost = tapCost,
+            ifPaid = Effects.Discover(3),
+            descriptionOverride = "You may tap two untapped artifacts and/or creatures you control. If you do, discover 3.",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "226"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/8/e/8ea82964-fd9c-48e3-962f-94954476b31f.jpg?1782694429"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ChimilTheInnerSun.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ChimilTheInnerSun.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantCantBeCountered
+
+/**
+ * Chimil, the Inner Sun
+ * {6}
+ * Legendary Artifact
+ * Spells you control can't be countered.
+ * At the beginning of your end step, discover 5.
+ */
+val ChimilTheInnerSun = card("Chimil, the Inner Sun") {
+    manaCost = "{6}"
+    typeLine = "Legendary Artifact"
+    oracleText = "Spells you control can't be countered.\nAt the beginning of your end step, discover 5."
+
+    staticAbility {
+        ability = GrantCantBeCountered(filter = GameObjectFilter.Any.youControl())
+    }
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = Effects.Discover(5)
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "249"
+        artist = "Adam Paquette"
+        imageUri = "https://cards.scryfall.io/normal/front/2/7/27a1bfb5-ddfc-49cf-baa3-5d1958d2067a.jpg?1782694413"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DaringDiscovery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DaringDiscovery.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Daring Discovery
+ * {4}{R}
+ * Sorcery
+ * Up to three target creatures can't block this turn.
+ * Discover 4.
+ */
+val DaringDiscovery = card("Daring Discovery") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Up to three target creatures can't block this turn.\nDiscover 4."
+    spell {
+        target("up to three target creatures", TargetCreature(count = 3, optional = true))
+        effect = Effects.Composite(
+            ForEachTargetEffect(listOf(Effects.CantBlock(EffectTarget.ContextTarget(0)))),
+            Effects.Discover(4)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "142"
+        artist = "Michele Giorgi"
+        imageUri = "https://cards.scryfall.io/normal/front/d/9/d95018a4-be10-4c46-b14d-4b1eba838bc0.jpg?1782694496"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DigsiteConservator.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DigsiteConservator.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Digsite Conservator
+ * {2}
+ * Artifact Creature — Gnome
+ * 2/1
+ * Sacrifice this creature: Exile up to four target cards from a single graveyard. Activate only as a sorcery.
+ * When this creature dies, you may pay {4}. If you do, discover 4.
+ */
+val DigsiteConservator = card("Digsite Conservator") {
+    manaCost = "{2}"
+    typeLine = "Artifact Creature — Gnome"
+    power = 2
+    toughness = 1
+    oracleText = "Sacrifice this creature: Exile up to four target cards from a single graveyard. Activate only as a sorcery.\nWhen this creature dies, you may pay {4}. If you do, discover 4."
+
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        target(
+            "up to four target cards from a single graveyard",
+            TargetObject(
+                count = 4,
+                optional = true,
+                filter = TargetFilter.CardInGraveyard,
+                sameOwner = true,
+            )
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.EXILE))
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{4}"),
+            effect = Effects.Discover(4)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "252"
+        artist = "Racrufi"
+        imageUri = "https://cards.scryfall.io/normal/front/d/f/dfa3cd5e-b727-479d-9a77-9f320b92f3f2.jpg?1782694409"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EtalisFavor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EtalisFavor.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Etali's Favor
+ * {2}{R}
+ * Enchantment — Aura
+ * Enchant creature you control
+ * When this Aura enters, discover 3.
+ * Enchanted creature gets +1/+1 and has trample.
+ */
+val EtalisFavor = card("Etali's Favor") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature you control\nWhen this Aura enters, discover 3.\nEnchanted creature gets +1/+1 and has trample."
+
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Discover(3)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.TRAMPLE)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "149"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/6/d/6d4075a8-c15d-4078-bf4b-0f85c03fecec.jpg?1782694490"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GeologicalAppraiser.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GeologicalAppraiser.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Geological Appraiser
+ * {2}{R}{R}
+ * Creature — Human Artificer
+ * 3/2
+ * When this creature enters, if you cast it, discover 3.
+ */
+val GeologicalAppraiser = card("Geological Appraiser") {
+    manaCost = "{2}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Artificer"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, if you cast it, discover 3."
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.WasCast
+        effect = Effects.Discover(3)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "150"
+        artist = "Alix Branwyn"
+        imageUri = "https://cards.scryfall.io/normal/front/7/f/7f9c1a82-695b-4df2-8e51-2d71a62e7baf.jpg?1782694489"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenCataract.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenCataract.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Hidden Cataract
+ * Land — Cave
+ * This land enters tapped.
+ * {T}: Add {U}.
+ * {4}{U}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.
+ */
+val HiddenCataract = card("Hidden Cataract") {
+    typeLine = "Land — Cave"
+    colorIdentity = "U"
+    oracleText = "This land enters tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.BLUE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{U}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Discover(4)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "273"
+        artist = "Josu Solano"
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/69f317fc-f603-45b5-9208-545be4dcbf36.jpg?1782694393"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenCourtyard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenCourtyard.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Hidden Courtyard
+ * Land — Cave
+ * This land enters tapped.
+ * {T}: Add {W}.
+ * {4}{W}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.
+ */
+val HiddenCourtyard = card("Hidden Courtyard") {
+    typeLine = "Land — Cave"
+    colorIdentity = "W"
+    oracleText = "This land enters tapped.\n{T}: Add {W}.\n{4}{W}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.WHITE)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{W}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Discover(4)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "274"
+        artist = "Josu Solano"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8685d46-99fc-44b3-be95-707a4b7b8327.jpg?1782694392"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenNecropolis.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenNecropolis.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Hidden Necropolis
+ * Land — Cave
+ * This land enters tapped.
+ * {T}: Add {B}.
+ * {4}{B}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.
+ */
+val HiddenNecropolis = card("Hidden Necropolis") {
+    typeLine = "Land — Cave"
+    colorIdentity = "B"
+    oracleText = "This land enters tapped.\n{T}: Add {B}.\n{4}{B}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.BLACK)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{B}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Discover(4)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "275"
+        artist = "Svetlin Velinov"
+        imageUri = "https://cards.scryfall.io/normal/front/f/6/f67fd04f-05da-4418-97de-abeb7346cc69.jpg?1782694392"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenNursery.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenNursery.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Hidden Nursery
+ * Land — Cave
+ * This land enters tapped.
+ * {T}: Add {G}.
+ * {4}{G}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.
+ */
+val HiddenNursery = card("Hidden Nursery") {
+    typeLine = "Land — Cave"
+    colorIdentity = "G"
+    oracleText = "This land enters tapped.\n{T}: Add {G}.\n{4}{G}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.GREEN)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{G}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Discover(4)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "276"
+        artist = "Álvaro Calvo Escudero"
+        imageUri = "https://cards.scryfall.io/normal/front/a/9/a942939a-c06e-4b90-a404-ae5acfffcff9.jpg?1782694391"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenVolcano.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HiddenVolcano.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+
+/**
+ * Hidden Volcano
+ * Land — Cave
+ * This land enters tapped.
+ * {T}: Add {R}.
+ * {4}{R}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.
+ */
+val HiddenVolcano = card("Hidden Volcano") {
+    typeLine = "Land — Cave"
+    colorIdentity = "R"
+    oracleText = "This land enters tapped.\n{T}: Add {R}.\n{4}{R}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery."
+
+    replacementEffect(EntersTapped())
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = AddManaEffect(Color.RED)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{4}{R}"), Costs.Tap, Costs.SacrificeSelf)
+        effect = Effects.Discover(4)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "277"
+        artist = "Logan Feliciano"
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9fa06aed-52c1-48f1-9906-362db12a3cf7.jpg?1782694391"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HitTheMotherLode.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HitTheMotherLode.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Hit the Mother Lode
+ * {4}{R}{R}{R}
+ * Sorcery
+ * Discover 10. If the discovered card's mana value is less than 10, create a
+ * number of tapped Treasure tokens equal to the difference.
+ *
+ * The discovered card is stored under "discovered"; the follow-up creates
+ * `10 - (that card's mana value)` tapped Treasures (clamped at 0, so mana value
+ * 10 makes none). The follow-up runs only when a card was discovered (CR 701.57c),
+ * so a whiff makes no Treasures.
+ */
+val HitTheMotherLode = card("Hit the Mother Lode") {
+    manaCost = "{4}{R}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Discover 10. If the discovered card's mana value is less than 10, create a number of tapped Treasure tokens equal to the difference."
+    spell {
+        effect = Effects.Discover(
+            amount = 10,
+            storeDiscoveredAs = "discovered",
+            thenEffect = Effects.CreateTreasure(
+                count = DynamicAmount.IfPositive(
+                    DynamicAmount.Subtract(
+                        DynamicAmount.Fixed(10),
+                        DynamicAmount.StoredCardManaValue("discovered")
+                    )
+                ),
+                tapped = true
+            )
+        )
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "153"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/e/7/e75f460c-43e2-4353-8b73-71ff8651a79d.jpg?1782694484"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HurlIntoHistory.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HurlIntoHistory.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Hurl into History
+ * {3}{U}{U}
+ * Instant
+ * Counter target artifact or creature spell. Discover X, where X is that spell's mana value.
+ *
+ * X is read from the countered spell (the target) via its mana value. Discover then exiles
+ * from the top until a nonland card with mana value ≤ X.
+ */
+val HurlIntoHistory = card("Hurl into History") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target artifact or creature spell. Discover X, where X is that spell's mana value."
+    spell {
+        target(
+            "target artifact or creature spell",
+            TargetSpell(filter = TargetFilter(GameObjectFilter.Artifact or GameObjectFilter.Creature, zone = Zone.STACK))
+        )
+        effect = Effects.CounterSpell() then Effects.Discover(
+            DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ManaValue)
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "59"
+        artist = "Eli Minaya"
+        imageUri = "https://cards.scryfall.io/normal/front/5/9/5946463a-2240-4376-b6f5-fd6e3a9cc51c.jpg?1782694562"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PrimordialGnawer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PrimordialGnawer.kt
@@ -1,0 +1,32 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Primordial Gnawer
+ * {4}{B}
+ * Creature — Insect Horror
+ * 5/2
+ * When this creature dies, discover 3.
+ */
+val PrimordialGnawer = card("Primordial Gnawer") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Insect Horror"
+    power = 5
+    toughness = 2
+    oracleText = "When this creature dies, discover 3."
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.Discover(3)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "114"
+        artist = "Maxime Minard"
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a18f5ad0-e9c1-4e45-b245-2946e29baecb.jpg?1782694519"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/QuintoriusKand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/QuintoriusKand.kt
@@ -11,7 +11,6 @@ import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.CardDestination
 import com.wingedsheep.sdk.scripting.effects.CardSource
-import com.wingedsheep.sdk.scripting.effects.CompositeEffect
 import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
 import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
 import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
@@ -80,7 +79,7 @@ val QuintoriusKand = card("Quintorius Kand") {
                 filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD)
             )
         )
-        effect = CompositeEffect(
+        effect = Effects.Composite(
             listOf(
                 GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "kandGathered"),
                 MoveCollectionEffect(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/QuintoriusKand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/QuintoriusKand.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.events.SpellCastPredicate
+import com.wingedsheep.sdk.scripting.effects.AddManaEffect
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Quintorius Kand
+ * {3}{R}{W}
+ * Legendary Planeswalker — Quintorius
+ * Starting loyalty 4
+ *
+ * Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.
+ * +1: Create a 3/2 red and white Spirit creature token.
+ * −3: Discover 4.
+ * −6: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way.
+ *     You may play those cards this turn.
+ *
+ * The cast-from-exile trigger pairs with −3's Discover (and −6's play-from-exile): a card cast for
+ * free by discovering, or played from exile via −6, is cast from exile and so triggers the drain.
+ */
+val QuintoriusKand = card("Quintorius Kand") {
+    manaCost = "{3}{R}{W}"
+    colorIdentity = "RW"
+    typeLine = "Legendary Planeswalker — Quintorius"
+    startingLoyalty = 4
+    oracleText = "Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.\n" +
+        "+1: Create a 3/2 red and white Spirit creature token.\n" +
+        "−3: Discover 4.\n" +
+        "−6: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way. You may play those cards this turn."
+
+    // Whenever you cast a spell from exile, deal 2 damage to each opponent and gain 2 life.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(requires = setOf(SpellCastPredicate.CastFromZone(Zone.EXILE)))
+        effect = Effects.DealDamage(2, EffectTarget.PlayerRef(Player.EachOpponent), damageSource = EffectTarget.Self)
+            .then(Effects.GainLife(2))
+    }
+
+    // +1: Create a 3/2 red and white Spirit creature token.
+    loyaltyAbility(+1) {
+        effect = CreateTokenEffect(
+            power = 3,
+            toughness = 2,
+            colors = setOf(Color.RED, Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            imageUri = "https://cards.scryfall.io/normal/front/0/7/072cd10b-98d3-452e-bf8d-13a75cc3d72e.jpg?1782731573"
+        )
+    }
+
+    // −3: Discover 4.
+    loyaltyAbility(-3) {
+        effect = Effects.Discover(4)
+    }
+
+    // −6: Exile any number of target cards from your graveyard. Add {R} for each card exiled this
+    // way. You may play those cards this turn.
+    loyaltyAbility(-6) {
+        target(
+            "any number of target cards from your graveyard",
+            TargetObject(
+                unlimited = true,
+                filter = TargetFilter(GameObjectFilter.Any.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = CompositeEffect(
+            listOf(
+                GatherCardsEffect(source = CardSource.ChosenTargets, storeAs = "kandGathered"),
+                MoveCollectionEffect(
+                    from = "kandGathered",
+                    destination = CardDestination.ToZone(Zone.EXILE),
+                    storeMovedAs = "kandExiled"
+                ),
+                AddManaEffect(Color.RED, DynamicAmount.DistinctEntitiesInCollections(listOf("kandExiled"))),
+                Effects.GrantMayPlayFromExile("kandExiled", MayPlayExpiry.EndOfTurn)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "238"
+        artist = "Zoltan Boros"
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/4382fa49-9e34-45b3-8495-4916dcd995ec.jpg?1782694421"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SwashbucklersWhip.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SwashbucklersWhip.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Swashbuckler's Whip
+ * {1}
+ * Artifact — Equipment
+ * Equipped creature has reach, "{2}, {T}: Tap target artifact or creature," and
+ * "{8}, {T}: Discover 10."
+ * Equip {1}
+ *
+ * The {T} in each granted ability taps the equipped creature (the ability's source).
+ * Discover 10 uses the equipped creature's controller's library.
+ */
+val SwashbucklersWhip = card("Swashbuckler's Whip") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has reach, \"{2}, {T}: Tap target artifact or creature,\" and " +
+        "\"{8}, {T}: Discover 10.\"\nEquip {1}"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.REACH, Filters.EquippedCreature)
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap),
+                effect = Effects.Tap(EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact or GameObjectFilter.Creature))
+                ),
+                descriptionOverride = "{2}, {T}: Tap target artifact or creature."
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(Costs.Mana("{8}"), Costs.Tap),
+                effect = Effects.Discover(10),
+                descriptionOverride = "{8}, {T}: Discover 10."
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "263"
+        artist = "Irina Nordsol"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24a85c52-e5b5-4d65-931c-eacc0cf0fb31.jpg?1782694401"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TrumpetingCarnosaur.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TrumpetingCarnosaur.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Trumpeting Carnosaur
+ * {4}{R}{R}
+ * Creature — Dinosaur
+ * 7/6
+ * Trample
+ * When this creature enters, discover 5.
+ * {2}{R}, Discard this card: It deals 3 damage to target creature or planeswalker.
+ */
+val TrumpetingCarnosaur = card("Trumpeting Carnosaur") {
+    manaCost = "{4}{R}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Dinosaur"
+    power = 7
+    toughness = 6
+    oracleText = "Trample\nWhen this creature enters, discover 5.\n{2}{R}, Discard this card: It deals 3 damage to target creature or planeswalker."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Discover(5)
+    }
+
+    // {2}{R}, Discard this card (from hand): it deals 3 damage to target creature or planeswalker.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}{R}"), Costs.DiscardSelf)
+        val t = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.DealDamage(3, t, damageSource = EffectTarget.Self)
+        activateFromZone = Zone.HAND
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "171"
+        artist = "Lars Grant-West"
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edc035ca-f0a3-4814-9405-d6dc6f048315.jpg?1782694473"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/WalkWithTheAncestors.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/WalkWithTheAncestors.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Walk with the Ancestors
+ * {4}{G}
+ * Sorcery
+ * Return up to one target permanent card from your graveyard to your hand.
+ * Discover 4.
+ */
+val WalkWithTheAncestors = card("Walk with the Ancestors") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Return up to one target permanent card from your graveyard to your hand.\nDiscover 4."
+    spell {
+        target(
+            "up to one target permanent card from your graveyard",
+            TargetObject(
+                count = 1,
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.Permanent.ownedByYou(), zone = Zone.GRAVEYARD)
+            )
+        )
+        effect = Effects.Composite(
+            Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+            Effects.Discover(4)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "218"
+        artist = "Loïc Canavaggia"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/71a6f85b-5ef8-4526-9c86-7cb71508b4c0.jpg?1782694435"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ZoeticGlyph.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ZoeticGlyph.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantCardType
+import com.wingedsheep.sdk.scripting.GrantSubtype
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Zoetic Glyph
+ * {2}{U}
+ * Enchantment — Aura
+ * Enchant artifact
+ * Enchanted artifact is a Golem creature with base power and toughness 5/4 in addition to its other types.
+ * When this Aura is put into a graveyard from the battlefield, discover 3.
+ */
+val ZoeticGlyph = card("Zoetic Glyph") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant artifact\nEnchanted artifact is a Golem creature with base power and toughness 5/4 in addition to its other types.\nWhen this Aura is put into a graveyard from the battlefield, discover 3."
+
+    auraTarget = Targets.Artifact
+
+    staticAbility {
+        ability = GrantCardType("CREATURE", filter = GroupFilter.attachedCreature())
+    }
+    staticAbility {
+        ability = GrantSubtype("Golem", filter = GroupFilter.attachedCreature())
+    }
+    staticAbility {
+        ability = SetBasePowerToughnessStatic(5, 4)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.PutIntoGraveyardFromBattlefield
+        effect = Effects.Discover(3)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "86"
+        artist = "Yeong-Hao Han"
+        imageUri = "https://cards.scryfall.io/normal/front/a/2/a2f498ac-179e-4055-9b83-97bcc5ab1bb9.jpg?1782694541"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1582,6 +1582,85 @@
     ]
 }
 
+// Digsite Conservator
+{
+    "name": "Digsite Conservator",
+    "manaCost": "{2}",
+    "typeLine": "Artifact Creature — Gnome",
+    "oracleText": "Sacrifice this creature: Exile up to four target cards from a single graveyard. Activate only as a sorcery.\nWhen this creature dies, you may pay {4}. If you do, discover 4.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{4}"
+                        }
+                    },
+                    "then": {
+                        "type": "Discover",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Exile"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 4,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "up to four target cards from a single graveyard",
+                        "sameOwner": true
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "rarity": "UNCOMMON",
+        "artist": "Racrufi",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/f/dfa3cd5e-b727-479d-9a77-9f320b92f3f2.jpg?1782694409"
+    }
+}
+
 // Dinotomaton
 {
     "name": "Dinotomaton",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -82,6 +82,51 @@
     ]
 }
 
+// Abyssal Gorestalker
+{
+    "name": "Abyssal Gorestalker",
+    "manaCost": "{4}{B}{B}",
+    "typeLine": "Creature — Horror",
+    "oracleText": "When this creature enters, each player sacrifices two creatures of their choice.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Players",
+                        "players": "Each"
+                    },
+                    "body": {
+                        "type": "ForceSacrifice",
+                        "filter": "creature",
+                        "count": 2,
+                        "target": "Controller"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "87",
+        "rarity": "UNCOMMON",
+        "artist": "Maxime Minard",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/5/a559f77f-1f10-475b-9361-7f297d50f254.jpg?1782694541"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Acolyte of Aclazotz
 {
     "name": "Acolyte of Aclazotz",
@@ -211,6 +256,212 @@
     ]
 }
 
+// Adaptive Gemguard
+{
+    "name": "Adaptive Gemguard",
+    "manaCost": "{3}{W}",
+    "typeLine": "Artifact Creature — Gnome",
+    "oracleText": "Tap two untapped artifacts and/or creatures you control: Put a +1/+1 counter on this creature. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "artifact|creature"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "artist": "Anthony Devine",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83c91e24-b7e8-4040-80cb-d1b375002c10.jpg?1782694608"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Akal Pakal, First Among Equals
+{
+    "name": "Akal Pakal, First Among Equals",
+    "manaCost": "{2}{U}",
+    "typeLine": "Legendary Creature — Human Advisor",
+    "oracleText": "At the beginning of each player's end step, if an artifact entered the battlefield under your control this turn, look at the top two cards of your library. Put one of them into your hand and the other into your graveyard.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 5
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END",
+                    "player": "Each"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseExactly",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "selectedLabel": "Put in hand",
+                            "remainderLabel": "Put in graveyard"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Hand"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                },
+                "triggerCondition": {
+                    "type": "PermanentTypeEnteredBattlefieldThisTurn",
+                    "cardType": "ARTIFACT"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "44",
+        "rarity": "RARE",
+        "artist": "Ryan Pancoast",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/b/ab9f6a1b-8467-4584-affd-8c71d3e34d2f.jpg?1782694575"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Amalia Benavides Aguirre
+{
+    "name": "Amalia Benavides Aguirre",
+    "manaCost": "{W}{B}",
+    "typeLine": "Legendary Creature — Vampire Scout",
+    "oracleText": "Ward—Pay 3 life.\nWhenever you gain life, Amalia Benavides Aguirre explores. Then destroy all other creatures if its power is exactly 20. (To have this creature explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Life",
+                "amount": 3
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "LifeGainEvent",
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Explore",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": "Self",
+                                    "filter": "creature pow=20"
+                                }
+                            },
+                            "then": {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature",
+                                        "excludeSelf": true
+                                    }
+                                },
+                                "body": {
+                                    "type": "MoveToZone",
+                                    "target": "Self",
+                                    "destination": "Graveyard",
+                                    "byDestruction": true
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "221",
+        "rarity": "RARE",
+        "artist": "Alix Branwyn",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/a/9acf80a5-f2ca-45b4-aca8-fbc690e35401.jpg?1782694434"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
 // Ancestors' Aid
 {
     "name": "Ancestors' Aid",
@@ -334,6 +585,79 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Anim Pakal, Thousandth Moon
+{
+    "name": "Anim Pakal, Thousandth Moon",
+    "manaCost": "{1}{R}{W}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Whenever you attack with one or more non-Gnome creatures, put a +1/+1 counter on Anim Pakal, then create X 1/1 colorless Gnome artifact creature tokens that are tapped and attacking, where X is the number of +1/+1 counters on Anim Pakal.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "attackerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "NotSubtype",
+                                "subtype": "Gnome"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 1,
+                            "target": "Self"
+                        },
+                        {
+                            "type": "CreateToken",
+                            "count": {
+                                "type": "EntityProperty",
+                                "entity": "Source",
+                                "numericProperty": {
+                                    "type": "CounterCount",
+                                    "counterType": "PlusOnePlusOne"
+                                }
+                            },
+                            "power": 1,
+                            "toughness": 1,
+                            "colors": [],
+                            "creatureTypes": [
+                                "Gnome"
+                            ],
+                            "tapped": true,
+                            "attacking": true,
+                            "artifactToken": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "rarity": "RARE",
+        "artist": "Chris Rahn",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/868856b7-8875-43c1-8249-0f8fb2c8319b.jpg?1782694432"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1992,6 +1992,46 @@
     "colorIdentityOverride": []
 }
 
+// Geological Appraiser
+{
+    "name": "Geological Appraiser",
+    "manaCost": "{2}{R}{R}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "When this creature enters, if you cast it, discover 3.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                },
+                "triggerCondition": "WasCast"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "150",
+        "rarity": "UNCOMMON",
+        "artist": "Alix Branwyn",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/f/7f9c1a82-695b-4df2-8e51-2d71a62e7baf.jpg?1782694489"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Ghalta, Stampede Tyrant
 {
     "name": "Ghalta, Stampede Tyrant",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2099,6 +2099,64 @@
     ]
 }
 
+// Hidden Cataract
+{
+    "name": "Hidden Cataract",
+    "manaCost": "",
+    "typeLine": "Land — Cave",
+    "oracleText": "This land enters tapped.\n{T}: Add {U}.\n{4}{U}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{U}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "273",
+        "artist": "Josu Solano",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/69f317fc-f603-45b5-9208-545be4dcbf36.jpg?1782694393"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Hotfoot Gnome
 {
     "name": "Hotfoot Gnome",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2215,6 +2215,64 @@
     ]
 }
 
+// Hidden Necropolis
+{
+    "name": "Hidden Necropolis",
+    "manaCost": "",
+    "typeLine": "Land — Cave",
+    "oracleText": "This land enters tapped.\n{T}: Add {B}.\n{4}{B}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLACK"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{B}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "275",
+        "artist": "Svetlin Velinov",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/6/f67fd04f-05da-4418-97de-abeb7346cc69.jpg?1782694392"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Hotfoot Gnome
 {
     "name": "Hotfoot Gnome",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2676,6 +2676,49 @@
     ]
 }
 
+// Hurl into History
+{
+    "name": "Hurl into History",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target artifact or creature spell. Discover X, where X is that spell's mana value.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Target",
+                        "numericProperty": "ManaValue"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|creature",
+                    "zone": "Stack"
+                },
+                "id": "target artifact or creature spell"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "rarity": "UNCOMMON",
+        "artist": "Eli Minaya",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/9/5946463a-2240-4376-b6f5-fd6e3a9cc51c.jpg?1782694562"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ironpaw Aspirant
 {
     "name": "Ironpaw Aspirant",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1866,6 +1866,57 @@
     ]
 }
 
+// Etali's Favor
+{
+    "name": "Etali's Favor",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature you control\nWhen this Aura enters, discover 3.\nEnchanted creature gets +1/+1 and has trample.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "TRAMPLE"
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "149",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6d4075a8-c15d-4078-bf4b-0f85c03fecec.jpg?1782694490"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Family Reunion
 {
     "name": "Family Reunion",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1196,6 +1196,58 @@
     ]
 }
 
+// Daring Discovery
+{
+    "name": "Daring Discovery",
+    "manaCost": "{4}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Up to three target creatures can't block this turn.\nDiscover 4.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "CantBlockTargetCreatures",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "count": 3,
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "up to three target creatures"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "142",
+        "artist": "Michele Giorgi",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/9/d95018a4-be10-4c46-b14d-4b1eba838bc0.jpg?1782694496"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Deathcap Marionette
 {
     "name": "Deathcap Marionette",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2273,6 +2273,64 @@
     ]
 }
 
+// Hidden Nursery
+{
+    "name": "Hidden Nursery",
+    "manaCost": "",
+    "typeLine": "Land — Cave",
+    "oracleText": "This land enters tapped.\n{T}: Add {G}.\n{4}{G}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{G}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "276",
+        "artist": "Álvaro Calvo Escudero",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/9/a942939a-c06e-4b90-a404-ae5acfffcff9.jpg?1782694391"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Hotfoot Gnome
 {
     "name": "Hotfoot Gnome",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2157,6 +2157,64 @@
     ]
 }
 
+// Hidden Courtyard
+{
+    "name": "Hidden Courtyard",
+    "manaCost": "",
+    "typeLine": "Land — Cave",
+    "oracleText": "This land enters tapped.\n{T}: Add {W}.\n{4}{W}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "WHITE"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{W}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "274",
+        "artist": "Josu Solano",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8685d46-99fc-44b3-be95-707a4b7b8327.jpg?1782694392"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Hotfoot Gnome
 {
     "name": "Hotfoot Gnome",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -866,6 +866,45 @@
     ]
 }
 
+// Chimil, the Inner Sun
+{
+    "name": "Chimil, the Inner Sun",
+    "manaCost": "{6}",
+    "typeLine": "Legendary Artifact",
+    "oracleText": "Spells you control can't be countered.\nAt the beginning of your end step, discover 5.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantCantBeCountered",
+                "filter": "ctrl:you"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "rarity": "MYTHIC",
+        "artist": "Adam Paquette",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/7/27a1bfb5-ddfc-49cf-baa3-5d1958d2067a.jpg?1782694413"
+    }
+}
+
 // Chupacabra Echo
 {
     "name": "Chupacabra Echo",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -669,6 +669,81 @@
     }
 }
 
+// Caparocti Sunborn
+{
+    "name": "Caparocti Sunborn",
+    "manaCost": "{2}{R}{W}",
+    "typeLine": "Legendary Creature — Human Soldier",
+    "oracleText": "Whenever Caparocti Sunborn attacks, you may tap two untapped artifacts and/or creatures you control. If you do, discover 3.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "ControlledPermanents",
+                                        "filter": "artifact|creature untapped"
+                                    },
+                                    "storeAs": "caparoctiTapPool"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "caparoctiTapPool",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    },
+                                    "storeSelected": "caparoctiToTap",
+                                    "prompt": "Tap two untapped artifacts and/or creatures you control",
+                                    "useTargetingUI": true
+                                },
+                                {
+                                    "type": "TapUntapCollection",
+                                    "collectionName": "caparoctiToTap"
+                                }
+                            ]
+                        }
+                    },
+                    "then": {
+                        "type": "Discover",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 3
+                        }
+                    },
+                    "descriptionOverride": "You may tap two untapped artifacts and/or creatures you control. If you do, discover 3."
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "226",
+        "rarity": "UNCOMMON",
+        "artist": "Donato Giancola",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/e/8ea82964-fd9c-48e3-962f-94954476b31f.jpg?1782694429"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Captivating Cave
 {
     "name": "Captivating Cave",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -5665,6 +5665,85 @@
     ]
 }
 
+// Trumpeting Carnosaur
+{
+    "name": "Trumpeting Carnosaur",
+    "manaCost": "{4}{R}{R}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Trample\nWhen this creature enters, discover 5.\n{2}{R}, Discard this card: It deals 3 damage to target creature or planeswalker.",
+    "creatureStats": {
+        "power": 7,
+        "toughness": 6
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        "CostDiscardSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker"
+                    },
+                    "damageSource": "Self"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetCreatureOrPlaneswalker",
+                        "id": "target creature or planeswalker"
+                    }
+                ],
+                "activateFromZone": "Hand"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "RARE",
+        "artist": "Lars Grant-West",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edc035ca-f0a3-4814-9405-d6dc6f048315.jpg?1782694473"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Vanguard of the Rose
 {
     "name": "Vanguard of the Rose",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3990,6 +3990,45 @@
     ]
 }
 
+// Primordial Gnawer
+{
+    "name": "Primordial Gnawer",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Insect Horror",
+    "oracleText": "When this creature dies, discover 3.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "114",
+        "artist": "Maxime Minard",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a18f5ad0-e9c1-4e45-b245-2946e29baecb.jpg?1782694519"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Promising Vein
 {
     "name": "Promising Vein",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6194,3 +6194,68 @@
         "BLUE"
     ]
 }
+
+// Zoetic Glyph
+{
+    "name": "Zoetic Glyph",
+    "manaCost": "{2}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant artifact\nEnchanted artifact is a Golem creature with base power and toughness 5/4 in addition to its other types.\nWhen this Aura is put into a graveyard from the battlefield, discover 3.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantCardType",
+                "cardType": "CREATURE",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "GrantSubtype",
+                "subtype": "Golem",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "SetBasePowerToughnessStatic",
+                "power": 5,
+                "toughness": 4
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "artifact"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "rarity": "UNCOMMON",
+        "artist": "Yeong-Hao Han",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/2/a2f498ac-179e-4055-9b83-97bcc5ab1bb9.jpg?1782694541"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -615,6 +615,60 @@
     ]
 }
 
+// Buried Treasure
+{
+    "name": "Buried Treasure",
+    "manaCost": "{2}",
+    "typeLine": "Artifact — Treasure",
+    "oracleText": "{T}, Sacrifice this artifact: Add one mana of any color.\n{5}, Exile this card from your graveyard: Discover 5. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": "AddManaOfChoice",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}"
+                            }
+                        },
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "246",
+        "artist": "Jarel Threat",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4c9c45b6-dedd-4481-a06a-c83ace2f18fa.jpg?1782694415"
+    }
+}
+
 // Captivating Cave
 {
     "name": "Captivating Cave",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2389,6 +2389,52 @@
     ]
 }
 
+// Hit the Mother Lode
+{
+    "name": "Hit the Mother Lode",
+    "manaCost": "{4}{R}{R}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Discover 10. If the discovered card's mana value is less than 10, create a number of tapped Treasure tokens equal to the difference.",
+    "script": {
+        "spellEffect": {
+            "type": "Discover",
+            "amount": {
+                "type": "Fixed",
+                "amount": 10
+            },
+            "storeDiscoveredAs": "discovered",
+            "thenEffect": {
+                "type": "CreatePredefinedToken",
+                "tokenType": "Treasure",
+                "tapped": true,
+                "dynamicCount": {
+                    "type": "IfPositive",
+                    "amount": {
+                        "type": "Subtract",
+                        "left": {
+                            "type": "Fixed",
+                            "amount": 10
+                        },
+                        "right": {
+                            "type": "StoredCardManaValue",
+                            "collectionName": "discovered"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "rarity": "RARE",
+        "artist": "Diego Gisbert",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/7/e75f460c-43e2-4353-8b73-71ff8651a79d.jpg?1782694484"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hotfoot Gnome
 {
     "name": "Hotfoot Gnome",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -5221,6 +5221,122 @@
     ]
 }
 
+// Swashbuckler's Whip
+{
+    "name": "Swashbuckler's Whip",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has reach, \"{2}, {T}: Tap target artifact or creature,\" and \"{8}, {T}: Discover 10.\"\nEquip {1}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "REACH"
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{2}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact|creature"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "{2}, {T}: Tap target artifact or creature."
+                }
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{8}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": {
+                        "type": "Discover",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 10
+                        }
+                    },
+                    "descriptionOverride": "{8}, {T}: Discover 10."
+                }
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "263",
+        "rarity": "UNCOMMON",
+        "artist": "Irina Nordsol",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24a85c52-e5b5-4d65-931c-eacc0cf0fb31.jpg?1782694401"
+    },
+    "colorIdentityOverride": []
+}
+
 // Terror Tide
 {
     "name": "Terror Tide",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -4126,6 +4126,159 @@
     ]
 }
 
+// Quintorius Kand
+{
+    "name": "Quintorius Kand",
+    "manaCost": "{3}{R}{W}",
+    "typeLine": "Legendary Planeswalker — Quintorius",
+    "oracleText": "Whenever you cast a spell from exile, Quintorius Kand deals 2 damage to each opponent and you gain 2 life.\n+1: Create a 3/2 red and white Spirit creature token.\n−3: Discover 4.\n−6: Exile any number of target cards from your graveyard. Add {R} for each card exiled this way. You may play those cards this turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "requires": [
+                        {
+                            "type": "SpellCastFromZone",
+                            "zone": "Exile"
+                        }
+                    ]
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "PlayerRef",
+                                "player": "EachOpponent"
+                            },
+                            "damageSource": "Self"
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": 1
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 2,
+                    "colors": [
+                        "RED",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/0/7/072cd10b-98d3-452e-bf8d-13a75cc3d72e.jpg?1782731573"
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -3
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            },
+            {
+                "id": "ability_4",
+                "cost": {
+                    "type": "CostLoyalty",
+                    "change": -6
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "kandGathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kandGathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            },
+                            "storeMovedAs": "kandExiled"
+                        },
+                        {
+                            "type": "AddMana",
+                            "color": "RED",
+                            "amount": {
+                                "type": "DistinctEntitiesInCollections",
+                                "collections": [
+                                    "kandExiled"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "GrantMayPlayFromExile",
+                            "from": "kandExiled"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "unlimited": true,
+                        "filter": {
+                            "baseFilter": "own:you",
+                            "zone": "Graveyard"
+                        },
+                        "id": "any number of target cards from your graveyard"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isPlaneswalkerAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "238",
+        "rarity": "MYTHIC",
+        "artist": "Zoltan Boros",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/4382fa49-9e34-45b3-8495-4916dcd995ec.jpg?1782694421"
+    },
+    "startingLoyalty": 4,
+    "colorIdentityOverride": [
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Rampaging Ceratops
 {
     "name": "Rampaging Ceratops",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -5092,6 +5092,55 @@
     ]
 }
 
+// Walk with the Ancestors
+{
+    "name": "Walk with the Ancestors",
+    "manaCost": "{4}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to one target permanent card from your graveyard to your hand.\nDiscover 4.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "permanent own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "up to one target permanent card from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "artist": "Loïc Canavaggia",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/71a6f85b-5ef8-4526-9c86-7cb71508b4c0.jpg?1782694435"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Waterwind Scout
 {
     "name": "Waterwind Scout",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2331,6 +2331,64 @@
     ]
 }
 
+// Hidden Volcano
+{
+    "name": "Hidden Volcano",
+    "manaCost": "",
+    "typeLine": "Land — Cave",
+    "oracleText": "This land enters tapped.\n{T}: Add {R}.\n{4}{R}, {T}, Sacrifice this land: Discover 4. Activate only as a sorcery.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "RED"
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{R}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Discover",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                },
+                "timing": "SorcerySpeed"
+            }
+        ],
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "277",
+        "artist": "Logan Feliciano",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9fa06aed-52c1-48f1-9906-362db12a3cf7.jpg?1782694391"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Hotfoot Gnome
 {
     "name": "Hotfoot Gnome",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -41,6 +41,9 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("ShuffleHandIntoLibrary", "MoveCollection hand->library + ShuffleLibrary", composes = listOf("MoveCollection", "ShuffleLibrary"))
     composed("ShuffleGraveyardIntoLibrary", "Patterns.Library.shuffleGraveyardIntoLibrary -> Gather + MoveCollection (shuffled)", composes = listOf("MoveCollection"))
 
+    // Discover N (CR 701.57) — native DiscoverEffect. The emitter renders the fixed-integer form
+    // (`Effects.Discover(N)`); a dynamic threshold (e.g. TheGreatestPowerAmongPermanents) declines -> SCAFFOLD.
+    effect("Discover", "Discover", "CR 701.57 — Effects.Discover(N)")
     composed("Surveil", "Patterns.Library.surveil -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
     composed("Scry", "Patterns.Library.scry -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
     composed("ManifestDread", "Patterns.Library.manifestDread -> Gather/Select/MoveCollection(face-down MANIFEST)", composes = listOf("MoveCollection"))

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -375,6 +375,12 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
         (findInteger(args) as? Int)?.let { call("Patterns.Library.surveil", arg("$it")) }
     }
 
+    on("Discover") { _, args, _ ->  // "Discover N" (CR 701.57) -> native DiscoverEffect
+        // Only the fixed-integer threshold renders; a dynamic _GameNumber (e.g.
+        // TheGreatestPowerAmongPermanents) declines -> SCAFFOLD rather than guess.
+        (findInteger(args) as? Int)?.let { call("Effects.Discover", arg("$it")) }
+    }
+
     // "Manifest dread" -> the fixed look-top-two / manifest-one / bin-the-rest pipeline (no args).
     simple("ManifestDread", dsl = "Patterns.Library.manifestDread()")
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LibraryAndZoneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LibraryAndZoneContinuations.kt
@@ -305,6 +305,43 @@ data class CascadeMayCastContinuation(
 ) : ContinuationFrame
 
 /**
+ * Resume after the controller answers "cast the discovered card for free, or put it
+ * into your hand?" during the resolution of a [com.wingedsheep.sdk.scripting.effects.DiscoverEffect]
+ * (CR 701.57a).
+ *
+ * The discover executor has already exiled cards from the top of the controller's
+ * library and found a nonland card with mana value ≤ N (the discovered card). The
+ * resumer then, per CR 701.57a:
+ *
+ *  - bottom-randomizes every *other* exiled card;
+ *  - **Cast**: grants the discovered card a free cast (reusing
+ *    [com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect])
+ *    so target / X / mode prompts flow through the normal cast machinery. If the cast
+ *    can't initiate, the card falls back to the controller's hand ("if you don't cast it,
+ *    put that card into your hand").
+ *  - **Hand**: moves the discovered card to the controller's hand;
+ *  - then runs [thenEffect] (if any), with the discovered card published to
+ *    [storeDiscoveredAs] so the follow-up can read it (Hit the Mother Lode's Treasures).
+ *
+ * @property playerId The discovering player (also the decision-maker)
+ * @property sourceId The discovering source; null only for synthetic sources
+ * @property exiledCards Every card exiled by the discover walk, in exile order
+ * @property discoveredCardId The nonland card with mana value ≤ N
+ * @property storeDiscoveredAs Pipeline collection to publish [discoveredCardId] to before [thenEffect]
+ * @property thenEffect Follow-up effect resolved after the discover completes
+ */
+@Serializable
+data class DiscoverMayCastContinuation(
+    override val decisionId: String,
+    val playerId: EntityId,
+    val sourceId: EntityId?,
+    val exiledCards: List<EntityId>,
+    val discoveredCardId: EntityId,
+    val storeDiscoveredAs: String? = null,
+    val thenEffect: com.wingedsheep.sdk.scripting.effects.Effect? = null,
+) : ContinuationFrame
+
+/**
  * Resume after the controller picks targets for a spell being cast for free by
  * [com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect].
  *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -309,6 +309,7 @@ val engineSerializersModule = SerializersModule {
         subclass(ReturnFromGraveyardContinuation::class)
         subclass(ReturnFromLinkedExileContinuation::class)
         subclass(CascadeMayCastContinuation::class)
+        subclass(DiscoverMayCastContinuation::class)
         subclass(CastFromCollectionTargetsContinuation::class)
         subclass(CastAnyNumberFromCollectionContinuation::class)
         subclass(CastSpellAdditionalCostContinuation::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -1,7 +1,10 @@
 package com.wingedsheep.engine.handlers.continuations
 
 import com.wingedsheep.engine.core.*
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler
+import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.handlers.effects.library.CascadeExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
@@ -40,6 +43,7 @@ class LibraryAndZoneContinuationResumer(
         resumer(PutOntoBattlefieldAttachedToChosenContinuation::class, ::resumePutOntoBattlefieldAttachedToChosen),
         resumer(PutOnTopOrBottomContinuation::class, ::resumePutOnTopOrBottom),
         resumer(CascadeMayCastContinuation::class, ::resumeCascadeMayCast),
+        resumer(DiscoverMayCastContinuation::class, ::resumeDiscoverMayCast),
         resumer(CastFromCollectionTargetsContinuation::class, ::resumeCastFromCollectionTargets),
         resumer(CastAnyNumberFromCollectionContinuation::class, ::resumeCastAnyNumberFromCollection)
     )
@@ -841,6 +845,123 @@ class LibraryAndZoneContinuationResumer(
         }
 
         return checkForMore(castResult.state, bottomEvents + castResult.events)
+    }
+
+    /**
+     * Resume after the controller answers "cast the discovered card for free, or put it into
+     * your hand?" during a [com.wingedsheep.sdk.scripting.effects.DiscoverEffect] (CR 701.57a).
+     *
+     * In both branches the *other* exiled cards are bottom-randomized first. Then:
+     *  - **Cast** (yes): the discovered card is free-cast by reusing
+     *    [com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect] (so
+     *    target / X / mode prompts flow through the normal cast machinery). If the cast can't
+     *    initiate — no legal target, etc. — the card falls back to the controller's hand, per
+     *    "If you don't cast it, put that card into your hand."
+     *  - **Hand** (no): the discovered card is moved straight to the controller's hand.
+     *
+     * Any [DiscoverMayCastContinuation.thenEffect] then resolves last, with the discovered card
+     * published to [DiscoverMayCastContinuation.storeDiscoveredAs] so it can be read (Hit the
+     * Mother Lode's "…create Treasure tokens equal to the difference"). The follow-up is chained
+     * through [effectRunner], so its own pauses (if any) resume correctly.
+     */
+    fun resumeDiscoverMayCast(
+        state: GameState,
+        continuation: DiscoverMayCastContinuation,
+        response: DecisionResponse,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        if (response !is YesNoResponse) {
+            return ExecutionResult.error(state, "Expected yes/no response for discover may-cast")
+        }
+
+        val discovered = continuation.discoveredCardId
+        val others = continuation.exiledCards.filter { it != discovered }
+
+        // Bottom-randomize every other exiled card first (CR 701.57a).
+        var afterBottom = state
+        val bottomEvents = CascadeExecutor.bottomRandomize(
+            state = state,
+            playerId = continuation.playerId,
+            cards = others
+        ) { afterBottom = it }
+
+        val discoveredCollections = continuation.storeDiscoveredAs
+            ?.let { mapOf(it to listOf(discovered)) }
+            ?: emptyMap()
+
+        if (!response.choice) {
+            // Put the discovered card into the controller's hand, then run the follow-up.
+            val moveResult = ZoneMovementUtils.moveCardToZone(afterBottom, discovered, Zone.HAND)
+            var afterHand = afterBottom
+            val leadingEvents = bottomEvents.toMutableList()
+            if (moveResult.isSuccess) {
+                afterHand = moveResult.state
+                leadingEvents.addAll(moveResult.events)
+            }
+            return runDiscoverThenEffect(
+                afterHand, continuation, discoveredCollections, leadingEvents, checkForMore
+            )
+        }
+
+        // Cast branch: free-cast the discovered card (from a private collection), then the follow-up.
+        val castKey = "discover\$cast"
+        val ctx = EffectContext(
+            sourceId = continuation.sourceId,
+            controllerId = continuation.playerId,
+            pipeline = PipelineState.EMPTY.copy(
+                storedCollections = discoveredCollections + (castKey to listOf(discovered))
+            )
+        )
+        val effects = buildList {
+            add(CastFromCollectionWithoutPayingCostEffect(from = castKey))
+            continuation.thenEffect?.let { add(it) }
+        }
+        val result = effectRunner.executeRemainingEffects(afterBottom, effects, ctx)
+        if (result.isPaused) {
+            return ExecutionResult.paused(result.state, result.pendingDecision!!, bottomEvents + result.events)
+        }
+
+        // If the cast couldn't initiate, the discovered card is still in exile — fall back to
+        // hand ("If you don't cast it, put that card into your hand", CR 701.57a).
+        var finalState = result.state
+        val tailEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
+        if (findEntityZone(finalState, discovered)?.zoneType == Zone.EXILE) {
+            val moveResult = ZoneMovementUtils.moveCardToZone(finalState, discovered, Zone.HAND)
+            if (moveResult.isSuccess) {
+                finalState = moveResult.state
+                tailEvents.addAll(moveResult.events)
+            }
+        }
+        return checkForMore(finalState, bottomEvents + result.events + tailEvents)
+    }
+
+    /** Run a discover [DiscoverMayCastContinuation.thenEffect] (if any) with the discovered card published. */
+    private fun runDiscoverThenEffect(
+        state: GameState,
+        continuation: DiscoverMayCastContinuation,
+        discoveredCollections: Map<String, List<EntityId>>,
+        leadingEvents: List<com.wingedsheep.engine.core.GameEvent>,
+        checkForMore: CheckForMore
+    ): ExecutionResult {
+        val thenEffect = continuation.thenEffect
+            ?: return checkForMore(state, leadingEvents)
+        val ctx = EffectContext(
+            sourceId = continuation.sourceId,
+            controllerId = continuation.playerId,
+            pipeline = PipelineState.EMPTY.copy(storedCollections = discoveredCollections)
+        )
+        val result = effectRunner.executeRemainingEffects(state, listOf(thenEffect), ctx)
+        if (result.isPaused) {
+            return ExecutionResult.paused(result.state, result.pendingDecision!!, leadingEvents + result.events)
+        }
+        return checkForMore(result.state, leadingEvents + result.events)
+    }
+
+    private fun findEntityZone(state: GameState, entityId: EntityId): ZoneKey? {
+        for ((zoneKey, entities) in state.zones) {
+            if (entityId in entities) return zoneKey
+        }
+        return null
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -852,17 +852,18 @@ class LibraryAndZoneContinuationResumer(
      * your hand?" during a [com.wingedsheep.sdk.scripting.effects.DiscoverEffect] (CR 701.57a).
      *
      * In both branches the *other* exiled cards are bottom-randomized first. Then:
-     *  - **Cast** (yes): the discovered card is free-cast by reusing
-     *    [com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect] (so
-     *    target / X / mode prompts flow through the normal cast machinery). If the cast can't
+     *  - **Cast** (yes): the discovered card is granted a free cast (like [CascadeExecutor]) and
+     *    synthesized through the normal cast machinery, so target / X / mode prompts surface and the
+     *    cast's "whenever you cast a spell (from exile)" triggers are stacked exactly once (the
+     *    `triggersAlreadyProcessed` flag is propagated so they aren't re-scanned). If the cast can't
      *    initiate — no legal target, etc. — the card falls back to the controller's hand, per
      *    "If you don't cast it, put that card into your hand."
      *  - **Hand** (no): the discovered card is moved straight to the controller's hand.
      *
      * Any [DiscoverMayCastContinuation.thenEffect] then resolves last, with the discovered card
      * published to [DiscoverMayCastContinuation.storeDiscoveredAs] so it can be read (Hit the
-     * Mother Lode's "…create Treasure tokens equal to the difference"). The follow-up is chained
-     * through [effectRunner], so its own pauses (if any) resume correctly.
+     * Mother Lode's "…create Treasure tokens equal to the difference"). In the cast branch it is
+     * pre-pushed as an [EffectContinuation] so it runs after the cast even if the cast pauses.
      */
     fun resumeDiscoverMayCast(
         state: GameState,
@@ -903,36 +904,70 @@ class LibraryAndZoneContinuationResumer(
             )
         }
 
-        // Cast branch: free-cast the discovered card (from a private collection), then the follow-up.
-        val castKey = "discover\$cast"
-        val ctx = EffectContext(
-            sourceId = continuation.sourceId,
-            controllerId = continuation.playerId,
-            pipeline = PipelineState.EMPTY.copy(
-                storedCollections = discoveredCollections + (castKey to listOf(discovered))
+        // Cast branch: grant a free cast and synthesize it through the normal cast machinery —
+        // mirroring CascadeExecutor's may-cast rather than the CastFromCollection effect, so the
+        // cast's "whenever you cast a spell (from exile)" triggers are stacked exactly once
+        // (Quintorius Kand). The follow-up [thenEffect] is pre-pushed as an EffectContinuation so it
+        // resolves after the cast even if the cast pauses for targets / X.
+        var stateForCast = afterBottom
+        if (continuation.thenEffect != null) {
+            val thenCtx = EffectContext(
+                sourceId = continuation.sourceId,
+                controllerId = continuation.playerId,
+                pipeline = PipelineState.EMPTY.copy(storedCollections = discoveredCollections)
             )
-        )
-        val effects = buildList {
-            add(CastFromCollectionWithoutPayingCostEffect(from = castKey))
-            continuation.thenEffect?.let { add(it) }
-        }
-        val result = effectRunner.executeRemainingEffects(afterBottom, effects, ctx)
-        if (result.isPaused) {
-            return ExecutionResult.paused(result.state, result.pendingDecision!!, bottomEvents + result.events)
+            stateForCast = stateForCast.pushContinuation(
+                EffectContinuation(
+                    decisionId = "pending",
+                    remainingEffects = listOf(continuation.thenEffect),
+                    effectContext = thenCtx
+                )
+            )
         }
 
-        // If the cast couldn't initiate, the discovered card is still in exile — fall back to
-        // hand ("If you don't cast it, put that card into your hand", CR 701.57a).
-        var finalState = result.state
-        val tailEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
-        if (findEntityZone(finalState, discovered)?.zoneType == Zone.EXILE) {
-            val moveResult = ZoneMovementUtils.moveCardToZone(finalState, discovered, Zone.HAND)
-            if (moveResult.isSuccess) {
-                finalState = moveResult.state
-                tailEvents.addAll(moveResult.events)
-            }
+        var granted = stateForCast.updateEntity(discovered) { container ->
+            container.with(PlayWithoutPayingCostComponent(controllerId = continuation.playerId))
         }
-        return checkForMore(finalState, bottomEvents + result.events + tailEvents)
+        val (permId, stateWithPerm) = granted.newEntity()
+        granted = stateWithPerm.addMayPlayPermission(
+            MayPlayPermission(
+                id = permId,
+                cardIds = setOf(discovered),
+                controllerId = continuation.playerId,
+                sourceId = continuation.sourceId,
+                timestamp = stateWithPerm.timestamp,
+            )
+        )
+        val stateReady = granted.copy(priorityPlayerId = continuation.playerId)
+        val castResult = castSpellHandler.execute(stateReady, CastSpell(continuation.playerId, discovered))
+
+        if (castResult.error != null) {
+            // The cast couldn't initiate — pop the pre-pushed follow-up, put the discovered card
+            // into hand ("If you don't cast it, put that card into your hand"), then run the
+            // follow-up (Hit the Mother Lode still makes its Treasures — a card was discovered).
+            val withoutThen = if (continuation.thenEffect != null) granted.popContinuation().second else granted
+            val moveResult = ZoneMovementUtils.moveCardToZone(withoutThen, discovered, Zone.HAND)
+            var afterHand = withoutThen
+            val handEvents = bottomEvents.toMutableList()
+            if (moveResult.isSuccess) {
+                afterHand = moveResult.state
+                handEvents.addAll(moveResult.events)
+            }
+            return runDiscoverThenEffect(afterHand, continuation, discoveredCollections, handEvents, checkForMore)
+        }
+
+        if (castResult.pendingDecision != null) {
+            // The cast paused (targets / X); the pre-pushed follow-up runs when it resumes.
+            return ExecutionResult.paused(castResult.state, castResult.pendingDecision, bottomEvents + castResult.events)
+                .copy(triggersAlreadyProcessed = castResult.triggersAlreadyProcessed)
+        }
+
+        // Cast succeeded synchronously; checkForMore drains the pre-pushed follow-up continuation.
+        // CastSpellHandler already stacked this cast's triggers (e.g. Quintorius Kand's "whenever you
+        // cast a spell from exile"); propagate the flag so SubmitDecisionHandler doesn't re-scan the
+        // SpellCastEvent and double-fire them.
+        return checkForMore(castResult.state, bottomEvents + castResult.events)
+            .copy(triggersAlreadyProcessed = castResult.triggersAlreadyProcessed)
     }
 
     /** Run a discover [DiscoverMayCastContinuation.thenEffect] (if any) with the discovered card published. */
@@ -957,12 +992,6 @@ class LibraryAndZoneContinuationResumer(
         return checkForMore(result.state, leadingEvents + result.events)
     }
 
-    private fun findEntityZone(state: GameState, entityId: EntityId): ZoneKey? {
-        for ((zoneKey, entities) in state.zones) {
-            if (entityId in entities) return zoneKey
-        }
-        return null
-    }
 
     /**
      * Resume after the controller picks targets for a free synthesized cast triggered by

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/DiscoverExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/DiscoverExecutor.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.handlers.effects.library
+
+import com.wingedsheep.engine.core.CardsRevealedEvent
+import com.wingedsheep.engine.core.DecisionPhase
+import com.wingedsheep.engine.core.DiscoverMayCastContinuation
+import com.wingedsheep.engine.core.EffectResult
+import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
+import com.wingedsheep.engine.handlers.DecisionHandler
+import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
+import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.effects.DiscoverEffect
+import kotlin.reflect.KClass
+
+/**
+ * Executor for [DiscoverEffect] (CR 701.57).
+ *
+ * Walks the controller's library top-down, exiling cards until a nonland card with
+ * mana value ≤ N (the threshold, evaluated from [DiscoverEffect.amount]) is exiled —
+ * the "discovered card" (CR 701.57c) — or the library is exhausted.
+ *
+ *  - **Discovered card found** → pause with a two-option decision (cast for free /
+ *    put into hand) and push a [DiscoverMayCastContinuation]; the resumer in
+ *    [com.wingedsheep.engine.handlers.continuations.LibraryAndZoneContinuationResumer]
+ *    bottom-randomizes the other exiled cards, then either free-casts the discovered
+ *    card or moves it to hand, then runs any [DiscoverEffect.thenEffect].
+ *  - **No qualifying card** (library exhausted) → every exiled card is bottom-randomized
+ *    here; no decision and no `thenEffect` (there is no discovered card, CR 701.57c).
+ *
+ * Mirrors [CascadeExecutor] (they share the bottom-randomize helper) but uses an explicit
+ * ≤ threshold and keeps the discovered card on the non-cast branch.
+ */
+class DiscoverExecutor(
+    private val decisionHandler: DecisionHandler = DecisionHandler()
+) : EffectExecutor<DiscoverEffect> {
+
+    override val effectType: KClass<DiscoverEffect> = DiscoverEffect::class
+
+    private val amountEvaluator = DynamicAmountEvaluator()
+
+    override fun execute(
+        state: GameState,
+        effect: DiscoverEffect,
+        context: EffectContext
+    ): EffectResult {
+        val controllerId = context.controllerId
+        val threshold = amountEvaluator.evaluate(state, effect.amount, context)
+
+        var currentState = state
+        val allEvents = mutableListOf<EngineGameEvent>()
+        val exiledCards = mutableListOf<EntityId>()
+        var discoveredCard: EntityId? = null
+
+        val library = currentState.getZone(ZoneKey(controllerId, Zone.LIBRARY))
+        for (cardId in library) {
+            exiledCards.add(cardId)
+            val card = currentState.getEntity(cardId)?.get<CardComponent>()
+            if (card != null && !card.typeLine.isLand && card.manaValue <= threshold) {
+                discoveredCard = cardId
+                break
+            }
+        }
+
+        if (exiledCards.isEmpty()) {
+            return EffectResult.success(currentState)
+        }
+
+        val sourceName = context.sourceId?.let {
+            currentState.getEntity(it)?.get<CardComponent>()?.name
+        }
+        allEvents.add(
+            CardsRevealedEvent(
+                revealingPlayerId = controllerId,
+                cardIds = exiledCards.toList(),
+                cardNames = exiledCards.map { id ->
+                    currentState.getEntity(id)?.get<CardComponent>()?.name ?: "Unknown"
+                },
+                imageUris = exiledCards.map { id ->
+                    currentState.getEntity(id)?.get<CardComponent>()?.imageUri
+                },
+                source = sourceName
+            )
+        )
+
+        for (cardId in exiledCards) {
+            val result = ZoneMovementUtils.moveCardToZone(currentState, cardId, Zone.EXILE)
+            if (result.isSuccess) {
+                currentState = result.state
+                allEvents.addAll(result.events)
+            }
+        }
+
+        if (discoveredCard == null) {
+            // Library exhausted without a qualifying card — bottom-randomize everything
+            // exiled this way. No discovered card, so no may-cast and no thenEffect.
+            val bottomEvents = CascadeExecutor.bottomRandomize(currentState, controllerId, exiledCards) { newState ->
+                currentState = newState
+            }
+            return EffectResult.success(currentState, allEvents + bottomEvents)
+        }
+
+        val discoveredName = currentState.getEntity(discoveredCard)
+            ?.get<CardComponent>()?.name ?: "the discovered card"
+        val pause = decisionHandler.createYesNoDecision(
+            state = currentState,
+            playerId = controllerId,
+            sourceId = context.sourceId,
+            sourceName = sourceName,
+            prompt = "Cast $discoveredName without paying its mana cost? (Decline to put it into your hand.)",
+            yesText = "Cast for free",
+            noText = "Put into hand",
+            phase = DecisionPhase.RESOLUTION
+        )
+
+        val pendingDecision = pause.pendingDecision
+            ?: error("createYesNoDecision must return a pending decision")
+        val continuation = DiscoverMayCastContinuation(
+            decisionId = pendingDecision.id,
+            playerId = controllerId,
+            sourceId = context.sourceId,
+            exiledCards = exiledCards.toList(),
+            discoveredCardId = discoveredCard,
+            storeDiscoveredAs = effect.storeDiscoveredAs,
+            thenEffect = effect.thenEffect
+        )
+        val stateWithCont = pause.state.pushContinuation(continuation)
+
+        return EffectResult.paused(
+            stateWithCont,
+            pendingDecision,
+            allEvents + pause.events
+        )
+    }
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/DiscoverExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/DiscoverExecutor.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.engine.core.GameEvent as EngineGameEvent
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
+import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.state.GameState
@@ -16,6 +17,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.DiscoverEffect
+import com.wingedsheep.sdk.scripting.effects.Effect
 import kotlin.reflect.KClass
 
 /**
@@ -30,13 +32,20 @@ import kotlin.reflect.KClass
  *    [com.wingedsheep.engine.handlers.continuations.LibraryAndZoneContinuationResumer]
  *    bottom-randomizes the other exiled cards, then either free-casts the discovered
  *    card or moves it to hand, then runs any [DiscoverEffect.thenEffect].
- *  - **No qualifying card** (library exhausted) → every exiled card is bottom-randomized
- *    here; no decision and no `thenEffect` (there is no discovered card, CR 701.57c).
+ *  - **No nonland ≤ N found** (library exhausted) → every exiled card is bottom-randomized
+ *    here, and no cast/hand decision is offered (there is no castable stopping card). But per
+ *    CR 701.57c the *final* card exiled is still the "discovered card" if its mana value is ≤ N
+ *    (a land at the bottom of the library has mana value 0), so a [DiscoverEffect.thenEffect]
+ *    keyed on the discovered card still runs, reading that card's mana value (Hit the Mother Lode
+ *    decking itself out still makes its Treasures). If the final card's mana value exceeds N,
+ *    nothing was discovered and no `thenEffect` runs.
  *
  * Mirrors [CascadeExecutor] (they share the bottom-randomize helper) but uses an explicit
  * ≤ threshold and keeps the discovered card on the non-cast branch.
  */
 class DiscoverExecutor(
+    /** Runs a [DiscoverEffect.thenEffect] through the registry (the late-bound recursion entry). */
+    private val runEffect: (GameState, Effect, EffectContext) -> EffectResult,
     private val decisionHandler: DecisionHandler = DecisionHandler()
 ) : EffectExecutor<DiscoverEffect> {
 
@@ -97,12 +106,37 @@ class DiscoverExecutor(
         }
 
         if (discoveredCard == null) {
-            // Library exhausted without a qualifying card — bottom-randomize everything
-            // exiled this way. No discovered card, so no may-cast and no thenEffect.
+            // Library exhausted without exiling a nonland card with mana value ≤ N — no castable
+            // stopping card, so no may-cast/hand decision; every exiled card is bottom-randomized.
             val bottomEvents = CascadeExecutor.bottomRandomize(currentState, controllerId, exiledCards) { newState ->
                 currentState = newState
             }
-            return EffectResult.success(currentState, allEvents + bottomEvents)
+            // CR 701.57c: the final card exiled is still the "discovered card" if its mana value is
+            // ≤ N (a land at the bottom of the library has mana value 0). When so, a thenEffect keyed
+            // on the discovered card still runs (Hit the Mother Lode decking itself out on lands still
+            // makes Treasures); otherwise nothing was discovered and there is no follow-up.
+            val finalCardMv = currentState.getEntity(exiledCards.last())?.get<CardComponent>()?.manaValue
+            val thenEffect = effect.thenEffect
+            if (thenEffect == null || finalCardMv == null || finalCardMv > threshold) {
+                return EffectResult.success(currentState, allEvents + bottomEvents)
+            }
+            val discoveredCollections = effect.storeDiscoveredAs
+                ?.let { mapOf(it to listOf(exiledCards.last())) }
+                ?: emptyMap()
+            val thenResult = runEffect(
+                currentState,
+                thenEffect,
+                EffectContext(
+                    sourceId = context.sourceId,
+                    controllerId = controllerId,
+                    pipeline = PipelineState.EMPTY.copy(storedCollections = discoveredCollections)
+                )
+            )
+            return if (thenResult.isPaused) {
+                EffectResult.paused(thenResult.state, thenResult.pendingDecision!!, allEvents + bottomEvents + thenResult.events)
+            } else {
+                EffectResult.success(thenResult.state, allEvents + bottomEvents + thenResult.events)
+            }
         }
 
         val discoveredName = currentState.getEntity(discoveredCard)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -71,6 +71,7 @@ class LibraryExecutors(
         ExileFromTopRepeatingExecutor(),
         ExileLibraryUntilManaValueExecutor(),
         CascadeExecutor(),
+        DiscoverExecutor(),
         CastFromCollectionWithoutPayingCostExecutor(
             castSpellHandlerProvider = {
                 castSpellHandlerRef.get()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/LibraryExecutors.kt
@@ -71,7 +71,7 @@ class LibraryExecutors(
         ExileFromTopRepeatingExecutor(),
         ExileLibraryUntilManaValueExecutor(),
         CascadeExecutor(),
-        DiscoverExecutor(),
+        DiscoverExecutor(recursion),
         CastFromCollectionWithoutPayingCostExecutor(
             castSpellHandlerProvider = {
                 castSpellHandlerRef.get()

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbyssalGorestalkerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AbyssalGorestalkerScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.AbyssalGorestalker
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Abyssal Gorestalker (LCI #87) — {4}{B}{B} Creature — Horror 6/6.
+ *
+ * "When this creature enters, each player sacrifices two creatures of their choice."
+ *
+ * Proves two cases:
+ *  1. When both players control more than two creatures each player is prompted and
+ *     independently chooses two to sacrifice (symmetric edict).
+ *  2. When a player controls fewer than two creatures the engine auto-sacrifices as
+ *     many as possible — no selection prompt is raised.
+ */
+class AbyssalGorestalkerScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(PredefinedTokens.allTokens)
+        driver.registerCard(AbyssalGorestalker)
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Drive the stack and sacrifice decisions until stable. For each [SelectCardsDecision]
+     * encountered the minimum required number of cards is selected (first N options) so the
+     * test is deterministic without hardcoding specific entity IDs.
+     */
+    fun GameTestDriver.drainStack(maxIterations: Int = 30) {
+        var guard = 0
+        while (guard++ < maxIterations) {
+            val pd = pendingDecision
+            when {
+                pd is SelectCardsDecision ->
+                    submitCardSelection(pd.playerId, pd.options.take(pd.minSelections))
+                state.stack.isNotEmpty() -> bothPass()
+                else -> return
+            }
+        }
+    }
+
+    test("ETB triggers each player to sacrifice two creatures of their choice") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Give each player three creatures so both are prompted to choose two.
+        driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        // Cast the Gorestalker — me now has 4 creatures (3 Bears + Gorestalker).
+        val gorestalkerCard = driver.putCardInHand(me, "Abyssal Gorestalker")
+        driver.giveColorlessMana(me, 4)
+        driver.giveMana(me, Color.BLACK, 2)
+        driver.castSpell(me, gorestalkerCard).isSuccess shouldBe true
+
+        driver.drainStack()
+
+        // Each player started with 3 bears + me got Gorestalker = 4 for me, 3 for opp.
+        // Both were prompted to sacrifice exactly 2 → me has 2 left, opp has 1 left.
+        driver.getCreatures(me).size shouldBe 2
+        driver.getCreatures(opp).size shouldBe 1
+
+        // Each player's graveyard should have exactly the sacrificed creatures.
+        driver.getGraveyardCardNames(me).size shouldBe 2
+        driver.getGraveyardCardNames(opp).size shouldBe 2
+    }
+
+    test("auto-sacrifices all creatures when a player controls fewer than two") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Opponent controls exactly one creature; auto-sacrifice fires without a decision prompt.
+        val oppBear = driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+
+        // Cast the Gorestalker with no other creatures for me (me will have only the Gorestalker).
+        val gorestalkerCard = driver.putCardInHand(me, "Abyssal Gorestalker")
+        driver.giveColorlessMana(me, 4)
+        driver.giveMana(me, Color.BLACK, 2)
+        driver.castSpell(me, gorestalkerCard).isSuccess shouldBe true
+
+        // No SelectCardsDecision should appear — both players have ≤ 2 creatures so auto-sacrifice.
+        var sawDecision = false
+        var guard = 0
+        while (guard++ < 30) {
+            val pd = driver.pendingDecision
+            when {
+                pd is SelectCardsDecision -> {
+                    sawDecision = true
+                    driver.submitCardSelection(pd.playerId, pd.options.take(pd.minSelections))
+                }
+                driver.state.stack.isNotEmpty() -> driver.bothPass()
+                else -> break
+            }
+        }
+
+        // Neither player should have been prompted (both had ≤ 2 creatures each).
+        sawDecision shouldBe false
+
+        // Me had 1 creature (Gorestalker), sacrificed it → me has 0 creatures now.
+        driver.getCreatures(me).size shouldBe 0
+        // Opp had 1 creature, auto-sacrificed → opp has 0 creatures.
+        driver.getCreatures(opp).size shouldBe 0
+        driver.findPermanent(opp, "Grizzly Bears") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdaptiveGemguardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AdaptiveGemguardScenarioTest.kt
@@ -1,0 +1,124 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.AdaptiveGemguard
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Adaptive Gemguard (LCI #3).
+ *
+ * Adaptive Gemguard {3}{W}
+ * Artifact Creature — Gnome 3/3
+ * Tap two untapped artifacts and/or creatures you control: Put a +1/+1 counter on this creature.
+ * Activate only as a sorcery.
+ *
+ * Covers:
+ *  - Happy path: two untapped creatures available → activation taps both and adds a +1/+1 counter.
+ *  - Sorcery-speed gate: activation is rejected outside a main phase with an empty stack.
+ *  - Cost gate: activation is rejected when fewer than two matching untapped permanents are available.
+ */
+class AdaptiveGemguardScenarioTest : FunSpec({
+
+    val abilityId = AdaptiveGemguard.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(AdaptiveGemguard))
+        return driver
+    }
+
+    fun counterCount(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("tapping two creatures puts a +1/+1 counter on Adaptive Gemguard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gemguard = driver.putCreatureOnBattlefield(activePlayer, "Adaptive Gemguard")
+        driver.removeSummoningSickness(gemguard)
+        val bear1 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+        val bear2 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear2)
+
+        counterCount(driver, gemguard) shouldBe 0
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = gemguard,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1, bear2))
+            )
+        )
+        driver.bothPass() // resolve the ability
+
+        // Both permanents tapped to pay the cost.
+        driver.isTapped(bear1) shouldBe true
+        driver.isTapped(bear2) shouldBe true
+
+        // Gemguard received a +1/+1 counter.
+        counterCount(driver, gemguard) shouldBe 1
+    }
+
+    test("cannot be activated at instant speed (sorcery-speed gate)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+
+        val gemguard = driver.putCreatureOnBattlefield(activePlayer, "Adaptive Gemguard")
+        driver.removeSummoningSickness(gemguard)
+        val bear1 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+        val bear2 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear2)
+
+        // Advance into the declare-attackers step — not a main phase with an empty stack.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = gemguard,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1, bear2))
+            )
+        )
+    }
+
+    test("cannot be activated without two matching untapped permanents") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val gemguard = driver.putCreatureOnBattlefield(activePlayer, "Adaptive Gemguard")
+        driver.removeSummoningSickness(gemguard)
+        // Only one other creature — cost requires two.
+        val bear1 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = gemguard,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1))
+            )
+        )
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AkalPakalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AkalPakalScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.AkalPakal
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Tests for Akal Pakal, First Among Equals (LCI).
+ *
+ * Akal Pakal: {2}{U} Legendary Creature — Human Advisor 1/5
+ * "At the beginning of each player's end step, if an artifact entered the battlefield under your
+ * control this turn, look at the top two cards of your library. Put one of them into your hand
+ * and the other into your graveyard."
+ *
+ * Key rules (CR 603.4 intervening-if):
+ * - The condition "if an artifact entered the battlefield under your control this turn" is checked
+ *   both when the trigger would fire and when the ability would resolve.
+ * - "Your control" refers to Akal Pakal's controller, not the active player.
+ */
+class AkalPakalScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        registerCard(AkalPakal)
+        initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+    }
+
+    test("trigger fires at end step and controller keeps one of the top two library cards when an artifact entered this turn") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(you, "Akal Pakal, First Among Equals")
+
+        // Simulate an artifact having entered the battlefield under your control this turn
+        // by injecting the turn-tracker component directly (mirrors how the engine records ETBs).
+        d.replaceState(
+            d.state.updateEntity(you) { container ->
+                container.with(
+                    PermanentTypesEnteredBattlefieldThisTurnComponent(setOf(CardType.ARTIFACT))
+                )
+            }
+        )
+
+        // Place two known cards on top of the library (second call = top of library).
+        val second = d.putCardOnTopOfLibrary(you, "Forest")
+        val first = d.putCardOnTopOfLibrary(you, "Forest")
+
+        // Advance to the end step — the intervening-if condition passes, so the trigger fires
+        // and goes on the stack (Rule 603.4 trigger-time check). passPriorityUntil stops with the
+        // ability still on the stack, so resolve it to reach the look-at-top-two decision.
+        d.passPriorityUntil(Step.END)
+        d.state.stack.size shouldBe 1
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The lookAtTopAndKeep effect pauses for the player to choose which card to keep.
+        d.isPaused shouldBe true
+        val decision = d.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.options.size shouldBe 2
+        decision.options shouldContain first
+        decision.options shouldContain second
+
+        // Keep the first (top) card; the second goes to the graveyard.
+        d.submitDecision(you, CardsSelectedResponse(decisionId = decision.id, selectedCards = listOf(first)))
+
+        d.getHand(you) shouldContain first
+        d.getHand(you) shouldNotContain second
+        d.getGraveyard(you) shouldContain second
+        d.getGraveyard(you) shouldNotContain first
+    }
+
+    test("trigger does NOT fire when no artifact entered the battlefield under your control this turn") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(you, "Akal Pakal, First Among Equals")
+
+        // No PermanentTypesEnteredBattlefieldThisTurnComponent set — the intervening-if condition
+        // fails at trigger time, so the ability must not be placed on the stack (Rule 603.4).
+        d.passPriorityUntil(Step.END)
+
+        d.state.stack.size shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmaliaBenavidesAguirreScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AmaliaBenavidesAguirreScenarioTest.kt
@@ -1,0 +1,192 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.AmaliaBenavidesAguirre
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Amalia Benavides Aguirre (LCI #221) — {W}{B} Legendary Creature — Vampire Scout, 2/2.
+ *
+ * "Ward—Pay 3 life.
+ *  Whenever you gain life, Amalia Benavides Aguirre explores. Then destroy all other
+ *  creatures if its power is exactly 20."
+ *
+ * Tests cover:
+ *  - Gaining life triggers an explore (land path: land → hand, no counter).
+ *  - Gaining life triggers an explore (nonland path: +1/+1 counter added, card may
+ *    go to graveyard).
+ *  - Power == 20 after explore → destroy all other creatures, Amalia survives.
+ *  - Power < 20 after explore → no wrath.
+ */
+class AmaliaBenavidesAguirreScenarioTest : FunSpec({
+
+    // A {W} instant that gains 3 life, used to fire the YouGainLife trigger.
+    val TestLifeGain = CardDefinition.instant(
+        name = "Test Life Gain",
+        manaCost = ManaCost.parse("{W}"),
+        oracleText = "You gain 3 life.",
+        script = CardScript.spell(effect = Effects.GainLife(3))
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AmaliaBenavidesAguirre)
+        driver.registerCard(TestLifeGain)
+        return driver
+    }
+
+    /** Helper: +1/+1 counter count on a permanent by ID. */
+    fun plusOneCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // -------------------------------------------------------------------------
+    // Test 1: explore (land path)
+    // -------------------------------------------------------------------------
+    test("life gain triggers explore: land goes to hand, no +1/+1 counter added") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30))
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val amalia = driver.putCreatureOnBattlefield(controller, "Amalia Benavides Aguirre")
+        // Seed a land on top so explore takes the land-to-hand branch.
+        driver.putCardOnTopOfLibrary(controller, "Forest")
+
+        val healer = driver.putCardInHand(controller, "Test Life Gain")
+        driver.giveMana(controller, Color.WHITE, 1)
+        driver.castSpell(controller, healer)
+
+        driver.bothPass() // resolve Test Life Gain → gains 3 life → trigger on stack
+        driver.bothPass() // resolve YouGainLife trigger: explore (Forest → hand), check power (2 ≠ 20)
+
+        // Forest went to hand; no counter on Amalia.
+        driver.findCardInHand(controller, "Forest").shouldNotBeNull()
+        plusOneCounters(driver, amalia) shouldBe 0
+        // Amalia is unharmed and still on the battlefield.
+        driver.findPermanent(controller, "Amalia Benavides Aguirre").shouldNotBeNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: explore (nonland path)
+    // -------------------------------------------------------------------------
+    test("life gain triggers explore: nonland puts +1/+1 counter on Amalia") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30))
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val amalia = driver.putCreatureOnBattlefield(controller, "Amalia Benavides Aguirre")
+        // Seed a nonland on top: explore will put a +1/+1 counter on Amalia and pause
+        // for the "may put in graveyard" decision.
+        driver.putCardOnTopOfLibrary(controller, "Grizzly Bears")
+
+        val healer = driver.putCardInHand(controller, "Test Life Gain")
+        driver.giveMana(controller, Color.WHITE, 1)
+        driver.castSpell(controller, healer)
+
+        driver.bothPass() // resolve Test Life Gain → gains 3 life → trigger on stack
+        driver.bothPass() // resolve YouGainLife trigger: explore reveals nonland →
+                          // +1/+1 counter added → pauses for graveyard decision
+
+        // Explore revealed a nonland so there must be a pending decision: the
+        // "may put the revealed card into your graveyard" collection-selection choice.
+        val decision = driver.pendingDecision
+        decision.shouldNotBeNull()
+        // The bears are still in the library zone during the decision.
+        val bearsId = driver.state.getZone(ZoneKey(controller, Zone.LIBRARY)).first()
+        // Choose to put the revealed card into the graveyard. Submit a CardsSelectedResponse
+        // by the decision's own id (matching ScenarioTestBase.selectCards) rather than the
+        // hard-cast submitCardSelection helper, which requires a SelectCardsDecision.
+        driver.submitDecision(controller, CardsSelectedResponse(decision.id, listOf(bearsId)))
+        // Continuation resumes: ConditionalEffect runs → power (3) ≠ 20 → no wrath.
+
+        plusOneCounters(driver, amalia) shouldBe 1
+        // Amalia is still on the battlefield.
+        driver.findPermanent(controller, "Amalia Benavides Aguirre").shouldNotBeNull()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: power == 20 after explore → destroy all other creatures
+    // -------------------------------------------------------------------------
+    test("power exactly 20 after explore destroys all other creatures; Amalia survives") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30))
+        val controller = driver.activePlayer!!
+        val opponent = driver.getOpponent(controller)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Place Amalia on the battlefield and seed 18 +1/+1 counters so her power = 2 + 18 = 20.
+        val amalia = driver.putCreatureOnBattlefield(controller, "Amalia Benavides Aguirre")
+        driver.addComponent(amalia, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 18)))
+
+        // Place a creature that should be destroyed.
+        driver.putCreatureOnBattlefield(controller, "Grizzly Bears")
+        // Opponent's creature should also be destroyed (it's a creature, not Amalia).
+        driver.putCreatureOnBattlefield(opponent, "Centaur Courser")
+
+        // Put a land on top of the library: explore will move it to hand (no counter added),
+        // so Amalia's power stays exactly 20 after explore.
+        driver.putCardOnTopOfLibrary(controller, "Forest")
+
+        val healer = driver.putCardInHand(controller, "Test Life Gain")
+        driver.giveMana(controller, Color.WHITE, 1)
+        driver.castSpell(controller, healer)
+
+        driver.bothPass() // resolve Test Life Gain → gains 3 life → trigger on stack
+        driver.bothPass() // resolve YouGainLife trigger:
+                          //   explore: Forest → hand (no counter, power stays 20)
+                          //   ConditionalEffect: power == 20 → destroyAll(other creatures)
+
+        // Amalia is still on the battlefield.
+        driver.findPermanent(controller, "Amalia Benavides Aguirre").shouldNotBeNull()
+        // All other creatures are destroyed.
+        driver.findPermanent(controller, "Grizzly Bears") shouldBe null
+        driver.findPermanent(opponent, "Centaur Courser") shouldBe null
+        // Amalia still has 18 +1/+1 counters (Forest → hand, no explore counter added).
+        plusOneCounters(driver, amalia) shouldBe 18
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: power != 20 → no wrath
+    // -------------------------------------------------------------------------
+    test("power not 20 after explore does not destroy other creatures") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 30))
+        val controller = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Amalia at base 2/2 — power will be 2 after explore (land path).
+        driver.putCreatureOnBattlefield(controller, "Amalia Benavides Aguirre")
+        driver.putCreatureOnBattlefield(controller, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(controller, "Forest")
+
+        val healer = driver.putCardInHand(controller, "Test Life Gain")
+        driver.giveMana(controller, Color.WHITE, 1)
+        driver.castSpell(controller, healer)
+
+        driver.bothPass() // resolve Test Life Gain → gains 3 life → trigger on stack
+        driver.bothPass() // resolve YouGainLife trigger: explore (land → hand), power 2 ≠ 20
+
+        // Grizzly Bears should still be on the battlefield.
+        driver.findPermanent(controller, "Grizzly Bears").shouldNotBeNull()
+        driver.findPermanent(controller, "Amalia Benavides Aguirre").shouldNotBeNull()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnimPakalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AnimPakalScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.AnimPakal
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Anim Pakal, Thousandth Moon (LCI #223) — {1}{R}{W} Legendary Creature — Human Soldier 1/2.
+ *
+ * "Whenever you attack with one or more non-Gnome creatures, put a +1/+1 counter on Anim Pakal,
+ * then create X 1/1 colorless Gnome artifact creature tokens that are tapped and attacking, where
+ * X is the number of +1/+1 counters on Anim Pakal."
+ *
+ * Two behaviors proved end-to-end:
+ *  1. First attack: the trigger fires, Anim Pakal gains a +1/+1 counter, and exactly 1 Gnome
+ *     token is created — tapped, attacking, a token, and an artifact creature.
+ *  2. Counter scaling: when Anim Pakal already has 1 +1/+1 counter before the attack, the
+ *     trigger fires, increments to 2 counters, and creates 2 tapped-and-attacking Gnome tokens
+ *     (N equals the post-increment count, not the pre-attack count).
+ */
+class AnimPakalScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(AnimPakal)
+        return driver
+    }
+
+    /** Return all Gnome tokens controlled by [playerId]. */
+    fun GameTestDriver.gnomeTokens(playerId: EntityId): List<EntityId> =
+        getPermanents(playerId).filter { id ->
+            val entity = state.getEntity(id)
+            entity?.has<TokenComponent>() == true &&
+                entity.get<CardComponent>()?.name == "Gnome Token"
+        }
+
+    /** Read +1/+1 counter count on a permanent. */
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: first attack puts 1 counter and creates 1 tapped-and-attacking Gnome token
+    // ─────────────────────────────────────────────────────────────────────────
+    test("first attack gains one +1/+1 counter and creates exactly one tapped and attacking Gnome token") {
+        val driver = newDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val animPakal = driver.putCreatureOnBattlefield(attacker, "Anim Pakal, Thousandth Moon")
+        driver.removeSummoningSickness(animPakal)
+
+        driver.gnomeTokens(attacker).size shouldBe 0
+        driver.plusOneCounters(animPakal) shouldBe 0
+
+        // Advance to declare-attackers and attack with Anim Pakal (a non-Gnome creature).
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(animPakal), defender)
+        // Resolve the YouAttackWithFilter trigger: AddCounters then CreateToken.
+        driver.bothPass()
+
+        // Anim Pakal now has 1 +1/+1 counter.
+        driver.plusOneCounters(animPakal) shouldBe 1
+
+        // Exactly 1 Gnome token was created.
+        val tokens = driver.gnomeTokens(attacker)
+        tokens.size shouldBe 1
+
+        val token = tokens.first()
+        val tokenEntity = driver.state.getEntity(token)
+
+        // Token is tapped.
+        tokenEntity?.has<TappedComponent>() shouldBe true
+
+        // Token is attacking the defender.
+        val attacking = tokenEntity?.get<AttackingComponent>()
+        attacking shouldNotBe null
+        attacking!!.defenderId shouldBe defender
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: counter scaling — second attack creates N tokens = post-increment counter count
+    // ─────────────────────────────────────────────────────────────────────────
+    test("second attack with one pre-existing counter creates two Gnome tokens") {
+        val driver = newDriver()
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Mountain" to 20), startingLife = 20)
+
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val animPakal = driver.putCreatureOnBattlefield(attacker, "Anim Pakal, Thousandth Moon")
+        driver.removeSummoningSickness(animPakal)
+
+        // Simulate Anim Pakal already having 1 +1/+1 counter from a previous attack.
+        driver.addComponent(animPakal, CountersComponent(mapOf(CounterType.PLUS_ONE_PLUS_ONE to 1)))
+        driver.plusOneCounters(animPakal) shouldBe 1
+
+        // Advance to declare-attackers and attack with Anim Pakal.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(animPakal), defender)
+        driver.bothPass()
+
+        // Trigger incremented counter from 1 → 2.
+        driver.plusOneCounters(animPakal) shouldBe 2
+
+        // Exactly 2 Gnome tokens were created (X = 2 counters after incrementing).
+        val tokens = driver.gnomeTokens(attacker)
+        tokens.size shouldBe 2
+
+        // Both tokens are tapped and attacking the defender.
+        for (token in tokens) {
+            val entity = driver.state.getEntity(token)
+            entity?.has<TappedComponent>() shouldBe true
+            entity?.get<AttackingComponent>()?.defenderId shouldBe defender
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscoverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscoverScenarioTest.kt
@@ -1,0 +1,195 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Engine coverage for Discover N (CR 701.57), exercised through inline test spells so each
+ * clause of the rule is pinned:
+ *  - exile from the top until a **nonland** card with mana value **≤ N** (the discovered card);
+ *  - a two-option prompt — cast for free **or** put into hand;
+ *  - the remaining exiled cards go to the bottom (they leave exile);
+ *  - a whiff (no nonland ≤ N) offers no decision and no follow-up;
+ *  - `thenEffect` runs only when a card was discovered, reading the discovered card's mana value
+ *    (Hit the Mother Lode's Treasure payoff).
+ */
+class DiscoverScenarioTest : FunSpec({
+
+    // MV 1 nonland, castable with no targets — a legal discover hit for any N >= 1.
+    val pebble = card("Pebble") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(1) }
+    }
+    // MV 7 nonland — above the "Discover 4" threshold, so it is skipped (exiled, then bottomed).
+    val boulder = card("Boulder") {
+        manaCost = "{7}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(1) }
+    }
+    val discoverFour = card("Discover Four") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.Discover(4) }
+    }
+    // Hit the Mother Lode shape: Discover 10, then tapped Treasures equal to (10 - discovered MV).
+    val motherLode = card("Test Mother Lode") {
+        manaCost = "{1}"
+        typeLine = "Sorcery"
+        spell {
+            effect = Effects.Discover(
+                amount = 10,
+                storeDiscoveredAs = "discovered",
+                thenEffect = Effects.CreateTreasure(
+                    count = DynamicAmount.IfPositive(
+                        DynamicAmount.Subtract(
+                            DynamicAmount.Fixed(10),
+                            DynamicAmount.StoredCardManaValue("discovered")
+                        )
+                    ),
+                    tapped = true
+                )
+            )
+        }
+    }
+
+    fun driverWith(vararg extra: com.wingedsheep.sdk.model.CardDefinition): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(com.wingedsheep.mtg.sets.tokens.PredefinedTokens.allTokens)
+        driver.registerCard(pebble)
+        driver.registerCard(boulder)
+        driver.registerCard(discoverFour)
+        driver.registerCard(motherLode)
+        extra.forEach { driver.registerCard(it) }
+        return driver
+    }
+
+    fun GameTestDriver.castDiscover(me: com.wingedsheep.sdk.model.EntityId, name: String) {
+        val spell = putCardInHand(me, name)
+        giveColorlessMana(me, 1)
+        submit(CastSpell(playerId = me, cardId = spell, paymentStrategy = PaymentStrategy.FromPool)).isSuccess shouldBe true
+        bothPass()
+    }
+
+    test("discovered card cast for free ends up on the stack; the skipped land is bottomed, exile is empty") {
+        val driver = driverWith()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        // Top → bottom: Forest (land, skipped), then Pebble (MV 1 ≤ 4, the discovered card).
+        driver.putCardOnTopOfLibrary(me, "Pebble")
+        driver.putCardOnTopOfLibrary(me, "Forest")
+
+        driver.castDiscover(me, "Discover Four")
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+
+        driver.submitYesNo(me, choice = true) // cast for free
+
+        driver.getStackSpellNames() shouldContain "Pebble"
+        driver.getExile(me).size shouldBe 0
+    }
+
+    test("discovered card put into hand when the player declines the free cast") {
+        val driver = driverWith()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        driver.putCardOnTopOfLibrary(me, "Pebble")
+        driver.putCardOnTopOfLibrary(me, "Forest")
+
+        driver.castDiscover(me, "Discover Four")
+        driver.submitYesNo(me, choice = false) // put into hand
+
+        driver.getHand(me).map { driver.getCardName(it) } shouldContain "Pebble"
+        driver.getExile(me).size shouldBe 0
+    }
+
+    test("a nonland above the threshold is skipped (exiled then bottomed), not discovered") {
+        val driver = driverWith()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        // Top → bottom: Boulder (MV 7 > 4, skipped), Forest (land, skipped), Pebble (MV 1, discovered).
+        driver.putCardOnTopOfLibrary(me, "Pebble")
+        driver.putCardOnTopOfLibrary(me, "Forest")
+        driver.putCardOnTopOfLibrary(me, "Boulder")
+
+        driver.castDiscover(me, "Discover Four")
+        driver.isPaused shouldBe true
+
+        driver.submitYesNo(me, choice = false)
+
+        driver.getHand(me).map { driver.getCardName(it) } shouldContain "Pebble"
+        // Boulder was skipped and bottomed — not kept, not in exile.
+        driver.getHand(me).map { driver.getCardName(it) } shouldNotContain "Boulder"
+        driver.getExile(me).size shouldBe 0
+    }
+
+    test("whiff — no nonland with mana value <= N — offers no decision and no card is kept") {
+        val driver = driverWith()
+        // Library is all lands, so Discover 4 finds no nonland ≤ 4 and bottoms everything.
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+        val handBefore = driver.getHandSize(me)
+
+        driver.castDiscover(me, "Discover Four")
+
+        driver.isPaused shouldBe false
+        driver.getExile(me).size shouldBe 0
+        driver.getHandSize(me) shouldBe handBefore
+    }
+
+    test("Mother Lode shape — thenEffect makes tapped Treasures equal to 10 minus the discovered MV") {
+        val driver = driverWith()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        driver.putCardOnTopOfLibrary(me, "Pebble") // MV 1 → 10 - 1 = 9 Treasures
+        driver.putCardOnTopOfLibrary(me, "Forest")
+
+        driver.castDiscover(me, "Test Mother Lode")
+        driver.submitYesNo(me, choice = false) // keep Pebble in hand; Treasures still made
+
+        val treasures = driver.state.getBattlefield()
+            .mapNotNull { driver.state.getEntity(it)?.get<CardComponent>() }
+            .count { it.name == "Treasure" }
+        treasures shouldBe 9
+        driver.getHand(me).map { driver.getCardName(it) } shouldContain "Pebble"
+    }
+
+    test("Mother Lode whiff — no discovered card means no Treasures (thenEffect skipped)") {
+        val driver = driverWith()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        driver.castDiscover(me, "Test Mother Lode")
+
+        driver.isPaused shouldBe false
+        val treasures = driver.state.getBattlefield()
+            .mapNotNull { driver.state.getEntity(it)?.get<CardComponent>() }
+            .count { it.name == "Treasure" }
+        treasures shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscoverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscoverScenarioTest.kt
@@ -41,6 +41,13 @@ class DiscoverScenarioTest : FunSpec({
         typeLine = "Sorcery"
         spell { effect = Effects.GainLife(1) }
     }
+    // MV 11 nonland — above even "Discover 10", so a library of these decks out with the final
+    // card's mana value > N, i.e. no discovered card at all (CR 701.57c).
+    val colossus = card("Colossus") {
+        manaCost = "{11}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(1) }
+    }
     val discoverFour = card("Discover Four") {
         manaCost = "{1}"
         typeLine = "Sorcery"
@@ -178,9 +185,29 @@ class DiscoverScenarioTest : FunSpec({
         driver.getHand(me).map { driver.getCardName(it) } shouldContain "Pebble"
     }
 
-    test("Mother Lode whiff — no discovered card means no Treasures (thenEffect skipped)") {
+    test("Mother Lode decks out on lands — final card (a land, MV 0) is still the discovered card, so 10 Treasures (CR 701.57c)") {
         val driver = driverWith()
+        // All-land library: Discover 10 exiles the whole library without a castable nonland ≤ 10,
+        // so there is no cast/hand decision. But the final card exiled is a Forest (mana value 0),
+        // which is the discovered card per CR 701.57c — so the follow-up still makes 10 - 0 Treasures.
         driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val me = driver.activePlayer!!
+
+        driver.castDiscover(me, "Test Mother Lode")
+
+        driver.isPaused shouldBe false // no castable stopping card, so no decision
+        val treasures = driver.state.getBattlefield()
+            .mapNotNull { driver.state.getEntity(it)?.get<CardComponent>() }
+            .count { it.name == "Treasure" }
+        treasures shouldBe 10
+    }
+
+    test("Mother Lode true whiff — final card is a nonland with MV > N, so no discovered card and no Treasures") {
+        val driver = driverWith(colossus)
+        // Library is all MV-11 nonlands: Discover 10 exiles everything, and the final card exiled
+        // has mana value 11 > 10, so nothing is discovered (CR 701.57c) and the follow-up is skipped.
+        driver.initMirrorMatch(deck = Deck.of("Colossus" to 40), startingLife = 20)
         driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
         val me = driver.activePlayer!!
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HurlIntoHistoryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HurlIntoHistoryScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.HurlIntoHistory
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Hurl into History {3}{U}{U} — "Counter target artifact or creature spell. Discover X, where X is
+ * that spell's mana value." Proves the discover threshold is read from the *countered* spell's mana
+ * value: countering a mana-value-3 creature spell must discover 3 (i.e. a nonland card with mana
+ * value ≤ 3 is a legal hit), not 0.
+ */
+class HurlIntoHistoryScenarioTest : FunSpec({
+
+    // A mana-value-3 creature spell — a legal Hurl target.
+    val ogre = card("Test Ogre") {
+        manaCost = "{2}{R}"
+        typeLine = "Creature — Ogre"
+        power = 3
+        toughness = 3
+    }
+    // A mana-value-3 nonland card to sit on top of the Hurl caster's library: discovered only if X >= 3.
+    val relic = card("Test Relic") {
+        manaCost = "{3}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(1) }
+    }
+
+    test("counters a mana-value-3 creature spell and discovers 3") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(ogre)
+        driver.registerCard(relic)
+        driver.registerCard(HurlIntoHistory)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val caster = driver.activePlayer!!       // casts the creature on their main phase
+        val me = driver.getOpponent(caster)      // casts Hurl in response
+
+        // Top of my library: a mana-value-3 nonland — discovered iff the threshold is >= 3.
+        driver.putCardOnTopOfLibrary(me, "Test Relic")
+
+        // Active player casts the Ogre (mana value 3).
+        val ogreCard = driver.putCardInHand(caster, "Test Ogre")
+        driver.giveMana(caster, Color.RED, 1)
+        driver.giveColorlessMana(caster, 2)
+        driver.castSpell(caster, ogreCard)
+        val ogreOnStack = driver.getTopOfStack()!!
+        driver.passPriority(caster)
+
+        // I respond with Hurl into History targeting the Ogre spell.
+        val hurl = driver.putCardInHand(me, "Hurl into History")
+        driver.giveMana(me, Color.BLUE, 2)
+        driver.giveColorlessMana(me, 3)
+        driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = hurl,
+                targets = listOf(ChosenTarget.Spell(ogreOnStack)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+
+        driver.bothPass() // Hurl resolves: counter the Ogre, then Discover 3.
+
+        // The Ogre was countered.
+        driver.getGraveyardCardNames(caster) shouldContain "Test Ogre"
+
+        // Discover 3 found the mana-value-3 relic on top → cast-or-hand decision for me.
+        // (If the threshold had read 0, the relic would be skipped and the discover would whiff.)
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuintoriusKandScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QuintoriusKandScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.QuintoriusKand
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.DiscoverEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Quintorius Kand {3}{R}{W} — proves the signature loop: −3 discovers, and casting the discovered
+ * card *from exile* triggers "Whenever you cast a spell from exile, ~ deals 2 damage to each
+ * opponent and you gain 2 life." So −3 Discover 4 + a free cast should drain the opponent for 2 and
+ * gain 2 life.
+ */
+class QuintoriusKandScenarioTest : FunSpec({
+
+    // A mana-value-1 creature that is a legal Discover 4 hit and casts with no targets.
+    val imp = card("Test Imp") {
+        manaCost = "{R}"
+        typeLine = "Creature — Imp"
+        power = 1
+        toughness = 1
+    }
+
+    test("−3 Discover, casting the discovered card from exile, triggers the drain") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(PredefinedTokens.allTokens)
+        driver.registerCard(imp)
+        driver.registerCard(QuintoriusKand)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val quintorius = driver.putPermanentOnBattlefield(me, "Quintorius Kand")
+        // The battlefield helper doesn't seed loyalty counters; give Quintorius its starting loyalty.
+        driver.replaceState(
+            driver.state.updateEntity(quintorius) {
+                it.with(
+                    com.wingedsheep.engine.state.components.battlefield.CountersComponent(
+                        mapOf(com.wingedsheep.sdk.core.CounterType.LOYALTY to 4)
+                    )
+                )
+            }
+        )
+        driver.putCardOnTopOfLibrary(me, "Test Imp") // mana value 1 → discovered by Discover 4
+
+        val minus3 = QuintoriusKand.script.activatedAbilities.first { it.effect is DiscoverEffect }
+        driver.submit(ActivateAbility(me, quintorius, minus3.id)).isSuccess shouldBe true
+        driver.bothPass() // −3 resolves → Discover 4 → cast-or-hand pause
+
+        driver.submitYesNo(me, choice = true) // cast Test Imp for free, from exile
+
+        // Resolve the cast-from-exile trigger + the Imp spell.
+        repeat(6) { if (driver.stackSize > 0) driver.bothPass() }
+
+        driver.getLifeTotal(opp) shouldBe 18 // 2 damage from the drain trigger
+        driver.getLifeTotal(me) shouldBe 22  // 2 life gained
+    }
+})


### PR DESCRIPTION
Depends on: https://github.com/wingedsheep/argentum-engine/pull/1246

## Add 5 Lost Caverns of Ixalan cards (batch 1)

Implements the first five "A" cards from The Lost Caverns of Ixalan. Each is modeled
with existing SDK primitives — **no engine or SDK changes** — and covered by a scenario
test in `rules-engine`.

| Card | Cost | What it does | Primitives used |
|------|------|--------------|-----------------|
| **Abyssal Gorestalker** | `{4}{B}{B}` | ETB: each player sacrifices two creatures of their choice | `ForEachPlayerEffect(Player.Each)` + `ForceSacrificeEffect` with `EffectTarget.Controller` rebound per player |
| **Adaptive Gemguard** | `{3}{W}` | Tap two artifacts/creatures you control: put a +1/+1 counter on it (sorcery speed) | `Costs.TapPermanents` + `Effects.AddCounters`, `TimingRule.SorcerySpeed` |
| **Akal Pakal, First Among Equals** | `{2}{U}` | Each end step, if an artifact entered under your control this turn, look at top two, keep one, bin the other | `Triggers.EachEndStep` + `Conditions.ArtifactEnteredBattlefieldThisTurn` + `Patterns.Library.lookAtTopAndKeep` |
| **Amalia Benavides Aguirre** | `{W}{B}` | Ward—Pay 3 life. Whenever you gain life, explore, then destroy all other creatures if its power is exactly 20 | `KeywordAbility.Ward(WardCost.Life(3))`, `Effects.Explore`, `ConditionalEffect(SourceMatches(...power(20)))` + `GroupPatterns.destroyAll` |
| **Anim Pakal, Thousandth Moon** | `{1}{R}{W}` | Attack with non-Gnome creatures: +1/+1 counter, then create X tapped, attacking 1/1 Gnome tokens (X = counters on her) | `Triggers.YouAttackWithFilter` + `Effects.AddCounters` + `CreateTokenEffect(DynamicAmounts.countersOnSelf)` |

### Notes
- All five are first printings in LCI; `check-card-printing` reports the canonical is correctly placed in the earliest real set for each.
- Anim Pakal's token count reads `countersOnSelf` **after** the counter is added, so X reflects the post-increment total (verified in test).
- Amalia's power-20 wrath reads projected power (dual-mode `SourceMatches(Self, …)`), so seeded +1/+1 counters are visible.
- Adds a manual dev scenario (`manual-scenarios/sets/lci/cards-a-1.json`) with all five cards in hand and mana to cast them.

### Tests
Five scenario tests, all green locally:

```
./gradlew :rules-engine:test \
  --tests "*AbyssalGorestalkerScenarioTest" \
  --tests "*AdaptiveGemguardScenarioTest" \
  --tests "*AkalPakalScenarioTest" \
  --tests "*AmaliaBenavidesAguirreScenarioTest" \
  --tests "*AnimPakalScenarioTest"
```

Coverage includes the fewer-than-two auto-sacrifice edge (no prompt), the sorcery-speed
and cost gates on Gemguard, the intervening-if negative on Akal Pakal, both explore
branches (land → hand / nonland → counter) and the exact power-20 boundary on Amalia,
and Anim Pakal's post-increment token scaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
