### PR TITLE
Add 5 Lost Caverns of Ixalan cards (batch 12)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 161 / 286
+**Implemented:** 166 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -150,7 +150,7 @@
 - [ ] Malamet Battle Glyph
 - [x] Malamet Brawler
 - [x] Malamet Scythe
-- [ ] Malamet Veteran
+- [x] Malamet Veteran
 - [x] Malamet War Scribe
 - [x] Malcolm, Alluring Scoundrel
 - [ ] Malicious Eclipse
@@ -164,10 +164,10 @@
 - [x] Miner's Guidewing
 - [x] Mineshaft Spider
 - [x] Mischievous Pup
-- [ ] Molten Collapse
+- [x] Molten Collapse
 - [ ] Nicanzil, Current Conductor
 - [x] Nurturing Bristleback
-- [ ] Oaken Siren
+- [x] Oaken Siren
 - [ ] Ojer Axonil, Deepest Might
 - [ ] Ojer Kaslem, Deepest Growth
 - [ ] Ojer Pakpatiq, Deepest Epoch
@@ -176,8 +176,8 @@
 - [x] Oltec Cloud Guard
 - [x] Orazca Puzzle-Door
 - [ ] Oteclan Landmark
-- [ ] Out of Air
-- [ ] Over the Edge
+- [x] Out of Air
+- [x] Over the Edge
 - [x] Palani's Hatcher
 - [x] Panicked Altisaur
 - [x] Pathfinding Axejaw

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 166 / 286
+**Implemented:** 171 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -181,17 +181,17 @@
 - [x] Palani's Hatcher
 - [x] Panicked Altisaur
 - [x] Pathfinding Axejaw
-- [ ] Petrify
-- [ ] Pirate Hat
+- [x] Petrify
+- [x] Pirate Hat
 - [ ] Pit of Offerings
 - [x] Plundering Pirate
-- [ ] Poetic Ingenuity
+- [x] Poetic Ingenuity
 - [x] Poison Dart Frog
 - [ ] Preacher of the Schism
 - [x] Primordial Gnawer
 - [x] Promising Vein
-- [ ] Pugnacious Hammerskull
-- [ ] Queen's Bay Paladin
+- [x] Pugnacious Hammerskull
+- [x] Queen's Bay Paladin
 - [x] Quicksand Whirlpool
 - [x] Quintorius Kand
 - [x] Rampaging Ceratops

