### PR TITLE
Add 5 Lost Caverns of Ixalan cards (batch 17)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 191 / 286
+**Implemented:** 196 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -243,13 +243,13 @@
 - [ ] Sunbird Standard
 - [ ] Sunfire Torch
 - [ ] Sunken Citadel
-- [ ] Sunshot Militia
+- [x] Sunshot Militia
 - [x] Swashbuckler's Whip
-- [ ] Synapse Necromage
+- [x] Synapse Necromage
 - [ ] Tarrian's Journal
-- [ ] Tarrian's Soulcleaver
-- [ ] Tectonic Hazard
-- [ ] Tendril of the Mycotyrant
+- [x] Tarrian's Soulcleaver
+- [x] Tectonic Hazard
+- [x] Tendril of the Mycotyrant
 - [x] Terror Tide
 - [ ] The Ancient One
 - [ ] The Belligerent

--- a/manual-scenarios/sets/lci/cards-17.json
+++ b/manual-scenarios/sets/lci/cards-17.json
@@ -1,0 +1,50 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Sunshot Militia",
+      "Synapse Necromage",
+      "Tectonic Hazard",
+      "Tarrian's Soulcleaver",
+      "Tendril of the Mycotyrant"
+    ],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Mountain", "Swamp", "Grizzly Bears", "Forest", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Island"],
+    "battlefield": [
+      {"name": "Cenote Scout"},
+      {"name": "Grizzly Bears"},
+      {"name": "Basking Capybara"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Swamp", "Forest", "Mountain", "Island", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunshotMilitia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunshotMilitia.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sunshot Militia
+ * {1}{R}
+ * Creature — Human Soldier
+ * 1/3
+ * Tap two untapped artifacts and/or creatures you control: This creature deals 1 damage to each
+ * opponent. Activate only as a sorcery.
+ *
+ * The activation cost reuses the [Costs.TapPermanents] primitive (same shape as Adaptive Gemguard /
+ * Goldfury Strider): tap exactly two untapped artifacts or creatures you control (no "other"
+ * restriction — Sunshot Militia itself may be one of the two). The effect deals 1 damage to each
+ * opponent via [Effects.DealDamage] against [Player.EachOpponent].
+ */
+val SunshotMilitia = card("Sunshot Militia") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 3
+    oracleText = "Tap two untapped artifacts and/or creatures you control: This creature deals 1 damage to each opponent. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(
+            count = 2,
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature,
+        )
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Torgeir Fjereide"
+        flavorText = "As the Legion of Dusk closed in, Oltec citizens rallied to support the Thousand Moons and drive off the invaders."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3114f5c-21e9-43c3-abe3-3cf1da20916f.jpg?1782694475"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SynapseNecromage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SynapseNecromage.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Synapse Necromage
+ * {2}{B}
+ * Creature — Fungus Wizard
+ * 3/1
+ *
+ * When this creature dies, create two 1/1 black Fungus creature tokens with
+ * "This token can't block."
+ *
+ * Dies is CR 700.4 (battlefield to graveyard); modelled as the SELF-bound
+ * [Triggers.Dies]. The tokens are identical to Broodrage Mycoid / The Mycotyrant's
+ * 1/1 black Fungus "can't block" token — the "This token can't block" restriction is a
+ * static ability on the token itself, [CantBlock] with [GroupFilter.source()].
+ */
+val SynapseNecromage = card("Synapse Necromage") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Fungus Wizard"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature dies, create two 1/1 black Fungus creature tokens with \"This token can't block.\""
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Fungus"),
+            staticAbilities = listOf(CantBlock(GroupFilter.source()))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Piotr Foksowicz"
+        flavorText = "\"It's no good killing them? Then what do we do? Distract them with a tea party?\"\n—Mervin, Brazen Coalition prospector"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efeb22a4-37bf-487a-9cf4-74de4cbbc0a3.jpg?1782694510"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TarriansSoulcleaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TarriansSoulcleaver.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tarrian's Soulcleaver (LCI #264) — {1} Legendary Artifact — Equipment (rare)
+ *
+ * Equipped creature has vigilance.
+ * Whenever another artifact or creature is put into a graveyard from the battlefield,
+ * put a +1/+1 counter on equipped creature.
+ * Equip {2}
+ *
+ * Implementation notes:
+ * - Vigilance is a static [GrantKeyword] scoped to [Filters.EquippedCreature] (standard
+ *   equipment keyword grant, à la Sword of Vengeance).
+ * - The death payoff is a [Triggers.leavesBattlefield] trigger with `to = Zone.GRAVEYARD`
+ *   over the union filter `Artifact or Creature` (any controller — no controller predicate),
+ *   bound [TriggerBinding.OTHER] so the Soulcleaver itself (an artifact) never counts
+ *   ("another"). The counter lands on [EffectTarget.EquippedCreature]; if the Equipment is
+ *   unattached the trigger still fires but resolves as a no-op (no creature to grow).
+ * - [equipAbility] wires the Equip {2} sorcery-speed attach.
+ */
+val TarriansSoulcleaver = card("Tarrian's Soulcleaver") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Equipped creature has vigilance.\n" +
+        "Whenever another artifact or creature is put into a graveyard from the battlefield, " +
+        "put a +1/+1 counter on equipped creature.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Artifact.or(GameObjectFilter.Creature),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "264"
+        artist = "Nereida"
+        flavorText = "Tarrian's holy weapon still holds a fragment of his dark power... and his hunger."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99413817-1218-4947-b12f-9a952b095a89.jpg?1782694400"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TectonicHazard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TectonicHazard.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tectonic Hazard
+ * {R}
+ * Sorcery
+ * Tectonic Hazard deals 1 damage to each opponent and each creature they control.
+ */
+val TectonicHazard = card("Tectonic Hazard") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Tectonic Hazard deals 1 damage to each opponent and each creature they control."
+
+    spell {
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+            .then(Patterns.Group.dealDamageToAll(1, GroupFilter(GameObjectFilter.Creature.opponentControls())))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Jarel Threat"
+        flavorText = "\"The ground is on fire, the ceiling's made of spears, and I think a mushroom tried to curse me. Don't tell me not to panic!\"\n—Jino Grag, Brazen Coalition scout"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/5204c781-f568-4c7f-b3f7-ce4dd678689b.jpg?1782694475"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TendrilOfTheMycotyrant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TendrilOfTheMycotyrant.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Tendril of the Mycotyrant
+ * {1}{G} — Creature — Fungus Wizard (Uncommon) — The Lost Caverns of Ixalan #215
+ * Artist: Maxime Minard
+ * 2/2
+ *
+ * {5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. It becomes
+ * a 0/0 Fungus creature with haste. It's still a land.
+ *
+ * Modeled as an activated ability targeting a noncreature land you control:
+ *   AddCountersEffect (seven +1/+1 counters) then BecomeCreatureEffect with base 0/0,
+ *   Fungus, haste, Duration.Permanent. No "until end of turn" appears on the card — the
+ *   land stays a creature unless it leaves the battlefield. The +1/+1 counters keep the
+ *   effectively 0/0 body alive (0+7 = 7/7 while counters remain). It's still a land, so
+ *   BecomeCreature adds the creature type/P-T without removing land types.
+ *
+ * Same "become a 0/0 creature with haste + N +1/+1 counters" animate shape as Cosmium
+ * Confluence's Cave mode (LCI #181), reusing AddCounters + permanent BecomeCreature.
+ */
+val TendrilOfTheMycotyrant = card("Tendril of the Mycotyrant") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fungus Wizard"
+    oracleText = "{5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. " +
+        "It becomes a 0/0 Fungus creature with haste. It's still a land."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}{G}")
+        val land = target(
+            "target noncreature land you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.notCreature().youControl()))
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 7, land) then
+            Effects.BecomeCreature(
+                target = land,
+                power = 0,
+                toughness = 0,
+                keywords = setOf(Keyword.HASTE),
+                creatureTypes = setOf("Fungus"),
+                duration = Duration.Permanent
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Maxime Minard"
+        flavorText = "Every mycoid carries within itself the makings of an entire colony."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afa464fe-978f-43de-ac35-79be4b12f0d9.jpg?1782694437"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -11451,6 +11451,54 @@
     ]
 }
 
+// Sunshot Militia
+{
+    "name": "Sunshot Militia",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Tap two untapped artifacts and/or creatures you control: This creature deals 1 damage to each opponent. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "artifact|creature"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Torgeir Fjereide",
+        "flavorText": "As the Legion of Dusk closed in, Oltec citizens rallied to support the Thousand Moons and drive off the invaders.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3114f5c-21e9-43c3-abe3-3cf1da20916f.jpg?1782694475"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Swashbuckler's Whip
 {
     "name": "Swashbuckler's Whip",
@@ -11565,6 +11613,273 @@
         "imageUri": "https://cards.scryfall.io/normal/front/2/4/24a85c52-e5b5-4d65-931c-eacc0cf0fb31.jpg?1782694401"
     },
     "colorIdentityOverride": []
+}
+
+// Synapse Necromage
+{
+    "name": "Synapse Necromage",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Fungus Wizard",
+    "oracleText": "When this creature dies, create two 1/1 black Fungus creature tokens with \"This token can't block.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Fungus"
+                    ],
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Piotr Foksowicz",
+        "flavorText": "\"It's no good killing them? Then what do we do? Distract them with a tea party?\"\n—Mervin, Brazen Coalition prospector",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efeb22a4-37bf-487a-9cf4-74de4cbbc0a3.jpg?1782694510"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Tarrian's Soulcleaver
+{
+    "name": "Tarrian's Soulcleaver",
+    "manaCost": "{1}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Equipped creature has vigilance.\nWhenever another artifact or creature is put into a graveyard from the battlefield, put a +1/+1 counter on equipped creature.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact|creature",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "EquippedCreature"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "264",
+        "rarity": "RARE",
+        "artist": "Nereida",
+        "flavorText": "Tarrian's holy weapon still holds a fragment of his dark power... and his hunger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99413817-1218-4947-b12f-9a952b095a89.jpg?1782694400"
+    },
+    "colorIdentityOverride": []
+}
+
+// Tectonic Hazard
+{
+    "name": "Tectonic Hazard",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Tectonic Hazard deals 1 damage to each opponent and each creature they control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Jarel Threat",
+        "flavorText": "\"The ground is on fire, the ceiling's made of spears, and I think a mushroom tried to curse me. Don't tell me not to panic!\"\n—Jino Grag, Brazen Coalition scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/5204c781-f568-4c7f-b3f7-ce4dd678689b.jpg?1782694475"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Tendril of the Mycotyrant
+{
+    "name": "Tendril of the Mycotyrant",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Fungus Wizard",
+    "oracleText": "{5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. It becomes a 0/0 Fungus creature with haste. It's still a land.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 7,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target noncreature land you control"
+                            }
+                        },
+                        {
+                            "type": "BecomeCreature",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target noncreature land you control"
+                            },
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "keywords": [
+                                "HASTE"
+                            ],
+                            "creatureTypes": [
+                                "Fungus"
+                            ],
+                            "duration": "Permanent"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsLand",
+                                    {
+                                        "type": "Not",
+                                        "predicate": "IsCreature"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "target noncreature land you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Maxime Minard",
+        "flavorText": "Every mycoid carries within itself the makings of an entire colony.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afa464fe-978f-43de-ac35-79be4b12f0d9.jpg?1782694437"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Terror Tide

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -757,6 +757,14 @@ class TriggerMatcher(
 
         // Check filter
         if (trigger.filter != GameObjectFilter.Any) {
+            // A heterogeneous OR union (`Artifact or Creature.tapped()`) carries its branches in
+            // anyOf, each a complete filter — match if any branch matches. (A homogeneous OR
+            // instead collapses to a single CardPredicate.Or handled below.)
+            if (trigger.filter.anyOf.isNotEmpty()) {
+                return trigger.filter.anyOf.any { branch ->
+                    matchesZoneChangeTrigger(trigger.copy(filter = branch), binding, event, sourceId, controllerId, state)
+                }
+            }
             val projected = state.projectedState
             // Check card predicates (creature type, subtype, etc.)
             // Note: entity may not exist in state if it was a token cleaned up by SBAs.
@@ -774,13 +782,17 @@ class TriggerMatcher(
             }
             val isFaceDown = entity?.has<FaceDownComponent>() == true
 
-            for (predicate in trigger.filter.cardPredicates) {
-                when (predicate) {
+            // LKI-aware predicate evaluation. Composites (Or/And/Not — e.g. the collapsed
+            // `Artifact or Creature` union on Tarrian's Soulcleaver) must recurse through THIS
+            // function, not fall through to the live-entity path: a token is swept by 704.5d
+            // before the matcher runs, so the generic cardComponent-based path returns false for
+            // every predicate inside the composite and the trigger silently misses token deaths.
+            fun matchesLkiPredicate(predicate: com.wingedsheep.sdk.scripting.predicates.CardPredicate): Boolean {
+                return when (predicate) {
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature -> {
                         // For dying creatures: use base state (they're already in graveyard)
                         // Face-down permanents are 2/2 creatures (Rule 708.2) and count.
-                        val isCreature = isFaceDown || typeLine?.isCreature == true
-                        if (!isCreature) return false
+                        isFaceDown || typeLine?.isCreature == true
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent -> {
                         // LKI-safe permanent check. Anything that left the battlefield was, by
@@ -790,27 +802,21 @@ class TriggerMatcher(
                         // (captured on the event, like IsCreature/IsLand above) instead. Without this,
                         // "whenever another permanent you control leaves the battlefield" (Suki,
                         // Courageous Rescuer) silently misses a leaving token.
-                        val isPermanent = isFaceDown || typeLine?.isPermanent == true
-                        if (!isPermanent) return false
+                        isFaceDown || typeLine?.isPermanent == true
                     }
-                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLand -> {
-                        if (typeLine?.isLand != true) return false
-                    }
-                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact -> {
-                        if (typeLine?.isArtifact != true) return false
-                    }
-                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsEnchantment -> {
-                        if (typeLine?.isEnchantment != true) return false
-                    }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLand ->
+                        typeLine?.isLand == true
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact ->
+                        typeLine?.isArtifact == true
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsEnchantment ->
+                        typeLine?.isEnchantment == true
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype -> {
                         // For entering creatures: use projected state (they're on battlefield)
                         // For dying creatures: use base state (they're in graveyard, no projected subtypes)
                         if (event.toZone == Zone.BATTLEFIELD) {
-                            if (!projected.hasSubtype(event.entityId, predicate.subtype.value)) return false
+                            projected.hasSubtype(event.entityId, predicate.subtype.value)
                         } else {
-                            if (isFaceDown) return false
-                            if (typeLine == null) return false
-                            if (!typeLine.hasSubtype(predicate.subtype)) return false
+                            !isFaceDown && typeLine?.hasSubtype(predicate.subtype) == true
                         }
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasAnyOfSubtypes -> {
@@ -819,11 +825,9 @@ class TriggerMatcher(
                         // the entity (and its CardComponent) may already be gone, so read the
                         // last-known type line rather than the generic cardComponent path.
                         if (event.toZone == Zone.BATTLEFIELD) {
-                            if (predicate.subtypes.none { projected.hasSubtype(event.entityId, it.value) }) return false
+                            predicate.subtypes.any { projected.hasSubtype(event.entityId, it.value) }
                         } else {
-                            if (isFaceDown) return false
-                            if (typeLine == null) return false
-                            if (predicate.subtypes.none { typeLine.hasSubtype(it) }) return false
+                            !isFaceDown && typeLine != null && predicate.subtypes.any { typeLine.hasSubtype(it) }
                         }
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasKeyword -> {
@@ -833,9 +837,9 @@ class TriggerMatcher(
                         // have its keywords (e.g., Jackdaw Savior: "whenever a creature you control
                         // with flying dies").
                         if (event.fromZone == Zone.BATTLEFIELD && event.lastKnown?.keywords?.isNotEmpty() == true) {
-                            if (predicate.keyword.name !in (event.lastKnown?.keywords ?: emptySet())) return false
+                            predicate.keyword.name in (event.lastKnown?.keywords ?: emptySet())
                         } else {
-                            if (!projected.hasKeyword(event.entityId, predicate.keyword)) return false
+                            projected.hasKeyword(event.entityId, predicate.keyword)
                         }
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasChosenSubtype -> {
@@ -852,7 +856,7 @@ class TriggerMatcher(
                         val isChangelingCreatureType = cardComponent != null &&
                             Keyword.CHANGELING in cardComponent.baseKeywords &&
                             chosenType in Subtype.ALL_CREATURE_TYPES
-                        if (!hasSubtype && !isChangelingCreatureType) return false
+                        hasSubtype || isChangelingCreatureType
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNontoken -> {
                         // Token-ness is intrinsic; LKI is required because 704.5d sweeps the
@@ -865,27 +869,36 @@ class TriggerMatcher(
                         } else {
                             entity?.has<com.wingedsheep.engine.state.components.identity.TokenComponent>() == true
                         }
-                        if (isToken) return false
+                        !isToken
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsToken -> {
-                        val isToken = if (event.fromZone == Zone.BATTLEFIELD) {
+                        if (event.fromZone == Zone.BATTLEFIELD) {
                             event.lastKnown?.wasToken == true
                         } else {
                             entity?.has<com.wingedsheep.engine.state.components.identity.TokenComponent>() == true
                         }
-                        if (!isToken) return false
                     }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.Or ->
+                        predicate.predicates.any { matchesLkiPredicate(it) }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.And ->
+                        predicate.predicates.all { matchesLkiPredicate(it) }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.Not ->
+                        !matchesLkiPredicate(predicate.predicate)
                     else -> {
                         // For other predicates, check the entity's type
                         if (cardComponent == null) return false
-                        if (!matchesCardPredicate(
-                                predicate, cardComponent, projected, event.entityId, isFaceDown,
-                                lastKnownPower = event.lastKnown?.power,
-                                lastKnownToughness = event.lastKnown?.toughness,
-                                lastKnownWasToken = event.lastKnown?.wasToken == true
-                            )) return false
+                        matchesCardPredicate(
+                            predicate, cardComponent, projected, event.entityId, isFaceDown,
+                            lastKnownPower = event.lastKnown?.power,
+                            lastKnownToughness = event.lastKnown?.toughness,
+                            lastKnownWasToken = event.lastKnown?.wasToken == true
+                        )
                     }
                 }
+            }
+
+            for (predicate in trigger.filter.cardPredicates) {
+                if (!matchesLkiPredicate(predicate)) return false
             }
             // Check state predicates (face-down, tapped, etc.)
             for (predicate in trigger.filter.statePredicates) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -127,7 +127,7 @@ class CostPaymentService(private val services: EngineServices) {
                 is CostAtom.ReturnToHand ->
                     selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
                 is CostAtom.TapPermanents ->
-                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null), atom.count, useTargetingUI = true)
             }
         }
     }
@@ -476,7 +476,7 @@ class CostPaymentService(private val services: EngineServices) {
                         else candidates.size >= atom.count
                     }
                     is CostAtom.ReturnToHand -> controlledMatching(state, payerId, atom.filter, sourceId).size >= atom.count
-                    is CostAtom.TapPermanents -> controlledUntapped(state, payerId, atom.filter, sourceId).size >= atom.count
+                    is CostAtom.TapPermanents -> controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null).size >= atom.count
                 }
             }
         }
@@ -520,9 +520,10 @@ class CostPaymentService(private val services: EngineServices) {
                 state, filter.youControl(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
             )
 
-        fun controlledUntapped(state: GameState, playerId: EntityId, filter: GameObjectFilter, sourceId: EntityId): List<EntityId> =
+        /** [excludeSelfId] only for costs that say "another" — a plain "tap two untapped …" may tap the source itself. */
+        fun controlledUntapped(state: GameState, playerId: EntityId, filter: GameObjectFilter, excludeSelfId: EntityId?): List<EntityId> =
             BattlefieldFilterUtils.findMatchingOnBattlefield(
-                state, filter.youControl().untapped(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
+                state, filter.youControl().untapped(), PredicateContext(controllerId = playerId), excludeSelfId = excludeSelfId
             )
 
         /** Number of distinct card names among [candidates] — for "with different names" costs. */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.scripting.effects.RedirectScope
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -132,11 +133,15 @@ sealed interface SerializableModification {
     @Serializable
     data class AddColor(val colors: Set<String>) : SerializableModification
 
+    // The JSON field must not be named "type": the game-server persistence Json uses
+    // classDiscriminator = "type", and kotlinx.serialization refuses to encode a polymorphic
+    // class whose own property collides with the discriminator (JsonEncodingException the
+    // first time a BecomeCreature/AddCardType floating effect is saved).
     @Serializable
-    data class AddType(val type: String) : SerializableModification
+    data class AddType(@SerialName("cardType") val type: String) : SerializableModification
 
     @Serializable
-    data class RemoveType(val type: String) : SerializableModification
+    data class RemoveType(@SerialName("cardType") val type: String) : SerializableModification
 
     @Serializable
     data class ChangeController(val newControllerId: EntityId) : SerializableModification

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/FloatingEffectSerializationRoundTripTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/FloatingEffectSerializationRoundTripTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.hygiene
+
+import com.wingedsheep.engine.core.engineSerializersModule
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.FloatingEffectData
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import kotlin.reflect.KClass
+import kotlin.reflect.full.createType
+
+/**
+ * Guards GameState persistence against the JSON class-discriminator collision: the game
+ * server's `persistenceJson` (and kotlinx's default) uses `classDiscriminator = "type"`, and
+ * kotlinx.serialization throws [kotlinx.serialization.json.JsonEncodingException] the moment a
+ * polymorphic leaf whose own JSON field is named "type" is encoded.
+ *
+ * The bug this pins: `SerializableModification.AddType(val type: String)` crashed
+ * `RedisGameRepository.save` the first time a permanent animation (Tendril of the Mycotyrant's
+ * `BecomeCreature` → `AddType("CREATURE")` floating effect) was in the saved state. The
+ * property is now `@SerialName("cardType")`; this test fails on any future leaf that
+ * reintroduces a colliding field, at test time instead of mid-game.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class FloatingEffectSerializationRoundTripTest : FunSpec({
+
+    // Same discriminator the game server's persistenceJson uses (also kotlinx's default).
+    val json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        classDiscriminator = "type"
+        allowStructuredMapKeys = true
+        serializersModule = engineSerializersModule
+    }
+
+    fun sealedLeaves(klass: KClass<*>): List<KClass<*>> =
+        klass.sealedSubclasses.flatMap { sub ->
+            if (sub.sealedSubclasses.isEmpty()) listOf(sub) else sealedLeaves(sub)
+        }
+
+    test("no SerializableModification leaf has a JSON field colliding with the 'type' class discriminator") {
+        val leaves = sealedLeaves(SerializableModification::class)
+        leaves.isNotEmpty() shouldBe true
+        leaves.forEach { leaf ->
+            val descriptor = serializer(leaf.createType()).descriptor
+            val fieldNames = (0 until descriptor.elementsCount).map { descriptor.getElementName(it) }
+            withClue("${leaf.simpleName} would throw JsonEncodingException on save — rename the field with @SerialName") {
+                fieldNames shouldNotContain "type"
+            }
+        }
+    }
+
+    test("an ActiveFloatingEffect carrying AddType round-trips through persistence-shaped JSON") {
+        val effect = ActiveFloatingEffect(
+            id = EntityId("floating-1"),
+            effect = FloatingEffectData(
+                layer = Layer.TYPE,
+                modification = SerializableModification.AddType("CREATURE"),
+                affectedEntities = setOf(EntityId("land-1"))
+            ),
+            duration = Duration.Permanent,
+            sourceId = EntityId("tendril-1"),
+            sourceName = "Tendril of the Mycotyrant",
+            controllerId = EntityId("player-1"),
+            timestamp = 42L
+        )
+        val encoded = json.encodeToString(ActiveFloatingEffect.serializer(), effect)
+        json.decodeFromString(ActiveFloatingEffect.serializer(), encoded) shouldBe effect
+    }
+
+    test("an ActiveFloatingEffect carrying RemoveType round-trips through persistence-shaped JSON") {
+        val effect = ActiveFloatingEffect(
+            id = EntityId("floating-2"),
+            effect = FloatingEffectData(
+                layer = Layer.TYPE,
+                modification = SerializableModification.RemoveType("CREATURE"),
+                affectedEntities = setOf(EntityId("perm-1"))
+            ),
+            duration = Duration.Permanent,
+            sourceId = null,
+            controllerId = EntityId("player-1"),
+            timestamp = 43L
+        )
+        val encoded = json.encodeToString(ActiveFloatingEffect.serializer(), effect)
+        json.decodeFromString(ActiveFloatingEffect.serializer(), encoded) shouldBe effect
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
@@ -340,14 +340,26 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             game.state.getEntity(fodder)!!.has<TappedComponent>().shouldBeTrue()
         }
 
-        test("Tap: unaffordable when the only other permanent is already tapped") {
+        test("Tap: unaffordable when every permanent, including the source, is already tapped") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide", tapped = true)
+                .withCardOnBattlefield(1, "Savannah Lions", tapped = true)
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            service.canAfford(game.state, game.player1Id, Costs.pay.Tap(GameObjectFilter.Any, 1), source).shouldBeFalse()
+        }
+
+        test("Tap: the source itself is an eligible candidate when the cost doesn't say 'another'") {
+            // "Tap an untapped permanent you control" (Command Bridge, Sunshot Militia's cost
+            // shape) has no "other" — the untapped source may pay its own cost.
             val game = scenario().withPlayers()
                 .withCardOnBattlefield(1, "Goblin Guide")
                 .withCardOnBattlefield(1, "Savannah Lions", tapped = true)
                 .build()
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
-            service.canAfford(game.state, game.player1Id, Costs.pay.Tap(GameObjectFilter.Any, 1), source).shouldBeFalse()
+            service.canAfford(game.state, game.player1Id, Costs.pay.Tap(GameObjectFilter.Any, 1), source).shouldBeTrue()
         }
 
         // -----------------------------------------------------------------------------------------

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SunshotMilitiaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SunshotMilitiaScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SunshotMilitia
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sunshot Militia (LCI #168).
+ *
+ * Sunshot Militia {1}{R}
+ * Creature — Human Soldier 1/3
+ * Tap two untapped artifacts and/or creatures you control: This creature deals 1 damage to each
+ * opponent. Activate only as a sorcery.
+ *
+ * Covers:
+ *  - Happy path: tapping two creatures deals 1 damage to the opponent and taps both permanents.
+ *  - Self-tap: the Militia itself may be one of the two (its cost has no "other").
+ *  - Sorcery-speed gate: activation is rejected outside a main phase with an empty stack.
+ *  - Cost gate: activation is rejected without two matching untapped permanents.
+ */
+class SunshotMilitiaScenarioTest : FunSpec({
+
+    val abilityId = SunshotMilitia.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SunshotMilitia))
+        return driver
+    }
+
+    test("tapping two creatures deals 1 damage to each opponent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val militia = driver.putCreatureOnBattlefield(activePlayer, "Sunshot Militia")
+        driver.removeSummoningSickness(militia)
+        val bear1 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+        val bear2 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear2)
+
+        driver.getLifeTotal(opponent) shouldBe 20
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = militia,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1, bear2))
+            )
+        )
+        driver.bothPass() // resolve the ability
+
+        driver.isTapped(bear1) shouldBe true
+        driver.isTapped(bear2) shouldBe true
+        driver.getLifeTotal(opponent) shouldBe 19
+    }
+
+    test("the Militia itself may be one of the two tapped permanents (no \"other\" in the cost)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val militia = driver.putCreatureOnBattlefield(activePlayer, "Sunshot Militia")
+        driver.removeSummoningSickness(militia)
+        val bear = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = militia,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(militia, bear))
+            )
+        )
+        driver.bothPass() // resolve the ability
+
+        driver.isTapped(militia) shouldBe true
+        driver.isTapped(bear) shouldBe true
+        driver.getLifeTotal(opponent) shouldBe 19
+    }
+
+    test("cannot be activated at instant speed (sorcery-speed gate)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+
+        val militia = driver.putCreatureOnBattlefield(activePlayer, "Sunshot Militia")
+        driver.removeSummoningSickness(militia)
+        val bear1 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+        val bear2 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear2)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = militia,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1, bear2))
+            )
+        )
+    }
+
+    test("cannot be activated without two matching untapped permanents") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val militia = driver.putCreatureOnBattlefield(activePlayer, "Sunshot Militia")
+        driver.removeSummoningSickness(militia)
+        // Only Sunshot Militia itself is untapped — cost requires two matching permanents.
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = militia,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(militia))
+            )
+        )
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SynapseNecromageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SynapseNecromageScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SynapseNecromage
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Synapse Necromage (LCI #125): {2}{B} 3/1 Fungus Wizard
+ *
+ * "When this creature dies, create two 1/1 black Fungus creature tokens with
+ * 'This token can't block.'"
+ *
+ * Tests:
+ * 1. When Synapse Necromage dies, exactly two 1/1 black Fungus tokens are created,
+ *    each with the "can't block" static ability.
+ */
+class SynapseNecromageScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SynapseNecromage))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    fun GameTestDriver.fungusTokens(playerId: EntityId): List<EntityId> =
+        getCreatures(playerId).filter { getCardName(it) == "Fungus Token" }
+
+    test("dying Synapse Necromage creates two 1/1 black Fungus can't-block tokens") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val necromage = driver.putCreatureOnBattlefield(player, "Synapse Necromage")
+        val tokensBefore = driver.fungusTokens(player).size
+
+        // Kill the 3/1 Necromage with a Lightning Bolt so it dies through the real
+        // damage/SBA path → the dies trigger is detected and queued.
+        driver.giveMana(player, Color.RED, 1)
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.castSpellWithTargets(player, bolt, listOf(ChosenTarget.Permanent(necromage)))
+        driver.bothPass() // resolve the bolt -> Necromage dies, queuing its dies trigger
+        driver.bothPass() // resolve the dies trigger -> creates the two Fungus tokens
+
+        val tokensAfter = driver.fungusTokens(player)
+        tokensAfter.size shouldBe tokensBefore + 2
+
+        tokensAfter.forEach { token ->
+            driver.state.projectedState.getPower(token) shouldBe 1
+            driver.state.projectedState.getToughness(token) shouldBe 1
+            driver.state.projectedState.cantBlock(token) shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TarriansSoulcleaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TarriansSoulcleaverScenarioTest.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SynapseNecromage
 import com.wingedsheep.mtg.sets.definitions.lci.cards.TarriansSoulcleaver
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
@@ -29,6 +30,10 @@ import io.kotest.matchers.shouldBe
  *  2. Another creature dying (any controller) puts a +1/+1 counter on the equipped creature.
  *  3. An artifact dying puts a +1/+1 counter on the equipped creature (artifact branch of the OR).
  *  4. When the Soulcleaver is unattached, the death trigger resolves as a harmless no-op.
+ *  5. A TOKEN dying puts a +1/+1 counter on the equipped creature — regression for the
+ *     TriggerMatcher LKI gap: the union filter collapses to CardPredicate.Or, and the token
+ *     entity is swept by CR 704.5d before trigger matching, so the composite must be evaluated
+ *     against the event's last-known type line, not the live (gone) CardComponent.
  */
 class TarriansSoulcleaverScenarioTest : FunSpec({
 
@@ -36,7 +41,7 @@ class TarriansSoulcleaverScenarioTest : FunSpec({
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(TarriansSoulcleaver))
+        driver.registerCards(TestCards.all + listOf(TarriansSoulcleaver, SynapseNecromage))
         return driver
     }
 
@@ -145,5 +150,40 @@ class TarriansSoulcleaverScenarioTest : FunSpec({
 
         // No creature to receive the counter — the bear stays at zero and nothing crashes.
         plusOneCounters(driver, bear) shouldBe 0
+    }
+
+    test("a token dying puts a +1/+1 counter on the equipped creature (LKI regression)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putEquipmentAttached(driver.player1, "Tarrian's Soulcleaver", bear)
+        // Opponent's Synapse Necromage: killing it creates two Fungus tokens through the real
+        // token-creation path, so the tokens carry a genuine TokenComponent.
+        val necromage = driver.putCreatureOnBattlefield(driver.player2, "Synapse Necromage")
+
+        driver.advanceToPlayer1Main()
+
+        driver.giveMana(driver.player1, Color.RED, 1)
+        val bolt1 = driver.putCardInHand(driver.player1, "Lightning Bolt")
+        driver.castSpell(driver.player1, bolt1, targets = listOf(necromage)).isSuccess shouldBe true
+        driver.bothPass() // resolve the bolt -> Necromage dies, queuing both players' triggers
+        driver.bothPass() // resolve one trigger (APNAP)
+        driver.bothPass() // resolve the other trigger
+
+        // The Necromage (a real card) dying already grew the bear by one and left two tokens.
+        plusOneCounters(driver, bear) shouldBe 1
+        val fungusTokens = driver.getCreatures(driver.player2).filter { driver.getCardName(it) == "Fungus Token" }
+        fungusTokens.size shouldBe 2
+
+        // Kill a token: it dies AND is swept from the game by 704.5d in the same SBA pass, so
+        // the Soulcleaver's `Artifact or Creature` union must match on last-known info.
+        driver.giveMana(driver.player1, Color.RED, 1)
+        val bolt2 = driver.putCardInHand(driver.player1, "Lightning Bolt")
+        driver.castSpell(driver.player1, bolt2, targets = listOf(fungusTokens.first())).isSuccess shouldBe true
+        driver.bothPass() // resolve the bolt -> token dies and is swept
+        driver.bothPass() // resolve the Soulcleaver trigger
+
+        plusOneCounters(driver, bear) shouldBe 2
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TarriansSoulcleaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TarriansSoulcleaverScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TarriansSoulcleaver
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tarrian's Soulcleaver (LCI #264) — {1} Legendary Artifact — Equipment.
+ *
+ * Equipped creature has vigilance.
+ * Whenever another artifact or creature is put into a graveyard from the battlefield,
+ * put a +1/+1 counter on equipped creature.
+ * Equip {2}
+ *
+ * Tests:
+ *  1. Equipped creature has vigilance (static GrantKeyword).
+ *  2. Another creature dying (any controller) puts a +1/+1 counter on the equipped creature.
+ *  3. An artifact dying puts a +1/+1 counter on the equipped creature (artifact branch of the OR).
+ *  4. When the Soulcleaver is unattached, the death trigger resolves as a harmless no-op.
+ */
+class TarriansSoulcleaverScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TarriansSoulcleaver))
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.putEquipmentAttached(
+        playerId: EntityId,
+        cardName: String,
+        targetCreatureId: EntityId,
+    ): EntityId {
+        val equipmentId = putPermanentOnBattlefield(playerId, cardName)
+        var newState = state.updateEntity(equipmentId) { c -> c.with(AttachedToComponent(targetCreatureId)) }
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    // Player 1 may not be active at game start (random turn order) — advance until it is.
+    fun GameTestDriver.advanceToPlayer1Main() {
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.PRECOMBAT_MAIN)
+            safety++
+        }
+    }
+
+    test("equipped creature has vigilance") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putEquipmentAttached(driver.player1, "Tarrian's Soulcleaver", bear)
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(bear, Keyword.VIGILANCE) shouldBe true
+    }
+
+    test("another creature dying (any controller) puts a +1/+1 counter on the equipped creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putEquipmentAttached(driver.player1, "Tarrian's Soulcleaver", bear)
+        // A different creature the opponent controls — "another artifact or creature", any controller.
+        val victim = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+
+        driver.advanceToPlayer1Main()
+        plusOneCounters(driver, bear) shouldBe 0
+
+        // Destroy the victim for real so its dies (battlefield -> graveyard) trigger fires.
+        val doomBlade = driver.putCardInHand(driver.player1, "Doom Blade")
+        driver.giveMana(driver.player1, Color.BLACK, 2)
+        driver.castSpell(driver.player1, doomBlade, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // resolve Doom Blade -> victim dies, queuing the Soulcleaver trigger
+        driver.state.getBattlefield().contains(victim) shouldBe false
+        driver.bothPass() // resolve the Soulcleaver "another ... is put into a graveyard" trigger
+
+        plusOneCounters(driver, bear) shouldBe 1
+    }
+
+    test("an artifact dying puts a +1/+1 counter on the equipped creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putEquipmentAttached(driver.player1, "Tarrian's Soulcleaver", bear)
+        // A colorless artifact creature — matches the "artifact" branch of the trigger filter.
+        val artifact = driver.putCreatureOnBattlefield(driver.player1, "Artifact Creature")
+
+        driver.advanceToPlayer1Main()
+
+        val doomBlade = driver.putCardInHand(driver.player1, "Doom Blade")
+        driver.giveMana(driver.player1, Color.BLACK, 2)
+        driver.castSpell(driver.player1, doomBlade, targets = listOf(artifact)).isSuccess shouldBe true
+        driver.bothPass() // resolve Doom Blade -> artifact dies
+        driver.state.getBattlefield().contains(artifact) shouldBe false
+        driver.bothPass() // resolve the Soulcleaver trigger
+
+        plusOneCounters(driver, bear) shouldBe 1
+    }
+
+    test("unattached Soulcleaver: a creature dying resolves as a no-op") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        // Soulcleaver on the battlefield but attached to nothing.
+        driver.putPermanentOnBattlefield(driver.player1, "Tarrian's Soulcleaver")
+        val victim = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+
+        driver.advanceToPlayer1Main()
+
+        val doomBlade = driver.putCardInHand(driver.player1, "Doom Blade")
+        driver.giveMana(driver.player1, Color.BLACK, 2)
+        driver.castSpell(driver.player1, doomBlade, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // resolve Doom Blade
+        driver.bothPass() // resolve (or fizzle) the Soulcleaver trigger with no equipped creature
+
+        // No creature to receive the counter — the bear stays at zero and nothing crashes.
+        plusOneCounters(driver, bear) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TectonicHazardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TectonicHazardScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TectonicHazard
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tectonic Hazard (LCI #169) — {R} Sorcery.
+ *
+ * "Tectonic Hazard deals 1 damage to each opponent and each creature they control."
+ *
+ * Two damage sub-effects composed: 1 damage to each opponent (the player) and 1 damage
+ * to each creature that opponent controls. The caster and the caster's own creatures are
+ * untouched.
+ */
+class TectonicHazardScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(PredefinedTokens.allTokens)
+        driver.registerCard(TectonicHazard)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("deals 1 to the opponent and 1 to each of their creatures, sparing the caster's side") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Opponent's board: a 2/2 (survives 1 damage) and a 1/1 (dies to 1 damage).
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")     // 2/2
+        driver.putCreatureOnBattlefield(opp, "Llanowar Elves")    // 1/1
+        // Caster's own creatures must be untouched.
+        val myBears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")   // 2/2
+
+        val hazard = driver.putCardInHand(me, "Tectonic Hazard")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, hazard).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Opponent (the only opponent) took 1 damage; caster untouched.
+        driver.getLifeTotal(opp) shouldBe 19
+        driver.getLifeTotal(me) shouldBe 20
+
+        // The opponent's 1/1 died; their 2/2 and the caster's 2/2 survived.
+        driver.findPermanent(opp, "Llanowar Elves") shouldBe null
+        (driver.findPermanent(opp, "Grizzly Bears") != null) shouldBe true
+        (myBears == driver.findPermanent(me, "Grizzly Bears")) shouldBe true
+        driver.getCreatures(me).size shouldBe 1
+        driver.getCreatures(opp).size shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TendrilOfTheMycotyrantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TendrilOfTheMycotyrantScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TendrilOfTheMycotyrant
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Tendril of the Mycotyrant (LCI #215) — {1}{G} 2/2 Creature — Fungus Wizard.
+ *
+ * "{5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. It becomes a
+ *  0/0 Fungus creature with haste. It's still a land."
+ *
+ * Covered:
+ *  1. Activating the ability on a noncreature land you control puts seven +1/+1 counters on it
+ *     and permanently animates it into a 0/0 Fungus creature — a 7/7 while the counters remain —
+ *     that is still a land.
+ */
+class TendrilOfTheMycotyrantScenarioTest : FunSpec({
+
+    val abilityId = TendrilOfTheMycotyrant.activatedAbilities.first().id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TendrilOfTheMycotyrant)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("animating a noncreature land adds seven +1/+1 counters and makes it a 0/0 Fungus creature that is still a land") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        // The Tendril on the battlefield provides the activated ability.
+        val tendril = driver.putPermanentOnBattlefield(me, "Tendril of the Mycotyrant")
+
+        // A noncreature land you control to target.
+        val land = driver.putLandOnBattlefield(me, "Forest")
+
+        // {5}{G}{G}: 5 generic + 2 green.
+        driver.giveColorlessMana(me, 5)
+        driver.giveMana(me, Color.GREEN, 2)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = tendril,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(land))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        // Seven +1/+1 counters landed on the target land.
+        plusOneCounters(driver, land) shouldBe 7
+
+        // The land is now a creature (permanent BecomeCreature) and still on the battlefield.
+        driver.findPermanent(me, "Forest") shouldNotBe null
+        driver.state.projectedState.isCreature(land) shouldBe true
+
+        // It's still a land.
+        driver.state.projectedState.hasType(land, "LAND") shouldBe true
+
+        // Base 0/0 plus seven +1/+1 counters => a 7/7 body.
+        driver.state.projectedState.getPower(land) shouldBe 7
+        driver.state.projectedState.getToughness(land) shouldBe 7
+    }
+})


### PR DESCRIPTION
## LCI cards — batch 17 (5 cards) + 3 engine bug fixes surfaced by playtest

Seventeenth batch of Lost Caverns of Ixalan cards, each with a scenario test. **Stacked on `lci-cards-16`** — please review only the difference to that branch (the four commits listed below); everything under it is reviewed on the earlier batch PRs.

### Cards (commit `ce9c22a4c`)

- **Sunshot Militia** — {1}{R} Human Soldier; tap two untapped artifacts/creatures you control (sorcery-speed): deals 1 damage to each opponent. The Militia itself may be one of the two (no "other" — pinned by test).
- **Synapse Necromage** — {2}{B} Fungus Wizard; dies → create two 1/1 black Fungus tokens with "This token can't block."
- **Tectonic Hazard** — {R} sorcery; deals 1 damage to each opponent and each creature they control.
- **Tarrian's Soulcleaver** — {1} Legendary Equipment; equipped creature has vigilance; whenever another artifact or creature is put into a graveyard from the battlefield, +1/+1 counter on equipped creature; Equip {2}.
- **Tendril of the Mycotyrant** — {1}{G} Fungus Wizard; {5}{G}{G}: put seven +1/+1 counters on target noncreature land you control, it becomes a 0/0 Fungus with haste (still a land).

Includes a manual self-play scenario (`manual-scenarios/sets/lci/cards-17.json`) with all five in hand and mana to cast them.

Note: **Sunfire Torch** was triaged out of this batch to NEEDS-ENGINE (a granted triggered ability can't sacrifice its granting Equipment — `granterId` isn't threaded to triggered abilities; same family as Deconstruction Hammer) and replaced by Tendril of the Mycotyrant.

### Engine fixes (found by playtesting this batch — latent bugs, not new capabilities)

- **`b6cf3f071` — Fix zone-change trigger filters for composite predicates under LKI.** Union filters (`Artifact or Creature`, collapsed to `CardPredicate.Or`) fell into `TriggerMatcher`'s live-entity path, so Tarrian's Soulcleaver silently missed every **token** death (the token entity is swept by CR 704.5d before matching) and any permanent whose types were only projected at the moment of leaving. Composites now recurse through the LKI-aware evaluator; heterogeneous `anyOf` unions (previously fail-open in this matcher) match per branch. Regression test kills a real Fungus token and asserts the counter lands.
- **`50694928c` — Fix JSON discriminator collision on AddType/RemoveType floating effects.** `SerializableModification.AddType(val type: …)` collided with the persistence Json's `classDiscriminator = "type"`, crashing `RedisGameRepository.save` the first time a permanent animation (Tendril's `BecomeCreature`) was in the saved state. Fields renamed via `@SerialName("cardType")`; a hygiene test now walks every `SerializableModification` leaf so the next collision fails at test time. No migration concern — colliding states could never have been serialized.
- **`a004ed888` — Honor `excludeSelf` in TapPermanents PayCost candidates.** The PayCost prompt/affordability path always excluded the cost's source; per the atom's `excludeSelf` flag (false unless the card says "another"), an untapped source may pay its own "tap an untapped permanent you control" cost. The activation path already honored the flag; the two paths now agree.

### Verification

All 5 scenario test classes + the new regression tests pass; full `:rules-engine:test` (6842 tests) and `:mtg-sets:test` (snapshot + lint) green via `gradle-locked`; `just check-card-printing` clean for all five cards; LCI snapshot re-blessed (flavor-text addition only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
