### PR TITLE
feat: "attacks an opponent" trigger predicate + Kaalia of the Vast #1258

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2716,6 +2716,15 @@ Adding a new attack-time mechanic is one new sealed-case + one matcher branch
   at declaration — post-declaration state can't tell, since the per-turn attacker set
   already includes the just-declared attacker. Prefer the `AttacksFirstTimeEachTurn`
   sugar.
+- `AttackPredicate.DefenderIsPlayer` — the trigger's own attacker was declared as
+  attacking a **player**, not a planeswalker or a battle (CR 508.1). A creature only
+  ever attacks a player who is its controller's opponent, so on a `SELF` binding this is
+  exactly the "attacks an opponent" wording (Kaalia of the Vast — whose 2024 ruling
+  clarifies the ability "doesn't trigger if it attacks a planeswalker or battle").
+  Per-attacker, so use it on a `SELF` binding (or an ANY-binding attacker filter that
+  already scopes to one creature). The defender kind is fixed at declaration, so it's
+  captured on `AttackersDeclaredEvent.attackersAgainstPlayer` rather than re-derived
+  from post-declaration state. Prefer the `AttacksAnOpponent` sugar.
 
 Examples:
 
@@ -2725,6 +2734,11 @@ Triggers.attacks(requires = setOf(AttackPredicate.Alone))
 
 // "Whenever this creature attacks for the first time each turn" (prefer the sugar)
 Triggers.AttacksFirstTimeEachTurn
