### PR TITLE
Add 5 Lost Caverns of Ixalan cards (batch 10)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 156 / 286
+**Implemented:** 161 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -129,16 +129,16 @@
 - [x] Hunter's Blowgun
 - [x] Hurl into History
 - [ ] Idol of the Deep King
-- [ ] In the Presence of Ages
+- [x] In the Presence of Ages
 - [ ] Inti, Seneschal of the Sun
 - [ ] Intrepid Paleontologist
 - [ ] Inverted Iceberg
 - [x] Ironpaw Aspirant
-- [ ] Itzquinth, Firstborn of Gishath
-- [ ] Ixalli's Lorekeeper
+- [x] Itzquinth, Firstborn of Gishath
+- [x] Ixalli's Lorekeeper
 - [ ] Jade Seedstones
-- [ ] Jadelight Spelunker
-- [ ] Join the Dead
+- [x] Jadelight Spelunker
+- [x] Join the Dead
 - [ ] Kaslem's Stonetree
 - [ ] Kellan, Daring Traveler
 - [x] Kinjalli's Dawnrunner

--- a/manual-scenarios/sets/lci/cards-10.json
+++ b/manual-scenarios/sets/lci/cards-10.json
@@ -1,0 +1,49 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "In the Presence of Ages",
+      "Itzquinth, Firstborn of Gishath",
+      "Ixalli's Lorekeeper",
+      "Jadelight Spelunker",
+      "Join the Dead"
+    ],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Mountain", "Forest", "Ixalli's Lorekeeper", "Mountain", "Forest", "Mountain", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Swamp", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/InThePresenceOfAges.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/InThePresenceOfAges.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.RevealCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * In the Presence of Ages
+ * {2}{G}
+ * Instant — common #192 (LCI, Steve Prescott)
+ *
+ * Reveal the top four cards of your library. You may put a creature card and/or a land card from
+ * among them into your hand. Put the rest into your graveyard.
+ *
+ * Pipeline (MemoriesReturning storeRemainder-chain pattern):
+ *   1. GatherCards(TopOfLibrary(4)) → "top4"
+ *   2. RevealCollection("top4")        — publicly face-up for all players
+ *   3. SelectFromCollection("top4", ChooseUpTo(1), filter = Creature)
+ *        → storeSelected = "chosenCreature", storeRemainder = "afterCreature"
+ *   4. SelectFromCollection("afterCreature", ChooseUpTo(1), filter = Land)
+ *        → storeSelected = "chosenLand", storeRemainder = "rest"
+ *   5. MoveCollection("chosenCreature" → HAND, revealed = true)
+ *   6. MoveCollection("chosenLand"     → HAND, revealed = true)
+ *   7. MoveCollection("rest"           → GRAVEYARD)
+ *
+ * Chaining storeRemainder from the creature pick into the land pick's `from` ensures the second
+ * selection never re-offers a card already taken by the first, honoring the "and/or" constraint
+ * (each physical card can be chosen at most once).
+ */
+val InThePresenceOfAges = card("In the Presence of Ages") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Reveal the top four cards of your library. You may put a creature card and/or a " +
+        "land card from among them into your hand. Put the rest into your graveyard."
+
+    spell {
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(4)),
+                    storeAs = "top4"
+                ),
+                RevealCollectionEffect(from = "top4"),
+                // Step 1 of 2: optionally take one creature card.
+                SelectFromCollectionEffect(
+                    from = "top4",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Creature,
+                    storeSelected = "chosenCreature",
+                    storeRemainder = "afterCreature",
+                    prompt = "You may put a creature card into your hand",
+                    showAllCards = true
+                ),
+                // Step 2 of 2: optionally take one land card from whatever is left.
+                SelectFromCollectionEffect(
+                    from = "afterCreature",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Land,
+                    storeSelected = "chosenLand",
+                    storeRemainder = "rest",
+                    prompt = "You may put a land card into your hand",
+                    showAllCards = true
+                ),
+                MoveCollectionEffect(
+                    from = "chosenCreature",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                MoveCollectionEffect(
+                    from = "chosenLand",
+                    destination = CardDestination.ToZone(Zone.HAND),
+                    revealed = true
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.GRAVEYARD)
+                )
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "192"
+        artist = "Steve Prescott"
+        flavorText = "\"Finally, those glowing purple bone-monsters are gone and we can get back to the real excitement: archaeology!\"\n—Quintorius Kand"
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/97b1be22-3177-49af-bb06-42497d717c21.jpg?1782694455"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ItzquinthFirstbornOfGishath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ItzquinthFirstbornOfGishath.kt
@@ -21,9 +21,10 @@ import com.wingedsheep.sdk.scripting.targets.TargetOther
  * When Itzquinth enters, you may pay {2}. When you do, target Dinosaur you control deals
  * damage equal to its power to another target creature.
  *
- * The "When you do" phrasing creates a gated effect ([MayPayManaEffect]) where paying {2}
- * unlocks the bite. Targets are chosen when the ETB trigger goes on the stack (CR 603.3d),
- * before the may-pay decision is offered at resolution (CR 117.3a):
+ * The "When you do" phrasing is a reflexive trigger (CR 603.12), modeled as a gated effect
+ * ([MayPayManaEffect]) where paying {2} unlocks the bite. The ETB trigger resolves to the
+ * "Pay {2}?" decision first; only after payment does the reflexive trigger go on the stack
+ * and prompt for its two targets:
  *   - t1 (index 0): target Dinosaur you control — any Creature with subtype Dinosaur you
  *     control (including Itzquinth itself, which IS a Dinosaur).
  *   - t2 (index 1): another target creature — [TargetOther] ensures this differs from t1.
