### PR TITLE
fix: Bounce lands provide correct mana for affordability #1250

### DIFF
--- a/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/MultiColorLandManaTest.kt
+++ b/game-server/src/test/kotlin/com/wingedsheep/gameserver/ai/MultiColorLandManaTest.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.gameserver.ai
+
+import com.wingedsheep.engine.mechanics.mana.ManaSolver
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.mtg.sets.MtgSetCatalog
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+/**
+ * Regression for https://github.com/wingedsheep/argentum-engine/issues/1250 — "it only understands
+ * the single-color lands": a {1}{R}{G} spell couldn't be cast despite plenty of lands in play.
+ *
+ * A land whose single tap ability adds two DIFFERENT colored mana is scripted as a
+ * [com.wingedsheep.sdk.scripting.effects.CompositeEffect] via `.then()` — e.g. Gruul Turf's
+ * `{T}: Add {R}{G}` is `AddMana(RED).then(AddMana(GREEN))`. The [ManaSolver] source enumerator
+ * unwrapped a composite to its FIRST mana leaf only, so it saw Gruul Turf as a mono-red source and
+ * never knew it could make green. A {1}{R}{G} spell then looked unaffordable and the client never
+ * highlighted it.
+ *
+ * Basics and pain lands (Karplusan Forest — two *separate* R and G abilities) are unaffected,
+ * matching the report that only the multi-mana nonbasic land failed.
+ */
+class MultiColorLandManaTest : FunSpec({
+
+    fun driverWithAllSets(): GameTestDriver {
+        val driver = GameTestDriver()
+        MtgSetCatalog.all.forEach { set ->
+            driver.registerCards(set.cards)
+            driver.registerCards(set.basicLands)
+        }
+        // A trivial legal deck for both seats; battlefield is set up manually below.
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), skipMulligans = true, startingLife = 40)
+        return driver
+    }
+
+    // {1}{R}{G} — Grumgully, the Generous. Needs one red, one green, one generic.
+    val grumgullyCost = ManaCost.parse("{1}{R}{G}")
+
+    test("control: {1}{R}{G} is affordable off basic lands (harness sanity)") {
+        val driver = driverWithAllSets()
+        val player = driver.player1
+        // 3x Mountain + 1x Forest = R,R,R,G — clearly pays {1}{R}{G}.
+        repeat(3) { driver.putLandOnBattlefield(player, "Mountain") }
+        driver.putLandOnBattlefield(player, "Forest")
+
+        val solution = ManaSolver(driver.cardRegistry).solve(driver.state, player, grumgullyCost)
+        withClue("Basic lands must pay {1}{R}{G} — if this fails the harness itself is broken") {
+            solution.shouldNotBeNull()
+        }
+    }
+
+    test("Gruul Turf's green half is seen: {1}{R}{G} affordable when green comes only from Gruul Turf") {
+        val driver = driverWithAllSets()
+        val player = driver.player1
+        // Green is available ONLY from Gruul Turf ({T}: Add {R}{G}). The three Mountains supply
+        // red + generic. If the solver drops Gruul Turf's green half, it sees R,R,R,R — no green —
+        // and reports {1}{R}{G} unaffordable. That is the reported bug.
+        repeat(3) { driver.putLandOnBattlefield(player, "Mountain") }
+        driver.putLandOnBattlefield(player, "Gruul Turf")
+
+        val solution = ManaSolver(driver.cardRegistry).solve(driver.state, player, grumgullyCost)
+        withClue("Gruul Turf must contribute {G}; the solver dropped the second mana of its {R}{G} tap") {
+            solution.shouldNotBeNull()
+        }
+    }
+
+    test("Gruul Turf's red half is seen: {1}{R}{G} affordable when red comes only from Gruul Turf") {
+        val driver = driverWithAllSets()
+        val player = driver.player1
+        // Symmetric: red available ONLY from Gruul Turf; Forests supply green + generic.
+        repeat(3) { driver.putLandOnBattlefield(player, "Forest") }
+        driver.putLandOnBattlefield(player, "Gruul Turf")
+
+        val solution = ManaSolver(driver.cardRegistry).solve(driver.state, player, grumgullyCost)
+        withClue("Gruul Turf must contribute {R} as well as {G}") {
+            solution.shouldNotBeNull()
+        }
+    }
+})

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -983,6 +983,17 @@ class ManaSolver(
             val combinedColors = mutableSetOf<Color>()
             var producesColorless = false
             var maxManaAmount = 1
+            // Extra mana produced by the SAME tap when one mana ability adds more than one mana of
+            // different kinds via a CompositeEffect — Gruul Turf's "{T}: Add {R}{G}" and Mossfire
+            // Valley's "{1}, {T}: Add {R}{G}" are `AddMana(RED).then(AddMana(GREEN))`. `producesColors`
+            // models a *choice* of one color, so it can't hold "R AND G on one tap"; the additional
+            // leaves are folded into the bonus-mana channel that auras already use (the solver knows
+            // how to spend it — see useSource / spendBonusMana / payColoredPipFromAuraBonus). Without
+            // this the second color is dropped and a spell payable only with it (Grumgully {1}{R}{G})
+            // is wrongly reported unaffordable, so the client never highlights it.
+            var extraBonusColor: Color? = null
+            var extraBonusAmount = 0
+            var extraColorlessBonus = 0
             var anyAbilityHasNoPainCost = false
             var minPainAmount = Int.MAX_VALUE
             // Track which accepted abilities required sacrificing the source (e.g. Treasure).
@@ -1139,6 +1150,30 @@ class ManaSolver(
                 // tapping additional sources to cover them.
                 val effectColors = mutableSetOf<Color>()
                 val manaEffect = manaProducingEffect(ability.effect, state, entityId, playerId)
+                // A single tap that adds several mana of different kinds (Gruul Turf: {R}{G}). The
+                // primary leaf below feeds producesColors/maxManaAmount as usual; the *additional*
+                // fixed-color/colorless leaves have no home in the choice-based producesColors set,
+                // so route them through the bonus-mana channel. Only unconditional AddMana/
+                // AddColorlessMana leaves are folded — anything gated/choice-based stays with the
+                // primary path to avoid over-counting.
+                if (ability.effect is CompositeEffect && manaEffect is AddManaEffect) {
+                    var seenPrimary = false
+                    for (leaf in (ability.effect as CompositeEffect).effects) {
+                        when (leaf) {
+                            is AddManaEffect -> {
+                                if (!seenPrimary && leaf === manaEffect) {
+                                    seenPrimary = true // the primary leaf; handled by the `when` below
+                                } else {
+                                    extraBonusColor = extraBonusColor ?: leaf.color
+                                    extraBonusAmount += (leaf.amount as? DynamicAmount.Fixed)?.amount ?: 1
+                                }
+                            }
+                            is AddColorlessManaEffect ->
+                                extraColorlessBonus += (leaf.amount as? DynamicAmount.Fixed)?.amount ?: 1
+                            else -> {}
+                        }
+                    }
+                }
                 val effectRestriction: ManaRestriction? = when (val effect = manaEffect) {
                     is AddManaEffect -> {
                         combinedColors.add(effect.color)
@@ -1283,6 +1318,16 @@ class ManaSolver(
                     null
                 }
 
+                // A multi-mana composite tap ability contributes its extra colored mana as a
+                // bonus alongside a colored source; if the source is otherwise colorless-only
+                // (never happens for the two real cards, but keep it sound) the extra colored
+                // leaf still needs `producesColors` non-empty so its color is spendable.
+                if (extraBonusColor != null && combinedColors.isEmpty()) {
+                    combinedColors.add(extraBonusColor!!)
+                    extraBonusColor = null
+                    extraBonusAmount = maxOf(0, extraBonusAmount - 1)
+                }
+
                 return@mapNotNull ManaSource(
                     entityId = entityId,
                     name = card.name,
@@ -1296,6 +1341,9 @@ class ManaSolver(
                     painAmount = painAmount,
                     canAttack = canAttack,
                     manaAmount = maxManaAmount,
+                    bonusManaPerTap = extraBonusAmount,
+                    bonusManaColor = extraBonusColor,
+                    bonusManaColorlessPerTap = extraColorlessBonus,
                     restriction = sourceRestriction,
                     colorRiders = perColorRiders.mapValues { (_, v) -> v.toSet() },
                     colorRestrictions = restrictedColors,


### PR DESCRIPTION
Ref: https://github.com/wingedsheep/argentum-engine/issues/1250

## Problem

A `{1}{R}{G}` spell (e.g. Grumgully, the Generous) was reported as unaffordable — and therefore never highlighted as castable in the client — even with plenty of lands in play. As the issue put it, the solver "only understands the single-color lands."

The root cause is in `ManaSolver.kt`. A land whose single tap ability adds **two different colored mana** is scripted as a `CompositeEffect` via `.then()` — Gruul Turf's `{T}: Add {R}{G}` is `AddMana(RED).then(AddMana(GREEN))`. The source enumerator unwrapped a composite to its **first mana leaf only**, so it saw Gruul Turf as a mono-red source and never knew it could also make green. A `{1}{R}{G}` spell then looked unpayable.

Basic lands and pain lands (Karplusan Forest, which has two *separate* R and G abilities) were unaffected — matching the report that only the multi-mana nonbasic ("bounce"/Karoo) lands failed.

## Fix

When a tap ability is a `CompositeEffect` producing multiple mana, the primary leaf still feeds the existing `producesColors` / `maxManaAmount` path. Because `producesColors` models a *choice* of one color (it can't represent "R **and** G on one tap"), the **additional** fixed-color/colorless leaves are routed through the pre-existing bonus-mana channel that auras already use — `useSource` / `spendBonusMana` / `payColoredPipFromAuraBonus` already know how to spend it. This surfaces as three new fields on `ManaSource`: `bonusManaPerTap`, `bonusManaColor`, and `bonusManaColorlessPerTap`.

Only unconditional `AddMana` / `AddColorlessMana` leaves are folded in — anything gated or choice-based stays on the primary path to avoid over-counting. There's also a soundness guard: if a source is otherwise colorless-only, the extra colored leaf promotes into `combinedColors` so its color remains spendable (doesn't occur for the two real cards, but keeps the logic correct).

## Tests

New `MultiColorLandManaTest.kt`:
- **control** — `{1}{R}{G}` is affordable off basic lands (harness sanity check).
- **green half seen** — green available *only* from Gruul Turf; the spell must still be affordable.
- **red half seen** — symmetric case with red available only from Gruul Turf.

## Impact

- +130 lines across 2 files; no changes to existing behavior for single-color or separate-ability lands.
- Fixes affordability detection for Ravnica-style Karoo/bounce lands (Gruul Turf, Mossfire Valley, etc.), restoring correct castability highlighting in the client.

Closes #1250.
