### PR TITLE
LCI batch 9 (+ TapPermanents cast fix)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 151 / 286
+**Implemented:** 156 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -108,12 +108,12 @@
 - [x] Glorifier of Suffering
 - [ ] Glowcap Lantern
 - [x] Goblin Tomb Raider
-- [ ] Goldfury Strider
+- [x] Goldfury Strider
 - [ ] Grasping Shadows
 - [x] Greedy Freebooter
 - [ ] Growing Rites of Itlimoc
-- [ ] Guardian of the Great Door
-- [ ] Helping Hand
+- [x] Guardian of the Great Door
+- [x] Helping Hand
 - [x] Hermitic Nautilus
 - [x] Hidden Cataract
 - [x] Hidden Courtyard
@@ -125,8 +125,8 @@
 - [x] Hoverstone Pilgrim
 - [x] Huatli's Final Strike
 - [ ] Huatli, Poet of Unity
-- [ ] Hulking Raptor
-- [ ] Hunter's Blowgun
+- [x] Hulking Raptor
+- [x] Hunter's Blowgun
 - [x] Hurl into History
 - [ ] Idol of the Deep King
 - [ ] In the Presence of Ages

--- a/manual-scenarios/sets/lci/cards-9.json
+++ b/manual-scenarios/sets/lci/cards-9.json
@@ -1,0 +1,46 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Goldfury Strider",
+      "Guardian of the Great Door",
+      "Helping Hand",
+      "Hulking Raptor",
+      "Hunter's Blowgun"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": ["Coati Scavenger"],
+    "library": ["Plains", "Forest", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Forest", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GoldfuryStrider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GoldfuryStrider.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Goldfury Strider
+ * {4}{R}
+ * Artifact Creature — Golem
+ * 3/5
+ * Trample
+ * Tap two untapped artifacts and/or creatures you control: Target creature gets +2/+0 until end
+ * of turn. Activate only as a sorcery.
+ *
+ * The activation cost reuses the [Costs.TapPermanents] primitive (same shape as Adaptive
+ * Gemguard), requiring exactly two untapped artifacts or creatures you control. The effect
+ * applies a temporary power boost via [Effects.ModifyStats], referencing the declared target
+ * with [EffectTarget.ContextTarget].
+ */
+val GoldfuryStrider = card("Goldfury Strider") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact Creature — Golem"
+    power = 3
+    toughness = 5
+    oracleText = "Trample\nTap two untapped artifacts and/or creatures you control: Target creature gets +2/+0 until end of turn. Activate only as a sorcery."
+
+    keywords(Keyword.TRAMPLE)
+
+    activatedAbility {
+        cost = Costs.TapPermanents(
+            count = 2,
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature,
+        )
+        target = Targets.Creature
+        effect = Effects.ModifyStats(2, 0, EffectTarget.ContextTarget(0))
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "152"
+        artist = "José Parodi"
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/415904fe-b77f-4c1a-850f-688484d629e6.jpg?1782694487"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GuardianOfTheGreatDoor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GuardianOfTheGreatDoor.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+
+/**
+ * Guardian of the Great Door
+ * {W}{W}
+ * Creature — Angel
+ * 4/4
+ * As an additional cost to cast this spell, tap four untapped artifacts, creatures, and/or
+ * lands you control.
+ * Flying
+ *
+ * The mandatory additional cost is modeled as AdditionalCost.TapPermanents over an inline
+ * artifact-or-creature-or-land filter (CR 601.2f — paid as the spell is cast). The cost atom
+ * enforces "untapped you control" independently of the filter, so no redundant state predicates
+ * are added to the filter.
+ */
+val GuardianOfTheGreatDoor = card("Guardian of the Great Door") {
+    manaCost = "{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel"
+    oracleText = "As an additional cost to cast this spell, tap four untapped artifacts, creatures, " +
+        "and/or lands you control.\nFlying"
+    power = 4
+    toughness = 4
+
+    keywords(Keyword.FLYING)
+
+    additionalCost(
+        Costs.additional.TapPermanents(
+            count = 4,
+            filter = GameObjectFilter(
+                cardPredicates = listOf(
+                    CardPredicate.Or(
+                        listOf(
+                            CardPredicate.IsArtifact,
+                            CardPredicate.IsCreature,
+                            CardPredicate.IsLand
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "16"
+        artist = "Justyna Dura"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a86f3cb2-7822-4c19-bd84-cea177e5b6e9.jpg?1782694599"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GuardianOfTheGreatDoor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GuardianOfTheGreatDoor.kt
@@ -5,7 +5,6 @@ import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.predicates.CardPredicate
 
 /**
  * Guardian of the Great Door
@@ -35,17 +34,7 @@ val GuardianOfTheGreatDoor = card("Guardian of the Great Door") {
     additionalCost(
         Costs.additional.TapPermanents(
             count = 4,
-            filter = GameObjectFilter(
-                cardPredicates = listOf(
-                    CardPredicate.Or(
-                        listOf(
-                            CardPredicate.IsArtifact,
-                            CardPredicate.IsCreature,
-                            CardPredicate.IsLand
-                        )
-                    )
-                )
-            )
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature or GameObjectFilter.Land
         )
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HelpingHand.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HelpingHand.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.predicates.ControllerPredicate
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Helping Hand — {W}
+ * Sorcery
+ * Uncommon — The Lost Caverns of Ixalan #17
+ * Artist: Aldo Domínguez
+ *
+ * "Return target creature card with mana value 3 or less from your graveyard to the battlefield tapped."
+ *
+ * The target must be a creature card in the controller's own graveyard with mana value ≤ 3
+ * (CardPredicate.ManaValueAtMost(3) + ControllerPredicate.OwnedByYou in Zone.GRAVEYARD).
+ * The card enters the battlefield tapped (PutOntoBattlefield with tapped = true).
+ */
+val HelpingHand = card("Helping Hand") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Return target creature card with mana value 3 or less from your graveyard to the battlefield tapped."
+
+    spell {
+        val t = target(
+            "target creature card with mana value 3 or less from your graveyard",
+            TargetObject(
+                filter = TargetFilter(
+                    GameObjectFilter(
+                        cardPredicates = listOf(CardPredicate.IsCreature, CardPredicate.ManaValueAtMost(3)),
+                        controllerPredicate = ControllerPredicate.OwnedByYou
+                    ),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.PutOntoBattlefield(t, tapped = true)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "17"
+        artist = "Aldo Domínguez"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b8aa7126-5df3-42dd-b4a3-0d0ea59eeebd.jpg?1782694598"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HulkingRaptor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HulkingRaptor.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.WardCost
+
+/**
+ * Hulking Raptor — The Lost Caverns of Ixalan #191
+ * {2}{G}{G} · Creature — Dinosaur · 5/3 · Rare
+ *
+ * Ward {2}
+ * At the beginning of your first main phase, add {G}{G}.
+ *
+ * Ward {2}: `KeywordAbility.Ward(WardCost.Mana("{2}"))` — triggers whenever an opponent
+ * targets this creature; they must pay {2} or the spell/ability is countered.
+ *
+ * First-main mana: `Triggers.FirstMainPhase` fires at the start of the controller's
+ * precombat main phase; `Effects.AddMana(Color.GREEN, 2)` adds two unrestricted {G} to
+ * the controller's mana pool.
+ */
+val HulkingRaptor = card("Hulking Raptor") {
+    manaCost = "{2}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 5
+    toughness = 3
+    oracleText = "Ward {2}\nAt the beginning of your first main phase, add {G}{G}."
+
+    // Ward {2}: opponents must pay {2} to keep a spell/ability targeting this creature.
+    keywordAbility(KeywordAbility.Ward(WardCost.Mana("{2}")))
+
+    // At the beginning of your first main phase, add {G}{G}.
+    triggeredAbility {
+        trigger = Triggers.FirstMainPhase
+        effect = Effects.AddMana(Color.GREEN, 2)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "191"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/front/4/5/45f763af-5a6a-404c-8e8c-4dbed71277bc.jpg?1782694456"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HuntersBlowgun.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/HuntersBlowgun.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Hunter's Blowgun (LCI #255) — {1} Artifact — Equipment (common)
+ *
+ * Equipped creature gets +1/+1.
+ * Equipped creature has deathtouch during your turn. Otherwise, it has reach.
+ * Equip {2}
+ *
+ * Implementation notes:
+ * - The +1/+1 buff is a plain [ModifyStats] static scoped to [Filters.EquippedCreature] and
+ *   is always active while the equipment is attached.
+ * - Deathtouch is a [GrantKeyword] wrapped in a [ConditionalStaticAbility] gated by
+ *   [Conditions.IsYourTurn] (via the `condition` field of the `staticAbility { }` block,
+ *   which auto-wraps in [ConditionalStaticAbility]). Active only during the equipment
+ *   controller's own turns.
+ * - Reach uses the same pattern but gated by [Conditions.IsNotYourTurn], i.e. it applies
+ *   on all opponents' turns ("Otherwise, it has reach").
+ * - [equipAbility] wires up the Equip {2} activated ability (sorcery-speed attach).
+ */
+val HuntersBlowgun = card("Hunter's Blowgun") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1.\n" +
+        "Equipped creature has deathtouch during your turn. Otherwise, it has reach.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    // Equipped creature gets +1/+1 at all times.
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    // Equipped creature has deathtouch during the controller's turn.
+    staticAbility {
+        condition = Conditions.IsYourTurn
+        ability = GrantKeyword(Keyword.DEATHTOUCH, Filters.EquippedCreature)
+    }
+
+    // Equipped creature has reach during opponents' turns.
+    staticAbility {
+        condition = Conditions.IsNotYourTurn
+        ability = GrantKeyword(Keyword.REACH, Filters.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "255"
+        artist = "Hector Ortiz"
+        imageUri = "https://cards.scryfall.io/normal/front/3/3/3348abe7-6aa3-47f7-8203-a15f75007e33.jpg?1782694408"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -5074,6 +5074,69 @@
     ]
 }
 
+// Goldfury Strider
+{
+    "name": "Goldfury Strider",
+    "manaCost": "{4}{R}",
+    "typeLine": "Artifact Creature — Golem",
+    "oracleText": "Trample\nTap two untapped artifacts and/or creatures you control: Target creature gets +2/+0 until end of turn. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "artifact|creature"
+                    }
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "ContextTarget",
+                        "index": 0
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        }
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "152",
+        "rarity": "UNCOMMON",
+        "artist": "José Parodi",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/415904fe-b77f-4c1a-850f-688484d629e6.jpg?1782694487"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Greedy Freebooter
 {
     "name": "Greedy Freebooter",
@@ -5117,6 +5180,80 @@
     },
     "colorIdentityOverride": [
         "BLACK"
+    ]
+}
+
+// Guardian of the Great Door
+{
+    "name": "Guardian of the Great Door",
+    "manaCost": "{W}{W}",
+    "typeLine": "Creature — Angel",
+    "oracleText": "As an additional cost to cast this spell, tap four untapped artifacts, creatures, and/or lands you control.\nFlying",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "additionalCosts": [
+            {
+                "type": "AdditionalAtom",
+                "atom": {
+                    "type": "AtomTapPermanents",
+                    "count": 4,
+                    "filter": "artifact|creature|land"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "16",
+        "rarity": "UNCOMMON",
+        "artist": "Justyna Dura",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a86f3cb2-7822-4c19-bd84-cea177e5b6e9.jpg?1782694599"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Helping Hand
+{
+    "name": "Helping Hand",
+    "manaCost": "{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return target creature card with mana value 3 or less from your graveyard to the battlefield tapped.",
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "target creature card with mana value 3 or less from your graveyard"
+            },
+            "destination": "Battlefield",
+            "placement": "Tapped"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature mv<=3 own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "target creature card with mana value 3 or less from your graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "17",
+        "rarity": "UNCOMMON",
+        "artist": "Aldo Domínguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b8aa7126-5df3-42dd-b4a3-0d0ea59eeebd.jpg?1782694598"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -5692,6 +5829,129 @@
     "colorIdentityOverride": [
         "GREEN"
     ]
+}
+
+// Hulking Raptor
+{
+    "name": "Hulking Raptor",
+    "manaCost": "{2}{G}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Ward {2}\nAt the beginning of your first main phase, add {G}{G}.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 3
+    },
+    "keywords": [
+        "WARD"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Ward",
+            "cost": {
+                "type": "WardCost.Mana",
+                "manaCost": "{2}"
+            }
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "PRECOMBAT_MAIN"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "GREEN",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "191",
+        "rarity": "RARE",
+        "artist": "Néstor Ossandón Leal",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/5/45f763af-5a6a-404c-8e8c-4dbed71277bc.jpg?1782694456"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Hunter's Blowgun
+{
+    "name": "Hunter's Blowgun",
+    "manaCost": "{1}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1.\nEquipped creature has deathtouch during your turn. Otherwise, it has reach.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH"
+                },
+                "condition": "IsYourTurn"
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "REACH"
+                },
+                "condition": "IsNotYourTurn"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "255",
+        "artist": "Hector Ortiz",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/3/3348abe7-6aa3-47f7-8203-a15f75007e33.jpg?1782694408"
+    },
+    "colorIdentityOverride": []
 }
 
 // Hurl into History

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/CastSpellEnumerator.kt
@@ -162,6 +162,8 @@ class CastSpellEnumerator : ActionEnumerator {
             var discardCount = 0
             var bounceTargets = emptyList<EntityId>()
             var bounceCount = 0
+            var tapTargets = emptyList<EntityId>()
+            var tapCount = 0
             var beholdTargets = emptyList<EntityId>()
             var beholdCount = 0
             var blightOrPayCost: AdditionalCost.BlightOrPay? = null
@@ -227,7 +229,23 @@ class CastSpellEnumerator : ActionEnumerator {
                             bounceTargets = validBounceTargets
                             bounceCount = atom.count
                         }
-                        // Mana / tap / reveal aren't produced as spell additional costs today.
+                        is CostAtom.TapPermanents -> {
+                            // "As an additional cost to cast this spell, tap [count] untapped
+                            // [filter] you control" (e.g. Guardian of the Great Door). Mirrors the
+                            // ReturnToHand selection model above — permanents you control, chosen by
+                            // the caster — but the payment taps instead of bouncing. Without this
+                            // case the cost fell through to `else -> {}`, so no `AdditionalCostData`
+                            // reached the client: it couldn't prompt for the tap, yet the cast-time
+                            // validator still rejected the empty payment.
+                            val validTapTargets = context.costUtils.findAbilityTapTargets(state, playerId, atom.filter)
+                                .let { if (atom.excludeSelf) it.filter { id -> id != cardId } else it }
+                            if (validTapTargets.size < atom.count) {
+                                canPayAdditionalCosts = false
+                            }
+                            tapTargets = validTapTargets
+                            tapCount = atom.count
+                        }
+                        // Mana / reveal aren't produced as spell additional costs today.
                         else -> {}
                     }
                     is AdditionalCost.SacrificeCreaturesForCostReduction -> {
@@ -556,6 +574,7 @@ class CastSpellEnumerator : ActionEnumerator {
                 additionalCosts, sacrificeTargets, variableSacrificeTargets,
                 exileTargets, exileMinCount, discardTargets, discardCount,
                 bounceTargets, bounceCount,
+                tapTargets, tapCount,
                 beholdTargets, beholdCount,
                 blightVariableCost, blightVariableCreatures, blightVariableMaxX,
                 payXLifeCost, payXLifeMaxX
@@ -2022,6 +2041,8 @@ class CastSpellEnumerator : ActionEnumerator {
         discardCount: Int,
         bounceTargets: List<EntityId> = emptyList(),
         bounceCount: Int = 0,
+        tapTargets: List<EntityId> = emptyList(),
+        tapCount: Int = 0,
         beholdTargets: List<EntityId> = emptyList(),
         beholdCount: Int = 0,
         blightVariableCost: AdditionalCost.BlightVariable? = null,
@@ -2091,6 +2112,14 @@ class CastSpellEnumerator : ActionEnumerator {
                 costType = "ReturnToHand",
                 validBounceTargets = bounceTargets,
                 bounceCount = bounceCount
+            )
+        } else if (tapTargets.isNotEmpty()) {
+            val tapCostAtom = additionalCosts.firstNotNullOfOrNull { (it as? AdditionalCost.Atom)?.atom as? CostAtom.TapPermanents }
+            AdditionalCostData(
+                description = tapCostAtom?.description?.replaceFirstChar { it.uppercase() } ?: "Tap permanents you control",
+                costType = "TapPermanents",
+                validTapTargets = tapTargets,
+                tapCount = tapCount
             )
         } else if (beholdTargets.isNotEmpty()) {
             val flatCosts = additionalCosts.flatMap { if (it is AdditionalCost.Composite) it.steps else listOf(it) }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldfuryStriderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoldfuryStriderScenarioTest.kt
@@ -1,0 +1,155 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.GoldfuryStrider
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Goldfury Strider (LCI #152).
+ *
+ * Goldfury Strider {4}{R}
+ * Artifact Creature — Golem 3/5
+ * Trample
+ * Tap two untapped artifacts and/or creatures you control: Target creature gets +2/+0 until end
+ * of turn. Activate only as a sorcery.
+ *
+ * Covers:
+ *  - Static keyword: Goldfury Strider has trample.
+ *  - Happy path: two untapped creatures available → activation taps both and target gets +2/+0.
+ *  - Sorcery-speed gate: activation is rejected outside a main phase with an empty stack.
+ *  - Cost gate: activation is rejected when fewer than two matching untapped permanents are available.
+ */
+class GoldfuryStriderScenarioTest : FunSpec({
+
+    val abilityId = GoldfuryStrider.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GoldfuryStrider)
+        return driver
+    }
+
+    fun GameTestDriver.power(id: EntityId): Int = state.projectedState.getPower(id) ?: 0
+    fun GameTestDriver.toughness(id: EntityId): Int = state.projectedState.getToughness(id) ?: 0
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: Goldfury Strider has trample
+    // ─────────────────────────────────────────────────────────────────────────
+    test("Goldfury Strider has trample") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+
+        val strider = driver.putCreatureOnBattlefield(me, "Goldfury Strider")
+
+        driver.state.projectedState.hasKeyword(strider, Keyword.TRAMPLE) shouldBe true
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: Tapping two creatures pumps target creature +2/+0 until end of turn
+    // ─────────────────────────────────────────────────────────────────────────
+    test("tapping two untapped creatures gives target creature +2/+0 until end of turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val strider = driver.putCreatureOnBattlefield(me, "Goldfury Strider")
+        driver.removeSummoningSickness(strider)
+        val bear1 = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+        val bear2 = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.removeSummoningSickness(bear2)
+
+        // Target is the strider itself (any creature is legal)
+        driver.power(strider) shouldBe 3
+        driver.toughness(strider) shouldBe 5
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = strider,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1, bear2)),
+                targets = listOf(ChosenTarget.Permanent(strider))
+            )
+        )
+        driver.bothPass() // resolve the ability
+
+        // Both permanents tapped to pay the cost.
+        driver.isTapped(bear1) shouldBe true
+        driver.isTapped(bear2) shouldBe true
+
+        // Target received +2/+0 until end of turn.
+        driver.power(strider) shouldBe 5
+        driver.toughness(strider) shouldBe 5
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: Cannot be activated at instant speed (sorcery-speed gate)
+    // ─────────────────────────────────────────────────────────────────────────
+    test("cannot be activated at instant speed") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+
+        val strider = driver.putCreatureOnBattlefield(me, "Goldfury Strider")
+        driver.removeSummoningSickness(strider)
+        val bear1 = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+        val bear2 = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.removeSummoningSickness(bear2)
+        val target = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        // Advance into the declare-attackers step — not a main phase with an empty stack.
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = me,
+                sourceId = strider,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1, bear2)),
+                targets = listOf(ChosenTarget.Permanent(target))
+            )
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 4: Cannot be activated without two matching untapped permanents
+    // ─────────────────────────────────────────────────────────────────────────
+    test("cannot be activated without two matching untapped permanents") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val me = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val strider = driver.putCreatureOnBattlefield(me, "Goldfury Strider")
+        driver.removeSummoningSickness(strider)
+        // Only one other creature — cost requires two
+        val bear1 = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = me,
+                sourceId = strider,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1)),
+                targets = listOf(ChosenTarget.Permanent(strider))
+            )
+        )
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GuardianOfTheGreatDoorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GuardianOfTheGreatDoorScenarioTest.kt
@@ -10,6 +10,8 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.scripting.AdditionalCostPayment
 import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 /**
@@ -68,6 +70,39 @@ class GuardianOfTheGreatDoorScenarioTest : ScenarioTestBase() {
                 }
                 withClue("Guardian of the Great Door has flying") {
                     projector.project(game.state).hasKeyword(guardianId, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("legal-action enumeration surfaces TapPermanents cost info so the client can prompt") {
+                // Regression: the cast enumerator dropped TapPermanents through an `else -> {}`
+                // branch, so no AdditionalCostData reached the client. The frontend never asked for
+                // the four taps, submitted an empty payment, and the cast-time validator rejected it
+                // with "You must tap 4 …". The enumerator must expose the tap targets like it does
+                // for sacrifice / return-to-hand additional costs.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Guardian of the Great Door")
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spellId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Guardian of the Great Door"
+                }
+                val plains = game.state.getBattlefield(game.player1Id).filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Plains"
+                }
+
+                val castInfo = game.getLegalActions(1)
+                    .filter { it.actionType == "CastSpell" }
+                    .single { (it.action as? CastSpell)?.cardId == spellId }
+
+                withClue("Cast must expose TapPermanents cost info with the six untapped Plains as targets") {
+                    val costInfo = castInfo.additionalCostInfo.shouldNotBeNull()
+                    costInfo.costType shouldBe "TapPermanents"
+                    costInfo.tapCount shouldBe 4
+                    costInfo.validTapTargets shouldContainAll plains
                 }
             }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GuardianOfTheGreatDoorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GuardianOfTheGreatDoorScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Guardian of the Great Door (LCI #16) — "As an additional cost to cast this spell, tap four
+ * untapped artifacts, creatures, and/or lands you control.\nFlying"
+ *
+ * Exercises the `AdditionalCost.TapPermanents` cast additional cost over a combined
+ * artifact-or-creature-or-land filter (CR 601.2f — paid as the spell is cast), and verifies
+ * that the resolved permanent has flying.
+ */
+class GuardianOfTheGreatDoorScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Guardian of the Great Door — tap-four additional cost") {
+
+            test("taps the four chosen lands and resolves onto the battlefield with flying") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Guardian of the Great Door")
+                    // Two Plains for {W}{W} mana + four more to tap as the additional cost.
+                    .withLandsOnBattlefield(1, "Plains", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spellId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Guardian of the Great Door"
+                }
+                val allPlains = game.state.getBattlefield(game.player1Id).filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Plains"
+                }
+                // Pick four Plains for the tap additional cost; the remaining two pay {W}{W}.
+                val additionalTaps = allPlains.take(4)
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id, spellId, emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(tappedPermanents = additionalTaps)
+                    )
+                )
+                withClue("Cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                withClue("All four chosen permanents are tapped by the additional cost") {
+                    additionalTaps.forEach { id ->
+                        game.state.getEntity(id)?.has<TappedComponent>() shouldBe true
+                    }
+                }
+                withClue("Guardian of the Great Door resolves onto the battlefield") {
+                    game.isOnBattlefield("Guardian of the Great Door") shouldBe true
+                }
+                val guardianId = game.state.getBattlefield(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Guardian of the Great Door"
+                }
+                withClue("Guardian of the Great Door has flying") {
+                    projector.project(game.state).hasKeyword(guardianId, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("taps mix of creatures and lands as the additional cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Guardian of the Great Door")
+                    // Two Plains for {W}{W} mana, plus two Grizzly Bears and two Plains for the tap cost.
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spellId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Guardian of the Great Door"
+                }
+                val plains = game.state.getBattlefield(game.player1Id).filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Plains"
+                }
+                val bears = game.state.getBattlefield(game.player1Id).filter { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Grizzly Bears"
+                }
+                // Tap two Plains + two Grizzly Bears as the additional cost.
+                val additionalTaps = plains.take(2) + bears
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id, spellId, emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(tappedPermanents = additionalTaps)
+                    )
+                )
+                withClue("Cast with mixed creature/land taps should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Guardian of the Great Door resolves onto the battlefield") {
+                    game.isOnBattlefield("Guardian of the Great Door") shouldBe true
+                }
+            }
+
+            test("cannot be cast when fewer than four untapped permanents are tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Guardian of the Great Door")
+                    // Only two Plains — enough mana but not enough for the four-tap additional cost.
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spellId = game.state.getHand(game.player1Id).first { id ->
+                    game.state.getEntity(id)?.get<CardComponent>()?.name == "Guardian of the Great Door"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id, spellId, emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(tappedPermanents = emptyList())
+                    )
+                )
+                withClue("Cast should fail when the additional cost is not paid") {
+                    (cast.error != null) shouldBe true
+                }
+                game.isOnBattlefield("Guardian of the Great Door") shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HelpingHandScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HelpingHandScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Helping Hand (LCI #17, {W} Sorcery).
+ *
+ * "Return target creature card with mana value 3 or less from your graveyard to the battlefield tapped."
+ *
+ * Tests:
+ *  1. A creature card with mana value ≤ 3 (Centaur Courser, MV 3) moves from the graveyard
+ *     to the battlefield and enters tapped.
+ *  2. A creature card with mana value > 3 (Force of Nature, MV 5) is not a legal target —
+ *     the CastSpell action is rejected and the card remains in the graveyard.
+ */
+class HelpingHandScenarioTest : ScenarioTestBase() {
+    init {
+        context("Helping Hand") {
+
+            // ------------------------------------------------------------------
+            // Test 1: Valid target (MV = 3, exactly at the cap) — moved from
+            //         graveyard to battlefield, enters tapped.
+            // ------------------------------------------------------------------
+            test("returns a creature with mana value 3 from graveyard to battlefield tapped") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Helping Hand")
+                    .withCardInGraveyard(1, "Centaur Courser") // {2}{G}, MV 3 — exactly at the cap
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingGraveyardCard(1, "Helping Hand", 1, "Centaur Courser")
+                game.resolveStack()
+
+                withClue("Centaur Courser should be on the battlefield after reanimation") {
+                    game.isOnBattlefield("Centaur Courser") shouldBe true
+                }
+                withClue("Centaur Courser should no longer be in the graveyard") {
+                    game.isInGraveyard(1, "Centaur Courser") shouldBe false
+                }
+                val id = game.findPermanent("Centaur Courser")
+                    ?: error("Centaur Courser not found on battlefield")
+                withClue("Centaur Courser must enter the battlefield tapped") {
+                    (game.state.getEntity(id)?.has<TappedComponent>() ?: false) shouldBe true
+                }
+            }
+
+            // ------------------------------------------------------------------
+            // Test 2: Invalid target (MV = 5, above the cap) — CastSpell
+            //         is rejected; card stays in graveyard.
+            // ------------------------------------------------------------------
+            test("cannot target a creature card with mana value greater than 3") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Helping Hand")
+                    .withCardInGraveyard(1, "Force of Nature") // {3}{G}{G}, MV 5 — above the cap
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val result = game.castSpellTargetingGraveyardCard(1, "Helping Hand", 1, "Force of Nature")
+
+                withClue("Targeting a MV-5 creature should be rejected") {
+                    result.isSuccess shouldBe false
+                }
+                withClue("Force of Nature should remain in the graveyard") {
+                    game.isInGraveyard(1, "Force of Nature") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HulkingRaptorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HulkingRaptorScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.HulkingRaptor
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Hulking Raptor (LCI #191) — {2}{G}{G} Creature — Dinosaur 5/3.
+ *
+ * "Ward {2}
+ *  At the beginning of your first main phase, add {G}{G}."
+ *
+ * Covered:
+ *  1. First-main trigger: when HulkingRaptor is on the battlefield under the active player's
+ *     control, the precombat main phase fires [Triggers.FirstMainPhase], adding two unrestricted
+ *     green mana to the controller's pool.
+ *  2. Ward {2}: when an opponent targets HulkingRaptor with a spell and has enough mana to pay,
+ *     the engine presents a [SelectManaSourcesDecision] for the {2} ward cost.
+ *  3. Ward counters the targeting spell when the opponent cannot pay the {2} cost.
+ */
+class HulkingRaptorScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(HulkingRaptor)
+        return driver
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: First-main-phase trigger adds {G}{G} to the controller's pool
+    // ─────────────────────────────────────────────────────────────────────────
+    test("first-main trigger adds two unrestricted green mana to the controller's pool") {
+        val driver = newDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val player = driver.player1
+
+        // Put Hulking Raptor on the battlefield before the precombat main phase begins so
+        // the FirstMainPhase trigger fires when the phase transitions.
+        driver.putCreatureOnBattlefield(player, "Hulking Raptor")
+
+        // Advance to the precombat main step; the trigger fires and goes on the stack.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Both players pass priority → trigger resolves, adding {G}{G}.
+        driver.bothPass()
+
+        val pool = driver.state.getEntity(player)?.get<ManaPoolComponent>()
+        pool.shouldNotBeNull()
+        pool.green shouldBe 2
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: Ward {2} prompts the opponent when they can afford to pay
+    // ─────────────────────────────────────────────────────────────────────────
+    test("ward prompts the targeting player with a mana selection when they can pay {2}") {
+        val driver = newDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.player1
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent controls Hulking Raptor.
+        val raptor = driver.putCreatureOnBattlefield(opponent, "Hulking Raptor")
+
+        // Active player has {R} for Lightning Bolt and three Mountains to pay ward {2}.
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.putLandOnBattlefield(activePlayer, "Mountain")
+        driver.giveMana(activePlayer, Color.RED, 1)
+
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(raptor)))
+
+        // Ward trigger resolves — active player should see a mana-selection prompt.
+        driver.bothPass()
+
+        val decision = driver.pendingDecision
+        decision.shouldNotBeNull()
+        decision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        decision.playerId shouldBe activePlayer
+        decision.canDecline shouldBe true
+        decision.requiredCost shouldBe "{2}"
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: Ward {2} counters the targeting spell when the opponent cannot pay
+    // ─────────────────────────────────────────────────────────────────────────
+    test("ward counters the targeting spell when the caster cannot pay {2}") {
+        val driver = newDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        val activePlayer = driver.player1
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent controls Hulking Raptor.
+        val raptor = driver.putCreatureOnBattlefield(opponent, "Hulking Raptor")
+
+        // Active player has exactly {R} for Lightning Bolt — nothing left for ward {2}.
+        driver.giveMana(activePlayer, Color.RED, 1)
+        val bolt = driver.putCardInHand(activePlayer, "Lightning Bolt")
+        driver.castSpellWithTargets(activePlayer, bolt, listOf(ChosenTarget.Permanent(raptor)))
+
+        // Ward trigger fires; the caster cannot pay {2} — spell is countered immediately.
+        driver.bothPass()
+
+        // No pending decision — executor went straight to counter.
+        driver.pendingDecision shouldBe null
+
+        // Resolve any remaining items.
+        driver.bothPass()
+
+        // Raptor survives; Bolt was countered.
+        driver.findPermanent(opponent, "Hulking Raptor").shouldNotBeNull()
+        driver.getGraveyardCardNames(activePlayer).contains("Lightning Bolt") shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntersBlowgunScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HuntersBlowgunScenarioTest.kt
@@ -1,0 +1,138 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Hunter's Blowgun (LCI #255) — {1} Artifact — Equipment (common).
+ *
+ * Equipped creature gets +1/+1.
+ * Equipped creature has deathtouch during your turn. Otherwise, it has reach.
+ * Equip {2}
+ *
+ * Tests:
+ *  1. Equipped creature always gets +1/+1, regardless of whose turn it is.
+ *  2. Equipped creature has deathtouch on the controller's turn (IsYourTurn gate active).
+ *  3. Equipped creature does NOT have deathtouch on the opponent's turn.
+ *  4. Equipped creature has reach on the opponent's turn (IsNotYourTurn gate active).
+ *  5. Equipped creature does NOT have reach on the controller's turn.
+ *  6. Unequipped creature gains neither keyword and no stats bonus.
+ */
+class HuntersBlowgunScenarioTest : ScenarioTestBase() {
+
+    init {
+
+        context("Hunter's Blowgun — +1/+1 is always active") {
+
+            test("equipped creature gets +1/+1 during controller's turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Hunter's Blowgun", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+
+                withClue("Grizzly Bears base 2/2 + Blowgun +1/+1 = 3/3 on your turn") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 3
+                }
+            }
+
+            test("equipped creature gets +1/+1 during opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Hunter's Blowgun", "Grizzly Bears")
+                    .withActivePlayer(2) // Opponent's turn
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+
+                withClue("Grizzly Bears base 2/2 + Blowgun +1/+1 = 3/3 on opponent's turn too") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 3
+                }
+            }
+        }
+
+        context("Hunter's Blowgun — deathtouch during your turn, reach otherwise") {
+
+            test("equipped creature has deathtouch during controller's turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Hunter's Blowgun", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+
+                withClue("Equipped creature should have deathtouch on controller's turn") {
+                    projected.hasKeyword(bears, Keyword.DEATHTOUCH) shouldBe true
+                }
+                withClue("Equipped creature should NOT have reach on controller's turn") {
+                    projected.hasKeyword(bears, Keyword.REACH) shouldBe false
+                }
+            }
+
+            test("equipped creature has reach during opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Hunter's Blowgun", "Grizzly Bears")
+                    .withActivePlayer(2) // Opponent's turn
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+
+                withClue("Equipped creature should have reach on opponent's turn") {
+                    projected.hasKeyword(bears, Keyword.REACH) shouldBe true
+                }
+                withClue("Equipped creature should NOT have deathtouch on opponent's turn") {
+                    projected.hasKeyword(bears, Keyword.DEATHTOUCH) shouldBe false
+                }
+            }
+        }
+
+        context("Hunter's Blowgun — unequipped creature gets no bonus") {
+
+            test("creature without blowgun attached has no bonus during your turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Hunter's Blowgun") // not attached
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = game.state.projectedState
+
+                withClue("Grizzly Bears should stay 2/2 without the Blowgun equipped") {
+                    projected.getPower(bears) shouldBe 2
+                    projected.getToughness(bears) shouldBe 2
+                }
+                withClue("Unequipped creature should not have deathtouch") {
+                    projected.hasKeyword(bears, Keyword.DEATHTOUCH) shouldBe false
+                }
+                withClue("Unequipped creature should not have reach") {
+                    projected.hasKeyword(bears, Keyword.REACH) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -405,17 +405,19 @@ export function mergeResult(
           return casualtyCreature ? { ...action, casualtyCreature } : action
         }
         const fieldUpdate =
-          costType === 'DiscardCard'
-            ? { discardedCards: selectedTargets }
-            : costType === 'BouncePermanent'
-              ? { bouncedPermanents: selectedTargets }
-              : costType === 'ExileFromGraveyard'
-                ? { exiledCards: selectedTargets }
-                : costType === 'Behold' || costType === 'ChooseEntity'
-                  ? { beheldCards: selectedTargets }
-                  : costType === 'Blight' || costType === 'BlightVariable'
-                    ? { blightTargets: selectedTargets }
-                    : { sacrificedPermanents: selectedTargets }
+          costType === 'TapPermanents'
+            ? { tappedPermanents: selectedTargets }
+            : costType === 'DiscardCard'
+              ? { discardedCards: selectedTargets }
+              : costType === 'BouncePermanent'
+                ? { bouncedPermanents: selectedTargets }
+                : costType === 'ExileFromGraveyard'
+                  ? { exiledCards: selectedTargets }
+                  : costType === 'Behold' || costType === 'ChooseEntity'
+                    ? { beheldCards: selectedTargets }
+                    : costType === 'Blight' || costType === 'BlightVariable'
+                      ? { blightTargets: selectedTargets }
+                      : { sacrificedPermanents: selectedTargets }
         // Spread the existing additionalCostPayment so prior phases' fields
         // (e.g. `blightAmount` from a preceding BlightVariable phase) survive.
         const additionalCostPayment = {


### PR DESCRIPTION
## Lost Caverns of Ixalan — batch 9 (+ TapPermanents cast fix)

Stacked on `lci-cards-08`. This PR contains only the diff versus that branch.

### Cards (5)

| Card | Cost | Type | Notes |
|------|------|------|-------|
| Goldfury Strider | `{4}{R}` | Creature — Dinosaur | |
| Guardian of the Great Door | `{W}{W}` | Creature — Angel | Additional cost: tap four untapped artifacts/creatures/lands you control; Flying |
| Helping Hand | `{W}` | Sorcery | Return target creature card with mana value 3 or less from your graveyard to the battlefield tapped |
| Hulking Raptor | `{2}{G}{G}` | Creature — Dinosaur | Ward {2} + mana ability |
| Hunter's Blowgun | `{1}` | Artifact — Equipment | Equip {2} |

Each card has a passing scenario test and is checked off in
`backlog/sets/the-lost-caverns-of-ixalan/cards.md` (151 → 156 implemented).

### Engine/client fix — surface `TapPermanents` additional cost on cast

Implementing Guardian of the Great Door surfaced a pre-existing bug: casting a spell whose
`AdditionalCost.TapPermanents` cost required an interactive selection failed. `CastSpellEnumerator`
dropped `CostAtom.TapPermanents` through an `else -> {}` branch, so no `AdditionalCostData` reached
the client. The frontend never prompted for the taps, submitted an empty payment, and the cast-time
validator rejected it with *"You must tap 4 … to cast this spell."*

- **`CastSpellEnumerator`** — enumerate valid tap targets (mirroring the existing `ReturnToHand`
  path) and emit `AdditionalCostData(costType = "TapPermanents", validTapTargets, tapCount)`.
- **`web-client/pipelinePhases`** — map a `TapPermanents` `CastSpell` cost payment to
  `tappedPermanents` (it was falling through to `sacrificedPermanents`). The selection phase and
  target/count logic already existed and are used by activated abilities.
- Added a legal-action enumeration regression test to `GuardianOfTheGreatDoorScenarioTest` — prior
  tests only exercised the payment path, which already worked.

The `manual-scenarios/sets/lci/cards-9.json` playtest scenario (all five cards in hand + mana) is
included.

### Tests

`GuardianOfTheGreatDoorScenarioTest` (incl. the new enumeration test) passes; the four other batch-9
card scenario tests were run green during authoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
