### PR TITLE
Add 5 Lost Caverns of Ixalan cards (batch 11)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 161 / 286
+**Implemented:** 166 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -150,7 +150,7 @@
 - [ ] Malamet Battle Glyph
 - [x] Malamet Brawler
 - [x] Malamet Scythe
-- [ ] Malamet Veteran
+- [x] Malamet Veteran
 - [x] Malamet War Scribe
 - [x] Malcolm, Alluring Scoundrel
 - [ ] Malicious Eclipse
@@ -164,10 +164,10 @@
 - [x] Miner's Guidewing
 - [x] Mineshaft Spider
 - [x] Mischievous Pup
-- [ ] Molten Collapse
+- [x] Molten Collapse
 - [ ] Nicanzil, Current Conductor
 - [x] Nurturing Bristleback
-- [ ] Oaken Siren
+- [x] Oaken Siren
 - [ ] Ojer Axonil, Deepest Might
 - [ ] Ojer Kaslem, Deepest Growth
 - [ ] Ojer Pakpatiq, Deepest Epoch
@@ -176,8 +176,8 @@
 - [x] Oltec Cloud Guard
 - [x] Orazca Puzzle-Door
 - [ ] Oteclan Landmark
-- [ ] Out of Air
-- [ ] Over the Edge
+- [x] Out of Air
+- [x] Over the Edge
 - [x] Palani's Hatcher
 - [x] Panicked Altisaur
 - [x] Pathfinding Axejaw

