### PR TITLE
LCI cards batch 5 (5 cards) + tokens honor global enters-tapped

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 126 / 286
+**Implemented:** 131 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -38,10 +38,10 @@
 - [x] Broodrage Mycoid
 - [x] Buried Treasure
 - [x] Burning Sun Cavalry
-- [ ] Calamitous Cave-In
-- [ ] Canonized in Blood
+- [x] Calamitous Cave-In
+- [x] Canonized in Blood
 - [x] Caparocti Sunborn
-- [ ] Captain Storm, Cosmium Raider
+- [x] Captain Storm, Cosmium Raider
 - [x] Captivating Cave
 - [x] Careening Mine Cart
 - [x] Cartographer's Companion
@@ -50,11 +50,11 @@
 - [ ] Cavernous Maw
 - [x] Cenote Scout
 - [x] Chart a Course
-- [ ] Child of the Volcano
+- [x] Child of the Volcano
 - [x] Chimil, the Inner Sun
 - [x] Chupacabra Echo
 - [ ] Clay-Fired Bricks
-- [ ] Coati Scavenger
+- [x] Coati Scavenger
 - [x] Cogwork Wrestler
 - [x] Colossadactyl
 - [x] Compass Gnome

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 131 / 286
+**Implemented:** 136 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -60,19 +60,19 @@
 - [x] Compass Gnome
 - [x] Confounding Riddle
 - [ ] Contested Game Ball
-- [ ] Corpses of the Lost
+- [x] Corpses of the Lost
 - [x] Cosmium Blast
-- [ ] Cosmium Confluence
-- [ ] Council of Echoes
+- [x] Cosmium Confluence
+- [x] Council of Echoes
 - [ ] Curator of Sun's Creation
 - [x] Daring Discovery
-- [ ] Dauntless Dismantler
+- [x] Dauntless Dismantler
 - [x] Dead Weight
 - [x] Deathcap Marionette
 - [ ] Deconstruction Hammer
 - [x] Deep Goblin Skulltaker
 - [x] Deep-Cavern Bat