+
+// "Whenever this creature attacks a player / an opponent" — does NOT fire on attacking a
+// planeswalker or battle (Kaalia of the Vast). Prefer the sugar:
+Triggers.AttacksAnOpponent
+// equivalent to: Triggers.attacks(requires = setOf(AttackPredicate.DefenderIsPlayer))
 
 // "Whenever a nontoken creature you control attacks"
 Triggers.attacks(

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Triggers.kt
@@ -255,6 +255,20 @@ object Triggers {
     )
 
     /**
+     * When this creature attacks a player (i.e. attacks an opponent). (SELF.)
+     *
+     * Does **not** fire when the creature attacks a planeswalker or a battle — a creature only
+     * ever attacks an opponent when it attacks a player (CR 508.1). This is the "attacks an
+     * opponent" wording (Kaalia of the Vast, whose 2024 ruling clarifies the ability doesn't
+     * trigger on attacking a planeswalker or battle). Sugar for
+     * `attacks(requires = setOf(AttackPredicate.DefenderIsPlayer))`.
+     */
+    val AttacksAnOpponent: TriggerSpec = TriggerSpec(
+        event = AttackEvent(requires = setOf(AttackPredicate.DefenderIsPlayer)),
+        binding = TriggerBinding.SELF
+    )
+
+    /**
      * Generic "attacks" trigger factory. Use [Attacks] for the SELF-only
      * unfiltered case; reach for this factory for any other combination.
      *
@@ -276,6 +290,9 @@ object Triggers {
      *            binding = TriggerBinding.ANY)`
      * - "Battalion — whenever ~ and at least two other creatures attack":
      *   `attacks(requires = setOf(AttackPredicate.AttackerCountAtLeast(3)))`
+     * - "Whenever this creature attacks a player / an opponent"
+     *   (prefer the [AttacksAnOpponent] sugar):
+     *   `attacks(requires = setOf(AttackPredicate.DefenderIsPlayer))`
      * - "Whenever this creature attacks for the first time each turn"
      *   (prefer the [AttacksFirstTimeEachTurn] sugar):
      *   `attacks(requires = setOf(AttackPredicate.FirstTimeEachTurn))`

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/EventPattern.kt
@@ -566,7 +566,8 @@ sealed interface EventPattern : TextReplaceable<EventPattern> {
          *
          * Current cases: [AttackPredicate.Alone],
          * [AttackPredicate.AttackerCountAtLeast],
-         * [AttackPredicate.FirstTimeEachTurn].
+         * [AttackPredicate.FirstTimeEachTurn],
+         * [AttackPredicate.DefenderIsPlayer].
          */
         val requires: Set<AttackPredicate> = emptySet(),
     ) : EventPattern {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -570,6 +570,25 @@ sealed interface AttackPredicate {
     data object FirstTimeEachTurn : AttackPredicate {
         override val description = "for the first time each turn"
     }
+
+    /**
+     * The attacker was declared as attacking a **player** — not a planeswalker or a battle.
+     * (CR 508.1: an attacker is declared as attacking a player, planeswalker, or battle.)
+     *
+     * A creature can only attack a player who is its controller's opponent, so on a `SELF`
+     * binding this is exactly "attacks an opponent" (Kaalia of the Vast — whose 2024 ruling
+     * clarifies the ability "doesn't trigger if it attacks a planeswalker or battle"). The
+     * defender kind is fixed at declaration, so the matcher reads it from the stamped
+     * `AttackersDeclaredEvent.attackersAgainstPlayer` set rather than post-declaration state.
+     *
+     * Per-attacker by design: it gates against the trigger's own source, so use it with a
+     * `SELF` binding (or an ANY-binding attacker filter that already scopes to one creature).
+     */
+    @SerialName("AttacksDefenderIsPlayer")
+    @Serializable
+    data object DefenderIsPlayer : AttackPredicate {
+        override val description = "a player"
+    }
 }
 
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/KaaliaOfTheVast.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/cmd/cards/KaaliaOfTheVast.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.cmd.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Kaalia of the Vast
+ * {1}{R}{W}{B}
+ * Legendary Creature — Human Cleric
+ * 2/2
+ *
+ * Flying
+ * Whenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon
+ * creature card from your hand onto the battlefield tapped and attacking that opponent.
+ *
+ * Engine notes:
+ * - "attacks an opponent" is the whole reason for engine feature #1258. A creature can be
+ *   declared as attacking a player, a planeswalker, or a battle (CR 508.1); Kaalia's ability
+ *   fires only for the *player* case. The 2024-06-07 ruling makes this explicit: "Kaalia's
+ *   ability doesn't trigger if it attacks a planeswalker or battle." That gate is
+ *   `Triggers.AttacksAnOpponent` (SELF + `AttackPredicate.DefenderIsPlayer`), NOT the
+ *   unfiltered `Triggers.Attacks`.
+ * - "put an Angel, Demon, or Dragon creature card from your hand ... tapped and attacking"
+ *   reuses `Patterns.Hand.putFromHand(entersAttacking = true)`: GatherCards (hand) →
+ *   SelectFromCollection (ChooseUpTo 1 = "you may") → MoveCollection with
+ *   `ZonePlacement.TappedAndAttacking`, which adds the `AttackingComponent` against the
+ *   defending player. The subtype gate is
+ *   `GameObjectFilter.Creature.withAnySubtype("Angel", "Demon", "Dragon")`.
+ * - "that opponent": the two-player engine has a single opponent, and the tapped-and-attacking
+ *   placement attacks the first opponent in turn order — i.e. the player Kaalia attacked. The
+ *   multiplayer "that opponent" nuance is a pre-existing shared limitation of the
+ *   entersAttacking pipeline, not specific to Kaalia.
+ */
+val KaaliaOfTheVast = card("Kaalia of the Vast") {
+    manaCost = "{1}{R}{W}{B}"
+    colorIdentity = "BRW"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "Flying\n" +
+        "Whenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon " +
+        "creature card from your hand onto the battlefield tapped and attacking that opponent."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever Kaalia attacks an *opponent* (a player, not a planeswalker or battle), you may put
+    // an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and
+    // attacking that opponent.
+    triggeredAbility {
+        trigger = Triggers.AttacksAnOpponent
+        effect = Patterns.Hand.putFromHand(
+            filter = GameObjectFilter.Creature.withAnySubtype("Angel", "Demon", "Dragon"),
+            entersAttacking = true
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "206"
+        artist = "Michael Komarck"
+        flavorText = "I'll have my revenge if I have to call on every force from above and below."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b71d89b-7ba4-406f-8736-ac62b9864f21.jpg?1782715001"
+
+        ruling("2020-08-07", "Kaalia of the Vast's ability triggers only if it attacks a player. It won't trigger if it attacks a planeswalker.")
+        ruling("2024-06-07", "Kaalia of the Vast's ability doesn't trigger if it attacks a planeswalker or battle.")
+        ruling("2020-08-07", "The creature card is put onto the battlefield tapped and attacking the player Kaalia is attacking. It wasn't declared as an attacking creature, so abilities that trigger whenever a creature attacks won't trigger.")
+        ruling("2020-08-07", "The creature is attacking, but it was never declared as an attacker. This means that any \"whenever this creature attacks\" abilities of that creature won't trigger.")
+        ruling("2020-08-07", "Because the creature is put onto the battlefield attacking, it's never been declared as an attacker. Effects that care about attacking creatures being declared won't apply.")
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/CMD.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/CMD.json
@@ -41,6 +41,103 @@
     "colorIdentityOverride": []
 }
 
+// Kaalia of the Vast
+{
+    "name": "Kaalia of the Vast",
+    "manaCost": "{1}{R}{W}{B}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "Flying\nWhenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature card from your hand onto the battlefield tapped and attacking that opponent.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        "AttacksDefenderIsPlayer"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Hand",
+                                "filter": "creature Angel|Demon|Dragon"
+                            },
+                            "storeAs": "put_candidates"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "put_candidates",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "storeSelected": "putting"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "putting",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "TappedAndAttacking"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "206",
+        "rarity": "MYTHIC",
+        "artist": "Michael Komarck",
+        "flavorText": "I'll have my revenge if I have to call on every force from above and below.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b71d89b-7ba4-406f-8736-ac62b9864f21.jpg?1782715001",
+        "rulings": [
+            {
+                "date": "2020-08-07",
+                "text": "Kaalia of the Vast's ability triggers only if it attacks a player. It won't trigger if it attacks a planeswalker."
+            },
+            {
+                "date": "2024-06-07",
+                "text": "Kaalia of the Vast's ability doesn't trigger if it attacks a planeswalker or battle."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "The creature card is put onto the battlefield tapped and attacking the player Kaalia is attacking. It wasn't declared as an attacking creature, so abilities that trigger whenever a creature attacks won't trigger."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "The creature is attacking, but it was never declared as an attacker. This means that any \"whenever this creature attacks\" abilities of that creature won't trigger."
+            },
+            {
+                "date": "2020-08-07",
+                "text": "Because the creature is put onto the battlefield attacking, it's never been declared as an attacker. Effects that care about attacking creatures being declared won't apply."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED",
+        "WHITE"
+    ]
+}
+
 // Scavenging Ooze
 {
     "name": "Scavenging Ooze",

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -17,6 +17,12 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // declines -> SCAFFOLD.
     supported("WhenAnyNumberOfCountersOfTypeArePutOnAPermanent", "trigger: one or more counters of a type put on this permanent (CountersPlacedEvent, SELF)")
     supported("WhenACreatureAttacks", "trigger: attacks")
+    // "Whenever this creature attacks a player, …" — the attacks-a-player trigger, gated on the declared
+    // defender being a player (not a planeswalker or battle; CR 508.1 + Kaalia of the Vast's 2024-06-07
+    // ruling). Maps to AttackPredicate.DefenderIsPlayer / Triggers.AttacksAnOpponent for the SELF subject
+    // over a bare "a player" (Opponent / AnyPlayer) scope; the emitter renders that shape and declines a
+    // non-self attacker or a constrained player scope (attacks-you / life-total / controls-N).
+    supported("WhenACreatureAttacksAPlayer", "trigger: this creature attacks a player (Triggers.AttacksAnOpponent)")
     // "Whenever this creature attacks for the first time each turn, …" — SELF attack trigger gated on
     // the per-turn attacker set (AttackPredicate.FirstTimeEachTurn / Triggers.AttacksFirstTimeEachTurn,
     // Fear of Missing Out). Fires once on the first attack and not on a later combat phase the same turn.

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/CardStructure.kt
@@ -2892,6 +2892,21 @@ private fun EmitCtx.triggerSpecFor(rule: JsonObject): String? {
     if (jsonContains(trig, "_Trigger", "WhenACreatureAttacks") && isPlainCreatureFilter(trig))
         return "Triggers.attacks(binding = TriggerBinding.ANY)"
 
+    // "Whenever this creature attacks a player" (SELF) — the attacks-a-player trigger gated on the
+    // declared defender being a *player*, not a planeswalker or battle (AttackPredicate.DefenderIsPlayer
+    // / Triggers.AttacksAnOpponent; Kaalia of the Vast, CR 508.1 + Kaalia's 2024-06-07 ruling). The args
+    // are [subject, defending-player scope]; only the SELF subject over a bare Opponent / AnyPlayer scope
+    // ("a player") renders — both mean "attacks a player" for a single attacker, exactly what
+    // DefenderIsPlayer gates. A `SinglePlayer(You)` scope ("attacks you") or a constrained scope
+    // (LifeTotalIs / ControlsNum — a player at a life total / controlling N permanents; Preacher of the
+    // Schism, Owlbear Cub) has no calibrated Triggers.* constant, so it declines -> SCAFFOLD rather than
+    // widen the trigger. A non-self attacker (the batched "whenever a creature attacks a player" cursed-
+    // land cards) also declines, since the SELF sugar can't express an ANY-binding defender-player scope.
+    if (jsonContains(trig, "_Trigger", "WhenACreatureAttacksAPlayer") && isSelf(trig)) {
+        val scope = castScope(trig["args"].asArr?.getOrNull(1) as? JsonObject)
+        return if (scope == CastScope.OPPONENT || scope == CastScope.ANY) "Triggers.AttacksAnOpponent" else null
+    }
+
     // "Whenever you attack with N or more creatures" — WhenAPlayerAttacksWithANumberOfCreatures scoped to
     // You + a `>= N` comparison + a plain creature filter (Overwhelming Instinct). Only the
     // greater-than-or-equal (N-or-more) shape maps to YouAttackEvent(minAttackers); any other comparison

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/emitter/ZoneHandlers.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.tooling.coverage.Raw
 import com.wingedsheep.tooling.coverage.Registry
 import com.wingedsheep.tooling.coverage.amountNode
 import com.wingedsheep.tooling.coverage.arg
+import com.wingedsheep.tooling.coverage.argWordsTagged
 import com.wingedsheep.tooling.coverage.asArr
 import com.wingedsheep.tooling.coverage.asInt
 import com.wingedsheep.tooling.coverage.asStr
@@ -571,13 +572,42 @@ internal val zoneHandlers: Map<String, ActionHandler> = actionHandlers {
 
     on("PutACardFromHandOnBattlefield") { _, args, _ ->  // "you may put a [basic land] card from your hand …"
         val arr = args.asArr ?: return@on null
-        val blob = compact(arr.getOrNull(0))
+        val filterNode = arr.getOrNull(0)
+        val blob = compact(filterNode)
+        val flagBlob = compact(arr.getOrNull(1))
+
+        // "…onto the battlefield tapped and attacking that player" — the EntersAttackingPlayer flag
+        // (Kaalia of the Vast, paired with the attacks-a-player trigger above). Maps to
+        // `Patterns.Hand.putFromHand(entersAttacking = true)`, which places the card tapped and attacking
+        // the defending player (the engine's single-opponent read of "that opponent"). Only a creature
+        // filter carrying just a subtype clause renders exactly: `And(Or(IsCreatureType …), IsCardtype
+        // Creature)` -> `GameObjectFilter.Creature.withAnySubtype(…)`. Any other filter predicate (color,
+        // power, "Other", a non-creature card type) can't round-trip, so it declines -> SCAFFOLD rather
+        // than widen the eligible pool.
+        if ("EntersAttackingPlayer" in flagBlob) {
+            val subtypes = filterNode.argWordsTagged("IsCreatureType")
+            val onlyCreatureSubtypeFilter = subtypes.isNotEmpty() &&
+                "\"Creature\"" in blob && "IsCardtype" in blob &&
+                "IsCreatureType" in blob && "_Color" !in blob &&
+                "PowerIs" !in blob && "\"Other\"" !in blob && "ControlledByAPlayer" !in blob
+            if (!onlyCreatureSubtypeFilter) return@on null
+            val subtypeArgs = subtypes.joinToString(", ") { "\"$it\"" }
+            val filterExpr = if (subtypes.size == 1)
+                "GameObjectFilter.Creature.withSubtype($subtypeArgs)"
+            else
+                "GameObjectFilter.Creature.withAnySubtype($subtypeArgs)"
+            return@on Call("Patterns.Hand.putFromHand", listOf(
+                arg("filter", filterExpr),
+                arg("entersAttacking", "true"),
+            ))
+        }
+
         val filter = when {
             "IsSupertype" in blob && "\"Basic\"" in blob && "\"Land\"" in blob -> "GameObjectFilter.BasicLand"
             "\"Land\"" in blob && "IsSupertype" !in blob && "IsLandType" !in blob -> "GameObjectFilter.Land"
             else -> return@on null
         }
-        val entersTapped = "EntersTapped" in compact(arr.getOrNull(1))
+        val entersTapped = "EntersTapped" in flagBlob
         val parts = mutableListOf(arg("filter", filter))
         if (entersTapped) parts.add(arg("entersTapped", "true"))
         Call("Patterns.Hand.putFromHand", parts)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/GameEvent.kt
@@ -643,6 +643,12 @@ data class TargetsChosenEvent(
  * per-turn attacker set already includes the just-declared attacker by detection time, so
  * the "first time" fact is captured on the event at declaration (mirroring
  * `LifeChangeEvent.firstThisTurn` / `BecomesTargetEvent.firstTimeByThisController`).
+ *
+ * [attackersAgainstPlayer] is the subset of [attackers] declared as attacking a **player**
+ * (CR 508.1), as opposed to a planeswalker or battle. It backs
+ * `AttackPredicate.DefenderIsPlayer` ("attacks an opponent"): the defender kind is fixed at
+ * declaration and the event doesn't otherwise carry per-attacker defender identity, so the
+ * player-vs-permanent fact is stamped here rather than re-derived downstream.
  */
 @Serializable
 @SerialName("AttackersDeclaredEvent")
@@ -650,7 +656,8 @@ data class AttackersDeclaredEvent(
     val attackers: List<EntityId>,
     val attackerNames: List<String> = emptyList(),
     val attackingPlayerId: EntityId? = null,
-    val firstTimeAttackers: Set<EntityId> = emptySet()
+    val firstTimeAttackers: Set<EntityId> = emptySet(),
+    val attackersAgainstPlayer: Set<EntityId> = emptySet()
 ) : GameEvent
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1454,6 +1454,9 @@ class TriggerMatcher(
         // creatures attacking for the first time this turn. Stamped on the event at declaration
         // (post-declaration state can't tell, since the per-turn attacker set already includes it).
         AttackPredicate.FirstTimeEachTurn -> boundEntityId in event.firstTimeAttackers
+        // Per-attacker: the trigger's own source was declared as attacking a player (not a
+        // planeswalker or battle). Stamped on the event at declaration (CR 508.1 defender kind).
+        AttackPredicate.DefenderIsPlayer -> boundEntityId in event.attackersAgainstPlayer
     }
 
     private fun matchesSpellCastPredicate(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/AttackPhaseManager.kt
@@ -218,6 +218,12 @@ internal class AttackPhaseManager(
             ?.get<PlayerAttackersThisTurnComponent>()?.attackerIds ?: emptySet()
         val firstTimeAttackers = attackers.keys - previousAttackersThisTurn
 
+        // Attackers whose declared defender is a *player* (CR 508.1), not a planeswalker or
+        // battle. Backs AttackPredicate.DefenderIsPlayer ("attacks an opponent"); the defender
+        // kind is fixed at declaration and the event carries no per-attacker defender identity,
+        // so the fact is stamped here. `defenderId in turnOrder` is the player-identity idiom.
+        val attackersAgainstPlayer = attackers.filterValues { it in state.turnOrder }.keys
+
         newState = newState.updateEntity(attackingPlayer) { container ->
             var updated = container.with(AttackersDeclaredThisCombatComponent)
             if (attackers.isNotEmpty()) {
@@ -246,7 +252,8 @@ internal class AttackPhaseManager(
                     attackers.keys.toList(),
                     attackerNames,
                     attackingPlayer,
-                    firstTimeAttackers = firstTimeAttackers
+                    firstTimeAttackers = firstTimeAttackers,
+                    attackersAgainstPlayer = attackersAgainstPlayer
                 )
             )
         )

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AttacksAnOpponentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AttacksAnOpponentScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * `AttackPredicate.DefenderIsPlayer` / `Triggers.AttacksAnOpponent` — "Whenever this creature
+ * attacks a player (an opponent), …" (engine gap #1258, discovered adding Kaalia of the Vast).
+ *
+ * A creature is declared as attacking a player, a planeswalker, or a battle (CR 508.1). The
+ * unfiltered `Triggers.Attacks` fires regardless of that choice; this predicate gates the trigger
+ * to the *player* case only. Kaalia's 2024 ruling makes this concrete: her ability "doesn't
+ * trigger if it attacks a planeswalker or battle."
+ *
+ * The defender kind is fixed at declaration and the `AttackersDeclaredEvent` carries no
+ * per-attacker defender identity, so the player-vs-permanent fact is stamped on the event at
+ * declaration (`attackersAgainstPlayer`) rather than re-derived downstream — mirroring the
+ * `firstTimeAttackers` treatment for `AttackPredicate.FirstTimeEachTurn`.
+ *
+ * Battles: the engine does not yet model battles (no `CardType.BATTLE`) and attack validation only
+ * accepts an opponent player or an opponent's planeswalker as a defender
+ * (`AttackPhaseManager.validateAttacker` defender check). Because the predicate is defined
+ * positively — "the defender is a player" (`defenderId in turnOrder`) — a battle defender would
+ * fall out of `attackersAgainstPlayer` exactly like a planeswalker does, so the planeswalker case
+ * below is the representative "non-player defender" test until battles are wired in.
+ */
+class AttacksAnOpponentScenarioTest : FunSpec({
+
+    // Proof creature: a 2/2 that draws a card when it attacks a player (an opponent).
+    val opponentStriker = card("Opponent Striker") {
+        manaCost = "{1}{R}"
+        typeLine = "Creature — Scout"
+        power = 2
+        toughness = 2
+        oracleText = "Whenever Opponent Striker attacks a player, draw a card."
+        triggeredAbility {
+            trigger = Triggers.AttacksAnOpponent
+            effect = Effects.DrawCards(1)
+        }
+    }
+
+    // A minimal opponent planeswalker the striker can attack instead of the player.
+    val testWalker = card("Test Walker") {
+        manaCost = "{2}"
+        typeLine = "Legendary Planeswalker — Tester"
+        startingLoyalty = 3
+        loyaltyAbility(1) {
+            effect = Effects.GainLife(1)
+        }
+    }
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(
+            TestCards.all +
+                com.wingedsheep.mtg.sets.tokens.PredefinedTokens.allTokens +
+                listOf(opponentStriker, testWalker)
+        )
+        return d
+    }
+
+    test("fires when the creature attacks a player") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val striker = d.putCreatureOnBattlefield(active, "Opponent Striker")
+        d.removeSummoningSickness(striker)
+
+        val handBefore = d.getHandSize(active)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(active, listOf(striker), opp).error shouldBe null
+        repeat(6) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Attacked a player -> the trigger fired and drew a card.
+        d.getHandSize(active) shouldBe handBefore + 1
+    }
+
+    test("does NOT fire when the creature attacks a planeswalker") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        val active = d.activePlayer!!
+        val opp = d.getOpponent(active)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Opponent's planeswalker, seeded with loyalty so an SBA doesn't destroy it before combat.
+        val walker = d.putPermanentOnBattlefield(opp, "Test Walker")
+        d.replaceState(
+            d.state.updateEntity(walker) { c ->
+                c.with((c.get<CountersComponent>() ?: CountersComponent()).withAdded(CounterType.LOYALTY, 3))
+            }
+        )
+
+        val striker = d.putCreatureOnBattlefield(active, "Opponent Striker")
+        d.removeSummoningSickness(striker)
+
+        val handBefore = d.getHandSize(active)
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        // Attack the planeswalker, not the player.
+        d.declareAttackers(active, mapOf(striker to walker)).error shouldBe null
+        repeat(6) { if (d.pendingDecision != null) d.autoResolveDecision() else d.bothPass() }
+
+        // Attacked a planeswalker -> the "attacks a player" trigger must NOT fire.
+        d.getHandSize(active) shouldBe handBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaaliaOfTheVastScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaaliaOfTheVastScenarioTest.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Kaalia of the Vast (CMD #206) — {1}{R}{W}{B} Legendary Human Cleric, 2/2, flying.
+ *
+ * "Whenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon
+ *  creature card from your hand onto the battlefield tapped and attacking that opponent."
+ *
+ * This is the demonstration card for engine feature #1258: the trigger is gated on
+ * `Triggers.AttacksAnOpponent` (SELF + `AttackPredicate.DefenderIsPlayer`), so per Kaalia's
+ * 2024-06-07 ruling it fires only when she attacks a *player* — not a planeswalker (or battle).
+ *
+ * - attacks a player → the trigger fires; "you may put an Angel, Demon, or Dragon creature card"
+ *   is the `Patterns.Hand.putFromHand(entersAttacking = true)` ChooseUpTo-1 selection over
+ *   `Creature.withAnySubtype("Angel", "Demon", "Dragon")`; the chosen card enters tapped and
+ *   attacking. A non-Angel/Demon/Dragon creature card is not a selectable option.
+ * - attacks a planeswalker → the trigger must NOT fire, so no hand card is put in.
+ */
+class KaaliaOfTheVastScenarioTest : ScenarioTestBase() {
+
+    init {
+        // An eligible Dragon creature card to be cheated in when Kaalia attacks a player.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Dragon",
+                manaCost = ManaCost.parse("{4}{R}{R}"),
+                subtypes = setOf(Subtype("Dragon")),
+                power = 5,
+                toughness = 5
+            )
+        )
+        // An ineligible creature card (Bear — not Angel/Demon/Dragon) to prove the subtype filter.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Test Bear",
+                manaCost = ManaCost.parse("{1}{G}"),
+                subtypes = setOf(Subtype("Bear")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Kaalia of the Vast") {
+
+            test("attacks a player: may put an Angel/Demon/Dragon from hand tapped and attacking") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kaalia of the Vast", summoningSickness = false)
+                    .withCardInHand(1, "Test Dragon") // Dragon: eligible
+                    .withCardInHand(1, "Test Bear")   // Bear: NOT eligible
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                // Attack the opponent player (player 2).
+                game.declareAttackers(mapOf("Kaalia of the Vast" to 2)).error shouldBe null
+
+                // The attack-a-player trigger goes on the stack; resolving it asks the controller
+                // to choose up to one eligible creature card from hand.
+                game.resolveStack()
+                withClue("attack-a-player trigger paused for the hand-card selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+
+                // Only the Dragon qualifies; the Bear must not be a selectable option. Select it.
+                val dragon = game.findCardsInHand(1, "Test Dragon").single()
+                game.selectCards(listOf(dragon)).error shouldBe null
+                game.resolveStack()
+
+                val put = game.findPermanents("Test Dragon").singleOrNull()
+                    ?: error("Test Dragon should be on the battlefield once, found ${game.findPermanents("Test Dragon").size}")
+                withClue("the put creature enters tapped") {
+                    game.state.getEntity(put)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("the put creature enters attacking") {
+                    game.state.getEntity(put)?.has<AttackingComponent>() shouldBe true
+                }
+                withClue("Test Bear (not Angel/Demon/Dragon) stayed in hand — not eligible") {
+                    game.isInHand(1, "Test Bear") shouldBe true
+                }
+            }
+
+            test("attacks a planeswalker: the trigger does NOT fire (2024 ruling)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kaalia of the Vast", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Sorin, Solemn Visitor") // opponent planeswalker
+                    .withCardInHand(1, "Test Dragon")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Seed the planeswalker's loyalty so an SBA doesn't remove it before combat.
+                val sorin = game.findPermanent("Sorin, Solemn Visitor")!!
+                game.state = game.state.updateEntity(sorin) { container ->
+                    container.with(CountersComponent().withAdded(CounterType.LOYALTY, 4))
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                // Attack the planeswalker, not the player.
+                game.declareAttackersWithPlaneswalkerTargets(
+                    planeswalkerAttackers = mapOf("Kaalia of the Vast" to "Sorin, Solemn Visitor")
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("attacking a planeswalker must NOT trigger Kaalia's ability") {
+                    game.hasPendingDecision() shouldBe false
+                }
+                withClue("no creature was cheated onto the battlefield") {
+                    game.findPermanents("Test Dragon").size shouldBe 0
+                }
+                withClue("Test Dragon remains in hand") {
+                    game.isInHand(1, "Test Dragon") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
ref: https://github.com/wingedsheep/argentum-engine/issues/1258

## Problem

A triggered ability worded **"Whenever ~ attacks an opponent"** (i.e. attacks a *player*) must
**not** trigger when the creature attacks a planeswalker or a battle. The engine already models
attacking planeswalkers, but the only self-attack trigger — `Triggers.Attacks` (SELF, unfiltered)
— fired regardless of what the creature was declared as attacking.

Discovered while implementing **Kaalia of the Vast**, whose 2024-06-07 ruling makes this explicit:
*"Kaalia of the Vast's ability doesn't trigger if it attacks a planeswalker or battle."*

## Fix

Add a new attack-declaration fact and SELF-bound sugar over it, wired through the trigger matcher:

- **`AttackPredicate.DefenderIsPlayer`** (`EventFilters.kt`) — the attacker was declared as
  attacking a **player**, not a planeswalker or battle (CR 508.1). A creature can only attack a
  *player* who is its controller's opponent, so on a SELF binding this is exactly "attacks an
  opponent". Defined positively (defender **is a player**) so battles — which aren't modeled as a
  card type — fall out correctly.
- **`Triggers.AttacksAnOpponent`** (`Triggers.kt`) — SELF-bound `TriggerSpec` sugar for
  `attacks(requires = setOf(AttackPredicate.DefenderIsPlayer))`.
- **Per-declaration stamping** — the defender kind is fixed at declaration and
  `AttackersDeclaredEvent` carries no per-attacker defender identity, so
  `AttackPhaseManager` stamps the player-defender subset onto a new
  `AttackersDeclaredEvent.attackersAgainstPlayer` field (mirroring the existing
  `firstTimeAttackers` pattern), using the established `defenderId in state.turnOrder`
  player-identity idiom. `TriggerMatcher.matchesAttackPredicate` reads
  `boundEntityId in event.attackersAgainstPlayer`.

## Demonstration card — Kaalia of the Vast (CMD #206, canonical earliest printing)

`{1}{R}{W}{B}` Legendary Human Cleric, 2/2, flying.

> Whenever Kaalia of the Vast attacks an opponent, you may put an Angel, Demon, or Dragon creature
> card from your hand onto the battlefield tapped and attacking that opponent.

Implemented entirely from existing atoms: `Triggers.AttacksAnOpponent` +
`Patterns.Hand.putFromHand(filter = Creature.withAnySubtype("Angel", "Demon", "Dragon"),
entersAttacking = true)` — no new effect type. Relevant rulings (including both the 2020 and 2024
"doesn't trigger on a planeswalker/battle" clarifications) captured in `metadata`.

## mtgish tooling (Step 4.11 — wider benefit)

Taught the predictive generator the mechanic so it drafts across every set, not just this card:

- **Bridge** (`TriggersCostsAndContinuous.kt`) — `WhenACreatureAttacksAPlayer` → capability.
- **Emitter** (`CardStructure.kt`) — renders the SELF + opponent/any-scope trigger to
  `Triggers.AttacksAnOpponent` (declines constrained-scope and non-SELF shapes rather than
  over-claiming).
- **Emitter** (`ZoneHandlers.kt`) — renders the `EntersAttackingPlayer` put-from-hand shape to
  `Patterns.Hand.putFromHand(entersAttacking = true)` with a `Creature.withSubtype` /
  `withAnySubtype` filter.

Result: `just coverage-fidelity --emit "Kaalia of the Vast"` now produces a **complete AUTO-tier**
render matching the hand-authored card.

## Tests

- **`AttacksAnOpponentScenarioTest`** (rules-engine) — pins the predicate directly: fires when the
  creature attacks a player; does **not** fire when it attacks a planeswalker.
- **`KaaliaOfTheVastScenarioTest`** (rules-engine) — end-to-end through the card: on a player
  attack the trigger offers only Angel/Demon/Dragon cards (a Bear is not selectable) and the chosen
  card enters tapped **and** attacking; on a planeswalker attack no trigger fires and nothing is put
  in.
- **Golden nets** — `EmitterGoldenTest` unchanged (no fixture churn); CMD card-definition snapshot
  golden re-blessed for the new Kaalia card (purely additive, +97 lines).
- `docs/card-sdk-language-reference.md` updated with the new predicate and trigger sugar.

All rules-engine, mtg-sdk, mtg-sets (CMD snapshot + lint), and mtgish-tooling tests pass.

## Impact

- 14 files, +545 / −5. Backward-compatible: `attackersAgainstPlayer` is a defaulted field and the
  matcher `when` stays exhaustive.

Closes #1258.