--- a/manual-scenarios/sets/lci/cards-11.json
+++ b/manual-scenarios/sets/lci/cards-11.json
@@ -1,0 +1,59 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Malamet Veteran",
+      "Molten Collapse",
+      "Oaken Siren",
+      "Out of Air",
+      "Over the Edge"
+    ],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Cenote Scout"}
+    ],
+    "graveyard": [
+      "Basking Capybara",
+      "Belligerent Yearling",
+      "Compass Gnome",
+      "Forest"
+    ],
+    "library": ["Basking Capybara", "Forest", "Island"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Belligerent Yearling"],
+    "battlefield": [
+      {"name": "Earthshaker Dreadmaw"},
+      {"name": "Dead Weight", "attachedTo": "Earthshaker Dreadmaw"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Belligerent Yearling"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/sets/lci/cards-12.json
+++ b/manual-scenarios/sets/lci/cards-12.json
@@ -1,0 +1,52 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Petrify",
+      "Pirate Hat",
+      "Poetic Ingenuity",
+      "Pugnacious Hammerskull",
+      "Queen's Bay Paladin"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Greedy Freebooter"}
+    ],
+    "graveyard": ["Acolyte of Aclazotz"],
+    "library": ["Basking Capybara", "Forest", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Bartolomé del Presidio"},
+      {"name": "Basking Capybara"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Basking Capybara"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MalametVeteran.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MalametVeteran.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Malamet Veteran — {4}{G}
+ * Creature — Cat Warrior
+ * 5/4
+ *
+ * Trample
+ * Descend 4 — Whenever this creature attacks, if there are four or more permanent cards in your
+ * graveyard, put a +1/+1 counter on target creature.
+ *
+ * "Descend 4" is an ability word (CR 207.2c — no rules meaning of its own); the rules content is
+ * the intervening-if clause (CR 603.4): four or more permanent cards in your graveyard. Modeled as
+ * an attack trigger with an intervening-if [Conditions.CardsInGraveyardMatchingAtLeast]: the
+ * ability goes on the stack only when the condition holds at trigger time. Known engine gap: CR
+ * 603.4 also requires the condition to be rechecked as the ability resolves, but the engine
+ * evaluates `triggerCondition` only at detection time (`TriggerMatcher.filterByTriggerCondition`),
+ * so a graveyard emptied in response still resolves the trigger.
+ *
+ * Targeting is mandatory (no "may"): the controller must choose any creature (theirs or an
+ * opponent's) to receive the +1/+1 counter. If no legal target exists the ability doesn't go on the
+ * stack; if the sole target becomes illegal before resolution the ability fizzles.
+ */
+val MalametVeteran = card("Malamet Veteran") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Cat Warrior"
+    power = 5
+    toughness = 4
+    oracleText = "Trample\n" +
+        "Descend 4 — Whenever this creature attacks, if there are four or more permanent cards in " +
+        "your graveyard, put a +1/+1 counter on target creature."
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent)
+        val t = target("target creature", TargetCreature())
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, t)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "201"
+        artist = "Steve Prescott"
+        flavorText = "The mightiest Malamet warriors train as titan-killers, elite champions capable of " +
+            "facing down the caverns' most fearsome beasts."
+        imageUri = "https://cards.scryfall.io/normal/front/4/b/4b9b16b3-1cbd-4b63-85b2-e4053dfc1e93.jpg?1782694449"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MoltenCollapse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MoltenCollapse.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Molten Collapse
+ * {B}{R}
+ * Sorcery
+ *
+ * Choose one. If you descended this turn, you may choose both instead. (You descended if a
+ * permanent card was put into your graveyard from anywhere.)
+ * • Destroy target creature or planeswalker.
+ * • Destroy target noncreature, nonland permanent with mana value 1 or less.
+ *
+ * The conditional modal count is a cast-time `dynamicChooseCount`, exactly the Flame of Anor
+ * pattern: the floor stays `minChooseCount = 1` ("choose one" is mandatory), and the cap is 2
+ * when you descended this turn (CR 700.11 — a permanent card was put into your graveyard from
+ * anywhere), otherwise 1. Evaluated against the game state at cast time by
+ * [com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler].
+ *
+ * Mode 1's target is "creature or planeswalker" ([Targets.CreatureOrPlaneswalker]); mode 2's
+ * target is a nonland permanent that is not a creature with mana value 1 or less.
+ */
+val MoltenCollapse = card("Molten Collapse") {
+    manaCost = "{B}{R}"
+    colorIdentity = "BR"
+    typeLine = "Sorcery"
+    oracleText = "Choose one. If you descended this turn, you may choose both instead. " +
+        "(You descended if a permanent card was put into your graveyard from anywhere.)\n" +
+        "• Destroy target creature or planeswalker.\n" +
+        "• Destroy target noncreature, nonland permanent with mana value 1 or less."
+
+    spell {
+        modal(
+            chooseCount = 2,
+            minChooseCount = 1,
+            dynamicChooseCount = DynamicAmount.Conditional(
+                condition = Conditions.YouDescendedThisTurn(atLeast = 1),
+                ifTrue = DynamicAmount.Fixed(2),
+                ifFalse = DynamicAmount.Fixed(1)
+            )
+        ) {
+            mode("Destroy target creature or planeswalker") {
+                val victim = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+                effect = Effects.Destroy(victim)
+            }
+            mode("Destroy target noncreature, nonland permanent with mana value 1 or less") {
+                val victim = target(
+                    "target noncreature, nonland permanent with mana value 1 or less",
+                    TargetPermanent(
+                        filter = TargetFilter(
+                            GameObjectFilter.NonlandPermanent.notCreature().manaValueAtMost(1)
+                        )
+                    )
+                )
+                effect = Effects.Destroy(victim)
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "234"
+        artist = "Kasia 'Kafis' Zielińska"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/2487d124-210b-4808-888c-cd0a78aebd90.jpg?1782694423"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OakenSiren.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OakenSiren.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.ManaRestriction
+
+/**
+ * Oaken Siren
+ * {1}{U}
+ * Artifact Creature — Siren Pirate
+ * 1/2
+ * Common — LCI #66
+ *
+ * Flying, vigilance
+ * {T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an
+ *      artifact source.
+ *
+ * Mirrors Ixalli's Lorekeeper's restricted-mana pattern, but adds a fixed {U} (not any color)
+ * and keys the restriction to a *card type* instead of a subtype:
+ * [ManaRestriction.CardTypeSpellsOrAbilitiesOnly](CardType.ARTIFACT) with both `allowSpells`
+ * and `allowAbilities` true, so the mana pays for artifact spells and abilities of artifact
+ * sources — matching the printed oracle exactly.
+ */
+val OakenSiren = card("Oaken Siren") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Siren Pirate"
+    power = 1
+    toughness = 2
+    oracleText = "Flying, vigilance\n{T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source."
+
+    keywords(Keyword.FLYING, Keyword.VIGILANCE)
+
+    // {T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of
+    //      an artifact source.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddMana(
+            color = Color.BLUE,
+            amount = 1,
+            restriction = ManaRestriction.CardTypeSpellsOrAbilitiesOnly(
+                cardType = CardType.ARTIFACT,
+                allowSpells = true,
+                allowAbilities = true,
+            )
+        )
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "66"
+        artist = "Lars Grant-West"
+        flavorText = "The ship's carpenter adorned the figurehead with a small cosmium gem, never expecting the figurehead to take flight."
+        imageUri = "https://cards.scryfall.io/normal/front/d/7/d7731ef5-da74-4436-8ee7-01c065cbefae.jpg?1782694558"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OutOfAir.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OutOfAir.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.CostReductionSource
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
+
+/**
+ * Out of Air
+ * {2}{U}{U}
+ * Instant
+ * This spell costs {2} less to cast if it targets a creature spell.
+ * Counter target spell.
+ *
+ * The spell counters any target spell (`Targets.Spell`); the conditional discount is a
+ * self-cost reduction gated on the chosen target being a creature spell. Modeled exactly like
+ * Brush Off's generic half — [ModifySpellCost] on [SpellCostTarget.SelfCast] with
+ * [CostModification.ReduceGenericBy] over [CostReductionSource.FixedIfAnyTargetMatches], filtered
+ * to [GameObjectFilter.Creature] (a creature *spell on the stack*, the same way Brush Off's
+ * `InstantOrSorcery` filter matches an instant/sorcery spell). The reduction is generic-only, so
+ * no colored-pip reduction is needed. It resolves at cast time once the target is announced
+ * (CR 601.2f): if the target is a creature spell the generic cost drops by {2} to {U}{U}.
+ */
+val OutOfAir = card("Out of Air") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "This spell costs {2} less to cast if it targets a creature spell.\n" +
+        "Counter target spell."
+
+    spell {
+        target = Targets.Spell
+        effect = Effects.CounterSpell()
+    }
+
+    staticAbility {
+        ability = ModifySpellCost(
+            target = SpellCostTarget.SelfCast,
+            modification = CostModification.ReduceGenericBy(
+                CostReductionSource.FixedIfAnyTargetMatches(
+                    amount = 2,
+                    filter = GameObjectFilter.Creature,
+                ),
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "69"
+        artist = "Francisco Miyara"
+        flavorText = "\"The Core is not a simple trove to be plundered by intruders from the surface. " +
+            "It will reject those who do not accord it respect.\"\n—Akal Pakal, First Steward of Oteclan"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c263db55-fcac-4b49-b626-7c8092accfcd.jpg?1782694555"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OverTheEdge.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OverTheEdge.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Over the Edge — {1}{G}
+ * Sorcery
+ * Common — The Lost Caverns of Ixalan #205
+ * Artist: Ryan Valle
+ *
+ * "Choose one —
+ *  • Destroy target artifact or enchantment.
+ *  • Target creature you control explores, then it explores again."
+ *
+ * A "Choose one —" modal sorcery (CR 700.2 / 601.2b). Each mode declares its own target, so
+ * targeting legality is checked per chosen mode at cast time.
+ *
+ * Mode 0: Destroy a targeted artifact or enchantment ([Targets.ArtifactOrEnchantment] matches a
+ *   permanent that is an artifact and/or an enchantment).
+ *
+ * Mode 1: A creature you control explores twice (CR 701.44). "Explores, then it explores again"
+ *   = two sequential [Effects.Explore] calls on the same permanent, mirroring Defossilize. Each
+ *   explore reveals the top library card; a land goes to hand, otherwise a +1/+1 counter is put
+ *   on the creature and the player may put the revealed card into the graveyard. The target [c]
+ *   is a stable [com.wingedsheep.sdk.scripting.targets.EffectTarget.BoundVariable] so both
+ *   explores act on the same creature.
+ */
+val OverTheEdge = card("Over the Edge") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Choose one —\n" +
+        "• Destroy target artifact or enchantment.\n" +
+        "• Target creature you control explores, then it explores again. " +
+        "(Reveal the top card of your library. Put that card into your hand if it's a land. " +
+        "Otherwise, put a +1/+1 counter on that creature, then put the card back or put it " +
+        "into your graveyard. Then repeat this process.)"
+
+    spell {
+        modal {
+            mode("Destroy target artifact or enchantment") {
+                val artifactOrEnchantment = target("target artifact or enchantment", Targets.ArtifactOrEnchantment)
+                effect = Effects.Destroy(artifactOrEnchantment)
+            }
+            mode("Target creature you control explores, then it explores again") {
+                val creature = target("target creature you control", Targets.CreatureYouControl)
+                effect = Effects.Explore(creature)
+                    .then(Effects.Explore(creature))
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "205"
+        artist = "Ryan Valle"
+        imageUri = "https://cards.scryfall.io/normal/front/2/3/23dddddb-5409-4c28-bf32-e6473f2cc620.jpg?1782694445"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/Petrify.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/Petrify.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttack
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.PreventActivatedAbilities
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Petrify
+ * {1}{W}
+ * Enchantment — Aura
+ *
+ * Enchant artifact or creature
+ * Enchanted permanent can't attack or block, and its activated abilities can't be
+ * activated.
+ *
+ * Pacifism's combat lock (CantAttack/CantBlock scoped to the attached permanent) plus
+ * the Cursed Totem-style activation lock narrowed to just this Aura's host via
+ * [PreventActivatedAbilities] with `attachedToBySource()`. `GroupFilter.attachedCreature()`
+ * is actually a plain `Permanent` filter scoped to the attached object, so it correctly
+ * covers an artifact host as well as a creature.
+ */
+val Petrify = card("Petrify") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant artifact or creature\n" +
+        "Enchanted permanent can't attack or block, and its activated abilities can't " +
+        "be activated."
+
+    auraTarget = Targets.CreatureOrArtifact
+
+    staticAbility {
+        ability = CantAttack(filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = CantBlock(filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = PreventActivatedAbilities(
+            filter = GameObjectFilter.Permanent.attachedToBySource(),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Samuel Araya"
+        flavorText = "Those who break the laws of the Malamet become cold, silent " +
+            "warnings to others who might try."
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bbc5f28f-6361-455f-ac82-260a70e59316.jpg?1782694588"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PirateHat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PirateHat.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.AttachEquipmentEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Pirate Hat (LCI #70) — {1}{U} Artifact — Equipment
+ *
+ * Equipped creature gets +1/+1 and has "Whenever this creature attacks, draw a card,
+ * then discard a card."
+ * Equip Pirate {1}
+ * Equip {2}
+ *
+ * Implementation notes:
+ * - The +1/+1 pump is a [ModifyStats] static ability scoped to [Filters.EquippedCreature].
+ * - The attack-triggered loot (draw a card, then discard a card) is granted to the equipped
+ *   creature via [GrantTriggeredAbility] with [Triggers.attacks()] (SELF binding) so the ability
+ *   lives on the creature and fires when that creature attacks. The loot resolves for that
+ *   creature's controller via [Patterns.Hand.loot] (draw uses [EffectTarget.Controller]).
+ * - "Equip Pirate {1}" is a variant equip keyword ("{1}: Attach to target Pirate creature you
+ *   control. Equip only as a sorcery."), modeled as a sorcery-speed activated ability whose
+ *   target is restricted to a Pirate creature you control — mirroring Dúnedain Blade's
+ *   "Equip Human {1}". The unrestricted "Equip {2}" uses the [equipAbility] facade.
+ */
+val PirateHat = card("Pirate Hat") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, draw a card, " +
+        "then discard a card.\"\n" +
+        "Equip Pirate {1}\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    // Equipped creature gets +1/+1.
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    // Equipped creature has "Whenever this creature attacks, draw a card, then discard a card."
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.attacks().event,
+                binding = Triggers.attacks().binding,
+                effect = Patterns.Hand.loot()
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    // Equip Pirate {1}: attach only to a Pirate creature you control, sorcery speed.
+    activatedAbility {
+        cost = Costs.Mana(ManaCost.parse("{1}"))
+        timing = TimingRule.SorcerySpeed
+        val creature = target(
+            "Pirate creature you control",
+            TargetCreature(filter = TargetFilter.CreatureYouControl.withSubtype(Subtype.PIRATE))
+        )
+        effect = AttachEquipmentEffect(creature)
+        description = "Equip Pirate {1}"
+    }
+
+    // Equip {2}: attach to any creature you control, sorcery speed.
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "70"
+        artist = "Domenico Cava"
+        flavorText = "\"Landlubbers just don't understand the value of a proper hat.\""
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9d11e3d4-769d-47aa-8d3a-ce1ac60b68b8.jpg?1782694554"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PoeticIngenuity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PoeticIngenuity.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Poetic Ingenuity
+ * {2}{R}
+ * Enchantment
+ *
+ * Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.
+ * Whenever you cast an artifact spell, create a 3/1 red Dinosaur creature token. This
+ * ability triggers only once each turn.
+ *
+ * Modeling notes:
+ *  - The attack trigger is a once-per-combat group trigger ([Triggers.YouAttackWithFilter])
+ *    keyed on Dinosaurs you control — it fires once no matter how many Dinosaurs attack, not
+ *    once per Dinosaur. "That many Treasure tokens" reads the number of attacking Dinosaurs
+ *    at resolution via [DynamicAmount.AggregateBattlefield] over attacking Dinosaurs
+ *    (mirrors Choco, Seeker of Paradise's "look at that many cards" attacker-count idiom).
+ *    Known deviation: per the ruling, "that many" is fixed to the number of Dinosaurs that
+ *    attacked, so one removed from combat in response should still count; the resolution-time
+ *    battlefield read undercounts in that corner. Fixing it needs a trigger-snapshot count
+ *    primitive (add-feature) that no card in the engine has yet.
+ *  - The artifact-cast trigger uses the first-class `oncePerTurn = true` cap ("This ability
+ *    triggers only once each turn") — after it fires once in a turn, further artifact spells
+ *    that turn do not re-trigger it.
+ *  - The 3/1 red Dinosaur token has no imageUri because no separate token card exists in the
+ *    LCI dump for this stats/type combination (same as Bonehoard Dracosaur's token).
+ */
+val PoeticIngenuity = card("Poetic Ingenuity") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Enchantment"
+    oracleText = "Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.\n" +
+        "Whenever you cast an artifact spell, create a 3/1 red Dinosaur creature token. " +
+        "This ability triggers only once each turn."
+
+    // Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.
+    triggeredAbility {
+        trigger = Triggers.YouAttackWithFilter(GameObjectFilter.Creature.withSubtype(Subtype.DINOSAUR))
+        effect = Effects.CreateTreasure(
+            count = DynamicAmount.AggregateBattlefield(
+                Player.You,
+                GameObjectFilter.Creature.withSubtype(Subtype.DINOSAUR).attacking()
+            )
+        )
+    }
+
+    // Whenever you cast an artifact spell, create a 3/1 red Dinosaur creature token.
+    // This ability triggers only once each turn.
+    triggeredAbility {
+        trigger = Triggers.youCastSpell(spellFilter = GameObjectFilter.Artifact)
+        oncePerTurn = true
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 1,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Dinosaur")
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "161"
+        artist = "Kieran Yanner"
+        flavorText = "\"You inspire me.\""
+        imageUri = "https://cards.scryfall.io/normal/front/c/0/c035250e-6f6e-4d0f-b4fd-2a53d6069aa7.jpg?1782694481"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PugnaciousHammerskull.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/PugnaciousHammerskull.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pugnacious Hammerskull
+ * {2}{G}
+ * Creature — Dinosaur
+ * 6/6
+ * Whenever this creature attacks while you don't control another Dinosaur, put a stun counter on
+ * it. (If a permanent with a stun counter would become untapped, remove one from it instead.)
+ *
+ * Implementation notes:
+ * - `Triggers.Attacks` fires per AttackEvent for the creature itself (SELF binding).
+ * - The intervening-if (CR 603.4) is the negated, self-excluding control check
+ *   `Conditions.YouControl(Creature Dinosaur, negate = true, excludeSelf = true)`:
+ *   "you don't control another Dinosaur" — the Hammerskull itself is excluded from the search,
+ *   and `negate` inverts the existence test. Checked both when the trigger would go on the stack
+ *   and again on resolution; if either check finds another Dinosaur, the trigger doesn't fire (or
+ *   is removed before resolving).
+ * - `Effects.AddCounters(Counters.STUN, 1, EffectTarget.Self)` places one stun counter on the
+ *   Hammerskull, keeping it from untapping (CR 122.1d / stun counter replacement).
+ */
+val PugnaciousHammerskull = card("Pugnacious Hammerskull") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Dinosaur"
+    power = 6
+    toughness = 6
+    oracleText = "Whenever this creature attacks while you don't control another Dinosaur, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        triggerCondition = Conditions.YouControl(
+            GameObjectFilter.Creature.withSubtype(Subtype.DINOSAUR),
+            negate = true,
+            excludeSelf = true
+        )
+        effect = Effects.AddCounters(Counters.STUN, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "208"
+        artist = "Kev Walker"
+        flavorText = "\"I don't know whether it hates the mycoids or just loves breaking things. I say we leave it be.\"\n—Samin, Oltec scout"
+        imageUri = "https://cards.scryfall.io/normal/front/6/3/632e5635-a9bc-473a-a885-02e1fd258f7b.jpg?1782694442"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/QueensBayPaladin.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/QueensBayPaladin.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.TriggeredAbilityBuilder
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import com.wingedsheep.sdk.scripting.values.EntityNumericProperty
+import com.wingedsheep.sdk.scripting.values.EntityReference
+
+/**
+ * Queen's Bay Paladin
+ * {3}{B}{B}
+ * Creature — Vampire Knight
+ * 5/4
+ *
+ * Whenever this creature enters or attacks, return up to one target Vampire card from your
+ * graveyard to the battlefield with a finality counter on it. You lose life equal to its
+ * mana value. (If a creature with a finality counter on it would die, exile it instead.)
+ *
+ * Modeled as two triggered abilities (enters + attacks) sharing the same rider (extracted
+ * into [returnVampireRider]), mirroring Sentinel of the Nameless City's "enters or attacks"
+ * idiom. Each ability targets up to one Vampire card in the controller's graveyard
+ * (`optional = true` → "up to one target"),
+ * returns it to the battlefield, drops a finality counter on it (Rite of the Moth pattern:
+ * Move then AddCounters), and the controller loses life equal to the returned card's mana
+ * value (Phyrexian Delver pattern: `EntityProperty(Target(0), ManaValue)`). When no target
+ * is chosen the Move/AddCounters are no-ops and the life loss reads 0.
+ */
+val QueensBayPaladin = card("Queen's Bay Paladin") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Knight"
+    power = 5
+    toughness = 4
+    oracleText = "Whenever this creature enters or attacks, return up to one target Vampire card " +
+        "from your graveyard to the battlefield with a finality counter on it. You lose life equal " +
+        "to its mana value. (If a creature with a finality counter on it would die, exile it instead.)"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        returnVampireRider()
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        returnVampireRider()
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "115"
+        artist = "Slawomir Maniak"
+        imageUri = "https://cards.scryfall.io/normal/front/d/0/d0a3339d-6067-4af5-9536-7e2d5ddd8918.jpg?1782694518"
+    }
+}
+
+/**
+ * The rider shared by both trigger conditions: return up to one target Vampire card from
+ * your graveyard to the battlefield with a finality counter on it, then lose life equal
+ * to its mana value.
+ */
+private fun TriggeredAbilityBuilder.returnVampireRider() {
+    val returned = target(
+        "up to one target Vampire card from your graveyard",
+        TargetObject(
+            count = 1,
+            optional = true,
+            filter = TargetFilter(
+                GameObjectFilter.Any.withSubtype("Vampire").ownedByYou(),
+                zone = Zone.GRAVEYARD,
+            ),
+        ),
+    )
+    effect = Effects.Composite(
+        Effects.Move(returned, Zone.BATTLEFIELD, fromZone = Zone.GRAVEYARD),
+        AddCountersEffect(counterType = Counters.FINALITY, count = 1, target = returned),
+        Effects.LoseLife(
+            DynamicAmount.EntityProperty(EntityReference.Target(0), EntityNumericProperty.ManaValue),
+            EffectTarget.Controller,
+        ),
+    )
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6547,6 +6547,68 @@
     ]
 }
 
+// Malamet Veteran
+{
+    "name": "Malamet Veteran",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Cat Warrior",
+    "oracleText": "Trample\nDescend 4 — Whenever this creature attacks, if there are four or more permanent cards in your graveyard, put a +1/+1 counter on target creature.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target creature"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "201",
+        "artist": "Steve Prescott",
+        "flavorText": "The mightiest Malamet warriors train as titan-killers, elite champions capable of facing down the caverns' most fearsome beasts.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/b/4b9b16b3-1cbd-4b63-85b2-e4053dfc1e93.jpg?1782694449"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Malamet War Scribe
 {
     "name": "Malamet War Scribe",
@@ -7091,6 +7153,109 @@
     ]
 }
 
+// Molten Collapse
+{
+    "name": "Molten Collapse",
+    "manaCost": "{B}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one. If you descended this turn, you may choose both instead. (You descended if a permanent card was put into your graveyard from anywhere.)\n• Destroy target creature or planeswalker.\n• Destroy target noncreature, nonland permanent with mana value 1 or less.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature or planeswalker"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetCreatureOrPlaneswalker",
+                            "id": "target creature or planeswalker"
+                        }
+                    ],
+                    "description": "Destroy target creature or planeswalker"
+                },
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target noncreature, nonland permanent with mana value 1 or less"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {
+                                    "cardPredicates": [
+                                        "IsNonland",
+                                        "IsPermanent",
+                                        {
+                                            "type": "Not",
+                                            "predicate": "IsCreature"
+                                        },
+                                        {
+                                            "type": "ManaValueAtMost",
+                                            "max": 1
+                                        }
+                                    ]
+                                }
+                            },
+                            "id": "target noncreature, nonland permanent with mana value 1 or less"
+                        }
+                    ],
+                    "description": "Destroy target noncreature, nonland permanent with mana value 1 or less"
+                }
+            ],
+            "chooseCount": 2,
+            "minChooseCount": 1,
+            "dynamicChooseCount": {
+                "type": "Conditional",
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "ifTrue": {
+                    "type": "Fixed",
+                    "amount": 2
+                },
+                "ifFalse": {
+                    "type": "Fixed",
+                    "amount": 1
+                }
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "234",
+        "rarity": "RARE",
+        "artist": "Kasia 'Kafis' Zielińska",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/2487d124-210b-4808-888c-cd0a78aebd90.jpg?1782694423"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "RED"
+    ]
+}
+
 // Nurturing Bristleback
 {
     "name": "Nurturing Bristleback",
@@ -7145,6 +7310,50 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Oaken Siren
+{
+    "name": "Oaken Siren",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact Creature — Siren Pirate",
+    "oracleText": "Flying, vigilance\n{T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an artifact source.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING",
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "AddMana",
+                    "color": "BLUE",
+                    "restriction": {
+                        "type": "CardTypeSpellsOrAbilitiesOnly",
+                        "cardType": "ARTIFACT",
+                        "allowAbilities": true
+                    }
+                },
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "66",
+        "artist": "Lars Grant-West",
+        "flavorText": "The ship's carpenter adorned the figurehead with a small cosmium gem, never expecting the figurehead to take flight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/7/d7731ef5-da74-4436-8ee7-01c065cbefae.jpg?1782694558"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -7338,6 +7547,124 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Out of Air
+{
+    "name": "Out of Air",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "This spell costs {2} less to cast if it targets a creature spell.\nCounter target spell.",
+    "script": {
+        "spellEffect": "Counter",
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {},
+                    "zone": "Stack"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifySpellCost",
+                "target": "SelfCast",
+                "modification": {
+                    "type": "ReduceGenericBy",
+                    "source": {
+                        "type": "FixedIfAnyTargetMatches",
+                        "amount": 2,
+                        "filter": "creature"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "69",
+        "artist": "Francisco Miyara",
+        "flavorText": "\"The Core is not a simple trove to be plundered by intruders from the surface. It will reject those who do not accord it respect.\"\n—Akal Pakal, First Steward of Oteclan",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c263db55-fcac-4b49-b626-7c8092accfcd.jpg?1782694555"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Over the Edge
+{
+    "name": "Over the Edge",
+    "manaCost": "{1}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one —\n• Destroy target artifact or enchantment.\n• Target creature you control explores, then it explores again. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard. Then repeat this process.)",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target artifact or enchantment"
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact|enchantment"
+                            },
+                            "id": "target artifact or enchantment"
+                        }
+                    ],
+                    "description": "Destroy target artifact or enchantment"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Explore",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                }
+                            },
+                            {
+                                "type": "Explore",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature you control"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        }
+                    ],
+                    "description": "Target creature you control explores, then it explores again"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "205",
+        "artist": "Ryan Valle",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/3/23dddddb-5409-4c28-bf32-e6473f2cc620.jpg?1782694445"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -7846,6 +7846,197 @@
     ]
 }
 
+// Petrify
+{
+    "name": "Petrify",
+    "manaCost": "{1}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant artifact or creature\nEnchanted permanent can't attack or block, and its activated abilities can't be activated.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CantAttack",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "CantBlock",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "PreventActivatedAbilities",
+                "filter": {
+                    "cardPredicates": [
+                        "IsPermanent"
+                    ],
+                    "statePredicates": [
+                        "IsAttachedToBySource"
+                    ]
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature|artifact"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Samuel Araya",
+        "flavorText": "Those who break the laws of the Malamet become cold, silent warnings to others who might try.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bbc5f28f-6361-455f-ac82-260a70e59316.jpg?1782694588"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Pirate Hat
+{
+    "name": "Pirate Hat",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1 and has \"Whenever this creature attacks, draw a card, then discard a card.\"\nEquip Pirate {1}\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "Pirate creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature Pirate ctrl:you"
+                        },
+                        "id": "Pirate creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Equip Pirate {1}"
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Hand"
+                                        },
+                                        "storeAs": "hand"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "hand",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 1
+                                            }
+                                        },
+                                        "storeSelected": "discarded",
+                                        "prompt": "Choose 1 card to discard"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "discarded",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Graveyard"
+                                        },
+                                        "moveType": "Discard"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "70",
+        "artist": "Domenico Cava",
+        "flavorText": "\"Landlubbers just don't understand the value of a proper hat.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9d11e3d4-769d-47aa-8d3a-ce1ac60b68b8.jpg?1782694554"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Plundering Pirate
 {
     "name": "Plundering Pirate",
@@ -7876,6 +8067,77 @@
         "artist": "Francisco Miyara",
         "flavorText": "\"Whatever it is, it set off a trap. It must be valuable!\"",
         "imageUri": "https://cards.scryfall.io/normal/front/5/b/5bb2552f-8370-4931-83e1-93706d51413a.jpg"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Poetic Ingenuity
+{
+    "name": "Poetic Ingenuity",
+    "manaCost": "{2}{R}",
+    "typeLine": "Enchantment",
+    "oracleText": "Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.\nWhenever you cast an artifact spell, create a 3/1 red Dinosaur creature token. This ability triggers only once each turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "YouAttackEvent",
+                    "attackerFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasSubtype",
+                                "subtype": "Dinosaur"
+                            }
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure",
+                    "dynamicCount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature Dinosaur attacking"
+                    }
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsArtifact"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 1,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Dinosaur"
+                    ]
+                },
+                "oncePerTurn": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "161",
+        "rarity": "RARE",
+        "artist": "Kieran Yanner",
+        "flavorText": "\"You inspire me.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/0/c035250e-6f6e-4d0f-b4fd-2a53d6069aa7.jpg?1782694481"
     },
     "colorIdentityOverride": [
         "RED"
@@ -8055,6 +8317,168 @@
         "imageUri": "https://cards.scryfall.io/normal/front/e/9/e9681a54-6413-4ff4-b6b1-ee4decb25bfa.jpg"
     },
     "colorIdentityOverride": []
+}
+
+// Pugnacious Hammerskull
+{
+    "name": "Pugnacious Hammerskull",
+    "manaCost": "{2}{G}",
+    "typeLine": "Creature — Dinosaur",
+    "oracleText": "Whenever this creature attacks while you don't control another Dinosaur, put a stun counter on it. (If a permanent with a stun counter would become untapped, remove one from it instead.)",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "stun",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Dinosaur",
+                    "negate": true,
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "rarity": "RARE",
+        "artist": "Kev Walker",
+        "flavorText": "\"I don't know whether it hates the mycoids or just loves breaking things. I say we leave it be.\"\n—Samin, Oltec scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/3/632e5635-a9bc-473a-a885-02e1fd258f7b.jpg?1782694442"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Queen's Bay Paladin
+{
+    "name": "Queen's Bay Paladin",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Vampire Knight",
+    "oracleText": "Whenever this creature enters or attacks, return up to one target Vampire card from your graveyard to the battlefield with a finality counter on it. You lose life equal to its mana value. (If a creature with a finality counter on it would die, exile it instead.)",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target Vampire card from your graveyard"
+                            },
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "finality",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target Vampire card from your graveyard"
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Target",
+                                "numericProperty": "ManaValue"
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "Vampire own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to one target Vampire card from your graveyard"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target Vampire card from your graveyard"
+                            },
+                            "destination": "Battlefield",
+                            "fromZone": "Graveyard"
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "finality",
+                            "count": 1,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target Vampire card from your graveyard"
+                            }
+                        },
+                        {
+                            "type": "LoseLife",
+                            "amount": {
+                                "type": "EntityProperty",
+                                "entity": "Target",
+                                "numericProperty": "ManaValue"
+                            },
+                            "target": "Controller"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "Vampire own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to one target Vampire card from your graveyard"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "RARE",
+        "artist": "Slawomir Maniak",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/0/d0a3339d-6067-4af5-9536-7e2d5ddd8918.jpg?1782694518"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
 }
 
 // Quicksand Whirlpool

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MalametVeteranScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MalametVeteranScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.MalametVeteran
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Malamet Veteran (LCI #201) — {4}{G} Creature — Cat Warrior 5/4.
+ *
+ * "Trample
+ *  Descend 4 — Whenever this creature attacks, if there are four or more permanent cards in your
+ *  graveyard, put a +1/+1 counter on target creature."
+ *
+ * Covered end-to-end:
+ *  1. Descend 4 met (four permanent cards in the graveyard): attacking fires the trigger and a
+ *     +1/+1 counter is placed on the chosen target creature.
+ *  2. Descend 4 not met (three permanent cards): the intervening-if fails, so attacking produces
+ *     no trigger and no counter is placed.
+ */
+class MalametVeteranScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(MalametVeteran)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        return driver
+    }
+
+    /** Read +1/+1 counter count on a permanent. */
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("Descend 4 met: attacking puts a +1/+1 counter on the target creature") {
+        val driver = newDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val veteran = driver.putCreatureOnBattlefield(attacker, "Malamet Veteran")
+        driver.removeSummoningSickness(veteran)
+
+        // A second creature to receive the counter (any creature is a legal target).
+        val bear = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+
+        // Four permanent cards in the graveyard — meets the Descend 4 threshold.
+        repeat(4) { driver.putCardInGraveyard(attacker, "Forest") }
+
+        driver.plusOneCounters(bear) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(veteran), defender)
+        // The attack trigger goes on the stack; choose the counter target, then resolve.
+        driver.submitTargetSelection(attacker, listOf(bear))
+        driver.bothPass()
+
+        driver.plusOneCounters(bear) shouldBe 1
+    }
+
+    test("Descend 4 not met: attacking with only three permanent cards places no counter") {
+        val driver = newDriver()
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        val veteran = driver.putCreatureOnBattlefield(attacker, "Malamet Veteran")
+        driver.removeSummoningSickness(veteran)
+
+        val bear = driver.putCreatureOnBattlefield(attacker, "Grizzly Bears")
+
+        // Only three permanent cards — one short of Descend 4.
+        repeat(3) { driver.putCardInGraveyard(attacker, "Forest") }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(veteran), defender)
+        driver.bothPass()
+
+        // Intervening-if failed: no trigger, no counter on either creature.
+        driver.plusOneCounters(bear) shouldBe 0
+        driver.plusOneCounters(veteran) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenCollapseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoltenCollapseScenarioTest.kt
@@ -1,0 +1,211 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.MoltenCollapse
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Molten Collapse — {B}{R} Sorcery
+ *
+ * "Choose one. If you descended this turn, you may choose both instead.
+ *  • Destroy target creature or planeswalker.
+ *  • Destroy target noncreature, nonland permanent with mana value 1 or less."
+ *
+ * Pins the cast-time conditional modal count: the floor stays "choose one", and the cap is
+ * 2 only when the caster descended this turn (CR 700.11 — a permanent card was put into
+ * their graveyard from anywhere).
+ *
+ * Modes: 0 = destroy target creature or planeswalker,
+ *        1 = destroy target noncreature, nonland permanent with mana value 1 or less.
+ */
+class MoltenCollapseScenarioTest : FunSpec({
+
+    // A noncreature, nonland permanent with mana value 1 — a legal mode-1 target.
+    val Trinket: CardDefinition = CardDefinition.artifact(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    // A noncreature, nonland permanent with mana value 3 — NOT a legal mode-1 target.
+    val Relic: CardDefinition = CardDefinition.artifact(
+        name = "Test Relic",
+        manaCost = ManaCost.parse("{3}")
+    )
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all)
+        d.registerCard(MoltenCollapse)
+        d.registerCard(Trinket)
+        d.registerCard(Relic)
+        return d
+    }
+
+    /** Move a permanent card to the graveyard to trigger descend (CR 700.11). */
+    fun GameTestDriver.descend(entityId: EntityId) {
+        val result = ZoneTransitionService.moveToZone(
+            state = state,
+            entityId = entityId,
+            destinationZone = Zone.GRAVEYARD
+        )
+        replaceState(result.state)
+    }
+
+    fun castSetup(d: GameTestDriver): Pair<EntityId, EntityId> {
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 20, "Mountain" to 20), startingLife = 20)
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveMana(p1, Color.BLACK, 1)
+        d.giveMana(p1, Color.RED, 1)
+        return p1 to d.getOpponent(p1)
+    }
+
+    test("not descended — choosing both modes is illegal (effective max is one)") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val creature = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+        val trinket = d.putPermanentOnBattlefield(p2, "Test Trinket")
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(creature), ChosenTarget.Permanent(trinket)),
+            chosenModes = listOf(0, 1),
+            modeTargetsOrdered = listOf(
+                listOf(ChosenTarget.Permanent(creature)),
+                listOf(ChosenTarget.Permanent(trinket))
+            )
+        ))
+
+        result.isSuccess shouldBe false
+    }
+
+    test("not descended — choose mode 0 destroys target creature") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val creature = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(creature)),
+            chosenModes = listOf(0),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(creature)))
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        d.findPermanent(p2, "Centaur Courser").shouldBeNull()
+    }
+
+    test("not descended — choose mode 1 destroys a MV<=1 noncreature nonland permanent") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val trinket = d.putPermanentOnBattlefield(p2, "Test Trinket")
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(trinket)),
+            chosenModes = listOf(1),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(trinket)))
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        d.findPermanent(p2, "Test Trinket").shouldBeNull()
+    }
+
+    test("mode 1 cannot target a permanent with mana value greater than 1") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val relic = d.putPermanentOnBattlefield(p2, "Test Relic") // MV 3
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(relic)),
+            chosenModes = listOf(1),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(relic)))
+        ))
+
+        result.isSuccess shouldBe false
+    }
+
+    test("descended this turn — may choose both: destroy the creature AND the MV<=1 permanent") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val creature = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+        val trinket = d.putPermanentOnBattlefield(p2, "Test Trinket")
+
+        // Descend: move a permanent card (creature in hand) to the graveyard this turn.
+        val handBear = d.putCardInHand(p1, "Grizzly Bears")
+        d.descend(handBear)
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(creature), ChosenTarget.Permanent(trinket)),
+            chosenModes = listOf(0, 1),
+            modeTargetsOrdered = listOf(
+                listOf(ChosenTarget.Permanent(creature)),
+                listOf(ChosenTarget.Permanent(trinket))
+            )
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        d.findPermanent(p2, "Centaur Courser").shouldBeNull()
+        d.findPermanent(p2, "Test Trinket").shouldBeNull()
+    }
+
+    test("descended this turn — may still choose only one mode") {
+        val d = driver()
+        val (p1, p2) = castSetup(d)
+
+        val creature = d.putCreatureOnBattlefield(p2, "Centaur Courser")
+        val trinket = d.putPermanentOnBattlefield(p2, "Test Trinket")
+
+        val handBear = d.putCardInHand(p1, "Grizzly Bears")
+        d.descend(handBear)
+
+        val spell = d.putCardInHand(p1, "Molten Collapse")
+        val result = d.submit(CastSpell(
+            playerId = p1,
+            cardId = spell,
+            targets = listOf(ChosenTarget.Permanent(creature)),
+            chosenModes = listOf(0),
+            modeTargetsOrdered = listOf(listOf(ChosenTarget.Permanent(creature)))
+        ))
+        if (!result.isSuccess) throw AssertionError("cast failed: ${result.error}")
+
+        d.bothPass()
+        d.findPermanent(p2, "Centaur Courser").shouldBeNull()
+        // The unchosen mode leaves the trinket alone.
+        d.findPermanent(p2, "Test Trinket").shouldNotBeNull()
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OakenSirenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OakenSirenScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.OakenSiren
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Oaken Siren (LCI #66) — {1}{U} Artifact Creature — Siren Pirate 1/2
+ *
+ *   Flying, vigilance
+ *   {T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability of an
+ *        artifact source.
+ *
+ * Exercises [ManaRestriction.CardTypeSpellsOrAbilitiesOnly](CardType.ARTIFACT) with both spells
+ * and abilities allowed:
+ *  1. Tapping adds exactly one restricted {U} to the pool.
+ *  2. The restricted mana can pay for an artifact spell.
+ *  3. The restricted mana cannot pay for a non-artifact spell.
+ */
+class OakenSirenScenarioTest : FunSpec({
+
+    val testArtifact = CardDefinition.artifact(
+        name = "Test Artifact",
+        manaCost = ManaCost.parse("{U}")
+    )
+    val testCreature = CardDefinition.creature(
+        name = "Test Creature",
+        manaCost = ManaCost.parse("{U}"),
+        subtypes = setOf(Subtype("Human")),
+        power = 1,
+        toughness = 1
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + OakenSiren + testArtifact + testCreature)
+        return driver
+    }
+
+    val manaAbilityId = OakenSiren.activatedAbilities[0].id
+
+    fun GameTestDriver.tapForArtifactMana(playerId: EntityId) {
+        val siren = putPermanentOnBattlefield(playerId, "Oaken Siren")
+        submit(ActivateAbility(playerId, siren, manaAbilityId))
+    }
+
+    test("restricted mana is placed in pool after tapping") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForArtifactMana(p1)
+
+        val pool = driver.state.getEntity(p1)?.get<ManaPoolComponent>()
+        pool!!.restrictedMana.size shouldBe 1
+    }
+
+    test("restricted mana can pay for an artifact spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForArtifactMana(p1)
+
+        val artifact = driver.putCardInHand(p1, "Test Artifact")
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = artifact, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe true
+    }
+
+    test("restricted mana cannot pay for a non-artifact spell") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40))
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.tapForArtifactMana(p1)
+
+        val creature = driver.putCardInHand(p1, "Test Creature")
+        val result = driver.submit(
+            CastSpell(playerId = p1, cardId = creature, paymentStrategy = PaymentStrategy.FromPool)
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutOfAirScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OutOfAirScenarioTest.kt
@@ -1,0 +1,136 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.mana.CostCalculator
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.OwnerComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Out of Air (LCI).
+ *
+ * Oracle: "This spell costs {2} less to cast if it targets a creature spell.\nCounter target spell."
+ *
+ * Base cost is {2}{U}{U}. The counter half reuses [com.wingedsheep.sdk.dsl.Effects.CounterSpell]
+ * over `Targets.Spell` (any spell). The conditional discount is a self-cost reduction —
+ * `ModifySpellCost(SelfCast, ReduceGenericBy(FixedIfAnyTargetMatches(2, GameObjectFilter.Creature)))` —
+ * gated on the chosen target being a creature *spell on the stack*. It resolves at cast time once the
+ * target is announced (CR 601.2f): a creature-spell target drops the generic portion by {2} to {U}{U};
+ * any other spell is countered at full price.
+ */
+class OutOfAirScenarioTest : ScenarioTestBase() {
+
+    /** A minimal spell of [type] sitting on [casterId]'s stack, for cost-reduction target checks. */
+    private fun stackSpell(
+        casterId: EntityId,
+        type: CardType,
+        name: String,
+    ): Pair<EntityId, ComponentContainer> {
+        val id = EntityId.generate()
+        val container = ComponentContainer.of(
+            CardComponent(
+                cardDefinitionId = name,
+                name = name,
+                manaCost = ManaCost.parse("{1}"),
+                typeLine = TypeLine(cardTypes = setOf(type)),
+                oracleText = "",
+                colors = setOf(Color.GREEN),
+                ownerId = casterId,
+                spellEffect = null,
+            ),
+            OwnerComponent(casterId),
+        )
+        return id to container
+    }
+
+    private fun stateWith(casterId: EntityId, spellId: EntityId, container: ComponentContainer): GameState =
+        GameState()
+            .withEntity(casterId, ComponentContainer.EMPTY)
+            .withEntity(spellId, container)
+            .addToZone(ZoneKey(casterId, Zone.STACK), spellId)
+            .copy(turnOrder = listOf(casterId))
+
+    init {
+        context("Out of Air — conditional cost reduction") {
+
+            test("no chosen target → full {2}{U}{U} cost") {
+                val casterId = EntityId.generate()
+                val (spellId, container) = stackSpell(casterId, CardType.CREATURE, "Grizzly Bears")
+                val state = stateWith(casterId, spellId, container)
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    state, cardRegistry.requireCard("Out of Air"), casterId, chosenTargets = emptyList(),
+                )
+                cost.toString() shouldBe ManaCost.parse("{2}{U}{U}").toString()
+            }
+
+            test("targeting a creature spell reduces the cost by {2} to {U}{U}") {
+                val casterId = EntityId.generate()
+                val (spellId, container) = stackSpell(casterId, CardType.CREATURE, "Grizzly Bears")
+                val state = stateWith(casterId, spellId, container)
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    state, cardRegistry.requireCard("Out of Air"), casterId, chosenTargets = listOf(spellId),
+                )
+                cost.toString() shouldBe ManaCost.parse("{U}{U}").toString()
+            }
+
+            test("targeting a non-creature spell (instant) leaves the cost at {2}{U}{U}") {
+                val casterId = EntityId.generate()
+                val (spellId, container) = stackSpell(casterId, CardType.INSTANT, "Shock")
+                val state = stateWith(casterId, spellId, container)
+                val cost = CostCalculator(cardRegistry).calculateEffectiveCost(
+                    state, cardRegistry.requireCard("Out of Air"), casterId, chosenTargets = listOf(spellId),
+                )
+                cost.toString() shouldBe ManaCost.parse("{2}{U}{U}").toString()
+            }
+        }
+
+        context("Out of Air — counters target spell") {
+
+            test("with the {2} creature-spell discount it counters a creature spell for just {U}{U}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Out of Air")
+                    .withLandsOnBattlefield(1, "Island", 2) // only {U}{U} — must rely on the discount
+                    // Player 2 (active player) casts a creature spell for Out of Air to counter
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(2, "Grizzly Bears")
+                withClue("Casting Grizzly Bears should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                game.passPriority()
+
+                // Out of Air's printed cost is {2}{U}{U}=4, but two Islands only make {U}{U}=2 mana.
+                // The cast can only succeed if the "{2} less if it targets a creature spell" discount applies.
+                val counterResult = game.castSpellTargetingStackSpell(1, "Out of Air", "Grizzly Bears")
+                withClue("Casting Out of Air with only {U}{U} should succeed via the discount: ${counterResult.error}") {
+                    counterResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be countered — in player 2's graveyard, not on the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OverTheEdgeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OverTheEdgeScenarioTest.kt
@@ -1,0 +1,142 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Over the Edge (LCI #205, {1}{G} Sorcery).
+ *
+ * "Choose one —
+ *  • Destroy target artifact or enchantment.
+ *  • Target creature you control explores, then it explores again."
+ *
+ * Tests:
+ *  1. Mode 0 — targeting an enchantment destroys it (moves it to the graveyard).
+ *  2. Mode 1 — a creature you control explores twice, two land reveals go to hand with no counters.
+ *  3. Mode 1 — a creature you control explores twice, two nonland reveals each place a +1/+1 counter.
+ */
+class OverTheEdgeScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, name: String): Int {
+        val id = game.findPermanent(name) ?: return 0
+        return game.state.getEntity(id)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        context("Over the Edge") {
+
+            // -----------------------------------------------------------------------
+            // Test 1: Mode 0 — destroy target artifact or enchantment.
+            // -----------------------------------------------------------------------
+            test("mode 0: destroys target enchantment") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Over the Edge")
+                    .withCardOnBattlefield(1, "Test Enchantment")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enchantment = game.findPermanent("Test Enchantment")
+                withClue("Test Enchantment should start on the battlefield") {
+                    enchantment shouldNotBe null
+                }
+
+                game.castSpellWithMode(1, "Over the Edge", 0, enchantment)
+                game.resolveStack()
+
+                withClue("Test Enchantment should be destroyed (off the battlefield)") {
+                    game.isOnBattlefield("Test Enchantment") shouldBe false
+                }
+                withClue("Test Enchantment should be in its owner's graveyard") {
+                    game.isInGraveyard(1, "Test Enchantment") shouldBe true
+                }
+            }
+
+            // -----------------------------------------------------------------------
+            // Test 2: Mode 1 — creature explores twice with land reveals (no counters).
+            // -----------------------------------------------------------------------
+            test("mode 1: creature explores twice — two land reveals go to hand with no counter") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Over the Edge")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // Library: [Mountain (top/index-0), Forest (below/index-1)].
+                    // Each explore reveals a land → straight to hand, no +1/+1 counter, no decision.
+                    .withCardInLibrary(1, "Mountain")   // added first → index 0 = top
+                    .withCardInLibrary(1, "Forest")     // added second → index 1 = below
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")
+                val handBefore = game.state.getHand(game.player1Id).size  // has Over the Edge → 1
+
+                game.castSpellWithMode(1, "Over the Edge", 1, bears)
+                game.resolveStack()  // Explore×2, both lands — no pauses.
+
+                // Net hand delta: −1 (cast Over the Edge) +2 (two land reveals) = +1
+                withClue("hand should have grown by 1 (−1 cast Over the Edge, +2 lands from two explores)") {
+                    game.state.getHand(game.player1Id).size shouldBe handBefore - 1 + 2
+                }
+                withClue("land reveals must not place +1/+1 counters (CR 701.44a)") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 0
+                }
+                withClue("library should be empty after both top cards were drawn") {
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.LIBRARY)).size shouldBe 0
+                }
+            }
+
+            // -----------------------------------------------------------------------
+            // Test 3: Mode 1 — creature explores twice with nonland reveals (two counters).
+            // -----------------------------------------------------------------------
+            test("mode 1: creature explores twice — two nonland reveals each put a +1/+1 counter on it") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Over the Edge")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    // Library top is a nonland; keeping it on top (answerYesNo(true)) lets the
+                    // second explore reveal it again → two nonland reveals → two +1/+1 counters.
+                    .withCardInLibrary(1, "Lightning Bolt")   // top — revealed by both explores
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")
+
+                game.castSpellWithMode(1, "Over the Edge", 1, bears)
+
+                // Explore #1 reveals Lightning Bolt (nonland) → first counter, then pauses for the
+                // back-or-graveyard decision.
+                game.resolveStack()
+                withClue("first explore (nonland) should pause for the back-or-graveyard decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.answerYesNo(true)  // keep Lightning Bolt on top of library
+
+                // Explore #2 reveals Lightning Bolt again → second counter, pauses for its decision.
+                withClue("second explore (nonland) should pause for the back-or-graveyard decision") {
+                    (game.state.pendingDecision != null) shouldBe true
+                }
+                game.answerYesNo(true)  // keep Lightning Bolt on top
+                game.resolveStack()
+
+                withClue("two nonland explores must place two +1/+1 counters on Grizzly Bears") {
+                    plusOneCounters(game, "Grizzly Bears") shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PetrifyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PetrifyScenarioTest.kt
@@ -1,0 +1,94 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Petrify (LCI #30) — {1}{W} Enchantment — Aura.
+ *
+ *   Enchant artifact or creature
+ *   Enchanted permanent can't attack or block, and its activated abilities can't be
+ *   activated.
+ *
+ * Combines Pacifism's combat lock (`CantAttack`/`CantBlock` scoped to the attached
+ * permanent) with the Cursed Totem-style activation lock scoped to just this Aura's host
+ * (`PreventActivatedAbilities(GameObjectFilter.Permanent.attachedToBySource())`). Because
+ * the Aura enchants an artifact or creature, both halves must land on the enchanted
+ * permanent.
+ */
+class PetrifyScenarioTest : ScenarioTestBase() {
+
+    private val elvesManaAbilityId =
+        cardRegistry.getCard("Llanowar Elves")!!.script.activatedAbilities.first().id
+
+    init {
+        context("Petrify") {
+
+            test("enchanted creature can't attack or block") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Petrify", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Petrify should be on the battlefield") {
+                    game.isOnBattlefield("Petrify") shouldBe true
+                }
+                withClue("Enchanted creature can't attack") {
+                    game.state.projectedState.cantAttack(bears) shouldBe true
+                }
+                withClue("Enchanted creature can't block") {
+                    game.state.projectedState.cantBlock(bears) shouldBe true
+                }
+            }
+
+            test("enchanted creature's activated abilities can't be activated") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(2, "Llanowar Elves", summoningSickness = false)
+                    .withCardAttachedTo(1, "Petrify", "Llanowar Elves")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elves = game.findPermanent("Llanowar Elves")!!
+                val elvesActivation = game.getLegalActions(2).find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == elves && a.abilityId == elvesManaAbilityId
+                }
+                withClue("Petrify should lock the enchanted creature's mana ability") {
+                    elvesActivation shouldBe null
+                }
+            }
+
+            test("control: without Petrify the creature can attack and activate abilities") {
+                val game = scenario()
+                    .withPlayers("P1", "P2")
+                    .withCardOnBattlefield(2, "Llanowar Elves", summoningSickness = false)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val elves = game.findPermanent("Llanowar Elves")!!
+                withClue("Without the Aura the creature can attack") {
+                    game.state.projectedState.cantAttack(elves) shouldBe false
+                }
+                val elvesActivation = game.getLegalActions(2).find {
+                    val a = it.action
+                    a is ActivateAbility && a.sourceId == elves && a.abilityId == elvesManaAbilityId
+                }
+                withClue("Without the Aura the mana ability should be available") {
+                    (elvesActivation != null) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PirateHatScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PirateHatScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pirate Hat (LCI #70) — {1}{U} Artifact — Equipment.
+ *
+ * Equipped creature gets +1/+1 and has "Whenever this creature attacks, draw a card,
+ * then discard a card."
+ * Equip Pirate {1}
+ * Equip {2}
+ *
+ * Tests:
+ *  1. Equipped creature gets +1/+1 from the static ability.
+ *  2. Attacking with the equipped creature loots (draw a card, then discard a card).
+ *  3. An unequipped creature attacking does NOT loot (the grant is inactive).
+ */
+class PirateHatScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Pirate Hat") {
+
+            test("equipped creature gets +1/+1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardAttachedTo(1, "Pirate Hat", "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val projected = projector.project(game.state)
+
+                withClue("Grizzly Bears base 2/2 + Pirate Hat +1/+1 = 3/3") {
+                    projected.getPower(bears) shouldBe 3
+                    projected.getToughness(bears) shouldBe 3
+                }
+            }
+
+            test("attacking with the equipped creature loots (draw, then discard)") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Pirate Hat", "Grizzly Bears")
+                    .withCardInHand(1, "Grizzly Bears") // a card to discard
+                    .withCardInLibrary(1, "Grizzly Bears") // a card to draw
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libBefore = game.state.getLibrary(game.player1Id).size
+                val gyBefore = game.state.getGraveyard(game.player1Id).size
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Pirate Hat's attack trigger drew a card (library -1)") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libBefore - 1
+                }
+
+                // The loot's discard step presents a card-selection decision; choose one to discard.
+                val discard = game.getPendingDecision()
+                withClue("loot presents a discard selection over the hand") {
+                    (discard is SelectCardsDecision) shouldBe true
+                }
+                game.selectCards(listOf((discard as SelectCardsDecision).options.first())).error shouldBe null
+                game.resolveStack()
+
+                withClue("Pirate Hat's attack trigger discarded a card (graveyard +1)") {
+                    game.state.getGraveyard(game.player1Id).size shouldBe gyBefore + 1
+                }
+            }
+
+            test("unequipped creature attacking does NOT loot") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Pirate Hat")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val libBefore = game.state.getLibrary(game.player1Id).size
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("No loot — Pirate Hat is not equipped, grant is inactive") {
+                    game.state.getLibrary(game.player1Id).size shouldBe libBefore
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PoeticIngenuityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PoeticIngenuityScenarioTest.kt
@@ -1,0 +1,186 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.PoeticIngenuity
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Poetic Ingenuity (LCI #161) — {2}{R} Enchantment.
+ *
+ *  - Whenever one or more Dinosaurs you control attack, create that many Treasure tokens.
+ *  - Whenever you cast an artifact spell, create a 3/1 red Dinosaur creature token.
+ *    This ability triggers only once each turn.
+ *
+ * Both abilities compose existing primitives (group-attack trigger [Triggers.YouAttackWithFilter]
+ * with an [DynamicAmount.AggregateBattlefield] attacker count feeding [Effects.CreateTreasure];
+ * a `youCastSpell(Artifact)` trigger with `oncePerTurn = true` minting a [Effects.CreateToken]),
+ * so this scenario test is the behavioural gate.
+ */
+class PoeticIngenuityScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    // A plain non-legendary Dinosaur so multiple copies can attack together (no legend rule).
+    val testDinosaur = CardDefinition.creature(
+        name = "Test Dinosaur",
+        manaCost = ManaCost.parse("{G}"),
+        subtypes = setOf(Subtype("Dinosaur")),
+        power = 2,
+        toughness = 2,
+    )
+
+    // A cheap non-creature artifact, so casting it isolates the Dinosaur *creature* token count.
+    val testArtifact = CardDefinition(
+        name = "Test Artifact",
+        manaCost = ManaCost.parse("{1}"),
+        typeLine = TypeLine.artifact(),
+    )
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        // Treasure is a registry-backed predefined token; register it so CreateTreasure can mint one.
+        driver.registerCards(TestCards.all + PredefinedTokens.Treasure)
+        driver.registerCard(PoeticIngenuity)
+        driver.registerCard(testDinosaur)
+        driver.registerCard(testArtifact)
+        return driver
+    }
+
+    /** Resolve the stack to completion (no player decisions are expected). */
+    fun GameTestDriver.resolveStack() {
+        var guard = 0
+        while (!isPaused && stackSize > 0 && guard++ < 50) bothPass()
+    }
+
+    fun GameTestDriver.treasureCount(player: EntityId): Int =
+        getPermanents(player).count { getCardName(it) == "Treasure" }
+
+    fun GameTestDriver.dinosaurTokenCount(player: EntityId): Int =
+        getPermanents(player).count { getCardName(it) == "Dinosaur Token" }
+
+    /** From the controller's main phase, cross the opponent's turn and land on the next own main. */
+    fun GameTestDriver.advanceToMyNextMain(me: EntityId) {
+        passPriorityUntil(Step.END, maxPasses = 300)        // my end step (cleanup resets oncePerTurn)
+        passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)  // opponent's main
+        passPriorityUntil(Step.END, maxPasses = 300)        // opponent's end step
+        passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 300)  // my next main
+        activePlayer shouldBe me
+    }
+
+    test("two attacking Dinosaurs create two Treasures; a non-Dinosaur attacker doesn't count") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Poetic Ingenuity")
+        val dino1 = driver.putCreatureOnBattlefield(player, "Test Dinosaur")
+        val dino2 = driver.putCreatureOnBattlefield(player, "Test Dinosaur")
+        val lion = driver.putCreatureOnBattlefield(player, "Savannah Lions") // a non-Dinosaur (Cat)
+        driver.removeSummoningSickness(dino1)
+        driver.removeSummoningSickness(dino2)
+        driver.removeSummoningSickness(lion)
+
+        driver.treasureCount(player) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(dino1, dino2, lion), opponent)
+        driver.resolveStack()
+
+        withClue("two attacking Dinosaurs → two Treasures (the attacking Cat is not counted)") {
+            driver.treasureCount(player) shouldBe 2
+        }
+    }
+
+    test("a single attacking Dinosaur creates exactly one Treasure") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        val opponent = driver.getOpponent(player)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Poetic Ingenuity")
+        val dino = driver.putCreatureOnBattlefield(player, "Test Dinosaur")
+        driver.removeSummoningSickness(dino)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(player, listOf(dino), opponent)
+        driver.resolveStack()
+
+        withClue("one attacking Dinosaur → one Treasure") {
+            driver.treasureCount(player) shouldBe 1
+        }
+    }
+
+    test("casting an artifact spell creates a 3/1 Dinosaur creature token") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Poetic Ingenuity")
+        driver.dinosaurTokenCount(player) shouldBe 0
+
+        val artifact = driver.putCardInHand(player, "Test Artifact")
+        driver.giveMana(player, com.wingedsheep.sdk.core.Color.RED, 1)
+        driver.castSpell(player, artifact)
+        driver.resolveStack()
+
+        withClue("casting an artifact spell mints one Dinosaur token") {
+            driver.dinosaurTokenCount(player) shouldBe 1
+        }
+        val token = driver.getPermanents(player).first { driver.getCardName(it) == "Dinosaur Token" }
+        val projected = projector.project(driver.state)
+        withClue("the token is a 3/1") {
+            projected.getPower(token) shouldBe 3
+            projected.getToughness(token) shouldBe 1
+        }
+    }
+
+    test("the artifact-cast trigger fires only once each turn, then resets next turn") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.putPermanentOnBattlefield(player, "Poetic Ingenuity")
+
+        // Cast two artifact spells in the same turn — only the first mints a token.
+        val first = driver.putCardInHand(player, "Test Artifact")
+        driver.giveMana(player, com.wingedsheep.sdk.core.Color.RED, 1)
+        driver.castSpell(player, first)
+        driver.resolveStack()
+        driver.dinosaurTokenCount(player) shouldBe 1
+
+        val second = driver.putCardInHand(player, "Test Artifact")
+        driver.giveMana(player, com.wingedsheep.sdk.core.Color.RED, 1)
+        driver.castSpell(player, second)
+        driver.resolveStack()
+        withClue("a second artifact spell the same turn must not mint another token") {
+            driver.dinosaurTokenCount(player) shouldBe 1
+        }
+
+        // Next turn the cap resets — casting an artifact mints a token again.
+        driver.advanceToMyNextMain(player)
+        val third = driver.putCardInHand(player, "Test Artifact")
+        driver.giveMana(player, com.wingedsheep.sdk.core.Color.RED, 1)
+        driver.castSpell(player, third)
+        driver.resolveStack()
+        withClue("the cap resets each turn, so next turn's cast mints another token") {
+            driver.dinosaurTokenCount(player) shouldBe 2
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PugnaciousHammerskullScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PugnaciousHammerskullScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.PugnaciousHammerskull
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Pugnacious Hammerskull (LCI #208) — {2}{G} Creature — Dinosaur 6/6.
+ *
+ * Oracle: "Whenever this creature attacks while you don't control another Dinosaur, put a stun
+ * counter on it. (If a permanent with a stun counter would become untapped, remove one from it
+ * instead.)"
+ *
+ * "while you don't control another Dinosaur" is a negated, self-excluding intervening-if
+ * condition (CR 603.4): the Hammerskull's own Dinosaur type is excluded, and the check is checked
+ * both when the trigger would fire and again when it tries to resolve.
+ *
+ * Covered:
+ *  1. Attacking as the only Dinosaur → one stun counter is placed on it.
+ *  2. Attacking while controlling another Dinosaur → no trigger; no stun counter.
+ */
+class PugnaciousHammerskullScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(PugnaciousHammerskull)
+        return driver
+    }
+
+    fun GameTestDriver.stunCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: Attacking as the only Dinosaur places a stun counter on itself
+    // ─────────────────────────────────────────────────────────────────────────
+    test("attacking without another Dinosaur puts a stun counter on the Hammerskull") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val hammerskull = driver.putCreatureOnBattlefield(me, "Pugnacious Hammerskull")
+        driver.removeSummoningSickness(hammerskull)
+        // No other Dinosaur on our side (the Hammerskull's own type is excluded).
+
+        driver.stunCounters(hammerskull) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(hammerskull), opponent)
+
+        // Resolve the attacks trigger — one stun counter is placed.
+        driver.bothPass()
+
+        driver.stunCounters(hammerskull) shouldBe 1
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: Controlling another Dinosaur suppresses the trigger (intervening-if)
+    // ─────────────────────────────────────────────────────────────────────────
+    test("attacking while controlling another Dinosaur places no stun counter") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+
+        val me = driver.activePlayer!!
+        val opponent = driver.getOpponent(me)
+
+        val hammerskull = driver.putCreatureOnBattlefield(me, "Pugnacious Hammerskull")
+        driver.removeSummoningSickness(hammerskull)
+        // Ghalta, Primal Hunger is an Elder Dinosaur — "another Dinosaur" you control.
+        driver.putCreatureOnBattlefield(me, "Ghalta, Primal Hunger")
+
+        driver.stunCounters(hammerskull) shouldBe 0
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(hammerskull), opponent)
+
+        // The intervening-if fails — no trigger fires, no stun counter.
+        driver.bothPass()
+
+        driver.stunCounters(hammerskull) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QueensBayPaladinScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/QueensBayPaladinScenarioTest.kt
@@ -1,0 +1,164 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+/**
+ * Scenario tests for Queen's Bay Paladin (LCI #115).
+ *
+ * Queen's Bay Paladin {3}{B}{B}
+ * Creature — Vampire Knight 5/4
+ * Whenever this creature enters or attacks, return up to one target Vampire card from your
+ * graveyard to the battlefield with a finality counter on it. You lose life equal to its mana
+ * value. (If a creature with a finality counter on it would die, exile it instead.)
+ *
+ * The reanimation target is Highborn Vampire ({3}{B}, a vanilla Vampire Warrior, mana value 4),
+ * so a successful return costs the controller exactly 4 life.
+ *
+ * Coverage:
+ * 1. Enters trigger — reanimate the chosen Vampire with a finality counter; lose life = its MV.
+ * 2. Attacks trigger — same rider fires off the combat trigger, proving the "or attacks" half.
+ * 3. "Up to one target" — the controller declines (skips), so nothing returns and no life is lost.
+ * 4. "Vampire card" filter — a non-Vampire in the same graveyard is not a legal target and is
+ *    left behind while the Vampire is returned.
+ */
+class QueensBayPaladinScenarioTest : ScenarioTestBase() {
+
+    init {
+        test("enters: returns the target Vampire with a finality counter and loses life equal to its mana value") {
+            val game = scenario()
+                .withPlayers()
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withCardInHand(1, "Queen's Bay Paladin")
+                .withLandsOnBattlefield(1, "Swamp", 5) // {3}{B}{B}
+                .withCardInGraveyard(1, "Highborn Vampire")
+                .build()
+
+            val lifeBefore = game.getLifeTotal(1)
+
+            game.castSpell(1, "Queen's Bay Paladin").error shouldBe null
+            game.resolveStack()
+
+            val decision = game.getPendingDecision()
+            withClue("the enters trigger paused for a target selection") {
+                decision.shouldNotBeNull()
+                (decision as ChooseTargetsDecision).legalTargets[0]!! shouldContain
+                    game.findCardsInGraveyard(1, "Highborn Vampire").first()
+            }
+
+            game.selectTargets(game.findCardsInGraveyard(1, "Highborn Vampire")).error shouldBe null
+            game.resolveStack()
+
+            val returned = game.findPermanent("Highborn Vampire")
+            withClue("Highborn Vampire returned to the battlefield") {
+                returned.shouldNotBeNull()
+                game.isInGraveyard(1, "Highborn Vampire") shouldBe false
+            }
+            withClue("it entered with a finality counter") {
+                game.state.getEntity(returned!!)?.get<CountersComponent>()
+                    ?.getCount(CounterType.FINALITY) shouldBe 1
+            }
+            withClue("controller lost life equal to the returned card's mana value (4)") {
+                game.getLifeTotal(1) shouldBe lifeBefore - 4
+            }
+        }
+
+        test("attacks: the same rider fires when Queen's Bay Paladin attacks") {
+            val game = scenario()
+                .withPlayers()
+                .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                .withCardOnBattlefield(1, "Queen's Bay Paladin", summoningSickness = false)
+                .withCardInGraveyard(1, "Highborn Vampire")
+                .build()
+
+            val lifeBefore = game.getLifeTotal(1)
+
+            game.declareAttackers(mapOf("Queen's Bay Paladin" to 2)).error shouldBe null
+            if (game.getPendingDecision() == null) game.resolveStack()
+
+            val decision = game.getPendingDecision()
+            withClue("the attacks trigger paused for a target selection") {
+                decision.shouldNotBeNull()
+            }
+
+            game.selectTargets(game.findCardsInGraveyard(1, "Highborn Vampire")).error shouldBe null
+            game.resolveStack()
+
+            val returned = game.findPermanent("Highborn Vampire")
+            withClue("Highborn Vampire returned with a finality counter") {
+                returned.shouldNotBeNull()
+                game.state.getEntity(returned!!)?.get<CountersComponent>()
+                    ?.getCount(CounterType.FINALITY) shouldBe 1
+            }
+            withClue("controller lost 4 life (Highborn Vampire's mana value)") {
+                game.getLifeTotal(1) shouldBe lifeBefore - 4
+            }
+        }
+
+        test("up to one target: declining returns nothing and loses no life") {
+            val game = scenario()
+                .withPlayers()
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withCardInHand(1, "Queen's Bay Paladin")
+                .withLandsOnBattlefield(1, "Swamp", 5)
+                .withCardInGraveyard(1, "Highborn Vampire")
+                .build()
+
+            val lifeBefore = game.getLifeTotal(1)
+
+            game.castSpell(1, "Queen's Bay Paladin").error shouldBe null
+            game.resolveStack()
+
+            game.getPendingDecision().shouldNotBeNull()
+            // Choose no target ("up to one").
+            game.skipTargets().error shouldBe null
+            game.resolveStack()
+
+            withClue("Highborn Vampire stayed in the graveyard") {
+                game.isInGraveyard(1, "Highborn Vampire") shouldBe true
+                game.findPermanent("Highborn Vampire") shouldBe null
+            }
+            withClue("no life was lost because nothing was returned") {
+                game.getLifeTotal(1) shouldBe lifeBefore
+            }
+        }
+
+        test("Vampire filter: a non-Vampire card in the graveyard is not a legal target") {
+            val game = scenario()
+                .withPlayers()
+                .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                .withCardInHand(1, "Queen's Bay Paladin")
+                .withLandsOnBattlefield(1, "Swamp", 5)
+                .withCardInGraveyard(1, "Highborn Vampire")
+                .withCardInGraveyard(1, "Grizzly Bears") // Bear, not a Vampire
+                .build()
+
+            game.castSpell(1, "Queen's Bay Paladin").error shouldBe null
+            game.resolveStack()
+
+            val decision = game.getPendingDecision() as ChooseTargetsDecision
+            val legal = decision.legalTargets[0]!!
+            withClue("only the Vampire is a legal target") {
+                legal shouldContain game.findCardsInGraveyard(1, "Highborn Vampire").first()
+                legal shouldNotContain game.findCardsInGraveyard(1, "Grizzly Bears").first()
+            }
+
+            game.selectTargets(game.findCardsInGraveyard(1, "Highborn Vampire")).error shouldBe null
+            game.resolveStack()
+
+            withClue("the Vampire was returned; the non-Vampire stayed put") {
+                game.findPermanent("Highborn Vampire").shouldNotBeNull()
+                game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Depends on: https://github.com/wingedsheep/argentum-engine/pull/1265

Adds 5 Lost Caverns of Ixalan cards (batch 12), all built from existing SDK primitives — no engine changes.

> **Stacked PR:** this branch is based on `lci-cards-11` (batch 11). Only the top commit — "Add 5 Lost Caverns of Ixalan cards (batch 12)" — is in scope here; the batch 11 commit disappears from the diff once that PR merges.

## Cards

| Card | Cost | Type | Notes |
|------|------|------|-------|
| Petrify | {1}{W} | Enchantment — Aura | Pacifism combat lock + Cursed Totem-style activation lock scoped to the enchanted permanent (`PreventActivatedAbilities` with `attachedToBySource()`); covers artifact hosts too |
| Pirate Hat | {1}{U} | Artifact — Equipment | +1/+1 and granted attack-loot trigger via `GrantTriggeredAbility`; "Equip Pirate {1}" mirrors Dúnedain Blade's restricted-equip idiom |
| Poetic Ingenuity | {2}{R} | Enchantment | Once-per-combat group attack trigger (`YouAttackWithFilter`) + `AggregateBattlefield` attacker count; artifact-cast trigger uses the first-class `oncePerTurn` cap |
| Pugnacious Hammerskull | {2}{G} | Creature — Dinosaur 6/6 | Negated, self-excluding intervening-if (CR 603.4) via `Conditions.YouControl(negate = true, excludeSelf = true)`; stun counter (CR 122.1d) |
| Queen's Bay Paladin | {3}{B}{B} | Creature — Vampire Knight 5/4 | Enters-or-attacks pair sharing one rider (Sentinel of the Nameless City idiom); finality counter + life loss = returned card's mana value |

## Known deviation (documented in the card comment)

Poetic Ingenuity's "create that many Treasure tokens" reads the attacking-Dinosaur count at trigger **resolution**, so a Dinosaur removed from combat in response is not counted, while the ruling fixes the count at trigger time. Same idiom as Choco, Seeker of Paradise; a correct fix needs a trigger-snapshot count primitive (add-feature) that no card uses yet.

## Testing

- 14 scenario tests across 5 new test classes in `rules-engine` — all passing.
- `CardDefinitionSnapshotTest` and `CardLintTest` green; snapshot diff is purely additive (only the 5 new cards).
- Oracle text, metadata, and flavor verified against Scryfall; `just check-card-printing` passes for all 5 (each is an LCI original, canonical correctly placed).
- Also includes a manual self-play scenario (`manual-scenarios/sets/lci/cards-12.json`) with all five cards castable in one turn.

A self-review (per the repo's review-changes flow, scoped to the diff vs `lci-cards-11`) is attached as a PR comment; its actionable findings were folded into this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