@@ -64,6 +65,7 @@ val ItzquinthFirstbornOfGishath = card("Itzquinth, Firstborn of Gishath") {
         rarity = Rarity.UNCOMMON
         collectorNumber = "230"
         artist = "Lars Grant-West"
+        flavorText = "\"Dinosaurs have no concept of royalty, but they recognize the scent of the mightiest among them.\"\n—Atla Palani, nest tender"
         imageUri = "https://cards.scryfall.io/normal/front/7/1/7112c366-b36a-4bc8-aa64-6bad16bebc39.jpg?1782694426"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ItzquinthFirstbornOfGishath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ItzquinthFirstbornOfGishath.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Itzquinth, Firstborn of Gishath
+ * {R}{G}
+ * Legendary Creature — Dinosaur
+ * 2/3
+ * Haste
+ * When Itzquinth enters, you may pay {2}. When you do, target Dinosaur you control deals
+ * damage equal to its power to another target creature.
+ *
+ * The "When you do" phrasing creates a gated effect ([MayPayManaEffect]) where paying {2}
+ * unlocks the bite. Targets are chosen when the ETB trigger goes on the stack (CR 603.3d),
+ * before the may-pay decision is offered at resolution (CR 117.3a):
+ *   - t1 (index 0): target Dinosaur you control — any Creature with subtype Dinosaur you
+ *     control (including Itzquinth itself, which IS a Dinosaur).
+ *   - t2 (index 1): another target creature — [TargetOther] ensures this differs from t1.
+ * Damage amount = t1's power at resolution ([DynamicAmounts.targetPower(0)]), and the source
+ * of the damage is t1 ([damageSource = t1]), so effects that care about the dealer reference
+ * the Dinosaur, not Itzquinth.
+ */
+val ItzquinthFirstbornOfGishath = card("Itzquinth, Firstborn of Gishath") {
+    manaCost = "{R}{G}"
+    colorIdentity = "RG"
+    typeLine = "Legendary Creature — Dinosaur"
+    power = 2
+    toughness = 3
+    oracleText = "Haste\nWhen Itzquinth enters, you may pay {2}. When you do, target Dinosaur you control deals damage equal to its power to another target creature."
+
+    keywords(Keyword.HASTE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        // t1 (index 0): the Dinosaur you control that deals the damage.
+        val t1 = target(
+            "target Dinosaur you control",
+            TargetCreature(filter = TargetFilter.Creature.withSubtype("Dinosaur").youControl())
+        )
+        // t2 (index 1): must be a different creature from t1 (the "another" constraint).
+        val t2 = target(
+            "another target creature",
+            TargetOther(TargetCreature())
+        )
+        // "you may pay {2}. When you do" → Gate.MayPay; if paid, t1 deals damage to t2.
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}"),
+            effect = DealDamageEffect(DynamicAmounts.targetPower(0), t2, damageSource = t1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "230"
+        artist = "Lars Grant-West"
+        imageUri = "https://cards.scryfall.io/normal/front/7/1/7112c366-b36a-4bc8-aa64-6bad16bebc39.jpg?1782694426"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/IxallisLorekeeper.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/IxallisLorekeeper.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Ixalli's Lorekeeper
+ * {G}
+ * Creature — Human Druid
+ * 1/1
+ * Uncommon — LCI #194
+ *
+ * {T}: Add one mana of any color. Spend this mana only to cast a Dinosaur spell or
+ *      activate an ability of a Dinosaur source.
+ *
+ * The single activated ability is a mana ability that produces one mana of any color
+ * with [ManaRestriction.SubtypeSpellsOrAbilitiesOnly] baked to "Dinosaur" and
+ * `creatureOnly = false` (the default), so the mana is usable for both Dinosaur spells
+ * and activated abilities of Dinosaur sources — matching the printed oracle exactly.
+ */
+val IxallisLorekeeper = card("Ixalli's Lorekeeper") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    power = 1
+    toughness = 1
+    oracleText = "{T}: Add one mana of any color. Spend this mana only to cast a Dinosaur spell or activate an ability of a Dinosaur source."
+
+    // {T}: Add one mana of any color. Spend this mana only to cast a Dinosaur spell or
+    //      activate an ability of a Dinosaur source.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(
+            amount = 1,
+            restriction = ManaRestriction.SubtypeSpellsOrAbilitiesOnly("Dinosaur")
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "194"
+        artist = "Ernanda Souza"
+        flavorText = "\"Did we follow the dinosaurs out of the caverns, or did they follow us? These glyphs could change our entire understanding of our history.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4bc94ded-458d-4458-9c0b-136d825b885d.jpg?1782694453"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/JadelightSpelunker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/JadelightSpelunker.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.RepeatDynamicTimesEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Jadelight Spelunker — {X}{G}
+ * Creature — Merfolk Scout
+ * 1/1
+ * Rare — The Lost Caverns of Ixalan #196
+ * Artist: Izzy
+ *
+ * "When this creature enters, it explores X times."
+ *
+ * X is the value paid for the spell's {X} generic mana, stamped onto the spell's xValue
+ * and available in the ETB trigger context via [DynamicAmount.XValue] (CR 107.3a). The
+ * trigger repeats the Explore mechanic (CR 701.44) exactly X times via
+ * [RepeatDynamicTimesEffect]: each iteration reveals the top library card; a land goes to
+ * hand, otherwise the Spelunker gets a +1/+1 counter and the player may put the card in
+ * the graveyard. X=0 is legal and produces no explores.
+ */
+val JadelightSpelunker = card("Jadelight Spelunker") {
+    manaCost = "{X}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Merfolk Scout"
+    oracleText = "When this creature enters, it explores X times. (To have it explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)"
+    power = 1
+    toughness = 1
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = RepeatDynamicTimesEffect(
+            amount = DynamicAmount.XValue,
+            body = Effects.Explore(EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "196"
+        artist = "Izzy"
+        imageUri = "https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg?1782694451"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/JadelightSpelunker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/JadelightSpelunker.kt
@@ -44,6 +44,7 @@ val JadelightSpelunker = card("Jadelight Spelunker") {
         rarity = Rarity.RARE
         collectorNumber = "196"
         artist = "Izzy"
+        flavorText = "The River Heralds found clues to a grand heritage below Ixalan's surface."
         imageUri = "https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg?1782694451"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/JoinTheDead.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/JoinTheDead.kt
@@ -45,6 +45,7 @@ val JoinTheDead = card("Join the Dead") {
         rarity = Rarity.COMMON
         collectorNumber = "110"
         artist = "Olivier Bernard"
+        flavorText = "The more creatures that plunge to their deaths in the abyss, the more angry Echoes that arise to drag others down."
         imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bf6c25-a7d7-40b6-aa19-f852d348967f.jpg?1782694524"
     }
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/JoinTheDead.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/JoinTheDead.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Join the Dead — {1}{B}{B}
+ * Instant (common, LCI #110)
+ *
+ * Target creature gets -5/-5 until end of turn.
+ * Descend 4 — That creature gets -10/-10 until end of turn instead if there are four or more
+ * permanent cards in your graveyard.
+ *
+ * The "Descend 4" clause is a resolution-time conditional: [Conditions.CardsInGraveyardMatchingAtLeast]
+ * is evaluated when the spell resolves. If true, the -10/-10 branch fires via [ConditionalEffect]
+ * (lowers to GatedEffect with Gate.WhenCondition) and the -5/-5 branch is skipped. If false,
+ * the -5/-5 branch fires instead. Both branches apply the modifier until end of turn (Layer 7c,
+ * per CR 613).
+ *
+ * Rules note: "instead" in the Descend 4 line means the base -5/-5 does NOT also apply when
+ * the condition is met — the two modifiers are mutually exclusive.
+ */
+val JoinTheDead = card("Join the Dead") {
+    manaCost = "{1}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -5/-5 until end of turn.\n" +
+        "Descend 4 — That creature gets -10/-10 until end of turn instead if there are four or more permanent cards in your graveyard."
+
+    spell {
+        val t = target("target creature", TargetCreature())
+        effect = ConditionalEffect(
+            condition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent),
+            effect = Effects.ModifyStats(-10, -10, t),
+            elseEffect = Effects.ModifyStats(-5, -5, t)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "110"
+        artist = "Olivier Bernard"
+        imageUri = "https://cards.scryfall.io/normal/front/b/5/b5bf6c25-a7d7-40b6-aa19-f852d348967f.jpg?1782694524"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -5997,6 +5997,103 @@
     ]
 }
 
+// In the Presence of Ages
+{
+    "name": "In the Presence of Ages",
+    "manaCost": "{2}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Reveal the top four cards of your library. You may put a creature card and/or a land card from among them into your hand. Put the rest into your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "storeAs": "top4"
+                },
+                {
+                    "type": "RevealCollection",
+                    "from": "top4"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "top4",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "creature",
+                    "storeSelected": "chosenCreature",
+                    "storeRemainder": "afterCreature",
+                    "prompt": "You may put a creature card into your hand",
+                    "showAllCards": true
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "afterCreature",
+                    "selection": {
+                        "type": "ChooseUpTo",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "land",
+                    "storeSelected": "chosenLand",
+                    "storeRemainder": "rest",
+                    "prompt": "You may put a land card into your hand",
+                    "showAllCards": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "chosenCreature",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "chosenLand",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    },
+                    "revealed": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "artist": "Steve Prescott",
+        "flavorText": "\"Finally, those glowing purple bone-monsters are gone and we can get back to the real excitement: archaeology!\"\n—Quintorius Kand",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/97b1be22-3177-49af-bb06-42497d717c21.jpg?1782694455"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Ironpaw Aspirant
 {
     "name": "Ironpaw Aspirant",
@@ -6042,6 +6139,243 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Itzquinth, Firstborn of Gishath
+{
+    "name": "Itzquinth, Firstborn of Gishath",
+    "manaCost": "{R}{G}",
+    "typeLine": "Legendary Creature — Dinosaur",
+    "oracleText": "Haste\nWhen Itzquinth enters, you may pay {2}. When you do, target Dinosaur you control deals damage equal to its power to another target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Power"
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "another target creature"
+                        },
+                        "damageSource": {
+                            "type": "BoundVariable",
+                            "name": "target Dinosaur you control"
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature Dinosaur ctrl:you"
+                    },
+                    "id": "target Dinosaur you control"
+                },
+                "additionalTargetRequirements": [
+                    {
+                        "type": "TargetOther",
+                        "baseRequirement": {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        },
+                        "id": "another target creature"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "230",
+        "rarity": "UNCOMMON",
+        "artist": "Lars Grant-West",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/1/7112c366-b36a-4bc8-aa64-6bad16bebc39.jpg?1782694426"
+    },
+    "colorIdentityOverride": [
+        "RED",
+        "GREEN"
+    ]
+}
+
+// Ixalli's Lorekeeper
+{
+    "name": "Ixalli's Lorekeeper",
+    "manaCost": "{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "{T}: Add one mana of any color. Spend this mana only to cast a Dinosaur spell or activate an ability of a Dinosaur source.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddManaOfChoice",
+                    "restriction": {
+                        "type": "SubtypeSpellsOrAbilitiesOnly",
+                        "subtype": "Dinosaur"
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "194",
+        "rarity": "UNCOMMON",
+        "artist": "Ernanda Souza",
+        "flavorText": "\"Did we follow the dinosaurs out of the caverns, or did they follow us? These glyphs could change our entire understanding of our history.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4bc94ded-458d-4458-9c0b-136d825b885d.jpg?1782694453"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Jadelight Spelunker
+{
+    "name": "Jadelight Spelunker",
+    "manaCost": "{X}{G}",
+    "typeLine": "Creature — Merfolk Scout",
+    "oracleText": "When this creature enters, it explores X times. (To have it explore, reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "RepeatDynamicTimes",
+                    "amount": "XValue",
+                    "body": {
+                        "type": "Explore",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "196",
+        "rarity": "RARE",
+        "artist": "Izzy",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg?1782694451"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Join the Dead
+{
+    "name": "Join the Dead",
+    "manaCost": "{1}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -5/-5 until end of turn.\nDescend 4 — That creature gets -10/-10 until end of turn instead if there are four or more permanent cards in your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Gated",
+            "gate": {
+                "type": "Gate.WhenCondition",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            "then": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -10
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": -10
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target creature"
+                }
+            },
+            "otherwise": {
+                "type": "ModifyStats",
+                "powerModifier": {
+                    "type": "Fixed",
+                    "amount": -5
+                },
+                "toughnessModifier": {
+                    "type": "Fixed",
+                    "amount": -5
+                },
+                "target": {
+                    "type": "BoundVariable",
+                    "name": "target creature"
+                }
+            }
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "110",
+        "artist": "Olivier Bernard",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bf6c25-a7d7-40b6-aa19-f852d348967f.jpg?1782694524"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6215,6 +6215,7 @@
         "collectorNumber": "230",
         "rarity": "UNCOMMON",
         "artist": "Lars Grant-West",
+        "flavorText": "\"Dinosaurs have no concept of royalty, but they recognize the scent of the mightiest among them.\"\n—Atla Palani, nest tender",
         "imageUri": "https://cards.scryfall.io/normal/front/7/1/7112c366-b36a-4bc8-aa64-6bad16bebc39.jpg?1782694426"
     },
     "colorIdentityOverride": [
@@ -6295,6 +6296,7 @@
         "collectorNumber": "196",
         "rarity": "RARE",
         "artist": "Izzy",
+        "flavorText": "The River Heralds found clues to a grand heritage below Ixalan's surface.",
         "imageUri": "https://cards.scryfall.io/normal/front/6/8/68e633d3-47e2-48c5-9be3-574ce5023bf7.jpg?1782694451"
     },
     "colorIdentityOverride": [
@@ -6372,6 +6374,7 @@
     "metadata": {
         "collectorNumber": "110",
         "artist": "Olivier Bernard",
+        "flavorText": "The more creatures that plunge to their deaths in the abyss, the more angry Echoes that arise to drag others down.",
         "imageUri": "https://cards.scryfall.io/normal/front/b/5/b5bf6c25-a7d7-40b6-aa19-f852d348967f.jpg?1782694524"
     },
     "colorIdentityOverride": [

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InThePresenceOfAgesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InThePresenceOfAgesScenarioTest.kt
@@ -1,0 +1,131 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.InThePresenceOfAges
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * In the Presence of Ages — {2}{G} Instant (LCI #192, common)
+ *
+ * "Reveal the top four cards of your library. You may put a creature card and/or a land card from
+ * among them into your hand. Put the rest into your graveyard."
+ *
+ * Tests:
+ *  - Two independent optional selections (creature first, then land from the remainder)
+ *  - The chosen creature and land each go to hand; everything else goes to the graveyard
+ *  - Both selections are optional (min = 0 each)
+ *  - Declining both selections sends all four revealed cards to the graveyard
+ */
+class InThePresenceOfAgesScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + InThePresenceOfAges)
+        return driver
+    }
+
+    test("selecting a creature and a land puts both in hand; the other two go to the graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Stack the top 4 of the library (last call = top of library):
+        //   position 4 (deepest): Grizzly Bears — filler, goes to graveyard
+        //   position 3          : Grizzly Bears — filler, goes to graveyard
+        //   position 2          : Forest        — the land card we will take
+        //   position 1 (top)    : Grizzly Bears — the creature card we will take
+        val filler1 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val filler2 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val land = driver.putCardOnTopOfLibrary(player, "Forest")
+        val creature = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(player, "In the Presence of Ages")
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 2)
+
+        driver.castSpell(player, spell)
+        driver.bothPass() // resolve → pauses on the creature selection
+
+        // First decision: choose up to 1 creature card from the top 4.
+        val creatureDecision = driver.pendingDecision as SelectCardsDecision
+        creatureDecision.minSelections shouldBe 0
+        creatureDecision.maxSelections shouldBe 1
+        // Forest is a land, not a creature — it must not be selectable here.
+        creatureDecision.options.contains(land) shouldBe false
+        creatureDecision.options.contains(creature) shouldBe true
+
+        driver.submitCardSelection(player, listOf(creature))
+
+        // Second decision: choose up to 1 land card from the remaining three cards.
+        val landDecision = driver.pendingDecision as SelectCardsDecision
+        landDecision.minSelections shouldBe 0
+        landDecision.maxSelections shouldBe 1
+        // Only the Forest qualifies as a land in this step.
+        landDecision.options.contains(land) shouldBe true
+        // The already-chosen creature is gone from the pool; the two filler Bears are not land.
+        landDecision.options.contains(filler1) shouldBe false
+        landDecision.options.contains(filler2) shouldBe false
+
+        driver.submitCardSelection(player, listOf(land))
+        driver.isPaused shouldBe false
+
+        // Both chosen cards arrived in hand.
+        driver.getHand(player).contains(creature) shouldBe true
+        driver.getHand(player).contains(land) shouldBe true
+        // The two filler Grizzly Bears went to the graveyard.
+        driver.getGraveyard(player).contains(filler1) shouldBe true
+        driver.getGraveyard(player).contains(filler2) shouldBe true
+    }
+
+    test("declining both selections puts all four revealed cards into the graveyard") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Grizzly Bears" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val c1 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val c2 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+        val land = driver.putCardOnTopOfLibrary(player, "Forest")
+        val c3 = driver.putCardOnTopOfLibrary(player, "Grizzly Bears")
+
+        val spell = driver.putCardInHand(player, "In the Presence of Ages")
+        driver.giveMana(player, Color.GREEN, 1)
+        driver.giveColorlessMana(player, 2)
+
+        driver.castSpell(player, spell)
+        driver.bothPass()
+
+        // Decline the creature selection.
+        val creatureDecision = driver.pendingDecision as SelectCardsDecision
+        creatureDecision.minSelections shouldBe 0
+        driver.submitCardSelection(player, emptyList())
+
+        // Decline the land selection. The full four-card remainder is still in scope.
+        val landDecision = driver.pendingDecision as SelectCardsDecision
+        landDecision.minSelections shouldBe 0
+        landDecision.options.contains(land) shouldBe true
+        driver.submitCardSelection(player, emptyList())
+
+        driver.isPaused shouldBe false
+
+        // All four revealed cards ended up in the graveyard.
+        val graveyard = driver.getGraveyard(player)
+        graveyard.contains(c1) shouldBe true
+        graveyard.contains(c2) shouldBe true
+        graveyard.contains(land) shouldBe true
+        graveyard.contains(c3) shouldBe true
+        // None of them went to hand.
+        val hand = driver.getHand(player)
+        hand.contains(c1) shouldBe false
+        hand.contains(c2) shouldBe false
+        hand.contains(land) shouldBe false
+        hand.contains(c3) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ItzquinthFirstbornOfGishathScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ItzquinthFirstbornOfGishathScenarioTest.kt
@@ -1,0 +1,163 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.ItzquinthFirstbornOfGishath
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Itzquinth, Firstborn of Gishath (LCI #230) — {R}{G}, Legendary Creature — Dinosaur, 2/3.
+ *
+ * "Haste"
+ * "When Itzquinth enters, you may pay {2}. When you do, target Dinosaur you control deals
+ *  damage equal to its power to another target creature."
+ *
+ * Tests:
+ *  1. Haste is present in projected state and lets Itzquinth attack the turn it enters.
+ *  2. ETB trigger fires. "When you do" is a reflexive trigger (CR 603.12): the engine first
+ *     offers the "Pay {2}?" YesNoDecision; only after paying does the reflexive trigger go on
+ *     the stack and prompt for its two targets (ChooseTargetsDecision). The Dinosaur then deals
+ *     power-damage to the other creature.
+ *  3. Declining the may-pay skips targeting entirely and leaves the other creature unharmed.
+ */
+class ItzquinthFirstbornOfGishathScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        registerCard(ItzquinthFirstbornOfGishath)
+        initMirrorMatch(
+            deck = Deck.of("Mountain" to 20, "Forest" to 20),
+            startingLife = 20
+        )
+    }
+
+    // ─── Haste ───────────────────────────────────────────────────────────────
+
+    test("Itzquinth has haste in projected state") {
+        val d = driver()
+        val player = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val itz = d.putCreatureOnBattlefield(player, "Itzquinth, Firstborn of Gishath")
+
+        withClue("Itzquinth should have haste") {
+            d.state.projectedState.hasKeyword(itz, Keyword.HASTE) shouldBe true
+        }
+    }
+
+    test("haste lets Itzquinth attack the turn it enters") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val opponent = d.getOpponent(player)
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.putCreatureOnBattlefield(player, "Itzquinth, Firstborn of Gishath")
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val result = d.declareAttackers(player, listOf(
+            d.findPermanent(player, "Itzquinth, Firstborn of Gishath")!!
+        ), opponent)
+
+        withClue("Itzquinth should be able to attack on the turn it enters (haste): ${result.error}") {
+            result.isSuccess shouldBe true
+        }
+    }
+
+    // ─── ETB trigger: pay {2}, Dinosaur deals power-damage ──────────────────
+
+    test("ETB trigger: paying {2} causes Itzquinth (the Dinosaur) to deal 2 damage to another creature") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val opponent = d.getOpponent(player)
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent controls a 2/2 that will take the damage.
+        val victim = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        // {R}{G} in the pool pays the cast cleanly (FromPool, no mana-source prompt).
+        d.giveMana(player, Color.RED, 1)
+        d.giveMana(player, Color.GREEN, 1)
+        // Two untapped lands provide the {2} for the reflexive "you may pay" gate.
+        d.putLandOnBattlefield(player, "Mountain")
+        d.putLandOnBattlefield(player, "Forest")
+
+        val card = d.putCardInHand(player, "Itzquinth, Firstborn of Gishath")
+        d.castSpell(player, card).isSuccess shouldBe true
+
+        // Itzquinth resolves → enters the battlefield → ETB trigger resolves to the pay gate.
+        d.bothPass()
+
+        // Step 1: the "Pay {2}?" gate is offered FIRST (the reflexive-trigger order).
+        withClue("YesNoDecision (Pay {2}?) expected first") {
+            d.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        }
+        d.submitYesNo(player, true)
+
+        // Step 2: pay the {2} — auto-pay taps the two untapped lands.
+        withClue("SelectManaSourcesDecision expected to pay {2}") {
+            d.pendingDecision.shouldBeInstanceOf<SelectManaSourcesDecision>()
+        }
+        d.submitManaAutoPayOrDecline(player, autoPay = true)
+
+        // Step 3: paying spawns the reflexive trigger, which now prompts for its two targets.
+        withClue("ChooseTargetsDecision expected after paying {2}") {
+            d.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        }
+        val itz = d.findPermanent(player, "Itzquinth, Firstborn of Gishath")!!
+        // t1 (index 0) = Itzquinth (it IS a Dinosaur you control); t2 (index 1) = victim.
+        d.submitMultiTargetSelection(player, mapOf(0 to listOf(itz), 1 to listOf(victim)))
+        d.bothPass()
+
+        // Itzquinth is 2/3; dealing 2 damage kills the 2/2 Grizzly Bears.
+        withClue("Grizzly Bears should die to 2 damage from Itzquinth's bite") {
+            d.findPermanent(opponent, "Grizzly Bears") shouldBe null
+            d.getGraveyardCardNames(opponent) shouldContain "Grizzly Bears"
+        }
+        withClue("Itzquinth should survive (it dealt the damage, wasn't targeted for damage)") {
+            d.findPermanent(player, "Itzquinth, Firstborn of Gishath") shouldNotBe null
+        }
+    }
+
+    test("ETB trigger: declining to pay {2} leaves the other creature unharmed") {
+        val d = driver()
+        val player = d.activePlayer!!
+        val opponent = d.getOpponent(player)
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = d.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        d.giveMana(player, Color.RED, 1)
+        d.giveMana(player, Color.GREEN, 1)
+        d.giveColorlessMana(player, 2) // afford the cast and optionally the {2}
+
+        val card = d.putCardInHand(player, "Itzquinth, Firstborn of Gishath")
+        d.castSpell(player, card).isSuccess shouldBe true
+        d.bothPass()
+
+        // The "Pay {2}?" gate is offered first — decline it.
+        d.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        d.submitYesNo(player, false)
+        d.bothPass()
+
+        withClue("declining {2} means no reflexive trigger, so no target selection") {
+            d.pendingDecision shouldBe null
+        }
+        withClue("Grizzly Bears should survive when {2} is declined") {
+            d.findPermanent(opponent, "Grizzly Bears") shouldNotBe null
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IxallisLorekeeperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IxallisLorekeeperScenarioTest.kt
@@ -1,0 +1,106 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ColorChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.IxallisLorekeeper
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Ixalli's Lorekeeper (LCI #194) — {G} Creature — Human Druid 1/1
+ *
+ *   {T}: Add one mana of any color. Spend this mana only to cast a Dinosaur spell or
+ *        activate an ability of a Dinosaur source.
+ *
+ * Exercises [ManaRestriction.SubtypeSpellsOrAbilitiesOnly]("Dinosaur") with `creatureOnly = false`:
+ *  1. The one restricted mana can pay for a Dinosaur creature spell.
+ *  2. The one restricted mana cannot pay for a non-Dinosaur creature spell.
+ *  3. After tapping, exactly one restricted mana entry is present in the pool.
+ */
+class IxallisLorekeeperScenarioTest : FunSpec({
+
+    val testDinosaur = CardDefinition.creature(
+        name = "Test Dinosaur",
+        manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Dinosaur")),
+        power = 2,
+        toughness = 2
+    )
+    val testElf = CardDefinition.creature(
+        name = "Test Elf",
+        manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Elf")),
+        power = 1,
+        toughness = 1
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + IxallisLorekeeper + testDinosaur + testElf)
+        return driver
+    }
+
+    val manaAbilityId = IxallisLorekeeper.activatedAbilities[0].id
+
+    fun GameTestDriver.tapForDinoMana(playerId: EntityId) {
+        val lorekeeper = putPermanentOnBattlefield(playerId, "Ixalli's Lorekeeper")
+        submit(ActivateAbility(playerId, lorekeeper, manaAbilityId))
+        state.pendingDecision?.let { decision ->
+            submitDecision(playerId, ColorChosenResponse(decision.id, Color.GREEN))
+        }
+    }
+
+    test("restricted mana is placed in pool after tapping") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForDinoMana(p1)
+
+        val pool = driver.state.getEntity(p1)?.get<ManaPoolComponent>()
+        pool!!.restrictedMana.size shouldBe 1
+    }
+
+    test("restricted mana can pay for a Dinosaur spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForDinoMana(p1)
+
+        val dino = driver.putCardInHand(p1, "Test Dinosaur")
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = dino, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("restricted mana cannot pay for a non-Dinosaur spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForDinoMana(p1)
+
+        val elf = driver.putCardInHand(p1, "Test Elf")
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = elf, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JadelightSpelunkerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JadelightSpelunkerScenarioTest.kt
@@ -1,0 +1,143 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.engine.state.ZoneKey
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Jadelight Spelunker (LCI #196, {X}{G} Creature — Merfolk Scout 1/1).
+ *
+ * "When this creature enters, it explores X times."
+ *
+ * Tests:
+ *  1. X=2 with two lands on top of library — two lands go to hand, no +1/+1 counters.
+ *  2. X=2 with two nonlands on top of library — two +1/+1 counters placed, two
+ *     may-put-in-graveyard decisions (one per explore).
+ *  3. X=0 — no explores occur (no library changes, no counters).
+ *
+ * Jadelight Spelunker is auto-discovered in [com.wingedsheep.mtg.sets.definitions.lci.LostCavernsOfIxalanSet]
+ * via [TestCards.all], so no explicit card registration is required.
+ */
+class JadelightSpelunkerScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, name: String): Int {
+        val id = game.findPermanent(name) ?: return 0
+        return game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Jadelight Spelunker") {
+
+            // -----------------------------------------------------------------------
+            // Test 1: X=2 with lands on top — both go to hand, no counters
+            // -----------------------------------------------------------------------
+            test("ETB explores X times — X=2, two land reveals go to hand with no counters") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Jadelight Spelunker")
+                    // {X}{G} for X=2 → 3 mana: two Forests + one extra Green
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    // Library top to bottom: Mountain (index 0), Forest (index 1).
+                    // First explore → Mountain to hand. Second explore → Forest to hand.
+                    .withCardInLibrary(1, "Mountain")  // added first → index 0 = top
+                    .withCardInLibrary(1, "Forest")    // added second → index 1
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.state.getHand(game.player1Id).size  // has Spelunker → 1
+
+                game.castXSpell(1, "Jadelight Spelunker", xValue = 2).error shouldBe null
+                // Spelunker enters → ETB trigger queued → resolves: explores twice (both lands, no pauses)
+                game.resolveStack()
+
+                withClue("Jadelight Spelunker should be on the battlefield") {
+                    game.isOnBattlefield("Jadelight Spelunker") shouldBe true
+                }
+                // Net hand delta: −1 (cast Spelunker) +2 (two lands from explores) = +1
+                withClue("hand grows by 1: −1 cast + 2 land explores") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore - 1 + 2
+                }
+                withClue("land explores must not place +1/+1 counters (CR 701.44a)") {
+                    plusOneCounters(game, "Jadelight Spelunker") shouldBe 0
+                }
+                withClue("library is empty after both top cards were explored") {
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY)).size shouldBe 0
+                }
+            }
+
+            // -----------------------------------------------------------------------
+            // Test 2: X=2 with nonlands on top — two +1/+1 counters placed
+            // -----------------------------------------------------------------------
+            test("ETB explores X times — X=2, two nonland reveals each put a +1/+1 counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Jadelight Spelunker")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    // Lightning Bolt on top; both explores reveal it (player keeps it on top each time).
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castXSpell(1, "Jadelight Spelunker", xValue = 2).error shouldBe null
+                // Spelunker enters → ETB trigger resolves: explore #1 reveals Lightning Bolt (nonland)
+                // → counter placed → pauses for back-or-graveyard YesNo decision.
+                game.resolveStack()
+                withClue("first nonland explore pauses for the back-or-graveyard decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.answerYesNo(true)  // keep Lightning Bolt on top for second explore
+
+                // Explore #2 reveals Lightning Bolt again → another counter → pauses for second decision.
+                withClue("second nonland explore pauses for the back-or-graveyard decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.answerYesNo(true)  // keep it on top
+                game.resolveStack()     // finish resolution
+
+                withClue("two nonland explores must place two +1/+1 counters on Jadelight Spelunker") {
+                    plusOneCounters(game, "Jadelight Spelunker") shouldBe 2
+                }
+                withClue("Jadelight Spelunker should be on the battlefield") {
+                    game.isOnBattlefield("Jadelight Spelunker") shouldBe true
+                }
+            }
+
+            // -----------------------------------------------------------------------
+            // Test 3: X=0 — no explores, library and hand unchanged
+            // -----------------------------------------------------------------------
+            test("ETB explores X times — X=0 produces no explores") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Jadelight Spelunker")
+                    // {X}{G} for X=0 → only {G} needed
+                    .withLandsOnBattlefield(1, "Forest", 1)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castXSpell(1, "Jadelight Spelunker", xValue = 0).error shouldBe null
+                game.resolveStack()
+
+                withClue("Jadelight Spelunker enters even when X=0") {
+                    game.isOnBattlefield("Jadelight Spelunker") shouldBe true
+                }
+                withClue("no counters placed when X=0") {
+                    plusOneCounters(game, "Jadelight Spelunker") shouldBe 0
+                }
+                withClue("library is unchanged when X=0 — no explore occurred") {
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY)).size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JoinTheDeadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/JoinTheDeadScenarioTest.kt
@@ -1,0 +1,109 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.JoinTheDead
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Join the Dead (LCI #110): {1}{B}{B} Instant
+ *
+ * "Target creature gets -5/-5 until end of turn.
+ *  Descend 4 — That creature gets -10/-10 until end of turn instead if there are four or more
+ *  permanent cards in your graveyard."
+ *
+ * Covered:
+ *  - With fewer than four permanent cards in the graveyard: applies -5/-5 (base). A 7/7
+ *    creature survives at 2/2.
+ *  - With four or more permanent cards in the graveyard: applies -10/-10 instead (Descend 4).
+ *    The same 7/7 creature dies (projected -3/-3 triggers lethal SBA).
+ *
+ * The distinction proves the ConditionalEffect selects the correct branch: the two outcomes
+ * are mutually exclusive and produce clearly different projected stats.
+ */
+class JoinTheDeadScenarioTest : FunSpec({
+
+    // A large vanilla 7/7 creature: survives -5/-5 (→ 2/2) but dies to -10/-10 (→ -3/-3).
+    val BigVanillaCreature = CardDefinition.creature(
+        name = "Big Vanilla Creature",
+        manaCost = ManaCost.parse("{6}"),
+        subtypes = setOf(Subtype("Beast")),
+        power = 7,
+        toughness = 7
+    )
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(JoinTheDead, BigVanillaCreature))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true,
+            startingPlayer = 0
+        )
+        return driver
+    }
+
+    test("applies -5/-5 when fewer than four permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val caster = driver.player1
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe caster
+
+        // Place the target 7/7 creature on the opponent's battlefield.
+        val target = driver.putCreatureOnBattlefield(opponent, "Big Vanilla Creature")
+
+        // Seed caster's graveyard with only three permanent cards — one short of Descend 4.
+        repeat(3) { driver.putCardInGraveyard(caster, "Grizzly Bears") }
+
+        // Cast Join the Dead ({1}{B}{B}).
+        val spell = driver.putCardInHand(caster, "Join the Dead")
+        driver.giveColorlessMana(caster, 1)
+        driver.giveMana(caster, Color.BLACK, 2)
+        driver.castSpell(caster, spell, targets = listOf(target))
+        driver.bothPass() // spell resolves
+
+        // Condition (4+ permanents in GY) is false → base -5/-5 branch fires.
+        // 7/7 − 5/5 = 2/2 projected; creature survives.
+        projector.getProjectedPower(driver.state, target) shouldBe 2
+        projector.getProjectedToughness(driver.state, target) shouldBe 2
+        driver.findPermanent(opponent, "Big Vanilla Creature") shouldBe target
+    }
+
+    test("applies -10/-10 instead when four or more permanent cards are in the graveyard") {
+        val driver = createDriver()
+        val caster = driver.player1
+        val opponent = driver.getOpponent(caster)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.activePlayer shouldBe caster
+
+        // Place the target 7/7 creature on the opponent's battlefield.
+        val target = driver.putCreatureOnBattlefield(opponent, "Big Vanilla Creature")
+
+        // Seed caster's graveyard with exactly four permanent cards — meets Descend 4 threshold.
+        repeat(4) { driver.putCardInGraveyard(caster, "Grizzly Bears") }
+
+        // Cast Join the Dead ({1}{B}{B}).
+        val spell = driver.putCardInHand(caster, "Join the Dead")
+        driver.giveColorlessMana(caster, 1)
+        driver.giveMana(caster, Color.BLACK, 2)
+        driver.castSpell(caster, spell, targets = listOf(target))
+        driver.bothPass() // spell resolves → -10/-10 applied → 7/7 becomes -3/-3 → SBA destroys it
+
+        // Descend 4 condition is true → -10/-10 branch fires.
+        // 7/7 − 10/10 = -3/-3: state-based actions move it to the graveyard during resolution.
+        driver.findPermanent(opponent, "Big Vanilla Creature") shouldBe null
+        driver.getGraveyard(opponent) shouldContain target
+    }
+})


### PR DESCRIPTION
## LCI cards — batch 10 (5 cards)

Tenth batch of Lost Caverns of Ixalan cards, existing SDK primitives only (no engine changes), each with a scenario test. Stacked on `lci-cards-09` — review the diff vs that branch only.

- **In the Presence of Ages** — reveal the top four cards; put a creature card and/or a land card from among them into your hand, rest to graveyard (Gather → Reveal → Select → Select → Move pipeline with `storeRemainder` chaining for the "and/or").
- **Itzquinth, Firstborn of Gishath** — haste; ETB reflexive trigger (CR 603.12): you may pay {2}, and when you do, target Dinosaur you control deals damage equal to its power to another target creature.
- **Ixalli's Lorekeeper** — {T}: add one mana of any color, spend only to cast Dinosaur spells or activate abilities of Dinosaur sources (`ManaRestriction.SubtypeSpellsOrAbilitiesOnly`).
- **Jadelight Spelunker** — {X}{G}; ETB explores X times (`RepeatDynamicTimesEffect` over `Effects.Explore`).
- **Join the Dead** — target creature gets -5/-5; Descend 4 — -10/-10 instead with four or more permanent cards in your graveyard (`ConditionalEffect`).

Includes review fixes from an in-session `/review-changes` pass (posted as a PR comment): corrected Itzquinth's rules comment to describe the reflexive-trigger targeting flow, and added the three missing flavor texts.

All scenario tests pass; LCI snapshot re-blessed; linter green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
