### PR TITLE
Add 5 Lost Caverns of Ixalan cards (batch 6)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 136 / 286
+**Implemented:** 141 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -74,19 +74,19 @@
 - [x] Deep-Cavern Bat
 - [x] Deepfathom Echo
 - [ ] Deeproot Pilgrimage
-- [ ] Defossilize
-- [ ] Diamond Pick-Axe
-- [ ] Didact Echo
+- [x] Defossilize
+- [x] Diamond Pick-Axe
+- [x] Didact Echo
 - [x] Digsite Conservator
 - [x] Dinotomaton
 - [ ] Dire Flail
 - [x] Disruptor Wanderglyph
-- [ ] Disturbed Slumber
+- [x] Disturbed Slumber
 - [ ] Dowsing Device
 - [ ] Dreadmaw's Ire
 - [x] Dusk Rose Reliquary
 - [x] Earthshaker Dreadmaw
-- [ ] Eaten by Piranhas
+- [x] Eaten by Piranhas
 - [ ] Echo of Dusk
 - [ ] Echoing Deeps
 - [x] Enterprising Scallywag

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 131 / 286
+**Implemented:** 136 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -60,19 +60,19 @@
 - [x] Compass Gnome
 - [x] Confounding Riddle
 - [ ] Contested Game Ball
-- [ ] Corpses of the Lost
+- [x] Corpses of the Lost
 - [x] Cosmium Blast
-- [ ] Cosmium Confluence
-- [ ] Council of Echoes
+- [x] Cosmium Confluence
+- [x] Council of Echoes
 - [ ] Curator of Sun's Creation
 - [x] Daring Discovery
-- [ ] Dauntless Dismantler
+- [x] Dauntless Dismantler
 - [x] Dead Weight
 - [x] Deathcap Marionette
 - [ ] Deconstruction Hammer
 - [x] Deep Goblin Skulltaker
 - [x] Deep-Cavern Bat