--- a/manual-scenarios/sets/lci/cards-11.json
+++ b/manual-scenarios/sets/lci/cards-11.json
@@ -1,0 +1,59 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Malamet Veteran",
+      "Molten Collapse",
+      "Oaken Siren",
+      "Out of Air",
+      "Over the Edge"
+    ],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Cenote Scout"}
+    ],
+    "graveyard": [
+      "Basking Capybara",
+      "Belligerent Yearling",
+      "Compass Gnome",
+      "Forest"
+    ],
+    "library": ["Basking Capybara", "Forest", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Belligerent Yearling"],
+    "battlefield": [
+      {"name": "Earthshaker Dreadmaw"},
+      {"name": "Dead Weight", "attachedTo": "Earthshaker Dreadmaw"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Belligerent Yearling"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MalametVeteran.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MalametVeteran.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Malamet Veteran — {4}{G}
+ * Creature — Cat Warrior
+ * 5/4
+ *
+ * Trample
+ * Descend 4 — Whenever this creature attacks, if there are four or more permanent cards in your
+ * graveyard, put a +1/+1 counter on target creature.
+ *
+ * "Descend 4" is an ability word (CR 207.2c — no rules meaning of its own); the rules content is
+ * the intervening-if clause (CR 603.4): four or more permanent cards in your graveyard. Modeled as
+ * an attack trigger with an intervening-if [Conditions.CardsInGraveyardMatchingAtLeast]: the
+ * ability goes on the stack only when the condition holds at trigger time. Known engine gap: CR
+ * 603.4 also requires the condition to be rechecked as the ability resolves, but the engine
+ * evaluates `triggerCondition` only at detection time (`TriggerMatcher.filterByTriggerCondition`),
+ * so a graveyard emptied in response still resolves the trigger.
+ *
+ * Targeting is mandatory (no "may"): the controller must choose any creature (theirs or an
+ * opponent's) to receive the +1/+1 counter. If no legal target exists the ability doesn't go on the
+ * stack; if the sole target becomes illegal before resolution the ability fizzles.
+ */
+val MalametVeteran = card("Malamet Veteran") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Warrior"
+    power = 5
+    toughness = 4
+    oracleText = "Trample\n" +
+        "Descend 4 — Whenever this creature attacks, if there are four or more permanent cards in " +
+        "your graveyard, put a +1/+1 counter on target creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent)
+        val t = target("target creature", TargetCreature())
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "201"
+        artist = "Steve Prescott"
+        flavorText = "The mightiest Malamet warriors train as titan-killers, elite champions capable of " +
+            "facing down the caverns' most fearsome beasts."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b9b16b3-1cbd-4b63-85b2-e4053dfc1e93.jpg?1782694449"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MoltenCollapse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MoltenCollapse.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Molten Collapse
+ * {B}{R}
+ * Sorcery
+ *
+ * Choose one. If you descended this turn, you may choose both instead. (You descended if a
+ * permanent card was put into your graveyard from anywhere.)
+ * • Destroy target creature or planeswalker.
+ * • Destroy target noncreature, nonland permanent with mana value 1 or less.
+ *
+ * The conditional modal count is a cast-time `dynamicChooseCount`, exactly the Flame of Anor
+ * pattern: the floor stays `minChooseCount = 1` ("choose one" is mandatory), and the cap is 2
+ * when you descended this turn (CR 700.11 — a permanent card was put into your graveyard from
+ * anywhere), otherwise 1. Evaluated against the game state at cast time by
+ * [com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler].
+ *
+ * Mode 1's target is "creature or planeswalker" ([Targets.CreatureOrPlaneswalker]); mode 2's
+ * target is a nonland permanent that is not a creature with mana value 1 or less.
+ */
+val MoltenCollapse = card("Molten Collapse") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Sorcery"
+    oracleText = "Choose one. If you descended this turn, you may choose both instead. " +
+        "(You descended if a permanent card was put into your graveyard from anywhere.)\n" +
+        "• Destroy target creature or planeswalker.\n" +
+        "• Destroy target noncreature, nonland permanent with mana value 1 or less."
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.YouDescendedThisTurn(atLeast = 1),
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1)
+            )
+        ) {
+            mode("Destroy target creature or planeswalker") {
+                val victim = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+                effect = Effects.Destroy(victim)
+            }
+            mode("Destroy target noncreature, nonland permanent with mana value 1 or less") {
+                val victim = target(
+                    "target noncreature, nonland permanent with mana value 1 or less",
+                    TargetPermanent(
+                        filter = TargetFilter(
+                            GameObjectFilter.NonlandPermanent.notCreature().manaValueAtMost(1)
+                        )
+                    )
+                )
+                effect = Effects.Destroy(victim)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "234"
+        artist = "Kasia 'Kafis' Zielińska"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/2487d124-210b-4808-888c-cd0a78aebd90.jpg?1782694423"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OakenSiren.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OakenSiren.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Oaken Siren
+ * {1}{U}
+ * Artifact Creature — Siren Pirate
+ * 1/2
+ * Common — LCI #66
+ *
+ * Flying, vigilance
+ * {T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an
+ *      artifact source.
+ *
+ * Mirrors Ixalli's Lorekeeper's restricted-mana pattern, but adds a fixed {U} (not any color)
+ * and keys the restriction to a *card type* instead of a subtype:
+ * [ManaRestriction.CardTypeSpellsOrAbilitiesOnly](CardType.ARTIFACT) with both `allowSpells`
+ * and `allowAbilities` true, so the mana pays for artifact spells and abilities of artifact
+ * sources — matching the printed oracle exactly.
+ */
+val OakenSiren = card("Oaken Siren") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Siren Pirate"
+    power = 1
+    toughness = 2
+    oracleText = "Flying, vigilance\n{T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    // {T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of
+    //      an artifact source.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(
+            color = Color.BLUE,
+            amount = 1,
+            restriction = ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                cardType = CardType.ARTIFACT,
+                allowSpells = true,
+                allowAbilities = true,
+            )
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Lars Grant-West"
+        flavorText = "The ship's carpenter adorned the figurehead with a small cosmium gem, never expecting the figurehead to take flight."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7731ef5-da74-4436-8ee7-01c065cbefae.jpg?1782694558"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OutOfAir.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OutOfAir.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Out of Air
+ * {2}{U}{U}
+ * Instant
+ * This spell costs {2} less to cast if it targets a creature spell.
+ * Counter target spell.
+ *
+ * The spell counters any target spell (`Targets.Spell`); the conditional discount is a
+ * self-cost reduction gated on the chosen target being a creature spell. Modeled exactly like
+ * Brush Off's generic half — [ModifySpellCost] on [SpellCostTarget.SelfCast] with
+ * [CostModification.ReduceGenericBy] over [CostReductionSource.FixedIfAnyTargetMatches], filtered
+ * to [GameObjectFilter.Creature] (a creature *spell on the stack*, the same way Brush Off's
+ * `InstantOrSorcery` filter matches an instant/sorcery spell). The reduction is generic-only, so
+ * no colored-pip reduction is needed. It resolves at cast time once the target is announced
+ * (CR 601.2f): if the target is a creature spell the generic cost drops by {2} to {U}{U}.
+ */
+val OutOfAir = card("Out of Air") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if it targets a creature spell.\n" +
+        "Counter target spell."
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell()
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 2,
+                    filter = GameObjectFilter.Creature,
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Francisco Miyara"
+        flavorText = "\"The Core is not a simple trove to be plundered by intruders from the surface. " +
+            "It will reject those who do not accord it respect.\"\n—Akal Pakal, First Steward of Oteclan"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c263db55-fcac-4b49-b626-7c8092accfcd.jpg?1782694555"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OverTheEdge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OverTheEdge.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Over the Edge — {1}{G}
+ * Sorcery
+ * Common — The Lost Caverns of Ixalan #205
+ * Artist: Ryan Valle
+ *
+ * "Choose one —
+ *  • Destroy target artifact or enchantment.
+ *  • Target creature you control explores, then it explores again."
+ *
+ * A "Choose one —" modal sorcery (CR 700.2 / 601.2b). Each mode declares its own target, so
+ * targeting legality is checked per chosen mode at cast time.
+ *
+ * Mode 0: Destroy a targeted artifact or enchantment ([Targets.ArtifactOrEnchantment] matches a
+ *   permanent that is an artifact and/or an enchantment).
+ *
+ * Mode 1: A creature you control explores twice (CR 701.44). "Explores, then it explores again"
+ *   = two sequential [Effects.Explore] calls on the same permanent, mirroring Defossilize. Each
+ *   explore reveals the top library card; a land goes to hand, otherwise a +1/+1 counter is put
+ *   on the creature and the player may put the revealed card into the graveyard. The target [c]
+ *   is a stable [com.wingedsheep.sdk.scripting.targets.EffectTarget.BoundVariable] so both
+ *   explores act on the same creature.
+ */
+val OverTheEdge = card("Over the Edge") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Destroy target artifact or enchantment.\n" +
+        "• Target creature you control explores, then it explores again. " +
+        "(Reveal the top card of your library. Put that card into your hand if it's a land. " +
+        "Otherwise, put a +1/+1 counter on that creature, then put the card back or put it " +
+        "into your graveyard. Then repeat this process.)"
+
+    spell {
+        modal {
+            mode("Destroy target artifact or enchantment") {
+                val artifactOrEnchantment = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+                effect = Effects.Destroy(artifactOrEnchantment)
+            }
+            mode("Target creature you control explores, then it explores again") {
+                val creature = target("target creature you control", Targets.CreatureYouControl)
+                effect = Effects.Explore(creature)
+                    .then(Effects.Explore(creature))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "205"
+        artist = "Ryan Valle"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/23dddddb-5409-4c28-bf32-e6473f2cc620.jpg?1782694445"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6547,6 +6547,68 @@
     ]
 }
 
+// Malamet Veteran
+{
+    "name": "Malamet Veteran",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Cat Warrior",
+    "oracleText": "Trample\nDescend 4 — Whenever this creature attacks, if there are four or more permanent cards in your graveyard, put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "artist": "Steve Prescott",
+        "flavorText": "The mightiest Malamet warriors train as titan-killers, elite champions capable of facing down the caverns' most fearsome beasts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b9b16b3-1cbd-4b63-85b2-e4053dfc1e93.jpg?1782694449"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Malamet War Scribe
 {
     "name": "Malamet War Scribe",
@@ -7091,6 +7153,109 @@
     ]
 }
 
+// Molten Collapse
+{
+    "name": "Molten Collapse",
+    "manaCost": "{B}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one. If you descended this turn, you may choose both instead. (You descended if a permanent card was put into your graveyard from anywhere.)\n• Destroy target creature or planeswalker.\n• Destroy target noncreature, nonland permanent with mana value 1 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature or planeswalker"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetCreatureOrPlaneswalker",
+                            "id": "target creature or planeswalker"
+                        }
+                    ],
+                    "description": "Destroy target creature or planeswalker"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target noncreature, nonland permanent with mana value 1 or less"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsNonland",
+                                        "IsPermanent",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsCreature"
+                                        },
+                                        {
+                                            "type": "ManaValueAtMost",
+                                            "max": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "target noncreature, nonland permanent with mana value 1 or less"
+                        }
+                    ],
+                    "description": "Destroy target noncreature, nonland permanent with mana value 1 or less"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "RARE",
+        "artist": "Kasia 'Kafis' Zielińska",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/2487d124-210b-4808-888c-cd0a78aebd90.jpg?1782694423"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Nurturing Bristleback
 {
     "name": "Nurturing Bristleback",
@@ -7145,6 +7310,50 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Oaken Siren
+{
+    "name": "Oaken Siren",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact Creature — Siren Pirate",
+    "oracleText": "Flying, vigilance\n{T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE",
+                    "restriction": {
+                        "type": "CardTypeSpellsOrAbilitiesOnly",
+                        "cardType": "ARTIFACT",
+                        "allowAbilities": true
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Lars Grant-West",
+        "flavorText": "The ship's carpenter adorned the figurehead with a small cosmium gem, never expecting the figurehead to take flight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7731ef5-da74-4436-8ee7-01c065cbefae.jpg?1782694558"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -7338,6 +7547,124 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Out of Air
+{
+    "name": "Out of Air",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {2} less to cast if it targets a creature spell.\nCounter target spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 2,
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Francisco Miyara",
+        "flavorText": "\"The Core is not a simple trove to be plundered by intruders from the surface. It will reject those who do not accord it respect.\"\n—Akal Pakal, First Steward of Oteclan",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c263db55-fcac-4b49-b626-7c8092accfcd.jpg?1782694555"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Over the Edge
+{
+    "name": "Over the Edge",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Destroy target artifact or enchantment.\n• Target creature you control explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard. Then repeat this process.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact or enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact|enchantment"
+                            },
+                            "id": "target artifact or enchantment"
+                        }
+                    ],
+                    "description": "Destroy target artifact or enchantment"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Explore",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                }
+                            },
+                            {
+                                "type": "Explore",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        }
+                    ],
+                    "description": "Target creature you control explores, then it explores again"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "artist": "Ryan Valle",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/23dddddb-5409-4c28-bf32-e6473f2cc620.jpg?1782694445"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MalametVeteranScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MalametVeteranScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.MalametVeteran
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Malamet Veteran (LCI #201) — {4}{G} Creature — Cat Warrior 5/4.
+ *
+ * "Trample
+ *  Descend 4 — Whenever this creature attacks, if there are four or more permanent cards in your
+ *  graveyard, put a +1/+1 counter on target creature."
+ *
+ * Covered end-to-end:
+ *  1. Descend 4 met (four permanent cards in the graveyard): attacking fires the trigger and a
+ *     +1/+1 counter is placed on the chosen target creature.
+ *  2. Descend 4 not met (three permanent cards): the intervening-if fails, so attacking produces
+ *     no trigger and no counter is placed.
+ */
+class MalametVeteranScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MalametVeteran)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Read +1/+1 counter count on a permanent. */
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("Descend 4 met: attacking puts a +1/+1 counter on the target creature") {
+        val driver = newDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val veteran = driver.putCreatureOnBattlefield(attacker, "Malamet Veteran")
+        driver.removeSummoningSickness(veteran)
+
+        // A second creature to receive the counter (any creature is a legal target).
+        val bear = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+
+        // Four permanent cards in the graveyard — meets the Descend 4 threshold.
+        repeat(4) { driver.putCardInGraveyard(attacker, "Forest") }
+
+        driver.plusOneCounters(bear) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(veteran), defender)
+        // The attack trigger goes on the stack; choose the counter target, then resolve.
+        driver.submitTargetSelection(attacker, listOf(bear))
+        driver.bothPass()
+
+        driver.plusOneCounters(bear) shouldBe 1
+    }
+
+    test("Descend 4 not met: attacking with only three permanent cards places no counter") {
+        val driver = newDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val veteran = driver.putCreatureOnBattlefield(attacker, "Malamet Veteran")
+        driver.removeSummoningSickness(veteran)
+
+        val bear = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+
+        // Only three permanent cards — one short of Descend 4.
+        repeat(3) { driver.putCardInGraveyard(attacker, "Forest") }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(veteran), defender)
+        driver.bothPass()
+
+        // Intervening-if failed: no trigger, no counter on either creature.
+        driver.plusOneCounters(bear) shouldBe 0
+        driver.plusOneCounters(veteran) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenCollapseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenCollapseScenarioTest.kt
@@ -1,0 +1,211 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.MoltenCollapse
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Molten Collapse — {B}{R} Sorcery
+ *
+ * "Choose one. If you descended this turn, you may choose both instead.
+ *  • Destroy target creature or planeswalker.
+ *  • Destroy target noncreature, nonland permanent with mana value 1 or less."
+ *
+ * Pins the cast-time conditional modal count: the floor stays "choose one", and the cap is
+ * 2 only when the caster descended this turn (CR 700.11 — a permanent card was put into
+ * their graveyard from anywhere).
+ *
+ * Modes: 0 = destroy target creature or planeswalker,
+ *        1 = destroy target noncreature, nonland permanent with mana value 1 or less.
+ */
+class MoltenCollapseScenarioTest : FunSpec({
+
+    // A noncreature, nonland permanent with mana value 1 — a legal mode-1 target.
+    val Trinket: CardDefinition = CardDefinition.artifact(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    // A noncreature, nonland permanent with mana value 3 — NOT a legal mode-1 target.
+    val Relic: CardDefinition = CardDefinition.artifact(
+        name = "Test Relic",
+        manaCost = ManaCost.parse("{3}")
+    )
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(MoltenCollapse)
+        d.registerCard(Trinket)
+        d.registerCard(Relic)
+        return d
+    }
+
+    /** Move a permanent card to the graveyard to trigger descend (CR 700.11). */
+    fun GameTestDriver.descend(entityId: EntityId) {
+        val result = ZoneTransitionService.moveToZone(
+            state = state,
+            entityId = entityId,
+            destinationZone = Zone.GRAVEYARD
+        )
+        replaceState(result.state)
+    }
+
+    fun castSetup(d: GameTestDriver): Pair<EntityId, EntityId> {
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveMana(p1, Color.BLACK, 1)
+        d.giveMana(p1, Color.RED, 1)
+        return p1 to d.getOpponent(p1)
+    }
+
+    test("not descended — choosing both modes is illegal (effective max is one)") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val creature = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+        val trinket = d.putPermanentOnBattlefield(p2, "Test Trinket")
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(creature), ChosenTarget.Permanent(trinket)),
+            chosenModes = listOf(0, 1),
+            modeTargetsOrdered = listOf(
+                listOf(ChosenTarget.Permanent(creature)),
+                listOf(ChosenTarget.Permanent(trinket))
+            )
+        ))
+
+        result.isSuccess shouldBe false
+    }
+
+    test("not descended — choose mode 0 destroys target creature") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val creature = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(creature)),
+            chosenModes = listOf(0),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(creature)))
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        d.findPermanent(p2, "Centaur Courser").shouldBeNull()
+    }
+
+    test("not descended — choose mode 1 destroys a MV<=1 noncreature nonland permanent") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val trinket = d.putPermanentOnBattlefield(p2, "Test Trinket")
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(trinket)),
+            chosenModes = listOf(1),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(trinket)))
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        d.findPermanent(p2, "Test Trinket").shouldBeNull()
+    }
+
+    test("mode 1 cannot target a permanent with mana value greater than 1") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val relic = d.putPermanentOnBattlefield(p2, "Test Relic") // MV 3
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(relic)),
+            chosenModes = listOf(1),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(relic)))
+        ))
+
+        result.isSuccess shouldBe false
+    }
+
+    test("descended this turn — may choose both: destroy the creature AND the MV<=1 permanent") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val creature = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+        val trinket = d.putPermanentOnBattlefield(p2, "Test Trinket")
+
+        // Descend: move a permanent card (creature in hand) to the graveyard this turn.
+        val handBear = d.putCardInHand(p1, "Grizzly Bears")
+        d.descend(handBear)
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(creature), ChosenTarget.Permanent(trinket)),
+            chosenModes = listOf(0, 1),
+            modeTargetsOrdered = listOf(
+                listOf(ChosenTarget.Permanent(creature)),
+                listOf(ChosenTarget.Permanent(trinket))
+            )
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        d.findPermanent(p2, "Centaur Courser").shouldBeNull()
+        d.findPermanent(p2, "Test Trinket").shouldBeNull()
+    }
+
+    test("descended this turn — may still choose only one mode") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val creature = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+        val trinket = d.putPermanentOnBattlefield(p2, "Test Trinket")
+
+        val handBear = d.putCardInHand(p1, "Grizzly Bears")
+        d.descend(handBear)
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(creature)),
+            chosenModes = listOf(0),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(creature)))
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        d.findPermanent(p2, "Centaur Courser").shouldBeNull()
+        // The unchosen mode leaves the trinket alone.
+        d.findPermanent(p2, "Test Trinket").shouldNotBeNull()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OakenSirenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OakenSirenScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.OakenSiren
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Oaken Siren (LCI #66) — {1}{U} Artifact Creature — Siren Pirate 1/2
+ *
+ *   Flying, vigilance
+ *   {T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an
+ *        artifact source.
+ *
+ * Exercises [ManaRestriction.CardTypeSpellsOrAbilitiesOnly](CardType.ARTIFACT) with both spells
+ * and abilities allowed:
+ *  1. Tapping adds exactly one restricted {U} to the pool.
+ *  2. The restricted mana can pay for an artifact spell.
+ *  3. The restricted mana cannot pay for a non-artifact spell.
+ */
+class OakenSirenScenarioTest : FunSpec({
+
+    val testArtifact = CardDefinition.artifact(
+        name = "Test Artifact",
+        manaCost = ManaCost.parse("{U}")
+    )
+    val testCreature = CardDefinition.creature(
+        name = "Test Creature",
+        manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Human")),
+        power = 1,
+        toughness = 1
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + OakenSiren + testArtifact + testCreature)
+        return driver
+    }
+
+    val manaAbilityId = OakenSiren.activatedAbilities[0].id
+
+    fun GameTestDriver.tapForArtifactMana(playerId: EntityId) {
+        val siren = putPermanentOnBattlefield(playerId, "Oaken Siren")
+        submit(ActivateAbility(playerId, siren, manaAbilityId))
+    }
+
+    test("restricted mana is placed in pool after tapping") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForArtifactMana(p1)
+
+        val pool = driver.state.getEntity(p1)?.get<ManaPoolComponent>()
+        pool!!.restrictedMana.size shouldBe 1
+    }
+
+    test("restricted mana can pay for an artifact spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForArtifactMana(p1)
+
+        val artifact = driver.putCardInHand(p1, "Test Artifact")
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = artifact, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("restricted mana cannot pay for a non-artifact spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForArtifactMana(p1)
+
+        val creature = driver.putCardInHand(p1, "Test Creature")
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = creature, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutOfAirScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutOfAirScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Out of Air (LCI).
+ *
+ * Oracle: "This spell costs {2} less to cast if it targets a creature spell.\nCounter target spell."
+ *
+ * Base cost is {2}{U}{U}. The counter half reuses [com.wingedsheep.sdk.dsl.Effects.CounterSpell]
+ * over `Targets.Spell` (any spell). The conditional discount is a self-cost reduction —
+ * `ModifySpellCost(SelfCast, ReduceGenericBy(FixedIfAnyTargetMatches(2, GameObjectFilter.Creature)))` —
+ * gated on the chosen target being a creature *spell on the stack*. It resolves at cast time once the
+ * target is announced (CR 601.2f): a creature-spell target drops the generic portion by {2} to {U}{U};
+ * any other spell is countered at full price.
+ */
+class OutOfAirScenarioTest : ScenarioTestBase() {
+
+    /** A minimal spell of [type] sitting on [casterId]'s stack, for cost-reduction target checks. */
+    private fun stackSpell(
+        casterId: EntityId,
+        type: CardType,
+        name: String,
+    ): Pair<EntityId, ComponentContainer> {
+        val id = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = name,
+                name = name,
+                manaCost = ManaCost.parse("{1}"),
+                typeLine = TypeLine(cardTypes = setOf(type)),
+                oracleText = "",
+                colors = setOf(Color.GREEN),
+                ownerId = casterId,
+                spellEffect = null,
+            ),
+            OwnerComponent(casterId),
+        )
+        return id to container
+    }
+
+    private fun stateWith(casterId: EntityId, spellId: EntityId, container: ComponentContainer): GameState =
+        GameState()
+            .withEntity(casterId, ComponentContainer.EMPTY)
+            .withEntity(spellId, container)
+            .addToZone(ZoneKey(casterId, Zone.STACK), spellId)
+            .copy(turnOrder = listOf(casterId))
+
+    init {
+        context("Out of Air — conditional cost reduction") {
+
+            test("no chosen target → full {2}{U}{U} cost") {
+                val casterId = EntityId.generate()
+                val (spellId, container) = stackSpell(casterId, CardType.CREATURE, "Grizzly Bears")
+                val state = stateWith(casterId, spellId, container)
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    state, cardRegistry.requireCard("Out of Air"), casterId, chosenTargets = emptyList(),
+                )
+                cost.toString() shouldBe ManaCost.parse("{2}{U}{U}").toString()
+            }
+
+            test("targeting a creature spell reduces the cost by {2} to {U}{U}") {
+                val casterId = EntityId.generate()
+                val (spellId, container) = stackSpell(casterId, CardType.CREATURE, "Grizzly Bears")
+                val state = stateWith(casterId, spellId, container)
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    state, cardRegistry.requireCard("Out of Air"), casterId, chosenTargets = listOf(spellId),
+                )
+                cost.toString() shouldBe ManaCost.parse("{U}{U}").toString()
+            }
+
+            test("targeting a non-creature spell (instant) leaves the cost at {2}{U}{U}") {
+                val casterId = EntityId.generate()
+                val (spellId, container) = stackSpell(casterId, CardType.INSTANT, "Shock")
+                val state = stateWith(casterId, spellId, container)
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    state, cardRegistry.requireCard("Out of Air"), casterId, chosenTargets = listOf(spellId),
+                )
+                cost.toString() shouldBe ManaCost.parse("{2}{U}{U}").toString()
+            }
+        }
+
+        context("Out of Air — counters target spell") {
+
+            test("with the {2} creature-spell discount it counters a creature spell for just {U}{U}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Out of Air")
+                    .withLandsOnBattlefield(1, "Island", 2) // only {U}{U} — must rely on the discount
+                    // Player 2 (active player) casts a creature spell for Out of Air to counter
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(2, "Grizzly Bears")
+                withClue("Casting Grizzly Bears should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                game.passPriority()
+
+                // Out of Air's printed cost is {2}{U}{U}=4, but two Islands only make {U}{U}=2 mana.
+                // The cast can only succeed if the "{2} less if it targets a creature spell" discount applies.
+                val counterResult = game.castSpellTargetingStackSpell(1, "Out of Air", "Grizzly Bears")
+                withClue("Casting Out of Air with only {U}{U} should succeed via the discount: ${counterResult.error}") {
+                    counterResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be countered — in player 2's graveyard, not on the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OverTheEdgeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OverTheEdgeScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Over the Edge (LCI #205, {1}{G} Sorcery).
+ *
+ * "Choose one —
+ *  • Destroy target artifact or enchantment.
+ *  • Target creature you control explores, then it explores again."
+ *
+ * Tests:
+ *  1. Mode 0 — targeting an enchantment destroys it (moves it to the graveyard).
+ *  2. Mode 1 — a creature you control explores twice, two land reveals go to hand with no counters.
+ *  3. Mode 1 — a creature you control explores twice, two nonland reveals each place a +1/+1 counter.
+ */
+class OverTheEdgeScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, name: String): Int {
+        val id = game.findPermanent(name) ?: return 0
+        return game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Over the Edge") {
+
+            // -----------------------------------------------------------------------
+            // Test 1: Mode 0 — destroy target artifact or enchantment.
+            // -----------------------------------------------------------------------
+            test("mode 0: destroys target enchantment") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Over the Edge")
+                    .withCardOnBattlefield(1, "Test Enchantment")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enchantment = game.findPermanent("Test Enchantment")
+                withClue("Test Enchantment should start on the battlefield") {
+                    enchantment shouldNotBe null
+                }
+
+                game.castSpellWithMode(1, "Over the Edge", 0, enchantment)
+                game.resolveStack()
+
+                withClue("Test Enchantment should be destroyed (off the battlefield)") {
+                    game.isOnBattlefield("Test Enchantment") shouldBe false
+                }
+                withClue("Test Enchantment should be in its owner's graveyard") {
+                    game.isInGraveyard(1, "Test Enchantment") shouldBe true
+                }
+            }
+
+            // -----------------------------------------------------------------------
+            // Test 2: Mode 1 — creature explores twice with land reveals (no counters).
+            // -----------------------------------------------------------------------
+            test("mode 1: creature explores twice — two land reveals go to hand with no counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Over the Edge")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // Library: [Mountain (top/index-0), Forest (below/index-1)].
+                    // Each explore reveals a land → straight to hand, no +1/+1 counter, no decision.
+                    .withCardInLibrary(1, "Mountain")   // added first → index 0 = top
+                    .withCardInLibrary(1, "Forest")     // added second → index 1 = below
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")
+                val handBefore = game.state.getHand(game.player1Id).size  // has Over the Edge → 1
+
+                game.castSpellWithMode(1, "Over the Edge", 1, bears)
+                game.resolveStack()  // Explore×2, both lands — no pauses.
+
+                // Net hand delta: −1 (cast Over the Edge) +2 (two land reveals) = +1
+                withClue("hand should have grown by 1 (−1 cast Over the Edge, +2 lands from two explores)") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore - 1 + 2
+                }
+                withClue("land reveals must not place +1/+1 counters (CR 701.44a)") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 0
+                }
+                withClue("library should be empty after both top cards were drawn") {
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY)).size shouldBe 0
+                }
+            }
+
+            // -----------------------------------------------------------------------
+            // Test 3: Mode 1 — creature explores twice with nonland reveals (two counters).
+            // -----------------------------------------------------------------------
+            test("mode 1: creature explores twice — two nonland reveals each put a +1/+1 counter on it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Over the Edge")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // Library top is a nonland; keeping it on top (answerYesNo(true)) lets the
+                    // second explore reveal it again → two nonland reveals → two +1/+1 counters.
+                    .withCardInLibrary(1, "Lightning Bolt")   // top — revealed by both explores
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")
+
+                game.castSpellWithMode(1, "Over the Edge", 1, bears)
+
+                // Explore #1 reveals Lightning Bolt (nonland) → first counter, then pauses for the
+                // back-or-graveyard decision.
+                game.resolveStack()
+                withClue("first explore (nonland) should pause for the back-or-graveyard decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.answerYesNo(true)  // keep Lightning Bolt on top of library
+
+                // Explore #2 reveals Lightning Bolt again → second counter, pauses for its decision.
+                withClue("second explore (nonland) should pause for the back-or-graveyard decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.answerYesNo(true)  // keep Lightning Bolt on top
+                game.resolveStack()
+
+                withClue("two nonland explores must place two +1/+1 counters on Grizzly Bears") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 2
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Lost Caverns of Ixalan — batch 11

Stacked on `lci-cards-10` (#1263, merged). This PR contains only the batch-11 commit.

### Cards (5)

| Card | Cost | Type | Notes |
|------|------|------|-------|
| Malamet Veteran | `{4}{G}` | Creature — Cat Warrior 5/4 | Trample; Descend 4 attack trigger → +1/+1 counter on target creature |
| Molten Collapse | `{B}{R}` | Sorcery | Choose one; both if you descended this turn |
| Oaken Siren | `{1}{U}` | Artifact Creature — Siren Pirate 1/2 | Flying, vigilance; {T}: add {U} restricted to artifact spells/abilities |
| Out of Air | `{2}{U}{U}` | Instant | Counter target spell; {2} cheaper if it targets a creature spell |
| Over the Edge | `{1}{G}` | Sorcery | Choose one — destroy artifact/enchantment, or a creature you control explores twice |

All five are pure data — no engine or SDK changes, existing primitives only:

- **Malamet Veteran** — attack trigger with intervening-if `Conditions.CardsInGraveyardMatchingAtLeast(4, Permanent)`.
- **Molten Collapse** — modal with `dynamicChooseCount = DynamicAmount.Conditional(YouDescendedThisTurn, 2, 1)` (the Flame of Anor pattern); mode 2 filters `NonlandPermanent.notCreature().manaValueAtMost(1)`.
- **Oaken Siren** — `ManaRestriction.CardTypeSpellsOrAbilitiesOnly(ARTIFACT)` on `Effects.AddMana`.
- **Out of Air** — `ModifySpellCost(SelfCast, ReduceGenericBy(FixedIfAnyTargetMatches(2, Creature)))` (the Brush Off pattern).
- **Over the Edge** — modal: `Effects.Destroy` / `Effects.Explore(creature).then(Effects.Explore(creature))`.

Each card has a scenario test in `rules-engine` (9 tests total), the LCI snapshot golden is
re-blessed, and `backlog/.../cards.md` is checked off (161 → 166 implemented). The
`manual-scenarios/sets/lci/cards-11.json` hotseat scenario has all five cards in hand with mana
and meaningful targets for every mode.

Oracle text, P/T, collector numbers, artists, and flavor verified against Scryfall;
`just check-card-printing` passes for all five (LCI is the earliest real printing of each).

### Known engine gap (documented, not introduced here)

CR 603.4 requires intervening-if conditions to be rechecked as the ability resolves; the engine
currently evaluates `triggerCondition` only at detection time
(`TriggerMatcher.filterByTriggerCondition`). Malamet Veteran's card comment documents this gap.
The proper fix (carry the condition onto `TriggeredAbilityOnStackComponent`, recheck in
`StackResolver`) is a systemic `add-feature` follow-up affecting all intervening-if cards.

### Tests

- `:rules-engine:test` — MalametVeteran / MoltenCollapse / OakenSiren / OutOfAir / OverTheEdge
  scenario tests: 9/9 passed.
- `:mtg-sets:test` — CardDefinitionSnapshotTest + CardLintTest green across the full corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