-- [ ] Deepfathom Echo
+- [x] Deepfathom Echo
 - [ ] Deeproot Pilgrimage
 - [ ] Defossilize
 - [ ] Diamond Pick-Axe

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6122,7 +6122,8 @@ replacementEffect {
   which is a self-replacement consumed once as the source enters, this is a *runtime* replacement
   stamped into the source's `ReplacementEffectSourceComponent` (`StaticAbilityHandler.isRuntimeReplacementEffect`)
   and consulted from the battlefield against OTHER permanents as they enter — so `appliesTo.filter`
-  describes the *affected* permanents. The entry-tap paths (`PlayLandHandler`, `ZoneTransitionService`)
+  describes the *affected* permanents. The entry-tap paths (`PlayLandHandler`, `ZoneTransitionService`,
+  `StackResolver`, and `CreateTokenExecutor` for created tokens)
   ask `EnterUntappedReplacements.entersUntapped(...)` before marking a permanent tapped and skip the
   tap when it matches. Per CR 614 ordering this collapses "would enter tapped via another replacement"
   (controller chooses untapped) and "simply put onto the battlefield tapped" (no replacement → untapped)
@@ -6136,11 +6137,13 @@ replacementEffect {
   Imposing Sovereign / Authority of the Consuls "creatures your opponents control enter tapped"). Like
   `EntersUntapped`, it is a *runtime* replacement stamped into the source's `ReplacementEffectSourceComponent`
   and consulted from the battlefield against OTHER permanents as they enter, so `appliesTo.filter` describes
-  the *affected* permanents. The entry paths (`PlayLandHandler`, `ZoneTransitionService`) call
+  the *affected* permanents. The entry paths (`PlayLandHandler`, `ZoneTransitionService`, `StackResolver`,
+  and `CreateTokenExecutor` for created tokens) call
   `EnterTappedReplacements.entersTapped(...)` and mark the permanent tapped — **after** consulting
-  `EnterUntappedReplacements`, so per CR 614 an applicable `EntersUntapped` still wins. (Creature ETBs via
-  the stack are not yet wired to the global scan — `StackResolver` only consults the entering card's own
-  `EntersTapped` — so the opponent-creature variants would additionally need that hook.)
+  `EnterUntappedReplacements`, so per CR 614 an applicable `EntersUntapped` still wins. Created tokens are
+  covered too: e.g. Dauntless Dismantler's "Artifacts your opponents control enter tapped" taps an
+  opponent's Map/Treasure/Clue token, and Authority of the Consuls taps opponents' creature tokens (a token
+  entering attacking keeps its tapped state and is not overridden).
 - `RedirectZoneChange(newDestination, appliesTo, linkToSource = false)` — redirect a zone change to a
   different destination (Rest in Peace / Leyline of the Void: graveyard → exile). `appliesTo` is an
   `EventPattern.ZoneChangeEvent(filter, from?, to?)`; the `filter`'s `controllerPredicate` scopes it

--- a/manual-scenarios/sets/lci/cards-4.json
+++ b/manual-scenarios/sets/lci/cards-4.json
@@ -1,0 +1,55 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Calamitous Cave-In",
+      "Canonized in Blood",
+      "Captain Storm, Cosmium Raider",
+      "Child of the Volcano",
+      "Coati Scavenger",
+      "Waterwind Scout"
+    ],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Grizzly Bears"},
+      {"name": "Grizzly Bears"},
+      {"name": "Ajani, Outland Chaperone", "counters": {"LOYALTY": 2}}
+    ],
+    "graveyard": ["Hidden Courtyard", "Promising Vein"],
+    "library": ["Forest", "Mountain", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Swamp", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/sets/lci/cards-5.json
+++ b/manual-scenarios/sets/lci/cards-5.json
@@ -1,0 +1,61 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Corpses of the Lost",
+      "Cosmium Confluence",
+      "Council of Echoes",
+      "Dauntless Dismantler",
+      "Deepfathom Echo"
+    ],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Captivating Cave", "Forest", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Waterwind Scout",
+      "Millstone"
+    ],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Swamp", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CalamitousCaveIn.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CalamitousCaveIn.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Calamitous Cave-In — {3}{R}
+ * Sorcery (LCI #139, uncommon)
+ *
+ * "Calamitous Cave-In deals X damage to each creature and each planeswalker,
+ *  where X is the number of Caves you control plus the number of Cave cards
+ *  in your graveyard."
+ *
+ * X is evaluated at resolution as the sum of:
+ *   - Battlefield: permanents with the Cave land subtype you control
+ *     ([DynamicAmount.Count] over [Zone.BATTLEFIELD] filtered by [GameObjectFilter.Land.withSubtype("Cave")])
+ *   - Graveyard:   any card with the Cave subtype in your graveyard
+ *     ([DynamicAmount.Count] over [Zone.GRAVEYARD] filtered by [GameObjectFilter.Any.withSubtype("Cave")])
+ *
+ * The two counts are summed via [DynamicAmount.Add] and fed into
+ * [Patterns.Group.dealDamageToAll] over [GroupFilter]([GameObjectFilter.CreatureOrPlaneswalker]).
+ */
+val CalamitousCaveIn = card("Calamitous Cave-In") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Calamitous Cave-In deals X damage to each creature and each planeswalker, " +
+        "where X is the number of Caves you control plus the number of Cave cards in your graveyard."
+
+    spell {
+        val cavesControlled = DynamicAmount.Count(
+            player = Player.You,
+            zone = Zone.BATTLEFIELD,
+            filter = GameObjectFilter.Land.withSubtype("Cave"),
+        )
+        val cavesInGraveyard = DynamicAmount.Count(
+            player = Player.You,
+            zone = Zone.GRAVEYARD,
+            filter = GameObjectFilter.Any.withSubtype("Cave"),
+        )
+        effect = Patterns.Group.dealDamageToAll(
+            amount = DynamicAmount.Add(cavesControlled, cavesInGraveyard),
+            filter = GroupFilter(GameObjectFilter.CreatureOrPlaneswalker),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "139"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/8341ddd9-aac1-4773-b8ce-51e35f696263.jpg?1782694499"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CanonizedInBlood.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CanonizedInBlood.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Canonized in Blood — {1}{B}
+ * Enchantment
+ * Uncommon — LCI #96
+ *
+ * At the beginning of your end step, if you descended this turn, put a +1/+1 counter on target
+ * creature you control. (You descended if a permanent card was put into your graveyard from
+ * anywhere.)
+ * {5}{B}{B}, Sacrifice this enchantment: Create a 4/3 white and black Vampire Demon creature
+ * token with flying.
+ *
+ * "Descended this turn" is CR 700.11: at least one nontoken permanent card was put into your
+ * graveyard from any zone this turn. The intervening-if gate on the triggered ability fires only
+ * once per end step regardless of how many times you descended that turn, and cannot trigger if
+ * you have not descended as the end step begins.
+ */
+val CanonizedInBlood = card("Canonized in Blood") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "At the beginning of your end step, if you descended this turn, put a +1/+1 counter on target creature you control. (You descended if a permanent card was put into your graveyard from anywhere.)\n" +
+        "{5}{B}{B}, Sacrifice this enchantment: Create a 4/3 white and black Vampire Demon creature token with flying."
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouDescendedThisTurn()
+        val t = target("target creature you control", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{5}{B}{B}"), Costs.SacrificeSelf)
+        effect = Effects.CreateToken(
+            power = 4,
+            toughness = 3,
+            colors = setOf(Color.WHITE, Color.BLACK),
+            creatureTypes = setOf("Vampire", "Demon"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "96"
+        artist = "Antonio José Manzanedo"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/384b6892-5dfc-4607-b511-cf83544a9357.jpg?1782694534"
+        ruling(
+            "2023-11-10",
+            "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn."
+        )
+        ruling(
+            "2023-11-10",
+            "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended."
+        )
+        ruling(
+            "2023-11-10",
+            "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CaptainStormCosmiumRaider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CaptainStormCosmiumRaider.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Captain Storm, Cosmium Raider
+ * {U}{R}
+ * Legendary Creature — Human Pirate
+ * 2/2
+ * Whenever an artifact you control enters, put a +1/+1 counter on target Pirate you control.
+ *
+ * The trigger fires whenever any artifact you control enters the battlefield (including tokens
+ * such as Treasure or Clue tokens). The target is chosen on announcement (CR 603.3d); if there
+ * is no valid Pirate you control when the ability resolves the trigger fizzles (CR 608.2b).
+ * Captain Storm itself is a Pirate and is a legal target.
+ */
+val CaptainStormCosmiumRaider = card("Captain Storm, Cosmium Raider") {
+    manaCost = "{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Creature — Human Pirate"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever an artifact you control enters, put a +1/+1 counter on target Pirate you control."
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Artifact.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        val t = target(
+            "target Pirate you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.PIRATE)),
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "227"
+        artist = "Diego Gisbert"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/14c65f5a-10bd-4f9b-b816-46c2240b11ff.jpg?1782694427"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ChildOfTheVolcano.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ChildOfTheVolcano.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Child of the Volcano — {3}{R}
+ * Creature — Elemental
+ * 3/3
+ *
+ * Trample
+ * At the beginning of your end step, if you descended this turn, put a +1/+1 counter on this creature.
+ * (You descended if a permanent card was put into your graveyard from anywhere.)
+ *
+ * "Descended this turn" is CR 700.11: at least one nontoken permanent card was put into
+ * your graveyard from any zone this turn. The intervening-if gate fires only once per end
+ * step regardless of how many times you descended, and cannot trigger if you have not yet
+ * descended as the end step begins.
+ */
+val ChildOfTheVolcano = card("Child of the Volcano") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Elemental"
+    power = 3
+    toughness = 3
+    oracleText = "Trample\n" +
+        "At the beginning of your end step, if you descended this turn, put a +1/+1 counter on this creature. " +
+        "(You descended if a permanent card was put into your graveyard from anywhere.)"
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouDescendedThisTurn()
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "140"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/e/9/e964f026-9cbf-4fa2-acdc-60d19b88f183.jpg?1782694498"
+        ruling("2023-11-10", "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn.")
+        ruling("2023-11-10", "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended.")
+        ruling("2023-11-10", "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CoatiScavenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CoatiScavenger.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Coati Scavenger — {2}{G}
+ * Creature — Raccoon
+ * 3/2
+ *
+ * Descend 4 — When this creature enters, if there are four or more permanent cards in your
+ * graveyard, return target permanent card from your graveyard to your hand.
+ *
+ * "Descend 4" is an ability word (CR 207.2c) with no rules meaning of its own; it merely names the
+ * intervening-if condition (four or more permanent cards in your graveyard). The trigger fires on ETB
+ * only when the condition is already true at that moment and is rechecked at resolution — if the
+ * graveyard count drops below four before resolution the ability fizzles without effect (no valid
+ * target for the return effect in any case).
+ *
+ * Targeting is mandatory (no "may") — the controller must choose a permanent card from their
+ * graveyard to return if at least one exists. If none exists, the ability fizzles.
+ */
+val CoatiScavenger = card("Coati Scavenger") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Raccoon"
+    power = 3
+    toughness = 2
+    oracleText = "Descend 4 — When this creature enters, if there are four or more permanent cards in your graveyard, return target permanent card from your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent)
+        val card = target(
+            "target permanent card from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    baseFilter = GameObjectFilter.Permanent.ownedByYou(),
+                    zone = Zone.GRAVEYARD,
+                ),
+            ),
+        )
+        effect = Effects.ReturnToHand(card)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "179"
+        artist = "Alessandra Pisano"
+        imageUri = "https://cards.scryfall.io/normal/front/d/2/d2c70d86-1764-487d-a415-15ae79ba570c.jpg?1782694467"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CorpsesOfTheLost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CorpsesOfTheLost.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Corpses of the Lost — {2}{B}
+ * Enchantment
+ * Rare — LCI #98
+ *
+ * Skeletons you control get +1/+0 and have haste.
+ * When this enchantment enters, create a 2/2 black Skeleton Pirate creature token.
+ * At the beginning of your end step, if you descended this turn, you may pay 1 life.
+ * If you do, return this enchantment to its owner's hand.
+ * (You descended if a permanent card was put into your graveyard from anywhere.)
+ *
+ * The two static abilities are separate layer-6 continuous effects scoped to
+ * [Subtype.SKELETON] creatures the controller controls:
+ *  1. [ModifyStats] adds +1/+0 (power bonus, layer 7c).
+ *  2. [GrantKeyword] grants haste (layer 6).
+ *
+ * The end-step trigger is a "descend" trigger (CR 700.11) with an intervening-if gate
+ * ([Conditions.YouDescendedThisTurn]). On resolution the player is offered an optional
+ * life payment ([Gate.MayPay] via [OptionalCostEffect]); if paid, [Effects.ReturnToHand]
+ * bounces the source enchantment to its owner's hand.
+ */
+val CorpsesOfTheLost = card("Corpses of the Lost") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Skeletons you control get +1/+0 and have haste.\n" +
+        "When this enchantment enters, create a 2/2 black Skeleton Pirate creature token.\n" +
+        "At the beginning of your end step, if you descended this turn, you may pay 1 life. " +
+        "If you do, return this enchantment to its owner's hand. " +
+        "(You descended if a permanent card was put into your graveyard from anywhere.)"
+
+    // Static 1: Skeletons you control get +1/+0 (layer 7c).
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SKELETON).youControl())
+        )
+    }
+
+    // Static 2: Skeletons you control have haste (layer 6).
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SKELETON).youControl())
+        )
+    }
+
+    // ETB: create a 2/2 black Skeleton Pirate creature token.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Skeleton", "Pirate")
+        )
+    }
+
+    // End-step descend trigger: you may pay 1 life; if you do, return this to hand.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouDescendedThisTurn()
+        effect = OptionalCostEffect(
+            cost = PayLifeEffect(1),
+            ifPaid = Effects.ReturnToHand(EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "98"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg?1782694532"
+        ruling(
+            "2023-11-10",
+            "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn."
+        )
+        ruling(
+            "2023-11-10",
+            "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended."
+        )
+        ruling(
+            "2023-11-10",
+            "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CosmiumConfluence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CosmiumConfluence.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Cosmium Confluence
+ * {4}{G} — Sorcery (Rare) — The Lost Caverns of Ixalan #181
+ * Artist: Kasia 'Kafis' Zielińska
+ *
+ * Choose three. You may choose the same mode more than once.
+ * • Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.
+ * • Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature
+ *   with haste. It's still a land.
+ * • Destroy target enchantment.
+ *
+ * Modeled via [modal] with chooseCount = 3 and allowRepeat = true.
+ * Mode 0 — library tutoring via the Gather → Select → Move pipeline.
+ * Mode 1 — counter addition (AddCountersEffect) followed by permanent Cave animation
+ *   (BecomeCreatureEffect, Duration.Permanent). No "until end of turn" appears on the card;
+ *   the Cave stays a creature unless it leaves the battlefield. The +1/+1 counters keep the
+ *   effectively 0/0 body alive (0+3 = 3/3 while counters remain).
+ * Mode 2 — targeted enchantment destruction.
+ */
+val CosmiumConfluence = card("Cosmium Confluence") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose three. You may choose the same mode more than once.\n" +
+        "• Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.\n" +
+        "• Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land.\n" +
+        "• Destroy target enchantment."
+
+    spell {
+        modal(chooseCount = 3, allowRepeat = true) {
+            mode("Search your library for a Cave card, put it onto the battlefield tapped, then shuffle") {
+                effect = Patterns.Library.searchLibrary(
+                    filter = GameObjectFilter.Land.withSubtype("Cave"),
+                    destination = SearchDestination.BATTLEFIELD,
+                    entersTapped = true,
+                    shuffleAfter = true
+                )
+            }
+            mode("Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land") {
+                val cave = target(
+                    "a Cave you control",
+                    TargetPermanent(filter = TargetFilter.Land.withSubtype("Cave").youControl())
+                )
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, cave) then
+                    Effects.BecomeCreature(
+                        target = cave,
+                        power = 0,
+                        toughness = 0,
+                        keywords = setOf(Keyword.HASTE),
+                        creatureTypes = setOf("Elemental"),
+                        duration = Duration.Permanent
+                    )
+            }
+            mode("Destroy target enchantment") {
+                val enchantment = target("target enchantment", Targets.Enchantment)
+                effect = Effects.Destroy(enchantment)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "181"
+        artist = "Kasia 'Kafis' Zielińska"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg?1782694465"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CouncilOfEchoes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CouncilOfEchoes.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Council of Echoes — {4}{U}{U}
+ * Creature — Spirit Advisor
+ * 4/4
+ *
+ * Flying
+ * Descend 4 — When this creature enters, if there are four or more permanent cards in your
+ * graveyard, return up to one target nonland permanent other than this creature to its owner's
+ * hand.
+ *
+ * "Descend 4" is an ability word; the mechanic is an intervening-if triggered ability whose
+ * condition (CR 603.4) checks that the controller has four or more permanent cards in their
+ * graveyard at both the time the trigger would fire and at resolution. If the count drops
+ * below four before resolution the ability fizzles.
+ *
+ * "Up to one" makes the single target requirement optional (minimum 0). If the controller
+ * declines to choose any target the effect resolves as a no-op. The target must be a nonland
+ * permanent other than the Council itself ([TargetOther] excludes the source).
+ */
+val CouncilOfEchoes = card("Council of Echoes") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit Advisor"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\nDescend 4 — When this creature enters, if there are four or more permanent cards in your graveyard, return up to one target nonland permanent other than this creature to its owner's hand."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent)
+        val permanent = target(
+            "up to one target nonland permanent other than this creature",
+            TargetOther(baseRequirement = TargetPermanent(count = 1, optional = true, filter = TargetFilter.NonlandPermanent))
+        )
+        effect = Effects.ReturnToHand(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Fariba Khamseh"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85ad358d-a520-4d57-82b0-d2297da1fbde.jpg?1782694568"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DauntlessDismantler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DauntlessDismantler.kt
@@ -27,8 +27,8 @@ import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
  *   chosen X value, so X=1 costs three mana ({1}{1}{W}), X=2 costs five mana ({2}{2}{W}), etc.
  *   The destroy filter uses [CardPredicate.ManaValueEqualsX] so exactly the artifacts at the
  *   paid X value are destroyed — across ALL controllers (oracle says "each artifact", not "each
- *   artifact an opponent controls"). The controller sacrifices this creature as part of the cost
- *   (CR 601.2b), so the Dismantler is gone before the effect resolves.
+ *   artifact an opponent controls"). The controller sacrifices this creature as part of the
+ *   activation cost (CR 602.2b), so the Dismantler is gone before the effect resolves.
  */
 val DauntlessDismantler = card("Dauntless Dismantler") {
     manaCost = "{1}{W}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DauntlessDismantler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DauntlessDismantler.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
+
+/**
+ * Dauntless Dismantler
+ * {1}{W}
+ * Creature — Human Artificer
+ * 1/4
+ *
+ * Artifacts your opponents control enter tapped.
+ * {X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X.
+ *
+ * - "Artifacts your opponents control enter tapped" is a global [PermanentsEnterTapped] runtime
+ *   replacement whose `appliesTo` filter is scoped to artifacts controlled by opponents of the
+ *   Dismantler's controller. The controller-relative `opponentControls()` predicate is resolved
+ *   against the Dismantler's own controller at entry time — the same pattern used by
+ *   Authority of the Consuls for creatures.
+ * - The activated ability uses a double-X mana cost ({X}{X}{W}): both X symbols pay the same
+ *   chosen X value, so X=1 costs three mana ({1}{1}{W}), X=2 costs five mana ({2}{2}{W}), etc.
+ *   The destroy filter uses [CardPredicate.ManaValueEqualsX] so exactly the artifacts at the
+ *   paid X value are destroyed — across ALL controllers (oracle says "each artifact", not "each
+ *   artifact an opponent controls"). The controller sacrifices this creature as part of the cost
+ *   (CR 601.2b), so the Dismantler is gone before the effect resolves.
+ */
+val DauntlessDismantler = card("Dauntless Dismantler") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Artificer"
+    power = 1
+    toughness = 4
+    oracleText = "Artifacts your opponents control enter tapped.\n" +
+        "{X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X."
+
+    // Artifacts your opponents control enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Artifact.opponentControls(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    // {X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}{X}{W}"), Costs.SacrificeSelf)
+        effect = Effects.DestroyAll(
+            filter = GameObjectFilter.Artifact.manaValueEqualsX()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "Dibujante Nocturno"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d771631-0aab-4f09-b9a6-49b6b2d8d2aa.jpg?1782694606"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeepfathomEcho.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeepfathomEcho.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deepfathom Echo — {2}{G}{U}
+ * Creature — Merfolk Spirit
+ * 4/4
+ *
+ * "At the beginning of combat on your turn, this creature explores. Then you may have it
+ *  become a copy of another creature you control until end of turn."
+ *
+ * Implementation:
+ *  - `trigger = Triggers.BeginCombat` fires at the start of combat on the controller's turn.
+ *  - No target is declared at the `triggeredAbility` level. The "another creature you control"
+ *    is selected mid-resolution — inside the `MayEffect` — via `Effects.SelectTarget`. This
+ *    ensures the explore always runs unconditionally, and target selection happens only if the
+ *    player accepts the copy step.
+ *  - `Effects.Explore(EffectTarget.Self)` runs first (CR 701.44): reveals the top library card;
+ *    a land goes to the hand, a nonland puts a +1/+1 counter on Deepfathom Echo and the
+ *    controller may put that card into the graveyard.
+ *  - `MayEffect(...)` wraps the copy step. The engine asks the controller yes/no; if yes:
+ *    `Effects.SelectTarget(Targets.OtherCreatureYouControl, "copySource")` prompts for another
+ *    creature the controller controls (Deepfathom Echo is excluded by `OtherCreatureYouControl`
+ *    which carries `excludeSelf = true` via `TargetFilter.OtherCreatureYouControl`). When only
+ *    one valid creature exists, the engine auto-selects it without a prompt.
+ *  - `Effects.EachPermanentBecomesCopyOfTarget(target = PipelineTarget("copySource"),
+ *    duration = EndOfTurn, affected = Self)` — single-permanent shape (`affected = Self`):
+ *    Deepfathom Echo becomes a copy of the selected creature until end of turn, copiable values
+ *    only (Rule 707). Counters, tapped state, attachments, and non-copy continuous effects are
+ *    unaffected. End-of-turn cleanup restores Deepfathom Echo's original `CardComponent`
+ *    snapshot via `CopyOfComponent`.
+ */
+val DeepfathomEcho = card("Deepfathom Echo") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Merfolk Spirit"
+    power = 4
+    toughness = 4
+    oracleText = "At the beginning of combat on your turn, this creature explores. Then you may " +
+        "have it become a copy of another creature you control until end of turn. (To have this " +
+        "creature explore, reveal the top card of your library. Put that card into your hand if " +
+        "it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or " +
+        "put it into your graveyard.)"
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = Effects.Composite(listOf(
+            // Step 1: This creature explores (unconditional). Reveals top library card; land → hand,
+            // nonland → +1/+1 counter on this creature + optional graveyard put (CR 701.44).
+            Effects.Explore(EffectTarget.Self),
+            // Step 2: The controller may have this creature become a copy of another creature
+            // they control until end of turn. Target selection happens inside the MayEffect so
+            // it is only asked when the player accepts, and does not bind at stack-placement time.
+            MayEffect(
+                Effects.SelectTarget(Targets.OtherCreatureYouControl, "copySource")
+                    .then(Effects.EachPermanentBecomesCopyOfTarget(
+                        target = EffectTarget.PipelineTarget("copySource"),
+                        duration = Duration.EndOfTurn,
+                        affected = EffectTarget.Self
+                    ))
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7c7fb87-8448-49f4-a9ed-db97f6a41d98.jpg?1782694427"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1673,6 +1673,159 @@
     ]
 }
 
+// Calamitous Cave-In
+{
+    "name": "Calamitous Cave-In",
+    "manaCost": "{3}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Calamitous Cave-In deals X damage to each creature and each planeswalker, where X is the number of Caves you control plus the number of Cave cards in your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "ForEach",
+            "space": {
+                "type": "IterationSpace.Group",
+                "filter": {
+                    "baseFilter": "creature|planeswalker"
+                }
+            },
+            "body": {
+                "type": "DealDamage",
+                "amount": {
+                    "type": "Add",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Battlefield",
+                        "filter": "land Cave"
+                    },
+                    "right": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "Cave"
+                    }
+                },
+                "target": "Self"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "139",
+        "rarity": "UNCOMMON",
+        "artist": "Diego Gisbert",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/8341ddd9-aac1-4773-b8ce-51e35f696263.jpg?1782694499"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Canonized in Blood
+{
+    "name": "Canonized in Blood",
+    "manaCost": "{1}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "At the beginning of your end step, if you descended this turn, put a +1/+1 counter on target creature you control. (You descended if a permanent card was put into your graveyard from anywhere.)\n{5}{B}{B}, Sacrifice this enchantment: Create a 4/3 white and black Vampire Demon creature token with flying.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    },
+                    "id": "target creature you control"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{B}{B}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 4,
+                    "toughness": 3,
+                    "colors": [
+                        "WHITE",
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Vampire",
+                        "Demon"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "96",
+        "rarity": "UNCOMMON",
+        "artist": "Antonio José Manzanedo",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/384b6892-5dfc-4607-b511-cf83544a9357.jpg?1782694534",
+        "rulings": [
+            {
+                "date": "2023-11-10",
+                "text": "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Caparocti Sunborn
 {
     "name": "Caparocti Sunborn",
@@ -1745,6 +1898,57 @@
     "colorIdentityOverride": [
         "RED",
         "WHITE"
+    ]
+}
+
+// Captain Storm, Cosmium Raider
+{
+    "name": "Captain Storm, Cosmium Raider",
+    "manaCost": "{U}{R}",
+    "typeLine": "Legendary Creature — Human Pirate",
+    "oracleText": "Whenever an artifact you control enters, put a +1/+1 counter on target Pirate you control.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target Pirate you control"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature Pirate ctrl:you"
+                    },
+                    "id": "target Pirate you control"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "rarity": "UNCOMMON",
+        "artist": "Diego Gisbert",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/14c65f5a-10bd-4f9b-b816-46c2240b11ff.jpg?1782694427"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
     ]
 }
 
@@ -1945,6 +2149,74 @@
     ]
 }
 
+// Child of the Volcano
+{
+    "name": "Child of the Volcano",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Elemental",
+    "oracleText": "Trample\nAt the beginning of your end step, if you descended this turn, put a +1/+1 counter on this creature. (You descended if a permanent card was put into your graveyard from anywhere.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "140",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/9/e964f026-9cbf-4fa2-acdc-60d19b88f183.jpg?1782694498",
+        "rulings": [
+            {
+                "date": "2023-11-10",
+                "text": "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Chimil, the Inner Sun
 {
     "name": "Chimil, the Inner Sun",
@@ -2048,6 +2320,68 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Coati Scavenger
+{
+    "name": "Coati Scavenger",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Raccoon",
+    "oracleText": "Descend 4 — When this creature enters, if there are four or more permanent cards in your graveyard, return target permanent card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target permanent card from your graveyard"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "permanent own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target permanent card from your graveyard"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "179",
+        "rarity": "UNCOMMON",
+        "artist": "Alessandra Pisano",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/2/d2c70d86-1764-487d-a415-15ae79ba570c.jpg?1782694467"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2650,6 +2650,113 @@
     ]
 }
 
+// Corpses of the Lost
+{
+    "name": "Corpses of the Lost",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Skeletons you control get +1/+0 and have haste.\nWhen this enchantment enters, create a 2/2 black Skeleton Pirate creature token.\nAt the beginning of your end step, if you descended this turn, you may pay 1 life. If you do, return this enchantment to its owner's hand. (You descended if a permanent card was put into your graveyard from anywhere.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Skeleton",
+                        "Pirate"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayLife",
+                            "amount": 1
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature Skeleton ctrl:you"
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature Skeleton ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "RARE",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg?1782694532",
+        "rulings": [
+            {
+                "date": "2023-11-10",
+                "text": "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cosmium Blast
 {
     "name": "Cosmium Blast",
@@ -2702,6 +2809,209 @@
     ]
 }
 
+// Cosmium Confluence
+{
+    "name": "Cosmium Confluence",
+    "manaCost": "{4}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose three. You may choose the same mode more than once.\n• Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.\n• Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land.\n• Destroy target enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "land Cave"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    },
+                    "description": "Search your library for a Cave card, put it onto the battlefield tapped, then shuffle"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 3,
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "a Cave you control"
+                                }
+                            },
+                            {
+                                "type": "BecomeCreature",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "a Cave you control"
+                                },
+                                "power": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "toughness": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "keywords": [
+                                    "HASTE"
+                                ],
+                                "creatureTypes": [
+                                    "Elemental"
+                                ],
+                                "duration": "Permanent"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "land Cave ctrl:you"
+                            },
+                            "id": "a Cave you control"
+                        }
+                    ],
+                    "description": "Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target enchantment"
+                        }
+                    ],
+                    "description": "Destroy target enchantment"
+                }
+            ],
+            "chooseCount": 3,
+            "allowRepeat": true
+        }
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "RARE",
+        "artist": "Kasia 'Kafis' Zielińska",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg?1782694465"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Council of Echoes
+{
+    "name": "Council of Echoes",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Spirit Advisor",
+    "oracleText": "Flying\nDescend 4 — When this creature enters, if there are four or more permanent cards in your graveyard, return up to one target nonland permanent other than this creature to its owner's hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target nonland permanent other than this creature"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetOther",
+                    "baseRequirement": {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        }
+                    },
+                    "id": "up to one target nonland permanent other than this creature"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Fariba Khamseh",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85ad358d-a520-4d57-82b0-d2297da1fbde.jpg?1782694568"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Daring Discovery
 {
     "name": "Daring Discovery",
@@ -2751,6 +3061,84 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Dauntless Dismantler
+{
+    "name": "Dauntless Dismantler",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "Artifacts your opponents control enter tapped.\n{X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{X}{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsArtifact",
+                                        "ManaValueEqualsX"
+                                    ]
+                                }
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:opponent",
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "UNCOMMON",
+        "artist": "Dibujante Nocturno",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d771631-0aab-4f09-b9a6-49b6b2d8d2aa.jpg?1782694606"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -2992,6 +3380,78 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Deepfathom Echo
+{
+    "name": "Deepfathom Echo",
+    "manaCost": "{2}{G}{U}",
+    "typeLine": "Creature — Merfolk Spirit",
+    "oracleText": "At the beginning of combat on your turn, this creature explores. Then you may have it become a copy of another creature you control until end of turn. (To have this creature explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Explore",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SelectTarget",
+                                        "requirement": {
+                                            "type": "TargetObject",
+                                            "filter": {
+                                                "baseFilter": "creature ctrl:you",
+                                                "excludeSelf": true
+                                            }
+                                        },
+                                        "storeAs": "copySource"
+                                    },
+                                    {
+                                        "type": "EachPermanentBecomesCopyOfTarget",
+                                        "target": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "copySource"
+                                        },
+                                        "duration": "EndOfTurn",
+                                        "affected": "Self"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7c7fb87-8448-49f4-a9ed-db97f6a41d98.jpg?1782694427"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
     ]
 }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -53,6 +54,41 @@ object EnterTappedReplacements {
             }
         }
         return false
+    }
+
+    /**
+     * Resolve global "[filter] enter tapped/untapped" replacements for a token [tokenId] just
+     * placed onto [controllerId]'s battlefield, mirroring the entry-tap resolution in
+     * [ZoneTransitionService]. Tokens are permanents entering the battlefield, so they honor
+     * Dauntless Dismantler / Authority of the Consuls-style effects just like cast or played
+     * permanents — but [com.wingedsheep.engine.handlers.effects.BattlefieldEntry.place] (the
+     * ad-hoc insertion path token executors use) deliberately doesn't set tapped state, so each
+     * token-minting site calls this immediately after placing the token.
+     *
+     * [definedTapped] is whether the token was minted already tapped (its own `effect.tapped` /
+     * self-`EntersTapped`); [attacking] whether it entered attacking (a combat token keeps its
+     * tapped state and is never flipped untapped). Per CR 614 an applicable "enters untapped"
+     * replacement wins over a global "enters tapped".
+     *
+     * The token must already carry its `ControllerComponent` / `CardComponent` so the replacement
+     * filters ("artifacts your opponents control", …) resolve.
+     */
+    fun applyCreatedTokenEntryTap(
+        state: GameState,
+        tokenId: EntityId,
+        controllerId: EntityId,
+        definedTapped: Boolean = false,
+        attacking: Boolean = false,
+    ): GameState {
+        val entersUntapped = EnterUntappedReplacements.entersUntapped(state, tokenId, controllerId)
+        return when {
+            definedTapped && !attacking && entersUntapped ->
+                state.updateEntity(tokenId) { it.without<TappedComponent>() }
+            !definedTapped && !entersUntapped &&
+                entersTapped(state, tokenId, controllerId) ->
+                state.updateEntity(tokenId) { it.with(TappedComponent) }
+            else -> state
+        }
     }
 
     private fun matchesEnterFilter(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
@@ -129,6 +129,13 @@ class CreatePredefinedTokenExecutor(
 
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, tokenControllerId, tokenId)
+
+            // Predefined Map/Treasure/Clue/etc. tokens honor global "[filter] enter tapped"
+            // replacements (Dauntless Dismantler taps an opponent's artifact token).
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(
+                    newState, tokenId, tokenControllerId, definedTapped = effect.tapped,
+                )
         }
 
         val events = createdTokenIds.map { tokenId ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
@@ -142,6 +142,11 @@ class CreateTokenCopyOfChosenPermanentExecutor(
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
 
+            // A token copy honors global "[filter] enter tapped" replacements (Authority of the
+            // Consuls taps an opponent's token copy of a creature).
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
+
             val event = ZoneChangeEvent(
                 entityId = tokenId,
                 entityName = tokenCard.name,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
@@ -113,6 +113,11 @@ class CreateTokenCopyOfEquippedCreatureExecutor(
         newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
             .place(newState, controllerId, tokenId)
 
+        // A token copy honors global "[filter] enter tapped" replacements (Authority of the
+        // Consuls / Dauntless Dismantler on an opponent's token copy).
+        newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+            .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
+
         val events = listOf(
             ZoneChangeEvent(
                 entityId = tokenId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -131,6 +131,11 @@ class CreateTokenCopyOfSourceExecutor(
             // Add to battlefield
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
+
+            // A token copy honors global "[filter] enter tapped" replacements (Authority of the
+            // Consuls / Dauntless Dismantler on an opponent's token copy).
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
         }
 
         // Apply "enters with counters" replacement effects from other battlefield permanents

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -160,6 +160,12 @@ class CreateTokenCopyOfTargetExecutor(
             newState = newState.withEntity(tokenId, container)
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
+            // A token copy honors global "[filter] enter tapped" replacements (Authority of the
+            // Consuls / Dauntless Dismantler on an opponent's token copy).
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(
+                    newState, tokenId, controllerId, definedTapped = effect.tapped,
+                )
             createdTokens.add(tokenId)
 
             for (ability in effect.triggeredAbilities) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.event.DelayedTriggeredAbility
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
 import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
 import com.wingedsheep.engine.state.Component
 import com.wingedsheep.engine.state.ComponentContainer
@@ -229,6 +230,14 @@ class CreateTokenExecutor(
             // Add to battlefield
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, tokenControllerId, tokenId)
+
+            // Tokens honor global "[filter] enter tapped" replacements from other permanents
+            // (Dauntless Dismantler, Authority of the Consuls, …) — BattlefieldEntry.place doesn't
+            // set tapped state, so resolve it here now the token carries its controller/type.
+            newState = EnterTappedReplacements.applyCreatedTokenEntryTap(
+                newState, tokenId, tokenControllerId,
+                definedTapped = effect.tapped, attacking = effect.attacking,
+            )
         }
 
         // Apply "enters with counters" replacement effects from other battlefield permanents

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -217,6 +217,11 @@ object TokenCreationReplacementHelper {
                     newState = newState.withEntity(tokenId, tokenContainer)
                     newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                         .place(newState, tokenControllerId, tokenId)
+                    // Honor global "[filter] enter tapped" replacements on the added token too.
+                    newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                        .applyCreatedTokenEntryTap(
+                            newState, tokenId, tokenControllerId, definedTapped = tapped,
+                        )
 
                     events.add(
                         ZoneChangeEvent(
@@ -387,6 +392,9 @@ object TokenCreationReplacementHelper {
             newState = newState.withEntity(tokenId, container)
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
+            // Honor global "[filter] enter tapped" replacements on the copy too.
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
 
             // Apply the attached permanent's printed enters-with-counters replacement
             // effects (and any global ones from other permanents).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.BattlefieldEntry
+import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
 import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
 import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
@@ -98,6 +99,7 @@ object TokenFromDefinition {
 
         // As-enters: enters tapped (CR 614). The payLifeCost (shock-land) form is land-only.
         val entersTapped = cardDef.script.replacementEffects.filterIsInstance<EntersTapped>().firstOrNull()
+        var enteredTapped = false
         if (entersTapped != null && entersTapped.payLifeCost == null) {
             val shouldEnterTapped = entersTapped.unlessCondition?.let { condition ->
                 !conditionEvaluator.evaluate(
@@ -106,8 +108,16 @@ object TokenFromDefinition {
             } ?: true
             if (shouldEnterTapped) {
                 newState = newState.updateEntity(tokenId) { c -> c.with(TappedComponent) }
+                enteredTapped = true
             }
         }
+
+        // As-enters: global "[filter] enter tapped/untapped" replacements from OTHER permanents
+        // (Authority of the Consuls taps an opponent's minted creature token). Passing the self
+        // enters-tapped result lets an "enters untapped" replacement override it per CR 614.
+        newState = EnterTappedReplacements.applyCreatedTokenEntryTap(
+            newState, tokenId, controllerId, definedTapped = enteredTapped,
+        )
 
         // As-enters: the token's own + global "enters with counters" (CR 614).
         val (stateWithCounters, counterEvents) = EntersWithCountersHelper.applyEntersWithCounters(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/TapEventEnforcementTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/TapEventEnforcementTest.kt
@@ -74,6 +74,10 @@ class TapEventEnforcementTest : FunSpec({
             // Shock-land "pay life or enter tapped": declining to pay makes the land/permanent
             // *enter* tapped (CR 614 replacement on entry), which is not a tap transition.
             "com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt",
+            // Global "[filter] enter tapped/untapped" replacements applied to a token as it enters
+            // (shared helper called by every token executor) — entering tapped/untapped on entry is
+            // not a tap transition, so it emits no TappedEvent/UntappedEvent.
+            "com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt",
         )
 
         private data class RawTapMutation(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CalamitousCaveInScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CalamitousCaveInScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CalamitousCaveIn
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Calamitous Cave-In (LCI #139) — {3}{R} Sorcery.
+ *
+ * "Calamitous Cave-In deals X damage to each creature and each planeswalker,
+ *  where X is the number of Caves you control plus the number of Cave cards
+ *  in your graveyard."
+ *
+ * Covered:
+ *  1. Two Caves on the battlefield and none in the graveyard → X = 2.
+ *     A 2/2 creature (Grizzly Bears) takes exactly lethal damage and dies;
+ *     a sturdier 3/3 creature (Centaur Courser) survives.
+ *
+ *  2. Two Caves on the battlefield plus one Cave card in the graveyard → X = 3.
+ *     Adding the graveyard Cave raises X by 1; the formerly-surviving 3/3
+ *     (Centaur Courser) now takes exactly lethal damage and dies.
+ */
+class CalamitousCaveInScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CalamitousCaveIn)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /**
+     * Drain the stack without expecting any interactive decisions: just pass priority
+     * until the stack is empty (the sorcery resolves and SBAs clean up dying creatures).
+     */
+    fun GameTestDriver.drainStack(maxIterations: Int = 20) {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard++ < maxIterations) {
+            bothPass()
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: 2 Caves controlled, 0 Cave cards in GY → X = 2
+    //         Kills a 2/2; a 3/3 survives.
+    // ─────────────────────────────────────────────────────────────────────────
+    test("two Caves on the battlefield deal 2 damage to all creatures; 2/2 dies, 3/3 survives") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Caster controls two Cave lands (counts as X = 2).
+        driver.putPermanentOnBattlefield(me, "Captivating Cave")
+        driver.putPermanentOnBattlefield(me, "Captivating Cave")
+
+        // Opponent's board: Grizzly Bears (2/2) should die; Centaur Courser (3/3) should live.
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        val caveInCard = driver.putCardInHand(me, "Calamitous Cave-In")
+        // {3}{R}: 3 colorless + 1 red
+        driver.giveColorlessMana(me, 3)
+        driver.giveMana(me, Color.RED, 1)
+
+        val cast = driver.castSpell(me, caveInCard)
+        cast.isSuccess shouldBe true
+
+        driver.drainStack()
+
+        // Grizzly Bears (2 toughness) took 2 damage — exactly lethal → dead.
+        driver.findPermanent(opp, "Grizzly Bears") shouldBe null
+
+        // Centaur Courser (3 toughness) took 2 damage — not lethal → alive.
+        driver.findPermanent(opp, "Centaur Courser") shouldNotBe null
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: 2 Caves on the battlefield + 1 Cave card in the GY → X = 3
+    //         Graveyard Cave raises X to 3; the 3/3 now takes exactly lethal damage.
+    // ─────────────────────────────────────────────────────────────────────────
+    test("graveyard Cave increases X by 1; 3/3 that survived X=2 now dies at X=3") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Two Cave lands on the battlefield contribute 2 to X.
+        driver.putPermanentOnBattlefield(me, "Captivating Cave")
+        driver.putPermanentOnBattlefield(me, "Captivating Cave")
+        // One Cave card in the graveyard contributes +1 to X → X = 3.
+        driver.putCardInGraveyard(me, "Captivating Cave")
+
+        // A 3/3 creature that would survive X = 2 should die at X = 3.
+        driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        val caveInCard = driver.putCardInHand(me, "Calamitous Cave-In")
+        driver.giveColorlessMana(me, 3)
+        driver.giveMana(me, Color.RED, 1)
+
+        val cast = driver.castSpell(me, caveInCard)
+        cast.isSuccess shouldBe true
+
+        driver.drainStack()
+
+        // Centaur Courser (3 toughness) took 3 damage — exactly lethal → dead.
+        driver.findPermanent(opp, "Centaur Courser") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CanonizedInBloodScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CanonizedInBloodScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CanonizedInBlood
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Canonized in Blood (LCI #96): {1}{B} Enchantment
+ *
+ * 1. At the beginning of your end step, if you descended this turn, put a +1/+1 counter on
+ *    target creature you control.
+ * 2. {5}{B}{B}, Sacrifice this enchantment: Create a 4/3 white and black Vampire Demon creature
+ *    token with flying.
+ *
+ * Tests:
+ * 1. No counter is placed at the end step when the controller has not descended.
+ * 2. A +1/+1 counter is placed on the targeted creature when descended this turn.
+ * 3. Paying {5}{B}{B} and sacrificing the enchantment creates a 4/3 flying Vampire Demon token
+ *    and removes the enchantment from the battlefield.
+ */
+class CanonizedInBloodScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CanonizedInBlood))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    /**
+     * Move a permanent card to the graveyard to trigger descend (CR 700.11).
+     */
+    fun GameTestDriver.descend(entityId: EntityId) {
+        val result = ZoneTransitionService.moveToZone(
+            state = state,
+            entityId = entityId,
+            destinationZone = Zone.GRAVEYARD
+        )
+        replaceState(result.state)
+    }
+
+    fun plusCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.vampireDemonTokens(playerId: EntityId): List<EntityId> =
+        getCreatures(playerId).filter { getCardName(it) == "Vampire Demon Token" }
+
+    // -------------------------------------------------------------------------
+    // Test 1: trigger does not fire if not descended
+    // -------------------------------------------------------------------------
+    test("no counter is placed at end step when the controller has not descended") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Canonized in Blood")
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+        val countersBefore = plusCounters(driver, bear)
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        // Trigger should not have fired — no ChooseTargetsDecision pending.
+        (driver.pendingDecision is ChooseTargetsDecision) shouldBe false
+        plusCounters(driver, bear) shouldBe countersBefore
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: trigger fires and puts a +1/+1 counter on the targeted creature
+    // -------------------------------------------------------------------------
+    test("descended this turn: puts a +1/+1 counter on target creature at end step") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Canonized in Blood")
+        val bear = driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+        // Descend: move a permanent card (creature in hand) to the graveyard.
+        val handBear = driver.putCardInHand(player, "Grizzly Bears")
+        driver.descend(handBear)
+
+        val countersBefore = plusCounters(driver, bear)
+
+        // Advance to end step; the trigger fires and requests a target.
+        driver.passPriorityUntil(Step.END)
+        var safety = 0
+        while (safety++ < 20) {
+            when {
+                driver.pendingDecision is ChooseTargetsDecision ->
+                    driver.submitTargetSelection(player, listOf(bear))
+                driver.stackSize > 0 -> driver.bothPass()
+                else -> break
+            }
+        }
+
+        plusCounters(driver, bear) shouldBe countersBefore + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: activated ability — sacrifice enchantment, create Vampire Demon token
+    // -------------------------------------------------------------------------
+    test("{5}{B}{B} + sacrifice: creates a 4/3 flying Vampire Demon token and removes the enchantment") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val enchantment = driver.putPermanentOnBattlefield(player, "Canonized in Blood")
+        val tokensBefore = driver.vampireDemonTokens(player).size
+
+        // Pay {5}{B}{B} — 5 colorless + 2 black.
+        driver.giveColorlessMana(player, 5)
+        driver.giveMana(player, Color.BLACK, 2)
+
+        val abilityId = driver.cardRegistry.requireCard("Canonized in Blood").activatedAbilities[0].id
+        driver.submitSuccess(
+            ActivateAbility(playerId = player, sourceId = enchantment, abilityId = abilityId)
+        )
+        driver.bothPass() // let the ability resolve
+
+        // The enchantment is sacrificed as part of the cost.
+        driver.findPermanent(player, "Canonized in Blood") shouldBe null
+
+        // A 4/3 Vampire Demon token with flying is created.
+        val tokensAfter = driver.vampireDemonTokens(player)
+        tokensAfter.size shouldBe tokensBefore + 1
+
+        val token = tokensAfter.first()
+        driver.state.projectedState.getPower(token) shouldBe 4
+        driver.state.projectedState.getToughness(token) shouldBe 3
+        driver.state.projectedState.hasKeyword(token, Keyword.FLYING) shouldBe true
+
+        // The token is white and black.
+        driver.state.projectedState.hasColor(token, Color.WHITE) shouldBe true
+        driver.state.projectedState.hasColor(token, Color.BLACK) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptainStormCosmiumRaiderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CaptainStormCosmiumRaiderScenarioTest.kt
@@ -1,0 +1,130 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CaptainStormCosmiumRaider
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Captain Storm, Cosmium Raider (LCI #227).
+ *
+ * "Whenever an artifact you control enters, put a +1/+1 counter on target Pirate you control."
+ *
+ * Proves three scenarios:
+ *  1. Happy path — artifact enters → trigger fires → target Storm (itself a Pirate) →
+ *     Storm gains a +1/+1 counter.
+ *  2. Two artifacts entering in the same turn → two separate triggers, two counters.
+ *  3. Different target Pirate — when a second Pirate (Ragavan) is on the battlefield the
+ *     trigger can target it instead, leaving Storm with no counter.
+ */
+class CaptainStormCosmiumRaiderScenarioTest : FunSpec({
+
+    // A simple {0} artifact used to fire the "artifact you control enters" trigger.
+    val testArtifact = card("Test Artifact") {
+        manaCost = "{0}"
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CaptainStormCosmiumRaider)
+        driver.registerCard(testArtifact)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 1: happy path — artifact enters, trigger fires, Captain Storm is targeted
+    // ──────────────────────────────────────────────────────────────────────────
+
+    test("an artifact you control entering fires the trigger; Storm (a Pirate) gains a +1/+1 counter") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        // Captain Storm is itself a Legendary Creature — Human Pirate; it is a legal target.
+        val captain = driver.putCreatureOnBattlefield(me, "Captain Storm, Cosmium Raider")
+
+        // Cast the free artifact to fire the ETB trigger.
+        val artifact = driver.putCardInHand(me, "Test Artifact")
+        driver.castSpell(me, artifact).isSuccess shouldBe true
+        driver.bothPass() // artifact resolves, ETB trigger put on stack
+
+        // Engine pauses for target selection.
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(captain))
+        driver.bothPass() // trigger resolves
+
+        plusOneCounters(driver, captain) shouldBe 1
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 2: two artifacts entering in the same turn → two separate triggers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    test("each artifact entering fires a separate trigger; two artifacts yield two counters on Storm") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val captain = driver.putCreatureOnBattlefield(me, "Captain Storm, Cosmium Raider")
+
+        // First artifact.
+        driver.castSpell(me, driver.putCardInHand(me, "Test Artifact")).isSuccess shouldBe true
+        driver.bothPass() // first artifact resolves
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(captain))
+        driver.bothPass() // first trigger resolves → 1 counter
+
+        plusOneCounters(driver, captain) shouldBe 1
+
+        // Second artifact.
+        driver.castSpell(me, driver.putCardInHand(me, "Test Artifact")).isSuccess shouldBe true
+        driver.bothPass() // second artifact resolves
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(captain))
+        driver.bothPass() // second trigger resolves → 2 counters
+
+        plusOneCounters(driver, captain) shouldBe 2
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 3: any Pirate you control is a valid target, not just Storm itself
+    // ──────────────────────────────────────────────────────────────────────────
+
+    test("trigger can target any Pirate you control, not only Captain Storm itself") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+
+        val captain = driver.putCreatureOnBattlefield(me, "Captain Storm, Cosmium Raider")
+        // Ragavan is a Monkey Pirate; it is a valid target for the trigger.
+        val ragavan = driver.putCreatureOnBattlefield(me, "Ragavan, Nimble Pilferer")
+
+        val artifact = driver.putCardInHand(me, "Test Artifact")
+        driver.castSpell(me, artifact).isSuccess shouldBe true
+        driver.bothPass() // artifact resolves, trigger fires
+
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        // Target Ragavan instead of Storm.
+        driver.submitTargetSelection(me, listOf(ragavan))
+        driver.bothPass() // trigger resolves
+
+        // Ragavan received the counter; Storm did not.
+        plusOneCounters(driver, ragavan) shouldBe 1
+        plusOneCounters(driver, captain) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChildOfTheVolcanoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ChildOfTheVolcanoScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.ChildOfTheVolcano
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Child of the Volcano (LCI #140): {3}{R} 3/3 Elemental
+ *
+ * Trample
+ * "At the beginning of your end step, if you descended this turn, put a +1/+1 counter on this creature."
+ *
+ * Tests:
+ * 1. No +1/+1 counter is placed at end step when the controller has not descended.
+ * 2. A +1/+1 counter is placed at end step when the controller has descended this turn.
+ */
+class ChildOfTheVolcanoScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(ChildOfTheVolcano))
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    /** Move a permanent card to the graveyard to trigger the descend counter (CR 700.11). */
+    fun GameTestDriver.descend(entityId: EntityId) {
+        val result = ZoneTransitionService.moveToZone(
+            state = state,
+            entityId = entityId,
+            destinationZone = Zone.GRAVEYARD
+        )
+        replaceState(result.state)
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, id: EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("no +1/+1 counter is placed at end step when the controller has not descended") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val child = driver.putCreatureOnBattlefield(player, "Child of the Volcano")
+
+        val countersBefore = plusOneCounters(driver, child)
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        plusOneCounters(driver, child) shouldBe countersBefore
+    }
+
+    test("a +1/+1 counter is placed at end step when the controller has descended this turn") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val child = driver.putCreatureOnBattlefield(player, "Child of the Volcano")
+
+        // Put a permanent (creature) card into the graveyard — this satisfies CR 700.11 descend.
+        val bears = driver.putCardInHand(player, "Grizzly Bears")
+        driver.descend(bears)
+
+        val countersBefore = plusOneCounters(driver, child)
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass() // EOT trigger fires and resolves, placing the counter
+
+        plusOneCounters(driver, child) shouldBe countersBefore + 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoatiScavengerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CoatiScavengerScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CoatiScavenger
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Coati Scavenger (LCI #179): {2}{G} 3/2 Creature — Raccoon
+ * "Descend 4 — When this creature enters, if there are four or more permanent cards in your
+ * graveyard, return target permanent card from your graveyard to your hand."
+ *
+ * Tests:
+ *  - With four or more permanent cards in the graveyard: ETB trigger fires, the controller
+ *    selects a target permanent card from their graveyard, and it returns to their hand.
+ *  - With fewer than four permanent cards in the graveyard: the intervening-if condition
+ *    (Descend 4) is not met, the trigger does not fire, and graveyard remains unchanged.
+ */
+class CoatiScavengerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CoatiScavenger))
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        return driver
+    }
+
+    test("ETB trigger fires and returns a permanent card to hand when four or more permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // Seed the graveyard with exactly four permanent cards — meets the Descend 4 threshold.
+        // The first one is the card we will choose to return to hand; the others pad the count.
+        val returnTarget = driver.putCardInGraveyard(player, "Grizzly Bears")
+        repeat(3) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        // Cast Coati Scavenger ({2}{G}).
+        val coati = driver.putCardInHand(player, "Coati Scavenger")
+        driver.giveColorlessMana(player, 2)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.castSpell(player, coati)
+        // Coati Scavenger resolves → enters the battlefield → ETB trigger's intervening-if
+        // condition is true (four permanent cards in graveyard) → trigger fires and pauses for
+        // the controller to choose a target permanent card from their graveyard.
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(player, listOf(returnTarget)).isSuccess shouldBe true
+        // ETB trigger resolves: return target permanent card from graveyard to hand.
+        driver.bothPass()
+
+        driver.getHand(player) shouldContain returnTarget
+        driver.getGraveyard(player) shouldNotContain returnTarget
+    }
+
+    test("ETB trigger does not fire when fewer than four permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // Seed the graveyard with only three permanent cards — one short of the Descend 4 threshold.
+        val graveyardCards = List(3) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        // Cast Coati Scavenger ({2}{G}).
+        val coati = driver.putCardInHand(player, "Coati Scavenger")
+        driver.giveColorlessMana(player, 2)
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.castSpell(player, coati)
+        // Coati Scavenger resolves → enters the battlefield → ETB trigger's intervening-if
+        // condition is false (only three permanent cards in graveyard, not four) → trigger
+        // does not fire; no ChooseTargetsDecision is issued.
+        driver.bothPass()
+
+        (driver.pendingDecision is ChooseTargetsDecision) shouldBe false
+
+        // All three graveyard cards remain in the graveyard — nothing was returned.
+        graveyardCards.forEach { driver.getGraveyard(player) shouldContain it }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CorpsesOfTheLostScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CorpsesOfTheLostScenarioTest.kt
@@ -1,0 +1,172 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CorpsesOfTheLost
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Corpses of the Lost (LCI #98): {2}{B} Enchantment
+ *
+ * 1. Skeletons you control get +1/+0 and have haste (static anthem).
+ * 2. When this enchantment enters, create a 2/2 black Skeleton Pirate creature token (ETB).
+ * 3. At the beginning of your end step, if you descended this turn, you may pay 1 life.
+ *    If you do, return this enchantment to its owner's hand.
+ * 4. The end-step trigger does not fire if the controller has not descended.
+ */
+class CorpsesOfTheLostScenarioTest : FunSpec({
+
+    // A minimal 1/1 Skeleton for testing the static anthem without any extra abilities.
+    val testSkeleton = card("Test Skeleton") {
+        manaCost = "{B}"
+        typeLine = "Creature — Skeleton"
+        power = 1
+        toughness = 1
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CorpsesOfTheLost, testSkeleton))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    /**
+     * Move a permanent card to the graveyard to fire the zone-change event and
+     * increment the descend counter (CR 700.11).
+     */
+    fun GameTestDriver.descend(entityId: EntityId) {
+        val result = ZoneTransitionService.moveToZone(
+            state = state,
+            entityId = entityId,
+            destinationZone = Zone.GRAVEYARD
+        )
+        replaceState(result.state)
+    }
+
+    fun GameTestDriver.skeletonPirateTokens(playerId: EntityId): List<EntityId> =
+        getCreatures(playerId).filter { getCardName(it) == "Skeleton Pirate Token" }
+
+    // -------------------------------------------------------------------------
+    // Test 1: ETB creates a 2/2 black Skeleton Pirate token
+    // -------------------------------------------------------------------------
+    test("enters: creates a 2/2 black Skeleton Pirate creature token") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tokensBefore = driver.skeletonPirateTokens(player).size
+
+        // Cast Corpses of the Lost — {2}{B}.
+        val enchantment = driver.putCardInHand(player, "Corpses of the Lost")
+        driver.giveMana(player, Color.BLACK, 3)
+        driver.castSpell(player, enchantment).isSuccess shouldBe true
+
+        // Resolve the enchantment spell and its ETB token-creation trigger.
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && !driver.isPaused && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        val tokensAfter = driver.skeletonPirateTokens(player)
+        tokensAfter.size shouldBe tokensBefore + 1
+
+        val token = tokensAfter.first()
+        // Base stats are 2/2. The enchantment's own anthem (+1/+0 to Skeletons you control)
+        // is already active when the token enters, so projected power is 2+1 = 3.
+        driver.state.projectedState.getPower(token) shouldBe 3
+        driver.state.projectedState.getToughness(token) shouldBe 2
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: Skeletons you control get +1/+0 and have haste
+    // -------------------------------------------------------------------------
+    test("static: Skeletons you control get +1/+0 and have haste") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Put the enchantment on the battlefield directly (no ETB fires).
+        driver.putPermanentOnBattlefield(player, "Corpses of the Lost")
+
+        // Put a 1/1 Skeleton onto the battlefield.
+        val skeleton = driver.putCreatureOnBattlefield(player, "Test Skeleton")
+
+        // The static anthem should give it +1/+0, making it a 2/1, and grant haste.
+        driver.state.projectedState.getPower(skeleton) shouldBe 2
+        driver.state.projectedState.getToughness(skeleton) shouldBe 1
+        driver.state.projectedState.hasKeyword(skeleton, Keyword.HASTE) shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: End-step trigger fires when descended; paying 1 life bounces to hand
+    // -------------------------------------------------------------------------
+    test("descended: end-step trigger fires and paying 1 life returns enchantment to hand") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val enchantment = driver.putPermanentOnBattlefield(player, "Corpses of the Lost")
+        val lifeBefore = driver.getLifeTotal(player)
+        val handSizeBefore = driver.getHandSize(player)
+
+        // Descend: put a permanent card into the graveyard.
+        val bearCard = driver.putCardInHand(player, "Grizzly Bears")
+        driver.descend(bearCard)
+
+        // Advance to end step and resolve the descended trigger.
+        driver.passPriorityUntil(Step.END)
+        var safety = 0
+        while (safety++ < 20) {
+            when {
+                driver.pendingDecision is YesNoDecision ->
+                    driver.submitYesNo(player, true) // "Yes, pay 1 life"
+                driver.stackSize > 0 -> driver.bothPass()
+                else -> break
+            }
+        }
+
+        // Life decreased by 1 (the payment).
+        driver.getLifeTotal(player) shouldBe lifeBefore - 1
+
+        // The enchantment left the battlefield and is now in hand.
+        driver.findPermanent(player, "Corpses of the Lost") shouldBe null
+        driver.getHandSize(player) shouldBe handSizeBefore + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: End-step trigger does NOT fire if the controller has not descended
+    // -------------------------------------------------------------------------
+    test("not descended: end-step trigger does not fire") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val enchantment = driver.putPermanentOnBattlefield(player, "Corpses of the Lost")
+
+        // Do NOT descend — just advance to the end step.
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        // The trigger should not have fired — no YesNoDecision pending.
+        (driver.pendingDecision is YesNoDecision) shouldBe false
+
+        // The enchantment remains on the battlefield.
+        driver.findPermanent(player, "Corpses of the Lost") shouldNotBe null
+        driver.findPermanent(player, "Corpses of the Lost") shouldBe enchantment
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CosmiumConfluenceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CosmiumConfluenceScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CosmiumConfluence
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Cosmium Confluence (LCI #181) — {4}{G} Sorcery.
+ *
+ * "Choose three. You may choose the same mode more than once.
+ * • Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.
+ * • Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature
+ *   with haste. It's still a land.
+ * • Destroy target enchantment."
+ *
+ * Covered:
+ *  1. Choosing the same mode more than once (allowRepeat = true): mode 2 (destroy enchantment)
+ *     chosen twice and mode 1 (animate Cave) once — two enchantments are destroyed and one
+ *     Cave receives 3 +1/+1 counters and becomes a 0/0 Elemental creature permanently.
+ *
+ *  2. Mixed selection with repeated mode 1: mode 1 chosen twice (two different Caves, each
+ *     receiving 3 +1/+1 counters and becoming animated) and mode 2 once (destroys one
+ *     enchantment). Confirms the Confluence processes each mode-slot independently.
+ */
+class CosmiumConfluenceScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CosmiumConfluence)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Count +1/+1 counters on a permanent. */
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Drain the stack without interactive decisions (no library searches or modal re-choices). */
+    fun GameTestDriver.drainStack(maxIterations: Int = 20) {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard++ < maxIterations) {
+            bothPass()
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 1: Choose mode 2 twice and mode 1 once.
+    //         Verifies allowRepeat by using mode 2 (destroy enchantment) two times.
+    // ─────────────────────────────────────────────────────────────────────────────
+    test("choosing destroy enchantment twice and animate Cave once destroys both enchantments and animates Cave") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // One Cave you control (target for mode 1).
+        val cave = driver.putPermanentOnBattlefield(me, "Captivating Cave")
+
+        // Two enchantments for opponent (targets for the two mode 2 slots).
+        val ench1 = driver.putPermanentOnBattlefield(opp, "Test Enchantment")
+        val ench2 = driver.putPermanentOnBattlefield(opp, "Test Enchantment")
+
+        val spell = driver.putCardInHand(me, "Cosmium Confluence")
+        // {4}{G}: 4 colorless + 1 green.
+        driver.giveColorlessMana(me, 4)
+        driver.giveMana(me, Color.GREEN, 1)
+
+        // chosenModes = [2, 2, 1]: destroy ench1, destroy ench2, animate cave.
+        val cast = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(
+                    ChosenTarget.Permanent(ench1),
+                    ChosenTarget.Permanent(ench2),
+                    ChosenTarget.Permanent(cave)
+                ),
+                chosenModes = listOf(2, 2, 1),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(ench1)),
+                    listOf(ChosenTarget.Permanent(ench2)),
+                    listOf(ChosenTarget.Permanent(cave))
+                )
+            )
+        )
+        cast.isSuccess shouldBe true
+
+        driver.drainStack()
+
+        // Both enchantments should be destroyed.
+        driver.findPermanent(opp, "Test Enchantment") shouldBe null
+
+        // Cave should still be on the battlefield (permanent animation, not exiled/destroyed).
+        driver.findPermanent(me, "Captivating Cave") shouldNotBe null
+
+        // Mode 1 placed exactly 3 +1/+1 counters on the Cave.
+        plusOneCounters(driver, cave) shouldBe 3
+
+        // Mode 1 animated the Cave to a 0/0 Elemental creature (permanent BecomeCreature).
+        driver.state.projectedState.isCreature(cave) shouldBe true
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 2: Choose mode 1 twice and mode 2 once.
+    //         Two different Caves are animated; one enchantment is destroyed.
+    // ─────────────────────────────────────────────────────────────────────────────
+    test("choosing animate Cave twice and destroy enchantment once animates both Caves and destroys enchantment") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Two Caves you control (each targeted separately by the two mode 1 slots).
+        val cave1 = driver.putPermanentOnBattlefield(me, "Captivating Cave")
+        val cave2 = driver.putPermanentOnBattlefield(me, "Captivating Cave")
+
+        // One enchantment for mode 2.
+        val ench = driver.putPermanentOnBattlefield(opp, "Test Enchantment")
+
+        val spell = driver.putCardInHand(me, "Cosmium Confluence")
+        driver.giveColorlessMana(me, 4)
+        driver.giveMana(me, Color.GREEN, 1)
+
+        // chosenModes = [1, 1, 2]: animate cave1, animate cave2, destroy ench.
+        val cast = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(
+                    ChosenTarget.Permanent(cave1),
+                    ChosenTarget.Permanent(cave2),
+                    ChosenTarget.Permanent(ench)
+                ),
+                chosenModes = listOf(1, 1, 2),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(cave1)),
+                    listOf(ChosenTarget.Permanent(cave2)),
+                    listOf(ChosenTarget.Permanent(ench))
+                )
+            )
+        )
+        cast.isSuccess shouldBe true
+
+        driver.drainStack()
+
+        // Enchantment should be destroyed.
+        driver.findPermanent(opp, "Test Enchantment") shouldBe null
+
+        // Each Cave should have exactly 3 +1/+1 counters from its mode 1 slot.
+        plusOneCounters(driver, cave1) shouldBe 3
+        plusOneCounters(driver, cave2) shouldBe 3
+
+        // Both Caves should be animated into creatures.
+        driver.state.projectedState.isCreature(cave1) shouldBe true
+        driver.state.projectedState.isCreature(cave2) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CouncilOfEchoesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CouncilOfEchoesScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CouncilOfEchoes
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Council of Echoes (LCI #51): {4}{U}{U} 4/4 Creature — Spirit Advisor
+ * "Flying
+ *  Descend 4 — When this creature enters, if there are four or more permanent cards in your
+ *  graveyard, return up to one target nonland permanent other than this creature to its owner's
+ *  hand."
+ *
+ * Tests:
+ *  - With four or more permanent cards in the graveyard: ETB trigger fires, the controller
+ *    selects a nonland permanent on the battlefield to bounce (not the Council itself), and
+ *    it returns to its owner's hand.
+ *  - With fewer than four permanent cards in the graveyard: the intervening-if condition
+ *    (Descend 4) is not met; the trigger does not fire and no ChooseTargetsDecision is issued.
+ *  - "Up to one" is optional: when the condition is met the controller may decline to choose
+ *    any target; the trigger resolves as a no-op and the battlefield is unchanged.
+ */
+class CouncilOfEchoesScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CouncilOfEchoes))
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        return driver
+    }
+
+    test("ETB trigger fires and bounces chosen nonland permanent when four or more permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // A nonland permanent on the battlefield for the trigger to target.
+        val bounceTarget = driver.putPermanentOnBattlefield(player, "Grizzly Bears")
+
+        // Seed the graveyard with exactly four permanent cards — meets the Descend 4 threshold.
+        repeat(4) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        // Cast Council of Echoes ({4}{U}{U}).
+        val council = driver.putCardInHand(player, "Council of Echoes")
+        driver.giveColorlessMana(player, 4)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.castSpell(player, council)
+        // Council of Echoes resolves → enters the battlefield → the intervening-if condition
+        // is true (four permanent cards in graveyard) → trigger fires and pauses for the
+        // controller to choose up to one nonland permanent other than the Council itself.
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(player, listOf(bounceTarget)).isSuccess shouldBe true
+        // ETB trigger resolves: return target nonland permanent to its owner's hand.
+        driver.bothPass()
+
+        driver.getHand(player) shouldContain bounceTarget
+        driver.getPermanents(player) shouldNotContain bounceTarget
+    }
+
+    test("ETB trigger does not fire when fewer than four permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // Seed the graveyard with only three permanent cards — one short of the Descend 4 threshold.
+        repeat(3) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        // Cast Council of Echoes ({4}{U}{U}).
+        val council = driver.putCardInHand(player, "Council of Echoes")
+        driver.giveColorlessMana(player, 4)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.castSpell(player, council)
+        // Council resolves → enters the battlefield → intervening-if condition is false
+        // (only three permanent cards in graveyard) → trigger does not fire; no
+        // ChooseTargetsDecision is issued.
+        driver.bothPass()
+
+        (driver.pendingDecision is ChooseTargetsDecision) shouldBe false
+    }
+
+    test("controller may choose no target when condition is met — trigger resolves as no-op") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // A nonland permanent eligible to be bounced, but the controller will decline.
+        val eligibleTarget = driver.putPermanentOnBattlefield(player, "Grizzly Bears")
+
+        // Seed the graveyard with four permanent cards — condition is met.
+        repeat(4) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        val council = driver.putCardInHand(player, "Council of Echoes")
+        driver.giveColorlessMana(player, 4)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.castSpell(player, council)
+        driver.bothPass()
+
+        // Condition is met, so a ChooseTargetsDecision is issued.
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        // Decline — choose zero targets ("up to one" allows this).
+        driver.submitTargetSelection(player, emptyList()).isSuccess shouldBe true
+        driver.bothPass()
+
+        // No bounce occurred; the eligible permanent remains on the battlefield.
+        driver.getPermanents(player) shouldContain eligibleTarget
+        driver.getHand(player) shouldNotContain eligibleTarget
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessDismantlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessDismantlerScenarioTest.kt
@@ -6,8 +6,12 @@ import com.wingedsheep.engine.core.NumberChosenResponse
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.lci.cards.DauntlessDismantler
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -28,9 +32,39 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  */
 class DauntlessDismantlerScenarioTest : FunSpec({
 
+    // A {0} creature whose ETB creates a predefined Map artifact token (noncreature artifact),
+    // exercising the CreatePredefinedTokenExecutor path — the exact Waterwind Scout repro.
+    val mapMaker = card("Map Maker (test)") {
+        manaCost = "{0}"
+        typeLine = "Creature — Scout"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.CreateMapToken(1)
+        }
+    }
+
+    // A {0} creature whose ETB creates a 1/1 Artifact Creature — Construct token, exercising the
+    // general CreateTokenExecutor path.
+    val constructMaker = card("Construct Maker (test)") {
+        manaCost = "{0}"
+        typeLine = "Creature — Scout"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.CreateToken(
+                power = 1, toughness = 1, creatureTypes = setOf("Construct"), artifactToken = true,
+            )
+        }
+    }
+
     fun driver(): GameTestDriver {
         val d = GameTestDriver()
-        d.registerCards(TestCards.all + listOf(DauntlessDismantler))
+        d.registerCards(TestCards.all + listOf(DauntlessDismantler, mapMaker, constructMaker))
+        // CreatePredefinedTokenExecutor looks up the Map token definition by name.
+        d.registerCards(PredefinedTokens.allTokens)
         return d
     }
 
@@ -137,5 +171,75 @@ class DauntlessDismantlerScenarioTest : FunSpec({
 
         // Triskelion (MV 6) was NOT destroyed — it survives X=1.
         d.findPermanent(opp, "Triskelion") shouldNotBe null
+    }
+
+    // -------------------------------------------------------------------------
+    // Replacement applies to TOKENS too — "Artifacts your opponents control enter tapped"
+    // taps artifact tokens an opponent creates, not only cast/played artifacts.
+    // -------------------------------------------------------------------------
+
+    /**
+     * The reported bug: an opponent's Map token (created by Waterwind Scout in play) should enter
+     * tapped while player1's Dauntless Dismantler is on the battlefield. Predefined-token path
+     * (CreatePredefinedTokenExecutor).
+     */
+    test("opponent's created Map artifact token enters tapped (replacement applies to tokens)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!               // player2 — will create the token
+        val dismantlerOwner = d.getOpponent(active) // player1 — controls Dismantler
+
+        d.putCreatureOnBattlefield(dismantlerOwner, "Dauntless Dismantler")
+
+        // Player2 casts the {0} maker; its ETB creates a Map token under player2 (an opponent of
+        // Dismantler's controller).
+        val makerId = d.putCardInHand(active, "Map Maker (test)")
+        d.castSpell(active, makerId).isSuccess shouldBe true
+        repeat(12) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        val map = d.findPermanent(active, "Map")!!
+        d.isTapped(map) shouldBe true
+    }
+
+    /**
+     * The general CreateTokenExecutor path: an opponent's artifact-creature token also enters
+     * tapped under Dauntless Dismantler.
+     */
+    test("opponent's created artifact-creature token enters tapped (general token path)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!
+        val dismantlerOwner = d.getOpponent(active)
+
+        d.putCreatureOnBattlefield(dismantlerOwner, "Dauntless Dismantler")
+
+        val makerId = d.putCardInHand(active, "Construct Maker (test)")
+        d.castSpell(active, makerId).isSuccess shouldBe true
+        repeat(12) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        val construct = d.findPermanent(active, "Construct Token")!!
+        d.isTapped(construct) shouldBe true
+    }
+
+    /**
+     * Opponent-scoped: the Dismantler controller's OWN artifact token enters untapped — the
+     * replacement must not over-apply.
+     */
+    test("controller's own created artifact token does NOT enter tapped (opponent-scoped)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!  // player1 — controls Dismantler and makes the token
+
+        d.putCreatureOnBattlefield(active, "Dauntless Dismantler")
+
+        val makerId = d.putCardInHand(active, "Map Maker (test)")
+        d.castSpell(active, makerId).isSuccess shouldBe true
+        repeat(12) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        val map = d.findPermanent(active, "Map")!!
+        d.isTapped(map) shouldBe false
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessDismantlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessDismantlerScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.DauntlessDismantler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Dauntless Dismantler (LCI) — {1}{W} Creature — Human Artificer 1/4
+ *
+ * "Artifacts your opponents control enter tapped."
+ * "{X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X."
+ *
+ * Tests:
+ * 1. [PermanentsEnterTapped] replacement fires for opponents' artifacts — they enter tapped.
+ * 2. Replacement does NOT fire for the controller's own artifacts (opponent-scoped filter).
+ * 3. Activating with X=N destroys only artifacts with mana value N; Dismantler is sacrificed;
+ *    artifacts with a different mana value survive.
+ */
+class DauntlessDismantlerScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(DauntlessDismantler))
+        return d
+    }
+
+    // -------------------------------------------------------------------------
+    // Replacement effect — artifacts opponents control enter tapped
+    // -------------------------------------------------------------------------
+
+    /**
+     * Player 2 is the starting/active player. Player 1 (non-active) controls Dismantler.
+     * When player 2 (an opponent of player 1) casts Sol Ring during their main phase,
+     * the enters-tapped replacement fires and Sol Ring arrives tapped.
+     */
+    test("opponent's artifact enters tapped while Dismantler controls the battlefield") {
+        // startingPlayer = 1 makes player2 the active player so they can cast sorcery-speed
+        // permanents during their own main phase while player1's Dismantler is already in play.
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!            // player2 — will cast the artifact
+        val dismantlerOwner = d.getOpponent(active) // player1 — controls Dismantler
+
+        // Dismantler on player1's battlefield (replacement effect now active).
+        d.putCreatureOnBattlefield(dismantlerOwner, "Dauntless Dismantler")
+
+        // Player2 casts Sol Ring ({1}, MV 1) from hand — they are an opponent of player1.
+        val solRingId = d.putCardInHand(active, "Sol Ring")
+        d.giveColorlessMana(active, 1)
+        d.castSpell(active, solRingId).isSuccess shouldBe true
+        // Resolve the stack (Sol Ring resolves; no further triggered abilities expected).
+        repeat(10) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Sol Ring entered under player2 (opponent of Dismantler's controller) → tapped.
+        val solRing = d.findPermanent(active, "Sol Ring")!!
+        d.isTapped(solRing) shouldBe true
+    }
+
+    /**
+     * The replacement is opponent-scoped: the controller's own artifacts enter untapped.
+     */
+    test("controller's own artifact does NOT enter tapped (replacement is opponent-scoped)") {
+        val d = driver()
+        // Default startingPlayer=0: player1 is active and can cast sorcery-speed spells.
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!  // player1
+
+        d.putCreatureOnBattlefield(active, "Dauntless Dismantler")
+
+        // Player1 (Dismantler's controller) casts their own Sol Ring.
+        val solRingId = d.putCardInHand(active, "Sol Ring")
+        d.giveColorlessMana(active, 1)
+        d.castSpell(active, solRingId).isSuccess shouldBe true
+        repeat(10) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Sol Ring belongs to Dismantler's controller → NOT tapped.
+        val solRing = d.findPermanent(active, "Sol Ring")!!
+        d.isTapped(solRing) shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // Activated ability — {X}{X}{W}, Sacrifice: Destroy each artifact with MV X
+    // -------------------------------------------------------------------------
+
+    /**
+     * Activating with X=1 destroys all artifacts with mana value 1 (Sol Ring) and leaves
+     * artifacts with a different mana value (Triskelion, MV 6) untouched. The Dismantler
+     * is sacrificed as part of paying the cost (before the effect resolves).
+     */
+    test("activating with X=1 destroys MV-1 artifacts only; Dismantler is sacrificed") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+
+        val dismantler = d.putCreatureOnBattlefield(active, "Dauntless Dismantler")
+
+        // Set up targets on opponent's battlefield.
+        // Sol Ring ({1}, MV 1) — will be destroyed when X=1.
+        d.putPermanentOnBattlefield(opp, "Sol Ring")
+        // Triskelion ({6}, MV 6) — should survive when X=1.
+        d.putCreatureOnBattlefield(opp, "Triskelion")
+
+        // {X}{X}{W} with X=1 costs {1}{1}{W} = 2 generic + 1 white = 3 mana total.
+        d.giveMana(active, Color.WHITE, 1)
+        d.giveColorlessMana(active, 2)
+
+        val abilityId = DauntlessDismantler.activatedAbilities.first().id
+        // Bare activation (no pre-filled xValue) — engine pauses to ask for X.
+        val res = d.submit(ActivateAbility(playerId = active, sourceId = dismantler, abilityId = abilityId))
+        res.isPaused shouldBe true
+        d.pendingDecision.shouldBeInstanceOf<ChooseNumberDecision>()
+
+        // Choose X = 1.
+        d.submitDecision(active, NumberChosenResponse(d.pendingDecision!!.id, 1))
+        // Drain remaining decisions (mana payment, effect resolution, etc.).
+        repeat(15) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Dismantler was sacrificed as cost — no longer on battlefield.
+        d.findPermanent(active, "Dauntless Dismantler") shouldBe null
+
+        // Sol Ring (MV 1) was destroyed.
+        d.findPermanent(opp, "Sol Ring") shouldBe null
+
+        // Triskelion (MV 6) was NOT destroyed — it survives X=1.
+        d.findPermanent(opp, "Triskelion") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeepfathomEchoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeepfathomEchoScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.DeepfathomEcho
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Deepfathom Echo (LCI #228) — {2}{G}{U} 4/4 Creature — Merfolk Spirit
+ *
+ * "At the beginning of combat on your turn, this creature explores. Then you may have it
+ *  become a copy of another creature you control until end of turn."
+ *
+ * Tests:
+ *  1. Explore with a land on top → land goes to hand; player accepts the copy step →
+ *     Deepfathom Echo becomes a copy of the chosen other creature until end of turn
+ *     (copiable values only — power/toughness change, counters/attachments are unaffected).
+ *  2. Player declines the copy step → Deepfathom Echo stays a 4/4 Merfolk Spirit;
+ *     the land still went to hand from explore.
+ */
+class DeepfathomEchoScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DeepfathomEcho))
+        return driver
+    }
+
+    /**
+     * Advance to the begin-of-combat step on player 1's turn (mirrors the helper from
+     * JenovaAncientCalamityScenarioTest).
+     */
+    fun GameTestDriver.advanceToPlayer1BeginCombat() {
+        passPriorityUntil(Step.BEGIN_COMBAT)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.BEGIN_COMBAT)
+            safety++
+        }
+    }
+
+    test("explore (land → hand), accept copy: Echo becomes a copy of the chosen other creature until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Island" to 20),
+            startingLife = 20,
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        val player: EntityId = driver.player1
+
+        // Put Deepfathom Echo (4/4) and Grizzly Bears (2/2) on the battlefield.
+        val echo = driver.putCreatureOnBattlefield(player, "Deepfathom Echo")
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+        // Seed a land on top so explore takes the land-to-hand branch without pausing.
+        driver.putCardOnTopOfLibrary(player, "Forest")
+
+        val handSizeBefore = driver.getHandSize(player)
+
+        // Advance to player 1's begin-of-combat step. The trigger fires and goes on the stack;
+        // no decision is pending yet (no target is declared at stack-placement time — target
+        // selection is embedded inside the MayEffect and runs only at resolution if yes).
+        driver.advanceToPlayer1BeginCombat()
+
+        // Resolve the trigger: Explore runs (Forest → hand, no pause) → MayEffect → YesNoDecision.
+        driver.bothPass()
+
+        // The "you may have it become a copy" prompt should be pending.
+        (driver.pendingDecision is YesNoDecision) shouldBe true
+
+        // Accept the copy.
+        driver.submitYesNo(player, true)
+
+        // Grizzly Bears is the only other creature the controller controls (Deepfathom Echo is
+        // excluded by OtherCreatureYouControl's excludeSelf filter). SelectTargetEffect
+        // auto-selects it — no explicit ChooseTargetsDecision is expected.
+
+        // Advance state so the copy effect completes and priority is returned.
+        driver.bothPass()
+
+        // Forest went to hand during explore.
+        driver.getHandSize(player) shouldBe handSizeBefore + 1
+        driver.findCardInHand(player, "Forest").shouldNotBeNull()
+
+        // Deepfathom Echo is now a copy of Grizzly Bears: projected power/toughness = 2/2.
+        val projected = driver.state.projectedState
+        projected.getPower(echo) shouldBe 2
+        projected.getToughness(echo) shouldBe 2
+    }
+
+    test("explore (land → hand), decline copy: Echo remains a 4/4 Merfolk Spirit") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Island" to 20),
+            startingLife = 20,
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        val player: EntityId = driver.player1
+
+        val echo = driver.putCreatureOnBattlefield(player, "Deepfathom Echo")
+        // A second creature on the battlefield so the SelectTarget has a valid option,
+        // but the player will decline before any target is ever chosen.
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(player, "Forest")
+
+        val handSizeBefore = driver.getHandSize(player)
+
+        driver.advanceToPlayer1BeginCombat()
+
+        // Resolve the trigger: explore (Forest → hand) → MayEffect → YesNoDecision.
+        driver.bothPass()
+
+        (driver.pendingDecision is YesNoDecision) shouldBe true
+
+        // Decline the copy.
+        driver.submitYesNo(player, false)
+        driver.bothPass()
+
+        // Forest still went to hand during explore (explore is unconditional).
+        driver.getHandSize(player) shouldBe handSizeBefore + 1
+        driver.findCardInHand(player, "Forest").shouldNotBeNull()
+
+        // Deepfathom Echo was not copied — it is still a 4/4.
+        val projected = driver.state.projectedState
+        projected.getPower(echo) shouldBe 4
+        projected.getToughness(echo) shouldBe 4
+    }
+})


### PR DESCRIPTION
Depends on: https://github.com/wingedsheep/argentum-engine/pull/1252

## Lost Caverns of Ixalan — cards batch 5 (5 cards)

Stacked on `lci-cards-04`. This PR contains **only** the batch-5 diff against that base.

Adds five LCI cards plus one engine change (global enters-tapped replacements now apply to created tokens). Each card has a scenario test.

| Card | Cost | Type | Mechanic |
|------|------|------|----------|
| Corpses of the Lost | `{2}{B}` | Enchantment | Skeleton anthem (+1/+0 & haste); ETB 2/2 Skeleton Pirate token; end-step descend → may pay 1 life to bounce itself |
| Cosmium Confluence | `{4}{G}` | Sorcery | Choose three (repeatable): tutor a Cave (tapped) / animate a Cave permanently (+3 counters, 0/0 Elemental, still a land) / destroy target enchantment |
| Council of Echoes | `{4}{U}{U}` | Creature 4/4 | Flying; Descend 4 ETB → return up to one target nonland permanent other than itself to hand |
| Dauntless Dismantler | `{1}{W}` | Creature 1/4 | Artifacts your opponents control enter tapped; `{X}{X}{W}`, sac → destroy each artifact with mana value X |
| Deepfathom Echo | `{2}{G}{U}` | Creature 4/4 | Begin-combat: explores, then may become a copy of another creature you control until end of turn |

### Implementation notes

- **Corpses of the Lost** — split layer-6 anthem (`ModifyStats` +1/+0 and `GrantKeyword` haste over Skeletons you control); end-step intervening-if `Conditions.YouDescendedThisTurn()` (CR 700.11) with `OptionalCostEffect(PayLifeEffect(1), ifPaid = ReturnToHand(Self))`.
- **Cosmium Confluence** — `modal(chooseCount = 3, allowRepeat = true)`; mode 1 = `AddCounters` then `BecomeCreature(Duration.Permanent)` (permanent animation, still a land).
- **Council of Echoes** — Descend 4 is an ability word; modeled as intervening-if `CardsInGraveyardMatchingAtLeast(4, Permanent)` + optional `TargetOther(NonlandPermanent)` (up-to-one).
- **Dauntless Dismantler** — `PermanentsEnterTapped` runtime replacement scoped to `Artifact.opponentControls()`; `{X}{X}{W}, SacrificeSelf` destroys each artifact with `manaValueEqualsX()`.
- **Deepfathom Echo** — target for the copy is selected mid-resolution inside the `MayEffect`, so explore always runs and target selection happens only if the player accepts.

### Engine change — global enters-tapped replacements now apply to created tokens

`PermanentsEnterTapped` (Dauntless Dismantler, Authority of the Consuls, …) previously only affected cast/played permanents, not tokens. Added `EnterTappedReplacements.applyCreatedTokenEntryTap(...)`, a shared helper mirroring `ZoneTransitionService`'s CR-614 resolution order (consult `EnterUntappedReplacements` first, so an applicable "enters untapped" wins), called from every token-minting executor after `BattlefieldEntry.place(...)`. Entering tapped on entry is not a tap transition, so no `TappedEvent` is emitted (`TapEventEnforcementTest` allowlist updated). Fixes the reported Waterwind-Scout-under-Dismantler bug (an opponent's Map token now enters tapped).

### Tests

New scenario test classes for all five cards, all green (verified locally):
Corpses (4 — ETB token is 3/2 under its own anthem, static grant, descend bounce, no-descend no-op),
Cosmium (2 — `allowRepeat` mode 2×2 + mode 1, and mode 1×2 + mode 2),
Council (3 — Descend 4 met bounces, sub-threshold no-fire, up-to-one decline),
Dauntless (6 — opponent artifact + Map token + Construct token enter tapped, controller-scoped negatives, `{X}{X}{W}` X=1 destroy),
Deepfathom (2 — explore + accept copy → 2/2, explore + decline → stays 4/4).

`card-sdk-language-reference.md`, the LCI card snapshot, and the backlog implemented count (131 → 136) are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