-- [ ] Deepfathom Echo
+- [x] Deepfathom Echo
 - [ ] Deeproot Pilgrimage
 - [ ] Defossilize
 - [ ] Diamond Pick-Axe

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6122,7 +6122,8 @@ replacementEffect {
   which is a self-replacement consumed once as the source enters, this is a *runtime* replacement
   stamped into the source's `ReplacementEffectSourceComponent` (`StaticAbilityHandler.isRuntimeReplacementEffect`)
   and consulted from the battlefield against OTHER permanents as they enter — so `appliesTo.filter`
-  describes the *affected* permanents. The entry-tap paths (`PlayLandHandler`, `ZoneTransitionService`)
+  describes the *affected* permanents. The entry-tap paths (`PlayLandHandler`, `ZoneTransitionService`,
+  `StackResolver`, and `CreateTokenExecutor` for created tokens)
   ask `EnterUntappedReplacements.entersUntapped(...)` before marking a permanent tapped and skip the
   tap when it matches. Per CR 614 ordering this collapses "would enter tapped via another replacement"
   (controller chooses untapped) and "simply put onto the battlefield tapped" (no replacement → untapped)
@@ -6136,11 +6137,13 @@ replacementEffect {
   Imposing Sovereign / Authority of the Consuls "creatures your opponents control enter tapped"). Like
   `EntersUntapped`, it is a *runtime* replacement stamped into the source's `ReplacementEffectSourceComponent`
   and consulted from the battlefield against OTHER permanents as they enter, so `appliesTo.filter` describes
-  the *affected* permanents. The entry paths (`PlayLandHandler`, `ZoneTransitionService`) call
+  the *affected* permanents. The entry paths (`PlayLandHandler`, `ZoneTransitionService`, `StackResolver`,
+  and `CreateTokenExecutor` for created tokens) call
   `EnterTappedReplacements.entersTapped(...)` and mark the permanent tapped — **after** consulting
-  `EnterUntappedReplacements`, so per CR 614 an applicable `EntersUntapped` still wins. (Creature ETBs via
-  the stack are not yet wired to the global scan — `StackResolver` only consults the entering card's own
-  `EntersTapped` — so the opponent-creature variants would additionally need that hook.)
+  `EnterUntappedReplacements`, so per CR 614 an applicable `EntersUntapped` still wins. Created tokens are
+  covered too: e.g. Dauntless Dismantler's "Artifacts your opponents control enter tapped" taps an
+  opponent's Map/Treasure/Clue token, and Authority of the Consuls taps opponents' creature tokens (a token
+  entering attacking keeps its tapped state and is not overridden).
 - `RedirectZoneChange(newDestination, appliesTo, linkToSource = false)` — redirect a zone change to a
   different destination (Rest in Peace / Leyline of the Void: graveyard → exile). `appliesTo` is an
   `EventPattern.ZoneChangeEvent(filter, from?, to?)`; the `filter`'s `controllerPredicate` scopes it

--- a/manual-scenarios/sets/lci/cards-5.json
+++ b/manual-scenarios/sets/lci/cards-5.json
@@ -1,0 +1,61 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Corpses of the Lost",
+      "Cosmium Confluence",
+      "Council of Echoes",
+      "Dauntless Dismantler",
+      "Deepfathom Echo"
+    ],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Captivating Cave", "Forest", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [
+      "Waterwind Scout",
+      "Millstone"
+    ],
+    "battlefield": [
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Swamp", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/sets/lci/cards-6.json
+++ b/manual-scenarios/sets/lci/cards-6.json
@@ -1,0 +1,51 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Defossilize",
+      "Didact Echo",
+      "Diamond Pick-Axe",
+      "Disturbed Slumber",
+      "Disturbed Slumber",
+      "Eaten by Piranhas"
+    ],
+    "battlefield": [
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": ["Grizzly Bears"],
+    "library": ["Grizzly Bears", "Island", "Forest", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Plains", "Island"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/EatenByPiranhasReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/EatenByPiranhasReprint.kt
@@ -1,0 +1,23 @@
+package com.wingedsheep.mtg.sets.definitions.fdn.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Eaten by Piranhas reprint in FDN.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] lives in LCI's `cards/` package
+ * (the card's earliest real printing). This file contributes only the FDN-specific
+ * presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val EatenByPiranhasReprint = Printing(
+    oracleId = "c37eae65-1afe-4242-b677-24dd40e6f401",
+    name = "Eaten by Piranhas",
+    setCode = "FDN",
+    collectorNumber = "507",
+    artist = "Abz J Harding",
+    imageUri = "https://cards.scryfall.io/normal/front/4/7/475e28bb-1333-45e1-b6fd-83121c2f1ab9.jpg",
+    releaseDate = "2024-11-15",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CorpsesOfTheLost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CorpsesOfTheLost.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.OptionalCostEffect
+import com.wingedsheep.sdk.scripting.effects.PayLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Corpses of the Lost — {2}{B}
+ * Enchantment
+ * Rare — LCI #98
+ *
+ * Skeletons you control get +1/+0 and have haste.
+ * When this enchantment enters, create a 2/2 black Skeleton Pirate creature token.
+ * At the beginning of your end step, if you descended this turn, you may pay 1 life.
+ * If you do, return this enchantment to its owner's hand.
+ * (You descended if a permanent card was put into your graveyard from anywhere.)
+ *
+ * The two static abilities are separate layer-6 continuous effects scoped to
+ * [Subtype.SKELETON] creatures the controller controls:
+ *  1. [ModifyStats] adds +1/+0 (power bonus, layer 7c).
+ *  2. [GrantKeyword] grants haste (layer 6).
+ *
+ * The end-step trigger is a "descend" trigger (CR 700.11) with an intervening-if gate
+ * ([Conditions.YouDescendedThisTurn]). On resolution the player is offered an optional
+ * life payment ([Gate.MayPay] via [OptionalCostEffect]); if paid, [Effects.ReturnToHand]
+ * bounces the source enchantment to its owner's hand.
+ */
+val CorpsesOfTheLost = card("Corpses of the Lost") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment"
+    oracleText = "Skeletons you control get +1/+0 and have haste.\n" +
+        "When this enchantment enters, create a 2/2 black Skeleton Pirate creature token.\n" +
+        "At the beginning of your end step, if you descended this turn, you may pay 1 life. " +
+        "If you do, return this enchantment to its owner's hand. " +
+        "(You descended if a permanent card was put into your graveyard from anywhere.)"
+
+    // Static 1: Skeletons you control get +1/+0 (layer 7c).
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 0,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SKELETON).youControl())
+        )
+    }
+
+    // Static 2: Skeletons you control have haste (layer 6).
+    staticAbility {
+        ability = GrantKeyword(
+            keyword = Keyword.HASTE,
+            filter = GroupFilter(GameObjectFilter.Creature.withSubtype(Subtype.SKELETON).youControl())
+        )
+    }
+
+    // ETB: create a 2/2 black Skeleton Pirate creature token.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Skeleton", "Pirate")
+        )
+    }
+
+    // End-step descend trigger: you may pay 1 life; if you do, return this to hand.
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouDescendedThisTurn()
+        effect = OptionalCostEffect(
+            cost = PayLifeEffect(1),
+            ifPaid = Effects.ReturnToHand(EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "98"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg?1782694532"
+        ruling(
+            "2023-11-10",
+            "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn."
+        )
+        ruling(
+            "2023-11-10",
+            "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended."
+        )
+        ruling(
+            "2023-11-10",
+            "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger."
+        )
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CosmiumConfluence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CosmiumConfluence.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Cosmium Confluence
+ * {4}{G} — Sorcery (Rare) — The Lost Caverns of Ixalan #181
+ * Artist: Kasia 'Kafis' Zielińska
+ *
+ * Choose three. You may choose the same mode more than once.
+ * • Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.
+ * • Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature
+ *   with haste. It's still a land.
+ * • Destroy target enchantment.
+ *
+ * Modeled via [modal] with chooseCount = 3 and allowRepeat = true.
+ * Mode 0 — library tutoring via the Gather → Select → Move pipeline.
+ * Mode 1 — counter addition (AddCountersEffect) followed by permanent Cave animation
+ *   (BecomeCreatureEffect, Duration.Permanent). No "until end of turn" appears on the card;
+ *   the Cave stays a creature unless it leaves the battlefield. The +1/+1 counters keep the
+ *   effectively 0/0 body alive (0+3 = 3/3 while counters remain).
+ * Mode 2 — targeted enchantment destruction.
+ */
+val CosmiumConfluence = card("Cosmium Confluence") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose three. You may choose the same mode more than once.\n" +
+        "• Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.\n" +
+        "• Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land.\n" +
+        "• Destroy target enchantment."
+
+    spell {
+        modal(chooseCount = 3, allowRepeat = true) {
+            mode("Search your library for a Cave card, put it onto the battlefield tapped, then shuffle") {
+                effect = Patterns.Library.searchLibrary(
+                    filter = GameObjectFilter.Land.withSubtype("Cave"),
+                    destination = SearchDestination.BATTLEFIELD,
+                    entersTapped = true,
+                    shuffleAfter = true
+                )
+            }
+            mode("Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land") {
+                val cave = target(
+                    "a Cave you control",
+                    TargetPermanent(filter = TargetFilter.Land.withSubtype("Cave").youControl())
+                )
+                effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, cave) then
+                    Effects.BecomeCreature(
+                        target = cave,
+                        power = 0,
+                        toughness = 0,
+                        keywords = setOf(Keyword.HASTE),
+                        creatureTypes = setOf("Elemental"),
+                        duration = Duration.Permanent
+                    )
+            }
+            mode("Destroy target enchantment") {
+                val enchantment = target("target enchantment", Targets.Enchantment)
+                effect = Effects.Destroy(enchantment)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "181"
+        artist = "Kasia 'Kafis' Zielińska"
+        imageUri = "https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg?1782694465"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CouncilOfEchoes.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/CouncilOfEchoes.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Council of Echoes — {4}{U}{U}
+ * Creature — Spirit Advisor
+ * 4/4
+ *
+ * Flying
+ * Descend 4 — When this creature enters, if there are four or more permanent cards in your
+ * graveyard, return up to one target nonland permanent other than this creature to its owner's
+ * hand.
+ *
+ * "Descend 4" is an ability word; the mechanic is an intervening-if triggered ability whose
+ * condition (CR 603.4) checks that the controller has four or more permanent cards in their
+ * graveyard at both the time the trigger would fire and at resolution. If the count drops
+ * below four before resolution the ability fizzles.
+ *
+ * "Up to one" makes the single target requirement optional (minimum 0). If the controller
+ * declines to choose any target the effect resolves as a no-op. The target must be a nonland
+ * permanent other than the Council itself ([TargetOther] excludes the source).
+ */
+val CouncilOfEchoes = card("Council of Echoes") {
+    manaCost = "{4}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit Advisor"
+    power = 4
+    toughness = 4
+    oracleText = "Flying\nDescend 4 — When this creature enters, if there are four or more permanent cards in your graveyard, return up to one target nonland permanent other than this creature to its owner's hand."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent)
+        val permanent = target(
+            "up to one target nonland permanent other than this creature",
+            TargetOther(baseRequirement = TargetPermanent(count = 1, optional = true, filter = TargetFilter.NonlandPermanent))
+        )
+        effect = Effects.ReturnToHand(permanent)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "51"
+        artist = "Fariba Khamseh"
+        imageUri = "https://cards.scryfall.io/normal/front/8/5/85ad358d-a520-4d57-82b0-d2297da1fbde.jpg?1782694568"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DauntlessDismantler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DauntlessDismantler.kt
@@ -27,8 +27,8 @@ import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
  *   chosen X value, so X=1 costs three mana ({1}{1}{W}), X=2 costs five mana ({2}{2}{W}), etc.
  *   The destroy filter uses [CardPredicate.ManaValueEqualsX] so exactly the artifacts at the
  *   paid X value are destroyed — across ALL controllers (oracle says "each artifact", not "each
- *   artifact an opponent controls"). The controller sacrifices this creature as part of the cost
- *   (CR 601.2b), so the Dismantler is gone before the effect resolves.
+ *   artifact an opponent controls"). The controller sacrifices this creature as part of the
+ *   activation cost (CR 602.2b), so the Dismantler is gone before the effect resolves.
  */
 val DauntlessDismantler = card("Dauntless Dismantler") {
     manaCost = "{1}{W}"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DauntlessDismantler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DauntlessDismantler.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EventPattern
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PermanentsEnterTapped
+
+/**
+ * Dauntless Dismantler
+ * {1}{W}
+ * Creature — Human Artificer
+ * 1/4
+ *
+ * Artifacts your opponents control enter tapped.
+ * {X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X.
+ *
+ * - "Artifacts your opponents control enter tapped" is a global [PermanentsEnterTapped] runtime
+ *   replacement whose `appliesTo` filter is scoped to artifacts controlled by opponents of the
+ *   Dismantler's controller. The controller-relative `opponentControls()` predicate is resolved
+ *   against the Dismantler's own controller at entry time — the same pattern used by
+ *   Authority of the Consuls for creatures.
+ * - The activated ability uses a double-X mana cost ({X}{X}{W}): both X symbols pay the same
+ *   chosen X value, so X=1 costs three mana ({1}{1}{W}), X=2 costs five mana ({2}{2}{W}), etc.
+ *   The destroy filter uses [CardPredicate.ManaValueEqualsX] so exactly the artifacts at the
+ *   paid X value are destroyed — across ALL controllers (oracle says "each artifact", not "each
+ *   artifact an opponent controls"). The controller sacrifices this creature as part of the cost
+ *   (CR 601.2b), so the Dismantler is gone before the effect resolves.
+ */
+val DauntlessDismantler = card("Dauntless Dismantler") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Artificer"
+    power = 1
+    toughness = 4
+    oracleText = "Artifacts your opponents control enter tapped.\n" +
+        "{X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X."
+
+    // Artifacts your opponents control enter tapped.
+    replacementEffect(
+        PermanentsEnterTapped(
+            appliesTo = EventPattern.ZoneChangeEvent(
+                filter = GameObjectFilter.Artifact.opponentControls(),
+                to = Zone.BATTLEFIELD,
+            )
+        )
+    )
+
+    // {X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X.
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{X}{X}{W}"), Costs.SacrificeSelf)
+        effect = Effects.DestroyAll(
+            filter = GameObjectFilter.Artifact.manaValueEqualsX()
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "Dibujante Nocturno"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d771631-0aab-4f09-b9a6-49b6b2d8d2aa.jpg?1782694606"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeepfathomEcho.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeepfathomEcho.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deepfathom Echo — {2}{G}{U}
+ * Creature — Merfolk Spirit
+ * 4/4
+ *
+ * "At the beginning of combat on your turn, this creature explores. Then you may have it
+ *  become a copy of another creature you control until end of turn."
+ *
+ * Implementation:
+ *  - `trigger = Triggers.BeginCombat` fires at the start of combat on the controller's turn.
+ *  - No target is declared at the `triggeredAbility` level. The "another creature you control"
+ *    is selected mid-resolution — inside the `MayEffect` — via `Effects.SelectTarget`. This
+ *    ensures the explore always runs unconditionally, and target selection happens only if the
+ *    player accepts the copy step.
+ *  - `Effects.Explore(EffectTarget.Self)` runs first (CR 701.44): reveals the top library card;
+ *    a land goes to the hand, a nonland puts a +1/+1 counter on Deepfathom Echo and the
+ *    controller may put that card into the graveyard.
+ *  - `MayEffect(...)` wraps the copy step. The engine asks the controller yes/no; if yes:
+ *    `Effects.SelectTarget(Targets.OtherCreatureYouControl, "copySource")` prompts for another
+ *    creature the controller controls (Deepfathom Echo is excluded by `OtherCreatureYouControl`
+ *    which carries `excludeSelf = true` via `TargetFilter.OtherCreatureYouControl`). When only
+ *    one valid creature exists, the engine auto-selects it without a prompt.
+ *  - `Effects.EachPermanentBecomesCopyOfTarget(target = PipelineTarget("copySource"),
+ *    duration = EndOfTurn, affected = Self)` — single-permanent shape (`affected = Self`):
+ *    Deepfathom Echo becomes a copy of the selected creature until end of turn, copiable values
+ *    only (Rule 707). Counters, tapped state, attachments, and non-copy continuous effects are
+ *    unaffected. End-of-turn cleanup restores Deepfathom Echo's original `CardComponent`
+ *    snapshot via `CopyOfComponent`.
+ */
+val DeepfathomEcho = card("Deepfathom Echo") {
+    manaCost = "{2}{G}{U}"
+    colorIdentity = "GU"
+    typeLine = "Creature — Merfolk Spirit"
+    power = 4
+    toughness = 4
+    oracleText = "At the beginning of combat on your turn, this creature explores. Then you may " +
+        "have it become a copy of another creature you control until end of turn. (To have this " +
+        "creature explore, reveal the top card of your library. Put that card into your hand if " +
+        "it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or " +
+        "put it into your graveyard.)"
+
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        effect = Effects.Composite(listOf(
+            // Step 1: This creature explores (unconditional). Reveals top library card; land → hand,
+            // nonland → +1/+1 counter on this creature + optional graveyard put (CR 701.44).
+            Effects.Explore(EffectTarget.Self),
+            // Step 2: The controller may have this creature become a copy of another creature
+            // they control until end of turn. Target selection happens inside the MayEffect so
+            // it is only asked when the player accepts, and does not bind at stack-placement time.
+            MayEffect(
+                Effects.SelectTarget(Targets.OtherCreatureYouControl, "copySource")
+                    .then(Effects.EachPermanentBecomesCopyOfTarget(
+                        target = EffectTarget.PipelineTarget("copySource"),
+                        duration = Duration.EndOfTurn,
+                        affected = EffectTarget.Self
+                    ))
+            )
+        ))
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "228"
+        artist = "Matt Stewart"
+        imageUri = "https://cards.scryfall.io/normal/front/c/7/c7c7fb87-8448-49f4-a9ed-db97f6a41d98.jpg?1782694427"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/Defossilize.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/Defossilize.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Defossilize — {4}{B}
+ * Sorcery
+ * Uncommon — The Lost Caverns of Ixalan #103
+ * Artist: Dibujante Nocturno
+ *
+ * "Return target creature card from your graveyard to the battlefield.
+ *  That creature explores, then it explores again."
+ *
+ * Resolution (CR 608.2): all three effects execute sequentially as part of the spell resolving.
+ *  1. The targeted creature card is moved from the controller's graveyard to the battlefield
+ *     (not cast, so enters-when-cast conditions don't apply, and no mana was spent on it —
+ *     relevant for Satoru, the Infiltrator and similar).
+ *  2. That permanent explores once (CR 701.44): reveal top library card; if land → hand, else
+ *     put a +1/+1 counter on the creature and the player may put the revealed card in the
+ *     graveyard instead of leaving it on top.
+ *  3. That permanent explores a second time with the same procedure.
+ *
+ * The target reference [t] is an [com.wingedsheep.sdk.scripting.targets.EffectTarget.BoundVariable]
+ * whose entity ID is stable across zone changes, so it correctly identifies the same permanent
+ * on the battlefield for both [Effects.Explore] calls after [Effects.PutOntoBattlefield] moves it.
+ */
+val Defossilize = card("Defossilize") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card from your graveyard to the battlefield. " +
+        "That creature explores, then it explores again. " +
+        "(Reveal the top card of your library. Put that card into your hand if it's a land. " +
+        "Otherwise, put a +1/+1 counter on that creature, then put the card back or put it " +
+        "into your graveyard. Then repeat this process.)"
+
+    spell {
+        val t = target("target creature card from your graveyard", Targets.CreatureCardInYourGraveyard)
+        effect = Effects.PutOntoBattlefield(t)
+            .then(Effects.Explore(t))
+            .then(Effects.Explore(t))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "103"
+        artist = "Dibujante Nocturno"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3d9abaec-af72-4399-b162-5e62e7487242.jpg?1782694528"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DiamondPickAxe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DiamondPickAxe.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+
+/**
+ * Diamond Pick-Axe (LCI #143) — {R} Artifact — Equipment
+ *
+ * Indestructible (Effects that say "destroy" don't destroy this Equipment.)
+ * Equipped creature gets +1/+1 and has "Whenever this creature attacks, create a Treasure token."
+ * Equip {2}
+ *
+ * Implementation notes:
+ * - Indestructible is a printed keyword on the Equipment itself, not on the equipped creature —
+ *   wired via [keywords(Keyword.INDESTRUCTIBLE)].
+ * - The +1/+1 pump is a [ModifyStats] static ability scoped to [Filters.EquippedCreature].
+ * - The attack-triggered Treasure creation is granted to the equipped creature via
+ *   [GrantTriggeredAbility] with [Triggers.attacks()] (SELF binding) so the ability lives on the
+ *   creature and fires when that creature attacks — matching the oracle "Whenever this creature
+ *   attacks, create a Treasure token."
+ */
+val DiamondPickAxe = card("Diamond Pick-Axe") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Indestructible (Effects that say \"destroy\" don't destroy this Equipment.)\n" +
+        "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, create a Treasure token.\"\n" +
+        "Equip {2}"
+
+    // The Equipment itself is indestructible.
+    keywords(Keyword.INDESTRUCTIBLE)
+
+    // Equipped creature gets +1/+1.
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    // Equipped creature has "Whenever this creature attacks, create a Treasure token."
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.attacks().event,
+                binding = Triggers.attacks().binding,
+                effect = Effects.CreateTreasure()
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "143"
+        artist = "Dibujante Nocturno"
+        imageUri = "https://cards.scryfall.io/normal/front/4/a/4ae30fa7-3d1d-417f-80d7-a668236cb2c1.jpg?1782694493"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DidactEcho.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DidactEcho.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Didact Echo
+ * {4}{U}
+ * Creature — Spirit Cleric
+ * 3/2
+ *
+ * When this creature enters, draw a card.
+ * Descend 4 — This creature has flying as long as there are four or more permanent cards
+ * in your graveyard.
+ *
+ * The ETB trigger is unconditional — it always draws a card when Didact Echo enters the
+ * battlefield.
+ *
+ * The Descend 4 static ability is modelled as a [ConditionalStaticAbility] wrapping a
+ * [GrantKeyword](FLYING) over [GroupFilter.source()], gated by
+ * [Conditions.CardsInGraveyardMatchingAtLeast](4, Permanent). The condition is re-evaluated
+ * continuously in Layer 6, so flying appears and disappears as the graveyard count changes.
+ */
+val DidactEcho = card("Didact Echo") {
+    manaCost = "{4}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit Cleric"
+    power = 3
+    toughness = 2
+    oracleText = "When this creature enters, draw a card.\n" +
+        "Descend 4 — This creature has flying as long as there are four or more permanent cards in your graveyard."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = GrantKeyword(Keyword.FLYING, GroupFilter.source()),
+            condition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "53"
+        artist = "Irina Nordsol"
+        imageUri = "https://cards.scryfall.io/normal/front/3/c/3c068b2e-17cc-4fb8-bd79-b775a4713d74.jpg?1782694566"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DisturbedSlumber.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DisturbedSlumber.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Disturbed Slumber
+ * {1}{G}
+ * Instant — Common
+ *
+ * Until end of turn, target land you control becomes a 4/4 Dinosaur creature with reach and
+ * haste. It's still a land. It must be blocked this turn if able.
+ *
+ * Two effects on resolution:
+ *  1. [Effects.BecomeCreature] — Layer 4 adds CREATURE, Layer 4 sets subtypes to {Dinosaur},
+ *     Layer 6 grants Reach + Haste, Layer 7b sets base P/T to 4/4. All revert at end of turn.
+ *     LAND type is preserved (BecomeCreature does not strip it — "it's still a land").
+ *  2. [MustBeBlockedEffect] — floating must-be-blocked requirement: the land-creature must be
+ *     blocked this turn if able (one blocker is sufficient — `allCreatures = false`).
+ */
+val DisturbedSlumber = card("Disturbed Slumber") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Until end of turn, target land you control becomes a 4/4 Dinosaur creature with reach and haste. It's still a land. It must be blocked this turn if able."
+
+    spell {
+        val t = target(
+            "target land you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.youControl()))
+        )
+        effect = Effects.Composite(
+            Effects.BecomeCreature(
+                target = t,
+                power = 4,
+                toughness = 4,
+                keywords = setOf(Keyword.REACH, Keyword.HASTE),
+                creatureTypes = setOf("DINOSAUR")
+            ),
+            MustBeBlockedEffect(t, allCreatures = false)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "182"
+        artist = "David Palumbo"
+        imageUri = "https://cards.scryfall.io/normal/front/4/4/4404b8d6-3673-4d82-b9ed-d28e9b54e1f6.jpg?1782694464"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DisturbedSlumber.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DisturbedSlumber.kt
@@ -41,7 +41,7 @@ val DisturbedSlumber = card("Disturbed Slumber") {
                 power = 4,
                 toughness = 4,
                 keywords = setOf(Keyword.REACH, Keyword.HASTE),
-                creatureTypes = setOf("DINOSAUR")
+                creatureTypes = setOf("Dinosaur")
             ),
             MustBeBlockedEffect(t, allCreatures = false)
         )

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EatenByPiranhas.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/EatenByPiranhas.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.LoseAllAbilities
+import com.wingedsheep.sdk.scripting.SetBasePowerToughnessStatic
+import com.wingedsheep.sdk.scripting.TransformPermanent
+
+/**
+ * Eaten by Piranhas
+ * {1}{U}
+ * Enchantment — Aura
+ * Uncommon (LCI #54)
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature loses all abilities and is a black Skeleton creature with base power
+ * and toughness 1/1. (It loses all other colors, card types, and creature types.)
+ */
+val EatenByPiranhas = card("Eaten by Piranhas") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\nEnchant creature\nEnchanted creature loses all abilities and is a black Skeleton creature with base power and toughness 1/1. (It loses all other colors, card types, and creature types.)"
+
+    keywords(Keyword.FLASH)
+
+    auraTarget = Targets.Creature
+
+    // "loses all abilities" — Layer 6 (ABILITY)
+    staticAbility {
+        ability = LoseAllAbilities()
+    }
+
+    // "is a black Skeleton creature" — Layer 4 (TYPE: replaces card types + subtypes) +
+    // Layer 5 (COLOR: replaces all colors with black)
+    staticAbility {
+        ability = TransformPermanent(
+            setCardTypes = setOf("CREATURE"),
+            setSubtypes = setOf("Skeleton"),
+            setColors = setOf(Color.BLACK)
+        )
+    }
+
+    // "base power and toughness 1/1" — Layer 7b (POWER_TOUGHNESS, SET_BASE_VALUES)
+    staticAbility {
+        ability = SetBasePowerToughnessStatic(1, 1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "54"
+        artist = "Abz J Harding"
+        imageUri = "https://cards.scryfall.io/normal/front/b/0/b0c504ef-2382-4174-9b1d-5f38e12a28fc.jpg?1782694566"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3455,6 +3455,198 @@
     ]
 }
 
+// Defossilize
+{
+    "name": "Defossilize",
+    "manaCost": "{4}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card from your graveyard to the battlefield. That creature explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard. Then repeat this process.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    },
+                    "destination": "Battlefield"
+                },
+                {
+                    "type": "Explore",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    }
+                },
+                {
+                    "type": "Explore",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature card from your graveyard"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "103",
+        "rarity": "UNCOMMON",
+        "artist": "Dibujante Nocturno",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d9abaec-af72-4399-b162-5e62e7487242.jpg?1782694528"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Diamond Pick-Axe
+{
+    "name": "Diamond Pick-Axe",
+    "manaCost": "{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Indestructible (Effects that say \"destroy\" don't destroy this Equipment.)\nEquipped creature gets +1/+1 and has \"Whenever this creature attacks, create a Treasure token.\"\nEquip {2}",
+    "keywords": [
+        "INDESTRUCTIBLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "CreatePredefinedToken",
+                        "tokenType": "Treasure"
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "143",
+        "rarity": "UNCOMMON",
+        "artist": "Dibujante Nocturno",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/a/4ae30fa7-3d1d-417f-80d7-a668236cb2c1.jpg?1782694493"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Didact Echo
+{
+    "name": "Didact Echo",
+    "manaCost": "{4}{U}",
+    "typeLine": "Creature — Spirit Cleric",
+    "oracleText": "When this creature enters, draw a card.\nDescend 4 — This creature has flying as long as there are four or more permanent cards in your graveyard.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "FLYING",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "53",
+        "artist": "Irina Nordsol",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/c/3c068b2e-17cc-4fb8-bd79-b775a4713d74.jpg?1782694566"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Digsite Conservator
 {
     "name": "Digsite Conservator",
@@ -3627,6 +3819,68 @@
     "colorIdentityOverride": []
 }
 
+// Disturbed Slumber
+{
+    "name": "Disturbed Slumber",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Until end of turn, target land you control becomes a 4/4 Dinosaur creature with reach and haste. It's still a land. It must be blocked this turn if able.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "BecomeCreature",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land you control"
+                    },
+                    "power": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "toughness": {
+                        "type": "Fixed",
+                        "amount": 4
+                    },
+                    "keywords": [
+                        "REACH",
+                        "HASTE"
+                    ],
+                    "creatureTypes": [
+                        "DINOSAUR"
+                    ]
+                },
+                {
+                    "type": "MustBeBlocked",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target land you control"
+                    },
+                    "allCreatures": false
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "land ctrl:you"
+                },
+                "id": "target land you control"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "182",
+        "artist": "David Palumbo",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/4/4404b8d6-3673-4d82-b9ed-d28e9b54e1f6.jpg?1782694464"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Dusk Rose Reliquary
 {
     "name": "Dusk Rose Reliquary",
@@ -3758,6 +4012,54 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Eaten by Piranhas
+{
+    "name": "Eaten by Piranhas",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature\nEnchanted creature loses all abilities and is a black Skeleton creature with base power and toughness 1/1. (It loses all other colors, card types, and creature types.)",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "staticAbilities": [
+            "LoseAllAbilities",
+            {
+                "type": "TransformPermanent",
+                "setCardTypes": [
+                    "CREATURE"
+                ],
+                "setSubtypes": [
+                    "Skeleton"
+                ],
+                "setColors": [
+                    "BLACK"
+                ]
+            },
+            {
+                "type": "SetBasePowerToughnessStatic",
+                "power": 1,
+                "toughness": 1
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "rarity": "UNCOMMON",
+        "artist": "Abz J Harding",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/0/b0c504ef-2382-4174-9b1d-5f38e12a28fc.jpg?1782694566"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2650,6 +2650,113 @@
     ]
 }
 
+// Corpses of the Lost
+{
+    "name": "Corpses of the Lost",
+    "manaCost": "{2}{B}",
+    "typeLine": "Enchantment",
+    "oracleText": "Skeletons you control get +1/+0 and have haste.\nWhen this enchantment enters, create a 2/2 black Skeleton Pirate creature token.\nAt the beginning of your end step, if you descended this turn, you may pay 1 life. If you do, return this enchantment to its owner's hand. (You descended if a permanent card was put into your graveyard from anywhere.)",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Skeleton",
+                        "Pirate"
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayLife",
+                            "amount": 1
+                        }
+                    },
+                    "then": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Hand"
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0,
+                "filter": {
+                    "baseFilter": "creature Skeleton ctrl:you"
+                }
+            },
+            {
+                "type": "GrantKeyword",
+                "keyword": "HASTE",
+                "filter": {
+                    "baseFilter": "creature Skeleton ctrl:you"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "98",
+        "rarity": "RARE",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f661095-3645-4e44-ac39-752e417c2174.jpg?1782694532",
+        "rulings": [
+            {
+                "date": "2023-11-10",
+                "text": "Some cards refer to a player who has \"descended this turn.\" This means that a permanent card has been put into that player's graveyard from anywhere this turn."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, and while tokens are put into the graveyard before ceasing to exist, that action doesn't count as a player having descended."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "Abilities that begin with \"At the beginning of your end step, if you descended this turn\" will trigger only once during your end step, no matter how many times you descended this turn. However, if you haven't descended this turn as your end step begins, the ability won't trigger at all. It's not possible to put a permanent card into your graveyard during the end step in time to have the ability trigger."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Cosmium Blast
 {
     "name": "Cosmium Blast",
@@ -2702,6 +2809,209 @@
     ]
 }
 
+// Cosmium Confluence
+{
+    "name": "Cosmium Confluence",
+    "manaCost": "{4}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose three. You may choose the same mode more than once.\n• Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.\n• Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land.\n• Destroy target enchantment.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "GatherCards",
+                                "source": {
+                                    "type": "FromZone",
+                                    "zone": "Library",
+                                    "filter": "land Cave"
+                                },
+                                "storeAs": "searchable"
+                            },
+                            {
+                                "type": "SelectFromCollection",
+                                "from": "searchable",
+                                "selection": {
+                                    "type": "ChooseUpTo",
+                                    "count": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    }
+                                },
+                                "storeSelected": "found"
+                            },
+                            {
+                                "type": "MoveCollection",
+                                "from": "found",
+                                "destination": {
+                                    "type": "ToZone",
+                                    "zone": "Battlefield",
+                                    "placement": "Tapped"
+                                }
+                            },
+                            "ShuffleLibrary",
+                            "EmitLibrarySearchedEvent"
+                        ]
+                    },
+                    "description": "Search your library for a Cave card, put it onto the battlefield tapped, then shuffle"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 3,
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "a Cave you control"
+                                }
+                            },
+                            {
+                                "type": "BecomeCreature",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "a Cave you control"
+                                },
+                                "power": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "toughness": {
+                                    "type": "Fixed",
+                                    "amount": 0
+                                },
+                                "keywords": [
+                                    "HASTE"
+                                ],
+                                "creatureTypes": [
+                                    "Elemental"
+                                ],
+                                "duration": "Permanent"
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "land Cave ctrl:you"
+                            },
+                            "id": "a Cave you control"
+                        }
+                    ],
+                    "description": "Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature with haste. It's still a land"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "enchantment"
+                            },
+                            "id": "target enchantment"
+                        }
+                    ],
+                    "description": "Destroy target enchantment"
+                }
+            ],
+            "chooseCount": 3,
+            "allowRepeat": true
+        }
+    },
+    "metadata": {
+        "collectorNumber": "181",
+        "rarity": "RARE",
+        "artist": "Kasia 'Kafis' Zielińska",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/9/490a5054-0607-4e4a-a0a9-0e9eea7adb00.jpg?1782694465"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Council of Echoes
+{
+    "name": "Council of Echoes",
+    "manaCost": "{4}{U}{U}",
+    "typeLine": "Creature — Spirit Advisor",
+    "oracleText": "Flying\nDescend 4 — When this creature enters, if there are four or more permanent cards in your graveyard, return up to one target nonland permanent other than this creature to its owner's hand.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one target nonland permanent other than this creature"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetOther",
+                    "baseRequirement": {
+                        "type": "TargetObject",
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "nonland permanent"
+                        }
+                    },
+                    "id": "up to one target nonland permanent other than this creature"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "51",
+        "rarity": "UNCOMMON",
+        "artist": "Fariba Khamseh",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/5/85ad358d-a520-4d57-82b0-d2297da1fbde.jpg?1782694568"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Daring Discovery
 {
     "name": "Daring Discovery",
@@ -2751,6 +3061,84 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Dauntless Dismantler
+{
+    "name": "Dauntless Dismantler",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Artificer",
+    "oracleText": "Artifacts your opponents control enter tapped.\n{X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 4
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{X}{X}{W}"
+                            }
+                        },
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "BattlefieldMatching",
+                                "filter": {
+                                    "cardPredicates": [
+                                        "IsArtifact",
+                                        "ManaValueEqualsX"
+                                    ]
+                                }
+                            },
+                            "storeAs": "destroyAll_gathered"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "destroyAll_gathered",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            },
+                            "moveType": "Destroy"
+                        }
+                    ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "PermanentsEnterTapped",
+                "appliesTo": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact ctrl:opponent",
+                    "to": "Battlefield"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "UNCOMMON",
+        "artist": "Dibujante Nocturno",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3d771631-0aab-4f09-b9a6-49b6b2d8d2aa.jpg?1782694606"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -2992,6 +3380,78 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Deepfathom Echo
+{
+    "name": "Deepfathom Echo",
+    "manaCost": "{2}{G}{U}",
+    "typeLine": "Creature — Merfolk Spirit",
+    "oracleText": "At the beginning of combat on your turn, this creature explores. Then you may have it become a copy of another creature you control until end of turn. (To have this creature explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Explore",
+                            "target": "Self"
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": "Gate.MayDecide",
+                            "then": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "SelectTarget",
+                                        "requirement": {
+                                            "type": "TargetObject",
+                                            "filter": {
+                                                "baseFilter": "creature ctrl:you",
+                                                "excludeSelf": true
+                                            }
+                                        },
+                                        "storeAs": "copySource"
+                                    },
+                                    {
+                                        "type": "EachPermanentBecomesCopyOfTarget",
+                                        "target": {
+                                            "type": "PipelineTarget",
+                                            "collectionName": "copySource"
+                                        },
+                                        "duration": "EndOfTurn",
+                                        "affected": "Self"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "228",
+        "rarity": "RARE",
+        "artist": "Matt Stewart",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/7/c7c7fb87-8448-49f4-a9ed-db97f6a41d98.jpg?1782694427"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "BLUE"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -3848,7 +3848,7 @@
                         "HASTE"
                     ],
                     "creatureTypes": [
-                        "DINOSAUR"
+                        "Dinosaur"
                     ]
                 },
                 {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.ReplacementEffectSourceComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
 import com.wingedsheep.engine.state.components.identity.ControllerComponent
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
@@ -53,6 +54,41 @@ object EnterTappedReplacements {
             }
         }
         return false
+    }
+
+    /**
+     * Resolve global "[filter] enter tapped/untapped" replacements for a token [tokenId] just
+     * placed onto [controllerId]'s battlefield, mirroring the entry-tap resolution in
+     * [ZoneTransitionService]. Tokens are permanents entering the battlefield, so they honor
+     * Dauntless Dismantler / Authority of the Consuls-style effects just like cast or played
+     * permanents — but [com.wingedsheep.engine.handlers.effects.BattlefieldEntry.place] (the
+     * ad-hoc insertion path token executors use) deliberately doesn't set tapped state, so each
+     * token-minting site calls this immediately after placing the token.
+     *
+     * [definedTapped] is whether the token was minted already tapped (its own `effect.tapped` /
+     * self-`EntersTapped`); [attacking] whether it entered attacking (a combat token keeps its
+     * tapped state and is never flipped untapped). Per CR 614 an applicable "enters untapped"
+     * replacement wins over a global "enters tapped".
+     *
+     * The token must already carry its `ControllerComponent` / `CardComponent` so the replacement
+     * filters ("artifacts your opponents control", …) resolve.
+     */
+    fun applyCreatedTokenEntryTap(
+        state: GameState,
+        tokenId: EntityId,
+        controllerId: EntityId,
+        definedTapped: Boolean = false,
+        attacking: Boolean = false,
+    ): GameState {
+        val entersUntapped = EnterUntappedReplacements.entersUntapped(state, tokenId, controllerId)
+        return when {
+            definedTapped && !attacking && entersUntapped ->
+                state.updateEntity(tokenId) { it.without<TappedComponent>() }
+            !definedTapped && !entersUntapped &&
+                entersTapped(state, tokenId, controllerId) ->
+                state.updateEntity(tokenId) { it.with(TappedComponent) }
+            else -> state
+        }
     }
 
     private fun matchesEnterFilter(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/MustBeBlockedExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/combat/MustBeBlockedExecutor.kt
@@ -7,7 +7,6 @@ import com.wingedsheep.engine.mechanics.layers.Layer
 import com.wingedsheep.engine.mechanics.layers.SerializableModification
 import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.state.GameState
-import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.effects.MustBeBlockedEffect
 import kotlin.reflect.KClass
@@ -33,12 +32,13 @@ class MustBeBlockedExecutor : EffectExecutor<MustBeBlockedEffect> {
         val targetId = context.resolveTarget(effect.target)
             ?: return EffectResult.error(state, "No valid target for must-be-blocked effect")
 
-        // Verify target exists and is a creature
-        val targetContainer = state.getEntity(targetId)
-            ?: return EffectResult.error(state, "Target creature no longer exists")
-        val cardComponent = targetContainer.get<CardComponent>()
-            ?: return EffectResult.error(state, "Target is not a card")
-        if (!cardComponent.typeLine.isCreature) {
+        // Verify target exists and is a creature. Must use the projection, not the base type
+        // line: the target may only be a creature via a continuous effect — e.g. Disturbed
+        // Slumber animates a land with BecomeCreature immediately before this effect.
+        if (state.getEntity(targetId) == null) {
+            return EffectResult.error(state, "Target creature no longer exists")
+        }
+        if (!state.projectedState.isCreature(targetId)) {
             return EffectResult.error(state, "Target is not a creature")
         }
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreatePredefinedTokenExecutor.kt
@@ -129,6 +129,13 @@ class CreatePredefinedTokenExecutor(
 
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, tokenControllerId, tokenId)
+
+            // Predefined Map/Treasure/Clue/etc. tokens honor global "[filter] enter tapped"
+            // replacements (Dauntless Dismantler taps an opponent's artifact token).
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(
+                    newState, tokenId, tokenControllerId, definedTapped = effect.tapped,
+                )
         }
 
         val events = createdTokenIds.map { tokenId ->

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
@@ -142,6 +142,11 @@ class CreateTokenCopyOfChosenPermanentExecutor(
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
 
+            // A token copy honors global "[filter] enter tapped" replacements (Authority of the
+            // Consuls taps an opponent's token copy of a creature).
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
+
             val event = ZoneChangeEvent(
                 entityId = tokenId,
                 entityName = tokenCard.name,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfEquippedCreatureExecutor.kt
@@ -113,6 +113,11 @@ class CreateTokenCopyOfEquippedCreatureExecutor(
         newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
             .place(newState, controllerId, tokenId)
 
+        // A token copy honors global "[filter] enter tapped" replacements (Authority of the
+        // Consuls / Dauntless Dismantler on an opponent's token copy).
+        newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+            .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
+
         val events = listOf(
             ZoneChangeEvent(
                 entityId = tokenId,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -131,6 +131,11 @@ class CreateTokenCopyOfSourceExecutor(
             // Add to battlefield
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
+
+            // A token copy honors global "[filter] enter tapped" replacements (Authority of the
+            // Consuls / Dauntless Dismantler on an opponent's token copy).
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
         }
 
         // Apply "enters with counters" replacement effects from other battlefield permanents

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfTargetExecutor.kt
@@ -160,6 +160,12 @@ class CreateTokenCopyOfTargetExecutor(
             newState = newState.withEntity(tokenId, container)
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
+            // A token copy honors global "[filter] enter tapped" replacements (Authority of the
+            // Consuls / Dauntless Dismantler on an opponent's token copy).
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(
+                    newState, tokenId, controllerId, definedTapped = effect.tapped,
+                )
             createdTokens.add(tokenId)
 
             for (ability in effect.triggeredAbilities) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.event.DelayedTriggeredAbility
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
+import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
 import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
 import com.wingedsheep.engine.state.Component
 import com.wingedsheep.engine.state.ComponentContainer
@@ -229,6 +230,14 @@ class CreateTokenExecutor(
             // Add to battlefield
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, tokenControllerId, tokenId)
+
+            // Tokens honor global "[filter] enter tapped" replacements from other permanents
+            // (Dauntless Dismantler, Authority of the Consuls, …) — BattlefieldEntry.place doesn't
+            // set tapped state, so resolve it here now the token carries its controller/type.
+            newState = EnterTappedReplacements.applyCreatedTokenEntryTap(
+                newState, tokenId, tokenControllerId,
+                definedTapped = effect.tapped, attacking = effect.attacking,
+            )
         }
 
         // Apply "enters with counters" replacement effects from other battlefield permanents

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -217,6 +217,11 @@ object TokenCreationReplacementHelper {
                     newState = newState.withEntity(tokenId, tokenContainer)
                     newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                         .place(newState, tokenControllerId, tokenId)
+                    // Honor global "[filter] enter tapped" replacements on the added token too.
+                    newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                        .applyCreatedTokenEntryTap(
+                            newState, tokenId, tokenControllerId, definedTapped = tapped,
+                        )
 
                     events.add(
                         ZoneChangeEvent(
@@ -387,6 +392,9 @@ object TokenCreationReplacementHelper {
             newState = newState.withEntity(tokenId, container)
             newState = com.wingedsheep.engine.handlers.effects.BattlefieldEntry
                 .place(newState, controllerId, tokenId)
+            // Honor global "[filter] enter tapped" replacements on the copy too.
+            newState = com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
+                .applyCreatedTokenEntryTap(newState, tokenId, controllerId)
 
             // Apply the attached permanent's printed enters-with-counters replacement
             // effects (and any global ones from other permanents).

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.BattlefieldEntry
+import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
 import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
 import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
@@ -98,6 +99,7 @@ object TokenFromDefinition {
 
         // As-enters: enters tapped (CR 614). The payLifeCost (shock-land) form is land-only.
         val entersTapped = cardDef.script.replacementEffects.filterIsInstance<EntersTapped>().firstOrNull()
+        var enteredTapped = false
         if (entersTapped != null && entersTapped.payLifeCost == null) {
             val shouldEnterTapped = entersTapped.unlessCondition?.let { condition ->
                 !conditionEvaluator.evaluate(
@@ -106,8 +108,16 @@ object TokenFromDefinition {
             } ?: true
             if (shouldEnterTapped) {
                 newState = newState.updateEntity(tokenId) { c -> c.with(TappedComponent) }
+                enteredTapped = true
             }
         }
+
+        // As-enters: global "[filter] enter tapped/untapped" replacements from OTHER permanents
+        // (Authority of the Consuls taps an opponent's minted creature token). Passing the self
+        // enters-tapped result lets an "enters untapped" replacement override it per CR 614.
+        newState = EnterTappedReplacements.applyCreatedTokenEntryTap(
+            newState, tokenId, controllerId, definedTapped = enteredTapped,
+        )
 
         // As-enters: the token's own + global "enters with counters" (CR 614).
         val (stateWithCounters, counterEvents) = EntersWithCountersHelper.applyEntersWithCounters(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -746,20 +746,44 @@ internal class BlockPhaseManager(
             }
         }
 
-        // 2. "Must be blocked if able" (Gaea's Protector): at least one creature must block it
+        // 2. "Must be blocked if able" (Gaea's Protector): at least one creature must block it.
+        // Rule 509.1c only demands the maximum satisfiable number of requirements: a blocker
+        // that is the sole blocker of another must-be-blocked attacker (or is pinned to its
+        // current block by provoke) cannot be moved here without abandoning that requirement,
+        // so it doesn't count as "able". Two must-be-blocked attackers and one blocker means
+        // blocking either of them is legal.
         val mustBeBlockedIfAbleAttackers = findMustBeBlockedIfAbleAttackers(state)
-        for (attackerId in mustBeBlockedIfAbleAttackers) {
-            val blockersAssigned = attackerToBlockers[attackerId] ?: emptySet()
-            if (blockersAssigned.isNotEmpty()) continue
+        if (mustBeBlockedIfAbleAttackers.isNotEmpty()) {
+            val requiredAttackers = mustBeBlockedByAllAttackers.toSet() + mustBeBlockedIfAbleAttackers
+            val provokePins = state.floatingEffects
+                .filter { it.effect.modification is SerializableModification.MustBlockSpecificAttacker }
+                .flatMap { floatingEffect ->
+                    val modification =
+                        floatingEffect.effect.modification as SerializableModification.MustBlockSpecificAttacker
+                    floatingEffect.effect.affectedEntities.map { it to modification.attackerId }
+                }
+                .toSet()
 
-            // Check if any potential blocker can actually block this attacker
-            val canBeBlocked = potentialBlockers.any { blockerId ->
-                canCreatureBlockAttacker(state, blockerId, attackerId, blockingPlayer, projected)
+            for (attackerId in mustBeBlockedIfAbleAttackers) {
+                val blockersAssigned = attackerToBlockers[attackerId] ?: emptySet()
+                if (blockersAssigned.isNotEmpty()) continue
+
+                // A potential blocker only counts if moving it onto this attacker abandons no
+                // other requirement it is currently satisfying.
+                val canBeBlocked = potentialBlockers.any { blockerId ->
+                    if (!canCreatureBlockAttacker(state, blockerId, attackerId, blockingPlayer, projected)) {
+                        return@any false
+                    }
+                    blockers[blockerId].orEmpty().none { blocked ->
+                        (blocked in requiredAttackers && (attackerToBlockers[blocked]?.size ?: 0) <= 1) ||
+                            (blockerId to blocked) in provokePins
+                    }
+                }
+                if (!canBeBlocked) continue
+
+                val attackerName = state.getEntity(attackerId)?.get<CardComponent>()?.name ?: "Creature"
+                return "$attackerName must be blocked if able"
             }
-            if (!canBeBlocked) continue
-
-            val attackerName = state.getEntity(attackerId)?.get<CardComponent>()?.name ?: "Creature"
-            return "$attackerName must be blocked if able"
         }
 
         return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -747,41 +747,65 @@ internal class BlockPhaseManager(
         }
 
         // 2. "Must be blocked if able" (Gaea's Protector): at least one creature must block it.
-        // Rule 509.1c only demands the maximum satisfiable number of requirements: a blocker
-        // that is the sole blocker of another must-be-blocked attacker (or is pinned to its
-        // current block by provoke) cannot be moved here without abandoning that requirement,
-        // so it doesn't count as "able". Two must-be-blocked attackers and one blocker means
-        // blocking either of them is legal.
+        // Rule 509.1c: the declaration is illegal if the number of requirements being obeyed is
+        // fewer than the maximum number that could be obeyed. That maximum is a maximum bipartite
+        // matching between the must-be-blocked attackers and the blockers hypothetically free to
+        // cover them: a provoke-pinned blocker is only free for its pinned attacker, and a blocker
+        // that can block a Lure-style attacker is claimed by that requirement (section 1 forces it
+        // there). Per-pair blocking restrictions go through canCreatureBlockAttacker; declaration-
+        // wide restrictions (e.g. can't-block-alone) are not modelled, so the computed maximum can
+        // only over-count in those corners — never rejecting more than 509.1c would.
         val mustBeBlockedIfAbleAttackers = findMustBeBlockedIfAbleAttackers(state)
         if (mustBeBlockedIfAbleAttackers.isNotEmpty()) {
-            val requiredAttackers = mustBeBlockedByAllAttackers.toSet() + mustBeBlockedIfAbleAttackers
-            val provokePins = state.floatingEffects
+            val provokePinnedAttackers = state.floatingEffects
                 .filter { it.effect.modification is SerializableModification.MustBlockSpecificAttacker }
                 .flatMap { floatingEffect ->
                     val modification =
                         floatingEffect.effect.modification as SerializableModification.MustBlockSpecificAttacker
                     floatingEffect.effect.affectedEntities.map { it to modification.attackerId }
                 }
-                .toSet()
+                .groupBy({ it.first }, { it.second })
+                .mapValues { it.value.toSet() }
+            val lureClaimedBlockers = potentialBlockers.filter { blockerId ->
+                mustBeBlockedByAllAttackers.any { attackerId ->
+                    canCreatureBlockAttacker(state, blockerId, attackerId, blockingPlayer, projected)
+                }
+            }.toSet()
 
-            for (attackerId in mustBeBlockedIfAbleAttackers) {
-                val blockersAssigned = attackerToBlockers[attackerId] ?: emptySet()
-                if (blockersAssigned.isNotEmpty()) continue
+            fun canHypotheticallyBlock(blockerId: EntityId, attackerId: EntityId): Boolean {
+                if (blockerId in lureClaimedBlockers) return false
+                provokePinnedAttackers[blockerId]?.let { pins -> if (attackerId !in pins) return false }
+                return canCreatureBlockAttacker(state, blockerId, attackerId, blockingPlayer, projected)
+            }
 
-                // A potential blocker only counts if moving it onto this attacker abandons no
-                // other requirement it is currently satisfying.
-                val canBeBlocked = potentialBlockers.any { blockerId ->
-                    if (!canCreatureBlockAttacker(state, blockerId, attackerId, blockingPlayer, projected)) {
-                        return@any false
-                    }
-                    blockers[blockerId].orEmpty().none { blocked ->
-                        (blocked in requiredAttackers && (attackerToBlockers[blocked]?.size ?: 0) <= 1) ||
-                            (blockerId to blocked) in provokePins
+            // Kuhn's augmenting-path matching: try to give each attacker its own blocker,
+            // recursively re-homing a blocker's current attacker when contested.
+            val matchedAttackerOfBlocker = mutableMapOf<EntityId, EntityId>()
+            fun assignBlocker(attackerId: EntityId, visited: MutableSet<EntityId>): Boolean {
+                for (blockerId in potentialBlockers) {
+                    if (!canHypotheticallyBlock(blockerId, attackerId)) continue
+                    if (!visited.add(blockerId)) continue
+                    val currentAttacker = matchedAttackerOfBlocker[blockerId]
+                    if (currentAttacker == null || assignBlocker(currentAttacker, visited)) {
+                        matchedAttackerOfBlocker[blockerId] = attackerId
+                        return true
                     }
                 }
-                if (!canBeBlocked) continue
+                return false
+            }
 
-                val attackerName = state.getEntity(attackerId)?.get<CardComponent>()?.name ?: "Creature"
+            var maxSatisfiable = 0
+            for (attackerId in mustBeBlockedIfAbleAttackers) {
+                if (assignBlocker(attackerId, mutableSetOf())) maxSatisfiable++
+            }
+            val satisfied = mustBeBlockedIfAbleAttackers.count { !attackerToBlockers[it].isNullOrEmpty() }
+
+            if (satisfied < maxSatisfiable) {
+                val matchedAttackers = matchedAttackerOfBlocker.values.toSet()
+                val culpritId = mustBeBlockedIfAbleAttackers.first {
+                    it in matchedAttackers && attackerToBlockers[it].isNullOrEmpty()
+                }
+                val attackerName = state.getEntity(culpritId)?.get<CardComponent>()?.name ?: "Creature"
                 return "$attackerName must be blocked if able"
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/TapEventEnforcementTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/TapEventEnforcementTest.kt
@@ -74,6 +74,10 @@ class TapEventEnforcementTest : FunSpec({
             // Shock-land "pay life or enter tapped": declining to pay makes the land/permanent
             // *enter* tapped (CR 614 replacement on entry), which is not a tap transition.
             "com/wingedsheep/engine/handlers/continuations/ModalAndCloneContinuationResumer.kt",
+            // Global "[filter] enter tapped/untapped" replacements applied to a token as it enters
+            // (shared helper called by every token executor) — entering tapped/untapped on entry is
+            // not a tap transition, so it emits no TappedEvent/UntappedEvent.
+            "com/wingedsheep/engine/handlers/effects/EnterTappedReplacements.kt",
         )
 
         private data class RawTapMutation(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CorpsesOfTheLostScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CorpsesOfTheLostScenarioTest.kt
@@ -1,0 +1,172 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CorpsesOfTheLost
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Corpses of the Lost (LCI #98): {2}{B} Enchantment
+ *
+ * 1. Skeletons you control get +1/+0 and have haste (static anthem).
+ * 2. When this enchantment enters, create a 2/2 black Skeleton Pirate creature token (ETB).
+ * 3. At the beginning of your end step, if you descended this turn, you may pay 1 life.
+ *    If you do, return this enchantment to its owner's hand.
+ * 4. The end-step trigger does not fire if the controller has not descended.
+ */
+class CorpsesOfTheLostScenarioTest : FunSpec({
+
+    // A minimal 1/1 Skeleton for testing the static anthem without any extra abilities.
+    val testSkeleton = card("Test Skeleton") {
+        manaCost = "{B}"
+        typeLine = "Creature — Skeleton"
+        power = 1
+        toughness = 1
+    }
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CorpsesOfTheLost, testSkeleton))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    /**
+     * Move a permanent card to the graveyard to fire the zone-change event and
+     * increment the descend counter (CR 700.11).
+     */
+    fun GameTestDriver.descend(entityId: EntityId) {
+        val result = ZoneTransitionService.moveToZone(
+            state = state,
+            entityId = entityId,
+            destinationZone = Zone.GRAVEYARD
+        )
+        replaceState(result.state)
+    }
+
+    fun GameTestDriver.skeletonPirateTokens(playerId: EntityId): List<EntityId> =
+        getCreatures(playerId).filter { getCardName(it) == "Skeleton Pirate Token" }
+
+    // -------------------------------------------------------------------------
+    // Test 1: ETB creates a 2/2 black Skeleton Pirate token
+    // -------------------------------------------------------------------------
+    test("enters: creates a 2/2 black Skeleton Pirate creature token") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tokensBefore = driver.skeletonPirateTokens(player).size
+
+        // Cast Corpses of the Lost — {2}{B}.
+        val enchantment = driver.putCardInHand(player, "Corpses of the Lost")
+        driver.giveMana(player, Color.BLACK, 3)
+        driver.castSpell(player, enchantment).isSuccess shouldBe true
+
+        // Resolve the enchantment spell and its ETB token-creation trigger.
+        var guard = 0
+        while (driver.state.stack.isNotEmpty() && !driver.isPaused && guard++ < 20) {
+            driver.bothPass()
+        }
+
+        val tokensAfter = driver.skeletonPirateTokens(player)
+        tokensAfter.size shouldBe tokensBefore + 1
+
+        val token = tokensAfter.first()
+        // Base stats are 2/2. The enchantment's own anthem (+1/+0 to Skeletons you control)
+        // is already active when the token enters, so projected power is 2+1 = 3.
+        driver.state.projectedState.getPower(token) shouldBe 3
+        driver.state.projectedState.getToughness(token) shouldBe 2
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: Skeletons you control get +1/+0 and have haste
+    // -------------------------------------------------------------------------
+    test("static: Skeletons you control get +1/+0 and have haste") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Put the enchantment on the battlefield directly (no ETB fires).
+        driver.putPermanentOnBattlefield(player, "Corpses of the Lost")
+
+        // Put a 1/1 Skeleton onto the battlefield.
+        val skeleton = driver.putCreatureOnBattlefield(player, "Test Skeleton")
+
+        // The static anthem should give it +1/+0, making it a 2/1, and grant haste.
+        driver.state.projectedState.getPower(skeleton) shouldBe 2
+        driver.state.projectedState.getToughness(skeleton) shouldBe 1
+        driver.state.projectedState.hasKeyword(skeleton, Keyword.HASTE) shouldBe true
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: End-step trigger fires when descended; paying 1 life bounces to hand
+    // -------------------------------------------------------------------------
+    test("descended: end-step trigger fires and paying 1 life returns enchantment to hand") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val enchantment = driver.putPermanentOnBattlefield(player, "Corpses of the Lost")
+        val lifeBefore = driver.getLifeTotal(player)
+        val handSizeBefore = driver.getHandSize(player)
+
+        // Descend: put a permanent card into the graveyard.
+        val bearCard = driver.putCardInHand(player, "Grizzly Bears")
+        driver.descend(bearCard)
+
+        // Advance to end step and resolve the descended trigger.
+        driver.passPriorityUntil(Step.END)
+        var safety = 0
+        while (safety++ < 20) {
+            when {
+                driver.pendingDecision is YesNoDecision ->
+                    driver.submitYesNo(player, true) // "Yes, pay 1 life"
+                driver.stackSize > 0 -> driver.bothPass()
+                else -> break
+            }
+        }
+
+        // Life decreased by 1 (the payment).
+        driver.getLifeTotal(player) shouldBe lifeBefore - 1
+
+        // The enchantment left the battlefield and is now in hand.
+        driver.findPermanent(player, "Corpses of the Lost") shouldBe null
+        driver.getHandSize(player) shouldBe handSizeBefore + 1
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: End-step trigger does NOT fire if the controller has not descended
+    // -------------------------------------------------------------------------
+    test("not descended: end-step trigger does not fire") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val enchantment = driver.putPermanentOnBattlefield(player, "Corpses of the Lost")
+
+        // Do NOT descend — just advance to the end step.
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        // The trigger should not have fired — no YesNoDecision pending.
+        (driver.pendingDecision is YesNoDecision) shouldBe false
+
+        // The enchantment remains on the battlefield.
+        driver.findPermanent(player, "Corpses of the Lost") shouldNotBe null
+        driver.findPermanent(player, "Corpses of the Lost") shouldBe enchantment
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CosmiumConfluenceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CosmiumConfluenceScenarioTest.kt
@@ -1,0 +1,170 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CosmiumConfluence
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Cosmium Confluence (LCI #181) — {4}{G} Sorcery.
+ *
+ * "Choose three. You may choose the same mode more than once.
+ * • Search your library for a Cave card, put it onto the battlefield tapped, then shuffle.
+ * • Put three +1/+1 counters on a Cave you control. It becomes a 0/0 Elemental creature
+ *   with haste. It's still a land.
+ * • Destroy target enchantment."
+ *
+ * Covered:
+ *  1. Choosing the same mode more than once (allowRepeat = true): mode 2 (destroy enchantment)
+ *     chosen twice and mode 1 (animate Cave) once — two enchantments are destroyed and one
+ *     Cave receives 3 +1/+1 counters and becomes a 0/0 Elemental creature permanently.
+ *
+ *  2. Mixed selection with repeated mode 1: mode 1 chosen twice (two different Caves, each
+ *     receiving 3 +1/+1 counters and becoming animated) and mode 2 once (destroys one
+ *     enchantment). Confirms the Confluence processes each mode-slot independently.
+ */
+class CosmiumConfluenceScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(CosmiumConfluence)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    /** Count +1/+1 counters on a permanent. */
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /** Drain the stack without interactive decisions (no library searches or modal re-choices). */
+    fun GameTestDriver.drainStack(maxIterations: Int = 20) {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard++ < maxIterations) {
+            bothPass()
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 1: Choose mode 2 twice and mode 1 once.
+    //         Verifies allowRepeat by using mode 2 (destroy enchantment) two times.
+    // ─────────────────────────────────────────────────────────────────────────────
+    test("choosing destroy enchantment twice and animate Cave once destroys both enchantments and animates Cave") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // One Cave you control (target for mode 1).
+        val cave = driver.putPermanentOnBattlefield(me, "Captivating Cave")
+
+        // Two enchantments for opponent (targets for the two mode 2 slots).
+        val ench1 = driver.putPermanentOnBattlefield(opp, "Test Enchantment")
+        val ench2 = driver.putPermanentOnBattlefield(opp, "Test Enchantment")
+
+        val spell = driver.putCardInHand(me, "Cosmium Confluence")
+        // {4}{G}: 4 colorless + 1 green.
+        driver.giveColorlessMana(me, 4)
+        driver.giveMana(me, Color.GREEN, 1)
+
+        // chosenModes = [2, 2, 1]: destroy ench1, destroy ench2, animate cave.
+        val cast = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(
+                    ChosenTarget.Permanent(ench1),
+                    ChosenTarget.Permanent(ench2),
+                    ChosenTarget.Permanent(cave)
+                ),
+                chosenModes = listOf(2, 2, 1),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(ench1)),
+                    listOf(ChosenTarget.Permanent(ench2)),
+                    listOf(ChosenTarget.Permanent(cave))
+                )
+            )
+        )
+        cast.isSuccess shouldBe true
+
+        driver.drainStack()
+
+        // Both enchantments should be destroyed.
+        driver.findPermanent(opp, "Test Enchantment") shouldBe null
+
+        // Cave should still be on the battlefield (permanent animation, not exiled/destroyed).
+        driver.findPermanent(me, "Captivating Cave") shouldNotBe null
+
+        // Mode 1 placed exactly 3 +1/+1 counters on the Cave.
+        plusOneCounters(driver, cave) shouldBe 3
+
+        // Mode 1 animated the Cave to a 0/0 Elemental creature (permanent BecomeCreature).
+        driver.state.projectedState.isCreature(cave) shouldBe true
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // Test 2: Choose mode 1 twice and mode 2 once.
+    //         Two different Caves are animated; one enchantment is destroyed.
+    // ─────────────────────────────────────────────────────────────────────────────
+    test("choosing animate Cave twice and destroy enchantment once animates both Caves and destroys enchantment") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Two Caves you control (each targeted separately by the two mode 1 slots).
+        val cave1 = driver.putPermanentOnBattlefield(me, "Captivating Cave")
+        val cave2 = driver.putPermanentOnBattlefield(me, "Captivating Cave")
+
+        // One enchantment for mode 2.
+        val ench = driver.putPermanentOnBattlefield(opp, "Test Enchantment")
+
+        val spell = driver.putCardInHand(me, "Cosmium Confluence")
+        driver.giveColorlessMana(me, 4)
+        driver.giveMana(me, Color.GREEN, 1)
+
+        // chosenModes = [1, 1, 2]: animate cave1, animate cave2, destroy ench.
+        val cast = driver.submit(
+            CastSpell(
+                playerId = me,
+                cardId = spell,
+                targets = listOf(
+                    ChosenTarget.Permanent(cave1),
+                    ChosenTarget.Permanent(cave2),
+                    ChosenTarget.Permanent(ench)
+                ),
+                chosenModes = listOf(1, 1, 2),
+                modeTargetsOrdered = listOf(
+                    listOf(ChosenTarget.Permanent(cave1)),
+                    listOf(ChosenTarget.Permanent(cave2)),
+                    listOf(ChosenTarget.Permanent(ench))
+                )
+            )
+        )
+        cast.isSuccess shouldBe true
+
+        driver.drainStack()
+
+        // Enchantment should be destroyed.
+        driver.findPermanent(opp, "Test Enchantment") shouldBe null
+
+        // Each Cave should have exactly 3 +1/+1 counters from its mode 1 slot.
+        plusOneCounters(driver, cave1) shouldBe 3
+        plusOneCounters(driver, cave2) shouldBe 3
+
+        // Both Caves should be animated into creatures.
+        driver.state.projectedState.isCreature(cave1) shouldBe true
+        driver.state.projectedState.isCreature(cave2) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CouncilOfEchoesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CouncilOfEchoesScenarioTest.kt
@@ -1,0 +1,125 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.CouncilOfEchoes
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Council of Echoes (LCI #51): {4}{U}{U} 4/4 Creature — Spirit Advisor
+ * "Flying
+ *  Descend 4 — When this creature enters, if there are four or more permanent cards in your
+ *  graveyard, return up to one target nonland permanent other than this creature to its owner's
+ *  hand."
+ *
+ * Tests:
+ *  - With four or more permanent cards in the graveyard: ETB trigger fires, the controller
+ *    selects a nonland permanent on the battlefield to bounce (not the Council itself), and
+ *    it returns to its owner's hand.
+ *  - With fewer than four permanent cards in the graveyard: the intervening-if condition
+ *    (Descend 4) is not met; the trigger does not fire and no ChooseTargetsDecision is issued.
+ *  - "Up to one" is optional: when the condition is met the controller may decline to choose
+ *    any target; the trigger resolves as a no-op and the battlefield is unchanged.
+ */
+class CouncilOfEchoesScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(CouncilOfEchoes))
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        return driver
+    }
+
+    test("ETB trigger fires and bounces chosen nonland permanent when four or more permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // A nonland permanent on the battlefield for the trigger to target.
+        val bounceTarget = driver.putPermanentOnBattlefield(player, "Grizzly Bears")
+
+        // Seed the graveyard with exactly four permanent cards — meets the Descend 4 threshold.
+        repeat(4) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        // Cast Council of Echoes ({4}{U}{U}).
+        val council = driver.putCardInHand(player, "Council of Echoes")
+        driver.giveColorlessMana(player, 4)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.castSpell(player, council)
+        // Council of Echoes resolves → enters the battlefield → the intervening-if condition
+        // is true (four permanent cards in graveyard) → trigger fires and pauses for the
+        // controller to choose up to one nonland permanent other than the Council itself.
+        driver.bothPass()
+
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        driver.submitTargetSelection(player, listOf(bounceTarget)).isSuccess shouldBe true
+        // ETB trigger resolves: return target nonland permanent to its owner's hand.
+        driver.bothPass()
+
+        driver.getHand(player) shouldContain bounceTarget
+        driver.getPermanents(player) shouldNotContain bounceTarget
+    }
+
+    test("ETB trigger does not fire when fewer than four permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // Seed the graveyard with only three permanent cards — one short of the Descend 4 threshold.
+        repeat(3) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        // Cast Council of Echoes ({4}{U}{U}).
+        val council = driver.putCardInHand(player, "Council of Echoes")
+        driver.giveColorlessMana(player, 4)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.castSpell(player, council)
+        // Council resolves → enters the battlefield → intervening-if condition is false
+        // (only three permanent cards in graveyard) → trigger does not fire; no
+        // ChooseTargetsDecision is issued.
+        driver.bothPass()
+
+        (driver.pendingDecision is ChooseTargetsDecision) shouldBe false
+    }
+
+    test("controller may choose no target when condition is met — trigger resolves as no-op") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // A nonland permanent eligible to be bounced, but the controller will decline.
+        val eligibleTarget = driver.putPermanentOnBattlefield(player, "Grizzly Bears")
+
+        // Seed the graveyard with four permanent cards — condition is met.
+        repeat(4) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        val council = driver.putCardInHand(player, "Council of Echoes")
+        driver.giveColorlessMana(player, 4)
+        driver.giveMana(player, Color.BLUE, 2)
+        driver.castSpell(player, council)
+        driver.bothPass()
+
+        // Condition is met, so a ChooseTargetsDecision is issued.
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        // Decline — choose zero targets ("up to one" allows this).
+        driver.submitTargetSelection(player, emptyList()).isSuccess shouldBe true
+        driver.bothPass()
+
+        // No bounce occurred; the eligible permanent remains on the battlefield.
+        driver.getPermanents(player) shouldContain eligibleTarget
+        driver.getHand(player) shouldNotContain eligibleTarget
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessDismantlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessDismantlerScenarioTest.kt
@@ -6,8 +6,12 @@ import com.wingedsheep.engine.core.NumberChosenResponse
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.lci.cards.DauntlessDismantler
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -28,9 +32,39 @@ import io.kotest.matchers.types.shouldBeInstanceOf
  */
 class DauntlessDismantlerScenarioTest : FunSpec({
 
+    // A {0} creature whose ETB creates a predefined Map artifact token (noncreature artifact),
+    // exercising the CreatePredefinedTokenExecutor path — the exact Waterwind Scout repro.
+    val mapMaker = card("Map Maker (test)") {
+        manaCost = "{0}"
+        typeLine = "Creature — Scout"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.CreateMapToken(1)
+        }
+    }
+
+    // A {0} creature whose ETB creates a 1/1 Artifact Creature — Construct token, exercising the
+    // general CreateTokenExecutor path.
+    val constructMaker = card("Construct Maker (test)") {
+        manaCost = "{0}"
+        typeLine = "Creature — Scout"
+        power = 1
+        toughness = 1
+        triggeredAbility {
+            trigger = Triggers.EntersBattlefield
+            effect = Effects.CreateToken(
+                power = 1, toughness = 1, creatureTypes = setOf("Construct"), artifactToken = true,
+            )
+        }
+    }
+
     fun driver(): GameTestDriver {
         val d = GameTestDriver()
-        d.registerCards(TestCards.all + listOf(DauntlessDismantler))
+        d.registerCards(TestCards.all + listOf(DauntlessDismantler, mapMaker, constructMaker))
+        // CreatePredefinedTokenExecutor looks up the Map token definition by name.
+        d.registerCards(PredefinedTokens.allTokens)
         return d
     }
 
@@ -137,5 +171,75 @@ class DauntlessDismantlerScenarioTest : FunSpec({
 
         // Triskelion (MV 6) was NOT destroyed — it survives X=1.
         d.findPermanent(opp, "Triskelion") shouldNotBe null
+    }
+
+    // -------------------------------------------------------------------------
+    // Replacement applies to TOKENS too — "Artifacts your opponents control enter tapped"
+    // taps artifact tokens an opponent creates, not only cast/played artifacts.
+    // -------------------------------------------------------------------------
+
+    /**
+     * The reported bug: an opponent's Map token (created by Waterwind Scout in play) should enter
+     * tapped while player1's Dauntless Dismantler is on the battlefield. Predefined-token path
+     * (CreatePredefinedTokenExecutor).
+     */
+    test("opponent's created Map artifact token enters tapped (replacement applies to tokens)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!               // player2 — will create the token
+        val dismantlerOwner = d.getOpponent(active) // player1 — controls Dismantler
+
+        d.putCreatureOnBattlefield(dismantlerOwner, "Dauntless Dismantler")
+
+        // Player2 casts the {0} maker; its ETB creates a Map token under player2 (an opponent of
+        // Dismantler's controller).
+        val makerId = d.putCardInHand(active, "Map Maker (test)")
+        d.castSpell(active, makerId).isSuccess shouldBe true
+        repeat(12) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        val map = d.findPermanent(active, "Map")!!
+        d.isTapped(map) shouldBe true
+    }
+
+    /**
+     * The general CreateTokenExecutor path: an opponent's artifact-creature token also enters
+     * tapped under Dauntless Dismantler.
+     */
+    test("opponent's created artifact-creature token enters tapped (general token path)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!
+        val dismantlerOwner = d.getOpponent(active)
+
+        d.putCreatureOnBattlefield(dismantlerOwner, "Dauntless Dismantler")
+
+        val makerId = d.putCardInHand(active, "Construct Maker (test)")
+        d.castSpell(active, makerId).isSuccess shouldBe true
+        repeat(12) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        val construct = d.findPermanent(active, "Construct Token")!!
+        d.isTapped(construct) shouldBe true
+    }
+
+    /**
+     * Opponent-scoped: the Dismantler controller's OWN artifact token enters untapped — the
+     * replacement must not over-apply.
+     */
+    test("controller's own created artifact token does NOT enter tapped (opponent-scoped)") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!  // player1 — controls Dismantler and makes the token
+
+        d.putCreatureOnBattlefield(active, "Dauntless Dismantler")
+
+        val makerId = d.putCardInHand(active, "Map Maker (test)")
+        d.castSpell(active, makerId).isSuccess shouldBe true
+        repeat(12) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        val map = d.findPermanent(active, "Map")!!
+        d.isTapped(map) shouldBe false
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessDismantlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DauntlessDismantlerScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseNumberDecision
+import com.wingedsheep.engine.core.NumberChosenResponse
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.DauntlessDismantler
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Dauntless Dismantler (LCI) — {1}{W} Creature — Human Artificer 1/4
+ *
+ * "Artifacts your opponents control enter tapped."
+ * "{X}{X}{W}, Sacrifice this creature: Destroy each artifact with mana value X."
+ *
+ * Tests:
+ * 1. [PermanentsEnterTapped] replacement fires for opponents' artifacts — they enter tapped.
+ * 2. Replacement does NOT fire for the controller's own artifacts (opponent-scoped filter).
+ * 3. Activating with X=N destroys only artifacts with mana value N; Dismantler is sacrificed;
+ *    artifacts with a different mana value survive.
+ */
+class DauntlessDismantlerScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + listOf(DauntlessDismantler))
+        return d
+    }
+
+    // -------------------------------------------------------------------------
+    // Replacement effect — artifacts opponents control enter tapped
+    // -------------------------------------------------------------------------
+
+    /**
+     * Player 2 is the starting/active player. Player 1 (non-active) controls Dismantler.
+     * When player 2 (an opponent of player 1) casts Sol Ring during their main phase,
+     * the enters-tapped replacement fires and Sol Ring arrives tapped.
+     */
+    test("opponent's artifact enters tapped while Dismantler controls the battlefield") {
+        // startingPlayer = 1 makes player2 the active player so they can cast sorcery-speed
+        // permanents during their own main phase while player1's Dismantler is already in play.
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true, startingPlayer = 1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!            // player2 — will cast the artifact
+        val dismantlerOwner = d.getOpponent(active) // player1 — controls Dismantler
+
+        // Dismantler on player1's battlefield (replacement effect now active).
+        d.putCreatureOnBattlefield(dismantlerOwner, "Dauntless Dismantler")
+
+        // Player2 casts Sol Ring ({1}, MV 1) from hand — they are an opponent of player1.
+        val solRingId = d.putCardInHand(active, "Sol Ring")
+        d.giveColorlessMana(active, 1)
+        d.castSpell(active, solRingId).isSuccess shouldBe true
+        // Resolve the stack (Sol Ring resolves; no further triggered abilities expected).
+        repeat(10) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Sol Ring entered under player2 (opponent of Dismantler's controller) → tapped.
+        val solRing = d.findPermanent(active, "Sol Ring")!!
+        d.isTapped(solRing) shouldBe true
+    }
+
+    /**
+     * The replacement is opponent-scoped: the controller's own artifacts enter untapped.
+     */
+    test("controller's own artifact does NOT enter tapped (replacement is opponent-scoped)") {
+        val d = driver()
+        // Default startingPlayer=0: player1 is active and can cast sorcery-speed spells.
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!  // player1
+
+        d.putCreatureOnBattlefield(active, "Dauntless Dismantler")
+
+        // Player1 (Dismantler's controller) casts their own Sol Ring.
+        val solRingId = d.putCardInHand(active, "Sol Ring")
+        d.giveColorlessMana(active, 1)
+        d.castSpell(active, solRingId).isSuccess shouldBe true
+        repeat(10) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Sol Ring belongs to Dismantler's controller → NOT tapped.
+        val solRing = d.findPermanent(active, "Sol Ring")!!
+        d.isTapped(solRing) shouldBe false
+    }
+
+    // -------------------------------------------------------------------------
+    // Activated ability — {X}{X}{W}, Sacrifice: Destroy each artifact with MV X
+    // -------------------------------------------------------------------------
+
+    /**
+     * Activating with X=1 destroys all artifacts with mana value 1 (Sol Ring) and leaves
+     * artifacts with a different mana value (Triskelion, MV 6) untouched. The Dismantler
+     * is sacrificed as part of paying the cost (before the effect resolves).
+     */
+    test("activating with X=1 destroys MV-1 artifacts only; Dismantler is sacrificed") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+
+        val dismantler = d.putCreatureOnBattlefield(active, "Dauntless Dismantler")
+
+        // Set up targets on opponent's battlefield.
+        // Sol Ring ({1}, MV 1) — will be destroyed when X=1.
+        d.putPermanentOnBattlefield(opp, "Sol Ring")
+        // Triskelion ({6}, MV 6) — should survive when X=1.
+        d.putCreatureOnBattlefield(opp, "Triskelion")
+
+        // {X}{X}{W} with X=1 costs {1}{1}{W} = 2 generic + 1 white = 3 mana total.
+        d.giveMana(active, Color.WHITE, 1)
+        d.giveColorlessMana(active, 2)
+
+        val abilityId = DauntlessDismantler.activatedAbilities.first().id
+        // Bare activation (no pre-filled xValue) — engine pauses to ask for X.
+        val res = d.submit(ActivateAbility(playerId = active, sourceId = dismantler, abilityId = abilityId))
+        res.isPaused shouldBe true
+        d.pendingDecision.shouldBeInstanceOf<ChooseNumberDecision>()
+
+        // Choose X = 1.
+        d.submitDecision(active, NumberChosenResponse(d.pendingDecision!!.id, 1))
+        // Drain remaining decisions (mana payment, effect resolution, etc.).
+        repeat(15) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Dismantler was sacrificed as cost — no longer on battlefield.
+        d.findPermanent(active, "Dauntless Dismantler") shouldBe null
+
+        // Sol Ring (MV 1) was destroyed.
+        d.findPermanent(opp, "Sol Ring") shouldBe null
+
+        // Triskelion (MV 6) was NOT destroyed — it survives X=1.
+        d.findPermanent(opp, "Triskelion") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeepfathomEchoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeepfathomEchoScenarioTest.kt
@@ -1,0 +1,137 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.DeepfathomEcho
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Deepfathom Echo (LCI #228) — {2}{G}{U} 4/4 Creature — Merfolk Spirit
+ *
+ * "At the beginning of combat on your turn, this creature explores. Then you may have it
+ *  become a copy of another creature you control until end of turn."
+ *
+ * Tests:
+ *  1. Explore with a land on top → land goes to hand; player accepts the copy step →
+ *     Deepfathom Echo becomes a copy of the chosen other creature until end of turn
+ *     (copiable values only — power/toughness change, counters/attachments are unaffected).
+ *  2. Player declines the copy step → Deepfathom Echo stays a 4/4 Merfolk Spirit;
+ *     the land still went to hand from explore.
+ */
+class DeepfathomEchoScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DeepfathomEcho))
+        return driver
+    }
+
+    /**
+     * Advance to the begin-of-combat step on player 1's turn (mirrors the helper from
+     * JenovaAncientCalamityScenarioTest).
+     */
+    fun GameTestDriver.advanceToPlayer1BeginCombat() {
+        passPriorityUntil(Step.BEGIN_COMBAT)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.BEGIN_COMBAT)
+            safety++
+        }
+    }
+
+    test("explore (land → hand), accept copy: Echo becomes a copy of the chosen other creature until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Island" to 20),
+            startingLife = 20,
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        val player: EntityId = driver.player1
+
+        // Put Deepfathom Echo (4/4) and Grizzly Bears (2/2) on the battlefield.
+        val echo = driver.putCreatureOnBattlefield(player, "Deepfathom Echo")
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+
+        // Seed a land on top so explore takes the land-to-hand branch without pausing.
+        driver.putCardOnTopOfLibrary(player, "Forest")
+
+        val handSizeBefore = driver.getHandSize(player)
+
+        // Advance to player 1's begin-of-combat step. The trigger fires and goes on the stack;
+        // no decision is pending yet (no target is declared at stack-placement time — target
+        // selection is embedded inside the MayEffect and runs only at resolution if yes).
+        driver.advanceToPlayer1BeginCombat()
+
+        // Resolve the trigger: Explore runs (Forest → hand, no pause) → MayEffect → YesNoDecision.
+        driver.bothPass()
+
+        // The "you may have it become a copy" prompt should be pending.
+        (driver.pendingDecision is YesNoDecision) shouldBe true
+
+        // Accept the copy.
+        driver.submitYesNo(player, true)
+
+        // Grizzly Bears is the only other creature the controller controls (Deepfathom Echo is
+        // excluded by OtherCreatureYouControl's excludeSelf filter). SelectTargetEffect
+        // auto-selects it — no explicit ChooseTargetsDecision is expected.
+
+        // Advance state so the copy effect completes and priority is returned.
+        driver.bothPass()
+
+        // Forest went to hand during explore.
+        driver.getHandSize(player) shouldBe handSizeBefore + 1
+        driver.findCardInHand(player, "Forest").shouldNotBeNull()
+
+        // Deepfathom Echo is now a copy of Grizzly Bears: projected power/toughness = 2/2.
+        val projected = driver.state.projectedState
+        projected.getPower(echo) shouldBe 2
+        projected.getToughness(echo) shouldBe 2
+    }
+
+    test("explore (land → hand), decline copy: Echo remains a 4/4 Merfolk Spirit") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Island" to 20),
+            startingLife = 20,
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        val player: EntityId = driver.player1
+
+        val echo = driver.putCreatureOnBattlefield(player, "Deepfathom Echo")
+        // A second creature on the battlefield so the SelectTarget has a valid option,
+        // but the player will decline before any target is ever chosen.
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.putCardOnTopOfLibrary(player, "Forest")
+
+        val handSizeBefore = driver.getHandSize(player)
+
+        driver.advanceToPlayer1BeginCombat()
+
+        // Resolve the trigger: explore (Forest → hand) → MayEffect → YesNoDecision.
+        driver.bothPass()
+
+        (driver.pendingDecision is YesNoDecision) shouldBe true
+
+        // Decline the copy.
+        driver.submitYesNo(player, false)
+        driver.bothPass()
+
+        // Forest still went to hand during explore (explore is unconditional).
+        driver.getHandSize(player) shouldBe handSizeBefore + 1
+        driver.findCardInHand(player, "Forest").shouldNotBeNull()
+
+        // Deepfathom Echo was not copied — it is still a 4/4.
+        val projected = driver.state.projectedState
+        projected.getPower(echo) shouldBe 4
+        projected.getToughness(echo) shouldBe 4
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DefossilizeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DefossilizeScenarioTest.kt
@@ -1,0 +1,153 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Defossilize (LCI #103, {4}{B} Sorcery).
+ *
+ * "Return target creature card from your graveyard to the battlefield.
+ *  That creature explores, then it explores again."
+ *
+ * Tests:
+ *  1. The targeted creature card moves from the graveyard to the battlefield.
+ *  2. The reanimated creature explores exactly twice.
+ *     - Both explores reveal lands → two cards go to hand, no +1/+1 counters.
+ *     - Both explores reveal nonlands → two +1/+1 counters are placed, with two
+ *       may-put-in-graveyard decisions (one per explore).
+ *
+ * Uses [ScenarioTestBase] / the [scenario] builder. Defossilize is auto-discovered in
+ * [com.wingedsheep.mtg.sets.definitions.lci.LostCavernsOfIxalanSet] via [TestCards.all],
+ * so no explicit card registration is required.
+ */
+class DefossilizeScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, name: String): Int {
+        val id = game.findPermanent(name) ?: return 0
+        return game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Defossilize") {
+
+            // -----------------------------------------------------------------------
+            // Test 1: Basic reanimation — creature goes from graveyard to battlefield
+            // -----------------------------------------------------------------------
+            test("returns target creature card from graveyard to battlefield") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Defossilize")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    // Two lands in library (both reveals go to hand, no decision pauses).
+                    .withCardInLibrary(1, "Forest")    // top
+                    .withCardInLibrary(1, "Mountain")  // below
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Defossilize", 1, "Grizzly Bears")
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be on the battlefield after reanimation") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("Grizzly Bears should no longer be in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                }
+            }
+
+            // -----------------------------------------------------------------------
+            // Test 2: Double explore with lands — both lands go to hand, no counters
+            // -----------------------------------------------------------------------
+            test("reanimated creature explores twice — two land reveals go to hand with no counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Defossilize")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    // Library: [Mountain (top/index-0), Forest (bottom/index-1)].
+                    // First explore → Mountain to hand.  Second explore → Forest to hand.
+                    // Neither is a nonland, so no may-put-in-graveyard decision fires
+                    // and no +1/+1 counters are added.
+                    .withCardInLibrary(1, "Mountain")   // added first → index 0 = top
+                    .withCardInLibrary(1, "Forest")     // added second → index 1 = below
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.state.getHand(game.player1Id).size  // has Defossilize → 1
+
+                game.castSpellTargetingGraveyardCard(1, "Defossilize", 1, "Grizzly Bears")
+                game.resolveStack()  // spell resolves: PutOntoBattlefield, Explore×2 (both lands — no pauses)
+
+                withClue("Grizzly Bears should be on the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                // Net hand delta: −1 (Defossilize cast) +2 (two land reveals) = +1
+                withClue("hand should have grown by 1 (−1 cast Defossilize, +2 lands drawn by two explores)") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore - 1 + 2
+                }
+                withClue("land reveals must not place +1/+1 counters (CR 701.44a)") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 0
+                }
+                withClue("library should be empty after both top cards were drawn") {
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY)).size shouldBe 0
+                }
+            }
+
+            // -----------------------------------------------------------------------
+            // Test 3: Double explore with nonlands — two +1/+1 counters placed
+            // -----------------------------------------------------------------------
+            test("reanimated creature explores twice — two nonland reveals each put a +1/+1 counter on it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Defossilize")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    // Library: [Lightning Bolt (top)].  Both explores reveal Lightning Bolt because
+                    // the player keeps it on top after each nonland reveal (answerYesNo(true)).
+                    // Two nonland reveals → two decisions → two +1/+1 counters placed.
+                    .withCardInLibrary(1, "Lightning Bolt")   // top — revealed by both explores
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Defossilize", 1, "Grizzly Bears")
+
+                // Spell resolves: PutOntoBattlefield then Explore #1.
+                // Explore #1 reveals Lightning Bolt (top card, nonland) → counter placed, then pauses
+                // for the ExploreEffect YesNoDecision ("put card back on top of library, or graveyard?").
+                game.resolveStack()
+                withClue("first explore (nonland) should pause for the back-or-graveyard decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                // Yes = keep Lightning Bolt on top of library so the second explore reveals it again.
+                game.answerYesNo(true)
+
+                // Answering resumes the composite continuation: Explore #2 reveals Lightning Bolt again
+                // (still on top), places the second counter, and pauses for its own YesNoDecision.
+                withClue("second explore (nonland) should pause for the back-or-graveyard decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.answerYesNo(true)  // keep Lightning Bolt on top
+                game.resolveStack()     // finish the resolution
+
+                withClue("two nonland explores must place two +1/+1 counters on Grizzly Bears") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 2
+                }
+                withClue("Grizzly Bears should be on the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiamondPickAxeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiamondPickAxeScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Diamond Pick-Axe (LCI #143) — {R} Artifact — Equipment.
+ *
+ * Indestructible (Effects that say "destroy" don't destroy this Equipment.)
+ * Equipped creature gets +1/+1 and has "Whenever this creature attacks, create a Treasure token."
+ * Equip {2}
+ *
+ * Tests:
+ *  1. Equipped creature gets +1/+1 from the static ability.
+ *  2. Attacking with the equipped creature creates a Treasure token.
+ *  3. The Pick-Axe itself has Indestructible (projected keyword check).
+ */
+class DiamondPickAxeScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Diamond Pick-Axe") {
+
+            test("equipped creature gets +1/+1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Diamond Pick-Axe", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = projector.project(game.state)
+
+                withClue("Grizzly Bears base 2/2 + Pick-Axe +1/+1 = 3/3") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 3
+                }
+            }
+
+            test("Diamond Pick-Axe itself is indestructible") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Diamond Pick-Axe")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pickAxe = game.findPermanent("Diamond Pick-Axe")!!
+                withClue("Diamond Pick-Axe has indestructible printed on itself") {
+                    projector.project(game.state).hasKeyword(pickAxe, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+
+            test("attacking with the equipped creature creates a Treasure token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Diamond Pick-Axe", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("No Treasure exists before attacking") {
+                    game.findAllPermanents("Treasure").size shouldBe 0
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Attacking with the equipped creature triggers and creates exactly one Treasure") {
+                    game.findAllPermanents("Treasure").size shouldBe 1
+                }
+            }
+
+            test("unequipped creature attacking does NOT create a Treasure token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Diamond Pick-Axe")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("No Treasure — Pick-Axe is not equipped, grant is inactive") {
+                    game.findAllPermanents("Treasure").size shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DidactEchoScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DidactEchoScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.DidactEcho
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Didact Echo (LCI #53): {4}{U} 3/2 Creature — Spirit Cleric
+ * "When this creature enters, draw a card.
+ *  Descend 4 — This creature has flying as long as there are four or more permanent cards
+ *  in your graveyard."
+ *
+ * Tests:
+ *  - ETB trigger always draws one card.
+ *  - With fewer than 4 permanent cards in the graveyard → no flying.
+ *  - With four or more permanent cards in the graveyard → gains flying.
+ */
+class DidactEchoScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(DidactEcho))
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+            startingPlayer = 0,
+        )
+        return driver
+    }
+
+    test("ETB trigger draws a card when Didact Echo enters the battlefield") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe player
+
+        // Add Didact Echo to hand, then snapshot — so the accounting is purely
+        // cast (−1) + ETB draw (+1) = net 0 against this baseline.
+        val echo = driver.putCardInHand(player, "Didact Echo")
+        val handBefore = driver.getHandSize(player)
+
+        // Cast Didact Echo ({4}{U}).
+        driver.giveColorlessMana(player, 4)
+        driver.giveMana(player, Color.BLUE, 1)
+        driver.castSpell(player, echo)
+        // Spell resolves → ETB fires → draw trigger resolves.
+        driver.bothPass()
+        driver.bothPass() // draw trigger
+
+        // Hand should be handBefore − 1 (Didact Echo cast) + 1 (ETB draw) = handBefore.
+        driver.getHandSize(player) shouldBe handBefore
+    }
+
+    test("does not have flying when fewer than 4 permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val echo = driver.putCreatureOnBattlefield(player, "Didact Echo")
+
+        // Only 3 permanent cards in the graveyard — one short of the Descend 4 threshold.
+        repeat(3) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(echo, Keyword.FLYING) shouldBe false
+    }
+
+    test("has flying when four or more permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val player = driver.player1
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val echo = driver.putCreatureOnBattlefield(player, "Didact Echo")
+
+        // Exactly 4 permanent cards in the graveyard — meets the Descend 4 threshold.
+        repeat(4) { driver.putCardInGraveyard(player, "Grizzly Bears") }
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(echo, Keyword.FLYING) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbedSlumberScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbedSlumberScenarioTest.kt
@@ -62,6 +62,38 @@ class DisturbedSlumberScenarioTest : FunSpec({
         projected.hasKeyword(forest, Keyword.HASTE) shouldBe true
     }
 
+    test("animated land must be blocked if able — declining to block is illegal") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putLandOnBattlefield(p1, "Forest")
+        driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        val spell = driver.putCardInHand(p1, "Disturbed Slumber")
+        driver.giveMana(p1, Color.GREEN, 2)
+
+        driver.castSpell(p1, spell, targets = listOf(forest)).isSuccess shouldBe true
+        driver.bothPass()
+
+        // The animated land has haste, so it can attack the turn it was animated.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(forest), p2).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // p2 controls a Grizzly Bears that can block, so declaring no blockers is illegal.
+        driver.declareBlockers(p2, emptyMap()).isSuccess shouldBe false
+
+        // Blocking the animated land is legal.
+        val bears = driver.findPermanent(p2, "Grizzly Bears")!!
+        driver.declareBlockers(p2, mapOf(bears to listOf(forest))).isSuccess shouldBe true
+    }
+
     test("animated land reverts to a non-creature land at end of turn") {
         val driver = createDriver()
         driver.initMirrorMatch(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbedSlumberScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbedSlumberScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Disturbed Slumber (LCI #182).
+ *
+ * {1}{G} Instant
+ * "Until end of turn, target land you control becomes a 4/4 Dinosaur creature with reach and
+ * haste. It's still a land. It must be blocked this turn if able."
+ */
+class DisturbedSlumberScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("target land becomes a 4/4 Dinosaur with reach and haste, and is still a land") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putLandOnBattlefield(activePlayer, "Forest")
+        val spell = driver.putCardInHand(activePlayer, "Disturbed Slumber")
+        // {1}{G}: give 2 green so the generic {1} and the colored {G} are both covered.
+        driver.giveMana(activePlayer, Color.GREEN, 2)
+
+        val castResult = driver.castSpell(activePlayer, spell, targets = listOf(forest))
+        castResult.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        val projected = projector.project(driver.state)
+        // The land is now a creature.
+        projected.hasType(forest, "CREATURE") shouldBe true
+        // It's still a land ("it's still a land").
+        projected.hasType(forest, "LAND") shouldBe true
+        // Base P/T is 4/4.
+        projected.getPower(forest) shouldBe 4
+        projected.getToughness(forest) shouldBe 4
+        // Creature type is Dinosaur.
+        projected.hasSubtype(forest, "DINOSAUR") shouldBe true
+        // Granted keywords: reach and haste.
+        projected.hasKeyword(forest, Keyword.REACH) shouldBe true
+        projected.hasKeyword(forest, Keyword.HASTE) shouldBe true
+    }
+
+    test("animated land reverts to a non-creature land at end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putLandOnBattlefield(activePlayer, "Forest")
+        val spell = driver.putCardInHand(activePlayer, "Disturbed Slumber")
+        driver.giveMana(activePlayer, Color.GREEN, 2)
+
+        driver.castSpell(activePlayer, spell, targets = listOf(forest))
+        driver.bothPass()
+
+        // Confirm the land is animated mid-turn.
+        val midTurn = projector.project(driver.state)
+        midTurn.hasType(forest, "CREATURE") shouldBe true
+
+        // Advance to the opponent's upkeep — the end-of-turn cleanup fires and the effect expires.
+        driver.passPriorityUntil(Step.UPKEEP)
+
+        val nextTurn = projector.project(driver.state)
+        nextTurn.hasType(forest, "CREATURE") shouldBe false
+        nextTurn.hasType(forest, "LAND") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbedSlumberScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbedSlumberScenarioTest.kt
@@ -94,6 +94,84 @@ class DisturbedSlumberScenarioTest : FunSpec({
         driver.declareBlockers(p2, mapOf(bears to listOf(forest))).isSuccess shouldBe true
     }
 
+    test("two must-be-blocked attackers, one blocker — blocking either is legal (Rule 509.1c)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putLandOnBattlefield(p1, "Forest")
+        val swamp = driver.putLandOnBattlefield(p1, "Swamp")
+        driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        val spell1 = driver.putCardInHand(p1, "Disturbed Slumber")
+        val spell2 = driver.putCardInHand(p1, "Disturbed Slumber")
+        driver.giveMana(p1, Color.GREEN, 4)
+
+        driver.castSpell(p1, spell1, targets = listOf(forest)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.castSpell(p1, spell2, targets = listOf(swamp)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(forest, swamp), p2).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        val bears = driver.findPermanent(p2, "Grizzly Bears")!!
+
+        // Declining to block is still illegal — the Bears must block one of them.
+        driver.declareBlockers(p2, emptyMap()).isSuccess shouldBe false
+
+        // One blocker can only satisfy one requirement: blocking either attacker is legal.
+        driver.declareBlockers(p2, mapOf(bears to listOf(forest))).isSuccess shouldBe true
+    }
+
+    test("two must-be-blocked attackers, two blockers — both must be blocked") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val forest = driver.putLandOnBattlefield(p1, "Forest")
+        val swamp = driver.putLandOnBattlefield(p1, "Swamp")
+        val bears1 = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        val bears2 = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+
+        val spell1 = driver.putCardInHand(p1, "Disturbed Slumber")
+        val spell2 = driver.putCardInHand(p1, "Disturbed Slumber")
+        driver.giveMana(p1, Color.GREEN, 4)
+
+        driver.castSpell(p1, spell1, targets = listOf(forest)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.castSpell(p1, spell2, targets = listOf(swamp)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(forest, swamp), p2).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // Both requirements can be satisfied, so leaving one attacker unblocked is illegal —
+        // whether by blocking only one attacker or by stacking both blockers on one.
+        driver.declareBlockers(p2, mapOf(bears1 to listOf(forest))).isSuccess shouldBe false
+        driver.declareBlockers(p2, mapOf(bears1 to listOf(forest), bears2 to listOf(forest))).isSuccess shouldBe false
+
+        // Covering both attackers is legal.
+        driver.declareBlockers(
+            p2,
+            mapOf(bears1 to listOf(forest), bears2 to listOf(swamp))
+        ).isSuccess shouldBe true
+    }
+
     test("animated land reverts to a non-creature land at end of turn") {
         val driver = createDriver()
         driver.initMirrorMatch(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbedSlumberScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DisturbedSlumberScenarioTest.kt
@@ -56,7 +56,7 @@ class DisturbedSlumberScenarioTest : FunSpec({
         projected.getPower(forest) shouldBe 4
         projected.getToughness(forest) shouldBe 4
         // Creature type is Dinosaur.
-        projected.hasSubtype(forest, "DINOSAUR") shouldBe true
+        projected.hasSubtype(forest, "Dinosaur") shouldBe true
         // Granted keywords: reach and haste.
         projected.hasKeyword(forest, Keyword.REACH) shouldBe true
         projected.hasKeyword(forest, Keyword.HASTE) shouldBe true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EatenByPiranhasScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EatenByPiranhasScenarioTest.kt
@@ -1,0 +1,105 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.EatenByPiranhas
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests for Eaten by Piranhas (LCI #54)
+ * {1}{U} — Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature
+ * Enchanted creature loses all abilities and is a black Skeleton creature with base power
+ * and toughness 1/1. (It loses all other colors, card types, and creature types.)
+ */
+class EatenByPiranhasScenarioTest : FunSpec({
+
+    // A 3/3 red creature with flying — used as the enchantment target
+    val FlyingDragon = CardDefinition.creature(
+        name = "Flying Dragon",
+        manaCost = ManaCost.parse("{2}{R}"),
+        subtypes = setOf(Subtype("Dragon")),
+        power = 3,
+        toughness = 3,
+        keywords = setOf(Keyword.FLYING)
+    )
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(FlyingDragon, EatenByPiranhas))
+        return driver
+    }
+
+    test("Eaten by Piranhas sets enchanted creature's base power and toughness to 1/1") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20))
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(activePlayer, "Flying Dragon")
+        val aura = driver.putCardInHand(activePlayer, "Eaten by Piranhas")
+        driver.giveMana(activePlayer, Color.BLUE, 1)
+        driver.giveColorlessMana(activePlayer, 1)
+        driver.castSpell(activePlayer, aura, listOf(creature))
+        driver.bothPass()
+
+        projector.getProjectedPower(driver.state, creature) shouldBe 1
+        projector.getProjectedToughness(driver.state, creature) shouldBe 1
+    }
+
+    test("Eaten by Piranhas causes enchanted creature to lose all abilities") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20))
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(activePlayer, "Flying Dragon")
+        val aura = driver.putCardInHand(activePlayer, "Eaten by Piranhas")
+        driver.giveMana(activePlayer, Color.BLUE, 1)
+        driver.giveColorlessMana(activePlayer, 1)
+        driver.castSpell(activePlayer, aura, listOf(creature))
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        projected.hasLostAllAbilities(creature) shouldBe true
+        projected.hasKeyword(creature, Keyword.FLYING) shouldBe false
+    }
+
+    test("Eaten by Piranhas makes enchanted creature a black Skeleton, losing original color and creature types") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20))
+
+        val activePlayer = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val creature = driver.putCreatureOnBattlefield(activePlayer, "Flying Dragon")
+        val aura = driver.putCardInHand(activePlayer, "Eaten by Piranhas")
+        driver.giveMana(activePlayer, Color.BLUE, 1)
+        driver.giveColorlessMana(activePlayer, 1)
+        driver.castSpell(activePlayer, aura, listOf(creature))
+        driver.bothPass()
+
+        val projected = driver.state.projectedState
+        // Gains Skeleton subtype, loses Dragon
+        projected.hasSubtype(creature, "Skeleton") shouldBe true
+        projected.hasSubtype(creature, "Dragon") shouldBe false
+        // Becomes black, loses red
+        projected.hasColor(creature, Color.BLACK) shouldBe true
+        projected.hasColor(creature, Color.RED) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MustBeBlockedMatchingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MustBeBlockedMatchingScenarioTest.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Rule 509.1c requires the declaration of blockers to obey the maximum satisfiable number of
+ * blocking requirements. When blockers differ in what they can block, that maximum is a
+ * matching problem, not a per-attacker check: with attackers A (ground) and B (flying) both
+ * "must be blocked if able", a ground-only blocker X and a flying blocker Y, the only
+ * declaration obeying both requirements is X→A, Y→B. Parking Y on A and leaving X idle obeys
+ * one requirement where two were satisfiable — illegal.
+ *
+ * Both attackers get the requirement from Deadly Allure ("Target creature gains deathtouch
+ * until end of turn and must be blocked this turn if able").
+ */
+class MustBeBlockedMatchingScenarioTest : FunSpec({
+
+    test("asymmetric blockers must be assigned so both must-be-blocked attackers are covered") {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 40),
+            startingLife = 20
+        )
+
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // p1 attacks with a ground creature and a flier, both must-be-blocked.
+        val groundAttacker = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val flyingAttacker = driver.putCreatureOnBattlefield(p1, "Birds of Paradise")
+        driver.removeSummoningSickness(groundAttacker)
+        driver.removeSummoningSickness(flyingAttacker)
+
+        // p2's blockers: Bears can block only the ground attacker; Birds can block either.
+        val groundBlocker = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        val flexibleBlocker = driver.putCreatureOnBattlefield(p2, "Birds of Paradise")
+
+        val allure1 = driver.putCardInHand(p1, "Deadly Allure")
+        val allure2 = driver.putCardInHand(p1, "Deadly Allure")
+        driver.giveMana(p1, Color.BLACK, 2)
+        driver.castSpell(p1, allure1, targets = listOf(groundAttacker)).isSuccess shouldBe true
+        driver.bothPass()
+        driver.castSpell(p1, allure2, targets = listOf(flyingAttacker)).isSuccess shouldBe true
+        driver.bothPass()
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(groundAttacker, flyingAttacker), p2).isSuccess shouldBe true
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+
+        // Parking the flexible blocker on the ground attacker strands the flier: the ground
+        // blocker can't reach it, so only one requirement is obeyed where two are satisfiable.
+        driver.declareBlockers(p2, mapOf(flexibleBlocker to listOf(groundAttacker))).isSuccess shouldBe false
+
+        // Same coverage count the other way round: flier blocked, ground attacker strandable
+        // only by wasting the ground blocker — leaving it idle is illegal too.
+        driver.declareBlockers(p2, mapOf(flexibleBlocker to listOf(flyingAttacker))).isSuccess shouldBe false
+
+        // The unique full-coverage assignment is legal.
+        driver.declareBlockers(
+            p2,
+            mapOf(groundBlocker to listOf(groundAttacker), flexibleBlocker to listOf(flyingAttacker))
+        ).isSuccess shouldBe true
+    }
+})

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -67,6 +67,70 @@ function getEventLogType(eventType: string): 'action' | 'turn' | 'combat' | 'sys
   }
 }
 
+type RawCardsRevealedEvent = {
+  type: 'cardsRevealed'
+  revealingPlayerId: EntityId
+  cardIds: readonly EntityId[]
+  cardNames: readonly string[]
+  imageUris: readonly (string | null)[]
+  source: string | null
+  cardOwnerIds?: readonly EntityId[]
+  fromZone?: string | null
+  toZone?: string | null
+}
+
+/**
+ * Merge every cardsRevealed event in a state update into one overlay payload. A single
+ * resolution can reveal cards more than once (e.g. a creature exploring twice), and the
+ * overlay can only show one reveal — so combine them rather than dropping all but the first.
+ *
+ * Fields that disagree across events degrade gracefully: mixed sources → no source label,
+ * mixed zone transitions → plain reveal, mixed revealers → per-card owner attribution
+ * (the same mechanism multi-player reveals like Psychic Battle already use). A card
+ * revealed twice in the same update is shown once.
+ */
+function mergeCardsRevealedEvents(
+  events: readonly RawCardsRevealedEvent[]
+): RawCardsRevealedEvent | undefined {
+  if (events.length <= 1) return events[0]
+
+  const first = events[0]!
+  const sameRevealer = events.every((e) => e.revealingPlayerId === first.revealingPlayerId)
+  const needOwners = !sameRevealer || events.some((e) => e.cardOwnerIds && e.cardOwnerIds.length > 0)
+  const sources = [...new Set(events.map((e) => e.source).filter((s): s is string => s != null))]
+  const sameTransition = events.every(
+    (e) => (e.fromZone ?? null) === (first.fromZone ?? null) && (e.toZone ?? null) === (first.toZone ?? null)
+  )
+
+  const seen = new Set<EntityId>()
+  const cardIds: EntityId[] = []
+  const cardNames: string[] = []
+  const imageUris: (string | null)[] = []
+  const cardOwnerIds: EntityId[] = []
+  for (const e of events) {
+    e.cardIds.forEach((id, i) => {
+      if (seen.has(id)) return
+      seen.add(id)
+      cardIds.push(id)
+      cardNames.push(e.cardNames[i] ?? 'Unknown Card')
+      imageUris.push(e.imageUris[i] ?? null)
+      cardOwnerIds.push(e.cardOwnerIds?.[i] ?? e.revealingPlayerId)
+    })
+  }
+
+  return {
+    type: 'cardsRevealed',
+    revealingPlayerId: first.revealingPlayerId,
+    cardIds,
+    cardNames,
+    imageUris,
+    source: sources.length === 1 ? sources[0]! : null,
+    ...(needOwners ? { cardOwnerIds } : {}),
+    fromZone: sameTransition ? first.fromZone ?? null : null,
+    toZone: sameTransition ? first.toZone ?? null : null,
+  }
+}
+
 /**
  * Common state update fields shared by both full and delta update messages.
  */
@@ -102,9 +166,14 @@ function processStateUpdate(
     (e) => e.type === 'handRevealed' && (e as { revealingPlayerId: EntityId }).revealingPlayerId !== playerId
   ) as { type: 'handRevealed'; cardIds: readonly EntityId[] } | undefined
 
-  const cardsRevealedEventRaw = msg.events.find(
+  const cardsRevealedEvents = msg.events.filter(
     (e) => e.type === 'cardsRevealed'
-  ) as { type: 'cardsRevealed'; revealingPlayerId: EntityId; cardIds: readonly EntityId[]; cardNames: readonly string[]; imageUris: readonly (string | null)[]; source: string | null; cardOwnerIds?: readonly EntityId[]; fromZone?: string | null; toZone?: string | null } | undefined
+  ) as { type: 'cardsRevealed'; revealingPlayerId: EntityId; cardIds: readonly EntityId[]; cardNames: readonly string[]; imageUris: readonly (string | null)[]; source: string | null; cardOwnerIds?: readonly EntityId[]; fromZone?: string | null; toZone?: string | null }[]
+
+  // A single resolution can reveal more than once (e.g. Defossilize's creature explores
+  // twice → two cardsRevealed events in one update). Merge them into one overlay payload
+  // instead of taking the first and silently dropping the rest.
+  const cardsRevealedEventRaw = mergeCardsRevealedEvents(cardsRevealedEvents)
 
   // A single effect can reveal cards from more than one player at once (Psychic Battle: each
   // player reveals their top card). The event carries per-card owners in that case; derive a

--- a/web-client/src/store/slices/handlers/gameplayHandlers.ts
+++ b/web-client/src/store/slices/handlers/gameplayHandlers.ts
@@ -168,7 +168,7 @@ function processStateUpdate(
 
   const cardsRevealedEvents = msg.events.filter(
     (e) => e.type === 'cardsRevealed'
-  ) as { type: 'cardsRevealed'; revealingPlayerId: EntityId; cardIds: readonly EntityId[]; cardNames: readonly string[]; imageUris: readonly (string | null)[]; source: string | null; cardOwnerIds?: readonly EntityId[]; fromZone?: string | null; toZone?: string | null }[]
+  ) as RawCardsRevealedEvent[]
 
   // A single resolution can reveal more than once (e.g. Defossilize's creature explores
   // twice → two cardsRevealed events in one update). Merge them into one overlay payload


### PR DESCRIPTION
Depends on: https://github.com/wingedsheep/argentum-engine/pull/1253

## LCI cards — batch 6 (5 cards)

Sixth batch of Lost Caverns of Ixalan cards, each with a scenario test. Stacked on `lci-cards-05` — review only the diff to that branch; the diff vs `main` includes batches 1–5 until those merge.

- **Defossilize** — return target creature card from your graveyard to the battlefield, then it explores twice (`PutOntoBattlefield` → `Explore` → `Explore`).
- **Diamond Pick-Axe** — indestructible Equipment; equipped creature gets +1/+1 and makes a Treasure whenever it attacks; Equip {2} (`ModifyStats` + `GrantTriggeredAbility`).
- **Didact Echo** — ETB draw a card; has flying as long as there are 4+ permanent cards in your graveyard (Descend 4, `ConditionalStaticAbility` + `CardsInGraveyardMatchingAtLeast`).
- **Disturbed Slumber** — turn target land you control into a 4/4 reach + haste Dinosaur until end of turn (still a land); it must be blocked this turn if able (`BecomeCreature` + `MustBeBlockedEffect`).
- **Eaten by Piranhas** — flash Aura: enchanted creature is a 1/1 black Skeleton and loses all abilities (`TransformPermanent` + `LoseAllAbilities` + `SetBasePowerToughnessStatic`, the Sugar Coat pattern). Includes the FDN reprint `Printing` row.

No new SDK types — all five cards compose existing primitives. The batch surfaced three bugs, fixed here:

- **`MustBeBlockedExecutor` used the base type line** to validate its target, rejecting permanents that are only creatures via a continuous effect (Disturbed Slumber's animated land). Now reads `projectedState.isCreature`.
- **"Must be blocked if able" over-enforced Rule 509.1c:** with two such attackers and one blocker, every declaration was rejected. The validator now computes the maximum satisfiable number of requirements via bipartite matching (provoke-pinned blockers only count for their pinned attacker; blockers claimed by a Lure-style requirement are excluded) and rejects only declarations that obey fewer. Covered by `MustBeBlockedMatchingScenarioTest` (asymmetric blockers) and two new Disturbed Slumber tests.
- **The client reveal overlay dropped all but the first `cardsRevealed` event** in a state update; a Defossilize resolution reveals twice (two explores). Events are now merged into one overlay payload (presentation-only, no game logic in the client).

All scenario tests pass; LCI snapshot re-blessed; linter and `check-card-printing` green for all five cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
