### PR TITLE
Add 5 Lost Caverns of Ixalan cards (batch 18)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 191 / 286
+**Implemented:** 196 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -243,13 +243,13 @@
 - [ ] Sunbird Standard
 - [ ] Sunfire Torch
 - [ ] Sunken Citadel
-- [ ] Sunshot Militia
+- [x] Sunshot Militia
 - [x] Swashbuckler's Whip
-- [ ] Synapse Necromage
+- [x] Synapse Necromage
 - [ ] Tarrian's Journal
-- [ ] Tarrian's Soulcleaver
-- [ ] Tectonic Hazard
-- [ ] Tendril of the Mycotyrant
+- [x] Tarrian's Soulcleaver
+- [x] Tectonic Hazard
+- [x] Tendril of the Mycotyrant
 - [x] Terror Tide
 - [ ] The Ancient One
 - [ ] The Belligerent

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 196 / 286
+**Implemented:** 201 / 286
 - [x] Abrade
 - [ ] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -252,17 +252,17 @@
 - [x] Tendril of the Mycotyrant
 - [x] Terror Tide
 - [ ] The Ancient One
-- [ ] The Belligerent
+- [x] The Belligerent
 - [ ] The Enigma Jewel
 - [ ] The Everflowing Well
 - [ ] The Millennium Calendar
-- [ ] The Mycotyrant
+- [x] The Mycotyrant
 - [ ] The Skullspore Nexus
-- [ ] Thousand Moons Crackshot
-- [ ] Thousand Moons Infantry
+- [x] Thousand Moons Crackshot
+- [x] Thousand Moons Infantry
 - [ ] Thousand Moons Smithy
 - [x] Thrashing Brontodon
-- [ ] Threefold Thunderhulk
+- [x] Threefold Thunderhulk
 - [ ] Throne of the Grim Captain
 - [ ] Tinker's Tote
 - [ ] Tishana's Tidebinder

--- a/manual-scenarios/sets/lci/cards-17.json
+++ b/manual-scenarios/sets/lci/cards-17.json
@@ -1,0 +1,50 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Sunshot Militia",
+      "Synapse Necromage",
+      "Tectonic Hazard",
+      "Tarrian's Soulcleaver",
+      "Tendril of the Mycotyrant"
+    ],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Forest", "Mountain", "Swamp", "Grizzly Bears", "Forest", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Island"],
+    "battlefield": [
+      {"name": "Cenote Scout"},
+      {"name": "Grizzly Bears"},
+      {"name": "Basking Capybara"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Swamp", "Forest", "Mountain", "Island", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/sets/lci/cards-18.json
+++ b/manual-scenarios/sets/lci/cards-18.json
@@ -1,0 +1,60 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "The Belligerent",
+      "The Mycotyrant",
+      "Thousand Moons Crackshot",
+      "Thousand Moons Infantry",
+      "Threefold Thunderhulk"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Tarrian's Soulcleaver"}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Forest", "Grizzly Bears", "Plains", "Mountain", "Swamp"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Island"],
+    "battlefield": [
+      {"name": "Cenote Scout"},
+      {"name": "Grizzly Bears"},
+      {"name": "Basking Capybara"}
+    ],
+    "graveyard": [],
+    "library": ["Island", "Swamp", "Forest", "Mountain", "Island", "Swamp"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": ["END"],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunshotMilitia.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunshotMilitia.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sunshot Militia
+ * {1}{R}
+ * Creature — Human Soldier
+ * 1/3
+ * Tap two untapped artifacts and/or creatures you control: This creature deals 1 damage to each
+ * opponent. Activate only as a sorcery.
+ *
+ * The activation cost reuses the [Costs.TapPermanents] primitive (same shape as Adaptive Gemguard /
+ * Goldfury Strider): tap exactly two untapped artifacts or creatures you control (no "other"
+ * restriction — Sunshot Militia itself may be one of the two). The effect deals 1 damage to each
+ * opponent via [Effects.DealDamage] against [Player.EachOpponent].
+ */
+val SunshotMilitia = card("Sunshot Militia") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Soldier"
+    power = 1
+    toughness = 3
+    oracleText = "Tap two untapped artifacts and/or creatures you control: This creature deals 1 damage to each opponent. Activate only as a sorcery."
+
+    activatedAbility {
+        cost = Costs.TapPermanents(
+            count = 2,
+            filter = GameObjectFilter.Artifact or GameObjectFilter.Creature,
+        )
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Torgeir Fjereide"
+        flavorText = "As the Legion of Dusk closed in, Oltec citizens rallied to support the Thousand Moons and drive off the invaders."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3114f5c-21e9-43c3-abe3-3cf1da20916f.jpg?1782694475"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SynapseNecromage.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SynapseNecromage.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Synapse Necromage
+ * {2}{B}
+ * Creature — Fungus Wizard
+ * 3/1
+ *
+ * When this creature dies, create two 1/1 black Fungus creature tokens with
+ * "This token can't block."
+ *
+ * Dies is CR 700.4 (battlefield to graveyard); modelled as the SELF-bound
+ * [Triggers.Dies]. The tokens are identical to Broodrage Mycoid / The Mycotyrant's
+ * 1/1 black Fungus "can't block" token — the "This token can't block" restriction is a
+ * static ability on the token itself, [CantBlock] with [GroupFilter.source()].
+ */
+val SynapseNecromage = card("Synapse Necromage") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Fungus Wizard"
+    power = 3
+    toughness = 1
+    oracleText = "When this creature dies, create two 1/1 black Fungus creature tokens with \"This token can't block.\""
+
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = Effects.CreateToken(
+            count = 2,
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Fungus"),
+            staticAbilities = listOf(CantBlock(GroupFilter.source()))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "125"
+        artist = "Piotr Foksowicz"
+        flavorText = "\"It's no good killing them? Then what do we do? Distract them with a tea party?\"\n—Mervin, Brazen Coalition prospector"
+        imageUri = "https://cards.scryfall.io/normal/front/e/f/efeb22a4-37bf-487a-9cf4-74de4cbbc0a3.jpg?1782694510"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TarriansSoulcleaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TarriansSoulcleaver.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tarrian's Soulcleaver (LCI #264) — {1} Legendary Artifact — Equipment (rare)
+ *
+ * Equipped creature has vigilance.
+ * Whenever another artifact or creature is put into a graveyard from the battlefield,
+ * put a +1/+1 counter on equipped creature.
+ * Equip {2}
+ *
+ * Implementation notes:
+ * - Vigilance is a static [GrantKeyword] scoped to [Filters.EquippedCreature] (standard
+ *   equipment keyword grant, à la Sword of Vengeance).
+ * - The death payoff is a [Triggers.leavesBattlefield] trigger with `to = Zone.GRAVEYARD`
+ *   over the union filter `Artifact or Creature` (any controller — no controller predicate),
+ *   bound [TriggerBinding.OTHER] so the Soulcleaver itself (an artifact) never counts
+ *   ("another"). The counter lands on [EffectTarget.EquippedCreature]; if the Equipment is
+ *   unattached the trigger still fires but resolves as a no-op (no creature to grow).
+ * - [equipAbility] wires the Equip {2} sorcery-speed attach.
+ */
+val TarriansSoulcleaver = card("Tarrian's Soulcleaver") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Legendary Artifact — Equipment"
+    oracleText = "Equipped creature has vigilance.\n" +
+        "Whenever another artifact or creature is put into a graveyard from the battlefield, " +
+        "put a +1/+1 counter on equipped creature.\n" +
+        "Equip {2}"
+
+    staticAbility {
+        ability = GrantKeyword(Keyword.VIGILANCE, Filters.EquippedCreature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Artifact.or(GameObjectFilter.Creature),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.OTHER,
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.EquippedCreature)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "264"
+        artist = "Nereida"
+        flavorText = "Tarrian's holy weapon still holds a fragment of his dark power... and his hunger."
+        imageUri = "https://cards.scryfall.io/normal/front/9/9/99413817-1218-4947-b12f-9a952b095a89.jpg?1782694400"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TectonicHazard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TectonicHazard.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tectonic Hazard
+ * {R}
+ * Sorcery
+ * Tectonic Hazard deals 1 damage to each opponent and each creature they control.
+ */
+val TectonicHazard = card("Tectonic Hazard") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Tectonic Hazard deals 1 damage to each opponent and each creature they control."
+
+    spell {
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent))
+            .then(Patterns.Group.dealDamageToAll(1, GroupFilter(GameObjectFilter.Creature.opponentControls())))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "169"
+        artist = "Jarel Threat"
+        flavorText = "\"The ground is on fire, the ceiling's made of spears, and I think a mushroom tried to curse me. Don't tell me not to panic!\"\n—Jino Grag, Brazen Coalition scout"
+        imageUri = "https://cards.scryfall.io/normal/front/5/2/5204c781-f568-4c7f-b3f7-ce4dd678689b.jpg?1782694475"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TendrilOfTheMycotyrant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TendrilOfTheMycotyrant.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Tendril of the Mycotyrant
+ * {1}{G} — Creature — Fungus Wizard (Uncommon) — The Lost Caverns of Ixalan #215
+ * Artist: Maxime Minard
+ * 2/2
+ *
+ * {5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. It becomes
+ * a 0/0 Fungus creature with haste. It's still a land.
+ *
+ * Modeled as an activated ability targeting a noncreature land you control:
+ *   AddCountersEffect (seven +1/+1 counters) then BecomeCreatureEffect with base 0/0,
+ *   Fungus, haste, Duration.Permanent. No "until end of turn" appears on the card — the
+ *   land stays a creature unless it leaves the battlefield. The +1/+1 counters keep the
+ *   effectively 0/0 body alive (0+7 = 7/7 while counters remain). It's still a land, so
+ *   BecomeCreature adds the creature type/P-T without removing land types.
+ *
+ * Same "become a 0/0 creature with haste + N +1/+1 counters" animate shape as Cosmium
+ * Confluence's Cave mode (LCI #181), reusing AddCounters + permanent BecomeCreature.
+ */
+val TendrilOfTheMycotyrant = card("Tendril of the Mycotyrant") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Fungus Wizard"
+    oracleText = "{5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. " +
+        "It becomes a 0/0 Fungus creature with haste. It's still a land."
+    power = 2
+    toughness = 2
+
+    activatedAbility {
+        cost = Costs.Mana("{5}{G}{G}")
+        val land = target(
+            "target noncreature land you control",
+            TargetPermanent(filter = TargetFilter(GameObjectFilter.Land.notCreature().youControl()))
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 7, land) then
+            Effects.BecomeCreature(
+                target = land,
+                power = 0,
+                toughness = 0,
+                keywords = setOf(Keyword.HASTE),
+                creatureTypes = setOf("Fungus"),
+                duration = Duration.Permanent
+            )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Maxime Minard"
+        flavorText = "Every mycoid carries within itself the makings of an entire colony."
+        imageUri = "https://cards.scryfall.io/normal/front/a/f/afa464fe-978f-43de-ac35-79be4b12f0d9.jpg?1782694437"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TheBelligerent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TheBelligerent.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
+
+/**
+ * The Belligerent
+ * {2}{U}{R}
+ * Legendary Artifact — Vehicle
+ * 5/5
+ *
+ * Whenever The Belligerent attacks, create a Treasure token. Until end of turn, you may look at the
+ * top card of your library any time, and you may play lands and cast spells from the top of your
+ * library.
+ * Crew 3
+ *
+ * The attack trigger creates the Treasure token (a one-shot effect). The "until end of turn" play
+ * window is modeled as the Lunar Whale pattern: two conditional statics gated on
+ * [Conditions.SourceAttackedThisTurn], since "attacked this turn" is functionally "from when it
+ * attacks until end of turn". [LookAtTopOfLibrary] grants the non-revealing peek, and
+ * [PlayLandsAndCastFilteredFromTopOfLibrary] with an unrestricted [GameObjectFilter.Any] spell
+ * filter grants "play lands and cast spells from the top of your library" (any card type).
+ */
+val TheBelligerent = card("The Belligerent") {
+    manaCost = "{2}{U}{R}"
+    colorIdentity = "UR"
+    typeLine = "Legendary Artifact — Vehicle"
+    power = 5
+    toughness = 5
+    oracleText = "Whenever The Belligerent attacks, create a Treasure token. Until end of turn, you " +
+        "may look at the top card of your library any time, and you may play lands and cast spells " +
+        "from the top of your library.\n" +
+        "Crew 3"
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = Effects.CreateTreasure(1)
+    }
+
+    staticAbility {
+        condition = Conditions.SourceAttackedThisTurn
+        ability = LookAtTopOfLibrary
+    }
+
+    staticAbility {
+        condition = Conditions.SourceAttackedThisTurn
+        ability = PlayLandsAndCastFilteredFromTopOfLibrary(spellFilter = GameObjectFilter.Any)
+    }
+
+    keywordAbility(KeywordAbility.crew(3))
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "225"
+        artist = "Bruce Brenneise"
+        imageUri = "https://cards.scryfall.io/normal/front/1/4/1454af8c-bce9-47d3-890f-283e2fea2cf2.jpg?1782694429"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TheBelligerent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TheBelligerent.kt
@@ -23,8 +23,12 @@ import com.wingedsheep.sdk.scripting.PlayLandsAndCastFilteredFromTopOfLibrary
  *
  * The attack trigger creates the Treasure token (a one-shot effect). The "until end of turn" play
  * window is modeled as the Lunar Whale pattern: two conditional statics gated on
- * [Conditions.SourceAttackedThisTurn], since "attacked this turn" is functionally "from when it
- * attacks until end of turn". [LookAtTopOfLibrary] grants the non-revealing peek, and
+ * [Conditions.SourceAttackedThisTurn]. This approximates the printed card, which grants the
+ * permission as a one-shot effect of the trigger: (a) if The Belligerent leaves the battlefield
+ * after attacking (dies in combat, bounced), the real permission lasts until end of turn but the
+ * statics end with the permanent; (b) the window opens at attack declaration rather than trigger
+ * resolution. Fixing both needs an until-end-of-turn floating permission grant (add-feature
+ * territory). [LookAtTopOfLibrary] grants the non-revealing peek, and
  * [PlayLandsAndCastFilteredFromTopOfLibrary] with an unrestricted [GameObjectFilter.Any] spell
  * filter grants "play lands and cast spells from the top of your library" (any card type).
  */

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TheMycotyrant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TheMycotyrant.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * The Mycotyrant
+ * {1}{B}{G}
+ * Legendary Creature — Elder Fungus
+ * *|*
+ *
+ * Trample
+ * The Mycotyrant's power and toughness are each equal to the number of creatures you
+ * control that are Fungi and/or Saprolings.
+ * At the beginning of your end step, create X 1/1 black Fungus creature tokens with
+ * "This token can't block," where X is the number of times you descended this turn.
+ * (You descend each time a permanent card is put into your graveyard from anywhere.)
+ *
+ * Modeled from three existing primitives, no engine changes:
+ * - Trample via [Keyword.TRAMPLE].
+ * - The characteristic-defining P/T is a self-referential count via [dynamicStats] over
+ *   [DynamicAmount.AggregateBattlefield] — the same shape as Burrowguard Mentor / Scion of
+ *   the Wild, filtered to creatures you control that are Fungi and/or Saprolings with
+ *   [GameObjectFilter.withAnySubtype] (subtype Fungus OR Saproling under AND-with-creature).
+ * - The end-step trigger reuses the 1/1 black Fungus "can't block" token minted by
+ *   Broodrage Mycoid / Synapse Necromage. Here the token *count* is dynamic: X is the
+ *   descend COUNT (not the descend-4/8 boolean) via [DynamicAmounts.descendedThisTurn]
+ *   (CR 700.11), of which The Mycotyrant is the canonical user.
+ */
+val TheMycotyrant = card("The Mycotyrant") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Elder Fungus"
+    power = 0
+    toughness = 0
+    oracleText = "Trample\n" +
+        "The Mycotyrant's power and toughness are each equal to the number of creatures you control that are Fungi and/or Saprolings.\n" +
+        "At the beginning of your end step, create X 1/1 black Fungus creature tokens with \"This token can't block,\" where X is the number of times you descended this turn. " +
+        "(You descend each time a permanent card is put into your graveyard from anywhere.)"
+
+    keywords(Keyword.TRAMPLE)
+    dynamicStats(
+        DynamicAmount.AggregateBattlefield(
+            Player.You,
+            GameObjectFilter.Creature.withAnySubtype("Fungus", "Saproling")
+        )
+    )
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        effect = CreateTokenEffect(
+            count = DynamicAmounts.descendedThisTurn(),
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Fungus"),
+            staticAbilities = listOf(CantBlock(GroupFilter.source()))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.MYTHIC
+        collectorNumber = "235"
+        artist = "Chase Stone"
+        imageUri = "https://cards.scryfall.io/normal/front/c/a/caef93cc-70d0-4cce-9aaa-13c0931b2ef7.jpg?1782694423"
+        ruling("2023-11-10", "The Mycotyrant's last ability counts the number of times you descended this turn, not just whether you descended. Each permanent card put into your graveyard from anywhere this turn counts once.")
+        ruling("2023-11-10", "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, so a token being put into your graveyard doesn't count as you descending.")
+        ruling("2023-11-10", "The Mycotyrant's power and toughness are each equal to the number of creatures you control that are Fungi and/or Saprolings, including The Mycotyrant itself if it's a Fungus. This is a characteristic-defining ability and applies in all zones, though it's only relevant on the battlefield.")
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThousandMoonsCrackshot.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThousandMoonsCrackshot.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.PayManaCostEffect
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Thousand Moons Crackshot
+ * {1}{W}
+ * Creature — Human Soldier
+ * 2/2
+ *
+ * Whenever this creature attacks, you may pay {2}{W}. When you do, tap target creature.
+ *
+ * The attack trigger is a "When you do" reflexive: the optional {2}{W} payment is the action,
+ * and the reflexive ability — which targets a creature, chosen as it goes on the stack — only
+ * fires if the payment is made.
+ */
+val ThousandMoonsCrackshot = card("Thousand Moons Crackshot") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    oracleText = "Whenever this creature attacks, you may pay {2}{W}. When you do, tap target creature."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = ReflexiveTriggerEffect(
+            // "you may pay {2}{W}"
+            action = PayManaCostEffect(ManaCost.parse("{2}{W}")),
+            optional = true,
+            // "When you do, tap target creature."
+            reflexiveEffect = Effects.Tap(EffectTarget.ContextTarget(0)),
+            reflexiveTargetRequirements = listOf(Targets.Creature)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "37"
+        artist = "Marie Magny"
+        flavorText = "The Thousand Moons practice every maneuver thousands of times, allowing them " +
+            "to strike flawlessly without hesitation in the heat of battle."
+        imageUri = "https://cards.scryfall.io/normal/front/7/4/741a7439-965d-49f2-b43e-053f29196e6b.jpg?1782694581"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThousandMoonsInfantry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThousandMoonsInfantry.kt
@@ -1,0 +1,31 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.UntapSelfDuringOtherUntapSteps
+
+/**
+ * Thousand Moons Infantry
+ * {2}{W}
+ * Creature — Human Soldier
+ * Untap this creature during each other player's untap step.
+ */
+val ThousandMoonsInfantry = card("Thousand Moons Infantry") {
+    manaCost = "{2}{W}"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "Untap this creature during each other player's untap step."
+    power = 2
+    toughness = 4
+
+    staticAbility {
+        ability = UntapSelfDuringOtherUntapSteps
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "38"
+        artist = "Manuel Castañón"
+        flavorText = "The Thousand Moons train and fight in tight-knit squads of ten. Every tenth Moon functions as an officer, every hundredth as a captain, and the thousandth, Anim Pakal, as supreme commander."
+        imageUri = "https://cards.scryfall.io/normal/front/c/1/c1974a8c-3328-4ff5-9a00-cb79ebb8ccf6.jpg?1782694580"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThousandMoonsInfantry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThousandMoonsInfantry.kt
@@ -12,6 +12,7 @@ import com.wingedsheep.sdk.scripting.UntapSelfDuringOtherUntapSteps
  */
 val ThousandMoonsInfantry = card("Thousand Moons Infantry") {
     manaCost = "{2}{W}"
+    colorIdentity = "W"
     typeLine = "Creature — Human Soldier"
     oracleText = "Untap this creature during each other player's untap step."
     power = 2

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThreefoldThunderhulk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ThreefoldThunderhulk.kt
@@ -1,0 +1,97 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Threefold Thunderhulk — The Lost Caverns of Ixalan #265
+ * {7} · Artifact Creature — Gnome · Rare · 0/0
+ * Artist: Xavier Ribeiro
+ *
+ * This creature enters with three +1/+1 counters on it.
+ * Whenever this creature enters or attacks, create a number of 1/1 colorless Gnome artifact
+ *   creature tokens equal to its power.
+ * {2}, Sacrifice another artifact: Put a +1/+1 counter on this creature.
+ *
+ * Ability 1 — [EntersWithCounters] replacement effect (count = 3, selfOnly = true) applies the
+ *   three +1/+1 counters as the Thunderhulk enters; base P/T is 0/0, so it is a 3/3 on entry.
+ *   Default counter type is PlusOnePlusOne, so no counterType parameter is needed.
+ *
+ * Ability 2 — The "enters or attacks" idiom is modeled as two triggered abilities sharing the
+ *   same effect (the Queen's Bay Paladin / Anim Pakal split). Each creates
+ *   [DynamicAmounts.sourcePower] (= power of the source creature, evaluated at resolution) many
+ *   1/1 colorless Gnome artifact creature tokens: no color set, `artifactToken = true`,
+ *   `creatureTypes = setOf("Gnome")`. Reading the *source's* power at resolution means later
+ *   +1/+1 counters (from ability 3, or any other pump) increase the token count on future
+ *   triggers, matching the printed "equal to its power". No imageUri: the local LCI Scryfall
+ *   dump has no Gnome token entry (matching Anim Pakal).
+ *
+ * Ability 3 — [Costs.Composite] of [Costs.Mana] "{2}" and
+ *   [Costs.SacrificeAnother] over [GameObjectFilter.Artifact] (excludeSelf, so the Thunderhulk
+ *   cannot sacrifice itself), with [Effects.AddCounters] putting one +1/+1 counter on the
+ *   Thunderhulk ([EffectTarget.Self]).
+ */
+val ThreefoldThunderhulk = card("Threefold Thunderhulk") {
+    manaCost = "{7}"
+    typeLine = "Artifact Creature — Gnome"
+    power = 0
+    toughness = 0
+    oracleText = "This creature enters with three +1/+1 counters on it.\n" +
+        "Whenever this creature enters or attacks, create a number of 1/1 colorless Gnome " +
+        "artifact creature tokens equal to its power.\n" +
+        "{2}, Sacrifice another artifact: Put a +1/+1 counter on this creature."
+
+    // This creature enters with three +1/+1 counters on it.
+    replacementEffect(EntersWithCounters(count = 3, selfOnly = true))
+
+    // Whenever this creature enters, create tokens equal to its power.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = CreateTokenEffect(
+            count = DynamicAmounts.sourcePower(),
+            power = 1,
+            toughness = 1,
+            colors = emptySet(),
+            creatureTypes = setOf("Gnome"),
+            artifactToken = true
+        )
+    }
+
+    // Whenever this creature attacks, create tokens equal to its power.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = CreateTokenEffect(
+            count = DynamicAmounts.sourcePower(),
+            power = 1,
+            toughness = 1,
+            colors = emptySet(),
+            creatureTypes = setOf("Gnome"),
+            artifactToken = true
+        )
+    }
+
+    // {2}, Sacrifice another artifact: Put a +1/+1 counter on this creature.
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}"),
+            Costs.SacrificeAnother(GameObjectFilter.Artifact)
+        )
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "265"
+        artist = "Xavier Ribeiro"
+        imageUri = "https://cards.scryfall.io/normal/front/1/9/1917c62f-d463-43eb-87ad-89ffbc88b6fe.jpg?1782694400"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -11451,6 +11451,54 @@
     ]
 }
 
+// Sunshot Militia
+{
+    "name": "Sunshot Militia",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Tap two untapped artifacts and/or creatures you control: This creature deals 1 damage to each opponent. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomTapPermanents",
+                        "count": 2,
+                        "filter": "artifact|creature"
+                    }
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Torgeir Fjereide",
+        "flavorText": "As the Legion of Dusk closed in, Oltec citizens rallied to support the Thousand Moons and drive off the invaders.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3114f5c-21e9-43c3-abe3-3cf1da20916f.jpg?1782694475"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Swashbuckler's Whip
 {
     "name": "Swashbuckler's Whip",
@@ -11565,6 +11613,273 @@
         "imageUri": "https://cards.scryfall.io/normal/front/2/4/24a85c52-e5b5-4d65-931c-eacc0cf0fb31.jpg?1782694401"
     },
     "colorIdentityOverride": []
+}
+
+// Synapse Necromage
+{
+    "name": "Synapse Necromage",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Fungus Wizard",
+    "oracleText": "When this creature dies, create two 1/1 black Fungus creature tokens with \"This token can't block.\"",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Fungus"
+                    ],
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "rarity": "UNCOMMON",
+        "artist": "Piotr Foksowicz",
+        "flavorText": "\"It's no good killing them? Then what do we do? Distract them with a tea party?\"\n—Mervin, Brazen Coalition prospector",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/f/efeb22a4-37bf-487a-9cf4-74de4cbbc0a3.jpg?1782694510"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Tarrian's Soulcleaver
+{
+    "name": "Tarrian's Soulcleaver",
+    "manaCost": "{1}",
+    "typeLine": "Legendary Artifact — Equipment",
+    "oracleText": "Equipped creature has vigilance.\nWhenever another artifact or creature is put into a graveyard from the battlefield, put a +1/+1 counter on equipped creature.\nEquip {2}",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "artifact|creature",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "EquippedCreature"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantKeyword",
+                "keyword": "VIGILANCE"
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "264",
+        "rarity": "RARE",
+        "artist": "Nereida",
+        "flavorText": "Tarrian's holy weapon still holds a fragment of his dark power... and his hunger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/9/99413817-1218-4947-b12f-9a952b095a89.jpg?1782694400"
+    },
+    "colorIdentityOverride": []
+}
+
+// Tectonic Hazard
+{
+    "name": "Tectonic Hazard",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Tectonic Hazard deals 1 damage to each opponent and each creature they control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "169",
+        "artist": "Jarel Threat",
+        "flavorText": "\"The ground is on fire, the ceiling's made of spears, and I think a mushroom tried to curse me. Don't tell me not to panic!\"\n—Jino Grag, Brazen Coalition scout",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/2/5204c781-f568-4c7f-b3f7-ce4dd678689b.jpg?1782694475"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Tendril of the Mycotyrant
+{
+    "name": "Tendril of the Mycotyrant",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Fungus Wizard",
+    "oracleText": "{5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. It becomes a 0/0 Fungus creature with haste. It's still a land.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{5}{G}{G}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "AddCounters",
+                            "counterType": "+1/+1",
+                            "count": 7,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target noncreature land you control"
+                            }
+                        },
+                        {
+                            "type": "BecomeCreature",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target noncreature land you control"
+                            },
+                            "power": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "toughness": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "keywords": [
+                                "HASTE"
+                            ],
+                            "creatureTypes": [
+                                "Fungus"
+                            ],
+                            "duration": "Permanent"
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsLand",
+                                    {
+                                        "type": "Not",
+                                        "predicate": "IsCreature"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "target noncreature land you control"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Maxime Minard",
+        "flavorText": "Every mycoid carries within itself the makings of an entire colony.",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/f/afa464fe-978f-43de-ac35-79be4b12f0d9.jpg?1782694437"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
 }
 
 // Terror Tide

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -11935,6 +11935,340 @@
     ]
 }
 
+// The Belligerent
+{
+    "name": "The Belligerent",
+    "manaCost": "{2}{U}{R}",
+    "typeLine": "Legendary Artifact — Vehicle",
+    "oracleText": "Whenever The Belligerent attacks, create a Treasure token. Until end of turn, you may look at the top card of your library any time, and you may play lands and cast spells from the top of your library.\nCrew 3",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 5
+    },
+    "keywords": [
+        "CREW"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Numeric",
+            "keyword": "CREW",
+            "n": 3
+        }
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Treasure"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": "LookAtTopOfLibrary",
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "AttackedThisTurn"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "PlayLandsAndCastFilteredFromTopOfLibrary",
+                    "spellFilter": {}
+                },
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            "AttackedThisTurn"
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "225",
+        "rarity": "RARE",
+        "artist": "Bruce Brenneise",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/4/1454af8c-bce9-47d3-890f-283e2fea2cf2.jpg?1782694429"
+    },
+    "colorIdentityOverride": [
+        "BLUE",
+        "RED"
+    ]
+}
+
+// The Mycotyrant
+{
+    "name": "The Mycotyrant",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Legendary Creature — Elder Fungus",
+    "oracleText": "Trample\nThe Mycotyrant's power and toughness are each equal to the number of creatures you control that are Fungi and/or Saprolings.\nAt the beginning of your end step, create X 1/1 black Fungus creature tokens with \"This token can't block,\" where X is the number of times you descended this turn. (You descend each time a permanent card is put into your graveyard from anywhere.)",
+    "creatureStats": {
+        "power": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature Fungus|Saproling"
+            }
+        },
+        "toughness": {
+            "type": "Dynamic",
+            "source": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature Fungus|Saproling"
+            }
+        }
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "DESCENDED"
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Fungus"
+                    ],
+                    "staticAbilities": [
+                        "CantBlock"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "235",
+        "rarity": "MYTHIC",
+        "artist": "Chase Stone",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/a/caef93cc-70d0-4cce-9aaa-13c0931b2ef7.jpg?1782694423",
+        "rulings": [
+            {
+                "date": "2023-11-10",
+                "text": "The Mycotyrant's last ability counts the number of times you descended this turn, not just whether you descended. Each permanent card put into your graveyard from anywhere this turn counts once."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "A permanent card is an artifact, battle, creature, enchantment, land, or planeswalker card. Tokens are not cards, so a token being put into your graveyard doesn't count as you descending."
+            },
+            {
+                "date": "2023-11-10",
+                "text": "The Mycotyrant's power and toughness are each equal to the number of creatures you control that are Fungi and/or Saprolings, including The Mycotyrant itself if it's a Fungus. This is a characteristic-defining ability and applies in all zones, though it's only relevant on the battlefield."
+            }
+        ]
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
+// Thousand Moons Crackshot
+{
+    "name": "Thousand Moons Crackshot",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever this creature attacks, you may pay {2}{W}. When you do, tap target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "PayManaCost",
+                        "cost": "{2}{W}"
+                    },
+                    "reflexiveEffect": {
+                        "type": "TapUntap",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "37",
+        "artist": "Marie Magny",
+        "flavorText": "The Thousand Moons practice every maneuver thousands of times, allowing them to strike flawlessly without hesitation in the heat of battle.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/4/741a7439-965d-49f2-b43e-053f29196e6b.jpg?1782694581"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Thousand Moons Infantry
+{
+    "name": "Thousand Moons Infantry",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Untap this creature during each other player's untap step.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "script": {
+        "staticAbilities": [
+            "UntapSelfDuringOtherUntapSteps"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "38",
+        "artist": "Manuel Castañón",
+        "flavorText": "The Thousand Moons train and fight in tight-knit squads of ten. Every tenth Moon functions as an officer, every hundredth as a captain, and the thousandth, Anim Pakal, as supreme commander.",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1974a8c-3328-4ff5-9a00-cb79ebb8ccf6.jpg?1782694580"
+    }
+}
+
+// Threefold Thunderhulk
+{
+    "name": "Threefold Thunderhulk",
+    "manaCost": "{7}",
+    "typeLine": "Artifact Creature — Gnome",
+    "oracleText": "This creature enters with three +1/+1 counters on it.\nWhenever this creature enters or attacks, create a number of 1/1 colorless Gnome artifact creature tokens equal to its power.\n{2}, Sacrifice another artifact: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 0,
+        "toughness": 0
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Gnome"
+                    ],
+                    "artifactToken": true
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [],
+                    "creatureTypes": [
+                        "Gnome"
+                    ],
+                    "artifactToken": true
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_3",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact",
+                                "excludeSelf": true
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 3,
+                "selfOnly": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "265",
+        "rarity": "RARE",
+        "artist": "Xavier Ribeiro",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/9/1917c62f-d463-43eb-87ad-89ffbc88b6fe.jpg?1782694400"
+    }
+}
+
 // Trumpeting Carnosaur
 {
     "name": "Trumpeting Carnosaur",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -12165,7 +12165,10 @@
         "artist": "Manuel Castañón",
         "flavorText": "The Thousand Moons train and fight in tight-knit squads of ten. Every tenth Moon functions as an officer, every hundredth as a captain, and the thousandth, Anim Pakal, as supreme commander.",
         "imageUri": "https://cards.scryfall.io/normal/front/c/1/c1974a8c-3328-4ff5-9a00-cb79ebb8ccf6.jpg?1782694580"
-    }
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
 }
 
 // Threefold Thunderhulk

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -757,6 +757,14 @@ class TriggerMatcher(
 
         // Check filter
         if (trigger.filter != GameObjectFilter.Any) {
+            // A heterogeneous OR union (`Artifact or Creature.tapped()`) carries its branches in
+            // anyOf, each a complete filter — match if any branch matches. (A homogeneous OR
+            // instead collapses to a single CardPredicate.Or handled below.)
+            if (trigger.filter.anyOf.isNotEmpty()) {
+                return trigger.filter.anyOf.any { branch ->
+                    matchesZoneChangeTrigger(trigger.copy(filter = branch), binding, event, sourceId, controllerId, state)
+                }
+            }
             val projected = state.projectedState
             // Check card predicates (creature type, subtype, etc.)
             // Note: entity may not exist in state if it was a token cleaned up by SBAs.
@@ -774,13 +782,17 @@ class TriggerMatcher(
             }
             val isFaceDown = entity?.has<FaceDownComponent>() == true
 
-            for (predicate in trigger.filter.cardPredicates) {
-                when (predicate) {
+            // LKI-aware predicate evaluation. Composites (Or/And/Not — e.g. the collapsed
+            // `Artifact or Creature` union on Tarrian's Soulcleaver) must recurse through THIS
+            // function, not fall through to the live-entity path: a token is swept by 704.5d
+            // before the matcher runs, so the generic cardComponent-based path returns false for
+            // every predicate inside the composite and the trigger silently misses token deaths.
+            fun matchesLkiPredicate(predicate: com.wingedsheep.sdk.scripting.predicates.CardPredicate): Boolean {
+                return when (predicate) {
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsCreature -> {
                         // For dying creatures: use base state (they're already in graveyard)
                         // Face-down permanents are 2/2 creatures (Rule 708.2) and count.
-                        val isCreature = isFaceDown || typeLine?.isCreature == true
-                        if (!isCreature) return false
+                        isFaceDown || typeLine?.isCreature == true
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsPermanent -> {
                         // LKI-safe permanent check. Anything that left the battlefield was, by
@@ -790,27 +802,21 @@ class TriggerMatcher(
                         // (captured on the event, like IsCreature/IsLand above) instead. Without this,
                         // "whenever another permanent you control leaves the battlefield" (Suki,
                         // Courageous Rescuer) silently misses a leaving token.
-                        val isPermanent = isFaceDown || typeLine?.isPermanent == true
-                        if (!isPermanent) return false
+                        isFaceDown || typeLine?.isPermanent == true
                     }
-                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLand -> {
-                        if (typeLine?.isLand != true) return false
-                    }
-                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact -> {
-                        if (typeLine?.isArtifact != true) return false
-                    }
-                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsEnchantment -> {
-                        if (typeLine?.isEnchantment != true) return false
-                    }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsLand ->
+                        typeLine?.isLand == true
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsArtifact ->
+                        typeLine?.isArtifact == true
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsEnchantment ->
+                        typeLine?.isEnchantment == true
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasSubtype -> {
                         // For entering creatures: use projected state (they're on battlefield)
                         // For dying creatures: use base state (they're in graveyard, no projected subtypes)
                         if (event.toZone == Zone.BATTLEFIELD) {
-                            if (!projected.hasSubtype(event.entityId, predicate.subtype.value)) return false
+                            projected.hasSubtype(event.entityId, predicate.subtype.value)
                         } else {
-                            if (isFaceDown) return false
-                            if (typeLine == null) return false
-                            if (!typeLine.hasSubtype(predicate.subtype)) return false
+                            !isFaceDown && typeLine?.hasSubtype(predicate.subtype) == true
                         }
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasAnyOfSubtypes -> {
@@ -819,11 +825,9 @@ class TriggerMatcher(
                         // the entity (and its CardComponent) may already be gone, so read the
                         // last-known type line rather than the generic cardComponent path.
                         if (event.toZone == Zone.BATTLEFIELD) {
-                            if (predicate.subtypes.none { projected.hasSubtype(event.entityId, it.value) }) return false
+                            predicate.subtypes.any { projected.hasSubtype(event.entityId, it.value) }
                         } else {
-                            if (isFaceDown) return false
-                            if (typeLine == null) return false
-                            if (predicate.subtypes.none { typeLine.hasSubtype(it) }) return false
+                            !isFaceDown && typeLine != null && predicate.subtypes.any { typeLine.hasSubtype(it) }
                         }
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasKeyword -> {
@@ -833,9 +837,9 @@ class TriggerMatcher(
                         // have its keywords (e.g., Jackdaw Savior: "whenever a creature you control
                         // with flying dies").
                         if (event.fromZone == Zone.BATTLEFIELD && event.lastKnown?.keywords?.isNotEmpty() == true) {
-                            if (predicate.keyword.name !in (event.lastKnown?.keywords ?: emptySet())) return false
+                            predicate.keyword.name in (event.lastKnown?.keywords ?: emptySet())
                         } else {
-                            if (!projected.hasKeyword(event.entityId, predicate.keyword)) return false
+                            projected.hasKeyword(event.entityId, predicate.keyword)
                         }
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.HasChosenSubtype -> {
@@ -852,7 +856,7 @@ class TriggerMatcher(
                         val isChangelingCreatureType = cardComponent != null &&
                             Keyword.CHANGELING in cardComponent.baseKeywords &&
                             chosenType in Subtype.ALL_CREATURE_TYPES
-                        if (!hasSubtype && !isChangelingCreatureType) return false
+                        hasSubtype || isChangelingCreatureType
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsNontoken -> {
                         // Token-ness is intrinsic; LKI is required because 704.5d sweeps the
@@ -865,27 +869,36 @@ class TriggerMatcher(
                         } else {
                             entity?.has<com.wingedsheep.engine.state.components.identity.TokenComponent>() == true
                         }
-                        if (isToken) return false
+                        !isToken
                     }
                     is com.wingedsheep.sdk.scripting.predicates.CardPredicate.IsToken -> {
-                        val isToken = if (event.fromZone == Zone.BATTLEFIELD) {
+                        if (event.fromZone == Zone.BATTLEFIELD) {
                             event.lastKnown?.wasToken == true
                         } else {
                             entity?.has<com.wingedsheep.engine.state.components.identity.TokenComponent>() == true
                         }
-                        if (!isToken) return false
                     }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.Or ->
+                        predicate.predicates.any { matchesLkiPredicate(it) }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.And ->
+                        predicate.predicates.all { matchesLkiPredicate(it) }
+                    is com.wingedsheep.sdk.scripting.predicates.CardPredicate.Not ->
+                        !matchesLkiPredicate(predicate.predicate)
                     else -> {
                         // For other predicates, check the entity's type
                         if (cardComponent == null) return false
-                        if (!matchesCardPredicate(
-                                predicate, cardComponent, projected, event.entityId, isFaceDown,
-                                lastKnownPower = event.lastKnown?.power,
-                                lastKnownToughness = event.lastKnown?.toughness,
-                                lastKnownWasToken = event.lastKnown?.wasToken == true
-                            )) return false
+                        matchesCardPredicate(
+                            predicate, cardComponent, projected, event.entityId, isFaceDown,
+                            lastKnownPower = event.lastKnown?.power,
+                            lastKnownToughness = event.lastKnown?.toughness,
+                            lastKnownWasToken = event.lastKnown?.wasToken == true
+                        )
                     }
                 }
+            }
+
+            for (predicate in trigger.filter.cardPredicates) {
+                if (!matchesLkiPredicate(predicate)) return false
             }
             // Check state predicates (face-down, tapped, etc.)
             for (predicate in trigger.filter.statePredicates) {

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/cost/CostPaymentService.kt
@@ -127,7 +127,7 @@ class CostPaymentService(private val services: EngineServices) {
                 is CostAtom.ReturnToHand ->
                     selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledMatching(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
                 is CostAtom.TapPermanents ->
-                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, atom.filter, sourceId), atom.count, useTargetingUI = true)
+                    selectionPrompt(state, payerId, resolved, sourceId, sourceName, ctx, controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null), atom.count, useTargetingUI = true)
             }
         }
     }
@@ -476,7 +476,7 @@ class CostPaymentService(private val services: EngineServices) {
                         else candidates.size >= atom.count
                     }
                     is CostAtom.ReturnToHand -> controlledMatching(state, payerId, atom.filter, sourceId).size >= atom.count
-                    is CostAtom.TapPermanents -> controlledUntapped(state, payerId, atom.filter, sourceId).size >= atom.count
+                    is CostAtom.TapPermanents -> controlledUntapped(state, payerId, atom.filter, if (atom.excludeSelf) sourceId else null).size >= atom.count
                 }
             }
         }
@@ -520,9 +520,10 @@ class CostPaymentService(private val services: EngineServices) {
                 state, filter.youControl(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
             )
 
-        fun controlledUntapped(state: GameState, playerId: EntityId, filter: GameObjectFilter, sourceId: EntityId): List<EntityId> =
+        /** [excludeSelfId] only for costs that say "another" — a plain "tap two untapped …" may tap the source itself. */
+        fun controlledUntapped(state: GameState, playerId: EntityId, filter: GameObjectFilter, excludeSelfId: EntityId?): List<EntityId> =
             BattlefieldFilterUtils.findMatchingOnBattlefield(
-                state, filter.youControl().untapped(), PredicateContext(controllerId = playerId), excludeSelfId = sourceId
+                state, filter.youControl().untapped(), PredicateContext(controllerId = playerId), excludeSelfId = excludeSelfId
             )
 
         /** Number of distinct card names among [candidates] — for "with different names" costs. */

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/ActiveFloatingEffect.kt
@@ -8,6 +8,7 @@ import com.wingedsheep.sdk.scripting.effects.RedirectScope
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -132,11 +133,15 @@ sealed interface SerializableModification {
     @Serializable
     data class AddColor(val colors: Set<String>) : SerializableModification
 
+    // The JSON field must not be named "type": the game-server persistence Json uses
+    // classDiscriminator = "type", and kotlinx.serialization refuses to encode a polymorphic
+    // class whose own property collides with the discriminator (JsonEncodingException the
+    // first time a BecomeCreature/AddCardType floating effect is saved).
     @Serializable
-    data class AddType(val type: String) : SerializableModification
+    data class AddType(@SerialName("cardType") val type: String) : SerializableModification
 
     @Serializable
-    data class RemoveType(val type: String) : SerializableModification
+    data class RemoveType(@SerialName("cardType") val type: String) : SerializableModification
 
     @Serializable
     data class ChangeController(val newControllerId: EntityId) : SerializableModification

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -421,66 +421,78 @@ class ClientStateTransformer(
     }
 
     /**
+     * Resolve a static ability that may be gated by a [ConditionalStaticAbility] (e.g. The
+     * Belligerent's play-from-top window, a [LookAtTopOfLibrary] gated on "attacked this turn").
+     * Unconditional abilities pass through unchanged; a conditional one resolves to its inner
+     * ability only while its condition currently holds for the granting permanent, and to null
+     * otherwise. Mirrors `CastPermissionUtils.activeStaticAbility` so that what a player can SEE
+     * stays in sync with what the legal-actions layer lets them DO.
+     */
+    private fun activeStaticAbility(
+        state: GameState,
+        ability: com.wingedsheep.sdk.scripting.StaticAbility,
+        sourceId: EntityId,
+        controllerId: EntityId
+    ): com.wingedsheep.sdk.scripting.StaticAbility? = when (ability) {
+        is ConditionalStaticAbility -> {
+            val context = EffectContext(sourceId = sourceId, controllerId = controllerId)
+            if (conditionEvaluator.evaluate(state, ability.condition, context)) ability.ability else null
+        }
+        else -> ability
+    }
+
+    /**
+     * Check whether any static ability active on [playerId]'s battlefield satisfies [predicate],
+     * honoring [ConditionalStaticAbility] gates via [activeStaticAbility].
+     */
+    private fun hasActiveStaticAbility(
+        state: GameState,
+        playerId: EntityId,
+        predicate: (com.wingedsheep.sdk.scripting.StaticAbility) -> Boolean
+    ): Boolean {
+        for (entityId in state.getBattlefield(playerId)) {
+            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
+            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
+            if (cardDef.script.staticAbilities.any { ability ->
+                    activeStaticAbility(state, ability, entityId, playerId)?.let(predicate) == true
+                }
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
      * Check if a player controls a permanent that reveals the top card of their library to all
      * players — either [PlayFromTopOfLibrary] (Future Sight) or [RevealTopOfLibrary] (Goblin Spy).
      * The two abilities share the public-reveal visibility; they diverge only in play permission,
      * which is handled by the cast/play-from-top paths (keyed on [PlayFromTopOfLibrary] alone).
      */
-    private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean {
-        for (entityId in state.getBattlefield(playerId)) {
-            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
-            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.any { it is PlayFromTopOfLibrary || it is RevealTopOfLibrary }) {
-                return true
-            }
-        }
-        return false
-    }
+    private fun revealsTopOfLibraryPublicly(state: GameState, playerId: EntityId): Boolean =
+        hasActiveStaticAbility(state, playerId) { it is PlayFromTopOfLibrary || it is RevealTopOfLibrary }
 
     /**
      * Check if [playerId] controls a permanent with [OpponentsPlayWithHandsRevealed]
      * (e.g., Seer's Vision). While they do, their opponents' hands are visible to them.
      */
-    private fun revealsOpponentHandsTo(state: GameState, playerId: EntityId): Boolean {
-        for (entityId in state.getBattlefield(playerId)) {
-            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
-            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.any { it is OpponentsPlayWithHandsRevealed }) {
-                return true
-            }
-        }
-        return false
-    }
+    private fun revealsOpponentHandsTo(state: GameState, playerId: EntityId): Boolean =
+        hasActiveStaticAbility(state, playerId) { it is OpponentsPlayWithHandsRevealed }
 
     /**
-     * Check if a player controls a permanent with LookAtTopOfLibrary (e.g., Lens of Clarity).
+     * Check if a player controls a permanent with an active LookAtTopOfLibrary (e.g., Lens of
+     * Clarity; The Belligerent's is gated behind "attacked this turn").
      * This reveals the top card of the controller's library privately (only to them).
      */
-    private fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean {
-        for (entityId in state.getBattlefield(playerId)) {
-            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
-            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.any { it is LookAtTopOfLibrary }) {
-                return true
-            }
-        }
-        return false
-    }
+    private fun hasLookAtTopOfLibrary(state: GameState, playerId: EntityId): Boolean =
+        hasActiveStaticAbility(state, playerId) { it is LookAtTopOfLibrary }
 
     /**
      * Check if a player controls a permanent with LookAtFaceDownCreatures (e.g., Lens of Clarity).
      * This reveals the identity of opponent's face-down battlefield creatures to the controller.
      */
-    private fun hasLookAtFaceDownCreatures(state: GameState, playerId: EntityId): Boolean {
-        for (entityId in state.getBattlefield(playerId)) {
-            val card = state.getEntity(entityId)?.get<CardComponent>() ?: continue
-            val cardDef = cardRegistry.getCard(card.cardDefinitionId) ?: continue
-            if (cardDef.script.staticAbilities.any { it is LookAtFaceDownCreatures }) {
-                return true
-            }
-        }
-        return false
-    }
+    private fun hasLookAtFaceDownCreatures(state: GameState, playerId: EntityId): Boolean =
+        hasActiveStaticAbility(state, playerId) { it is LookAtFaceDownCreatures }
 
     /**
      * Check if an individual card has been revealed to a specific player.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/FloatingEffectSerializationRoundTripTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/hygiene/FloatingEffectSerializationRoundTripTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.hygiene
+
+import com.wingedsheep.engine.core.engineSerializersModule
+import com.wingedsheep.engine.mechanics.layers.ActiveFloatingEffect
+import com.wingedsheep.engine.mechanics.layers.FloatingEffectData
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import kotlin.reflect.KClass
+import kotlin.reflect.full.createType
+
+/**
+ * Guards GameState persistence against the JSON class-discriminator collision: the game
+ * server's `persistenceJson` (and kotlinx's default) uses `classDiscriminator = "type"`, and
+ * kotlinx.serialization throws [kotlinx.serialization.json.JsonEncodingException] the moment a
+ * polymorphic leaf whose own JSON field is named "type" is encoded.
+ *
+ * The bug this pins: `SerializableModification.AddType(val type: String)` crashed
+ * `RedisGameRepository.save` the first time a permanent animation (Tendril of the Mycotyrant's
+ * `BecomeCreature` → `AddType("CREATURE")` floating effect) was in the saved state. The
+ * property is now `@SerialName("cardType")`; this test fails on any future leaf that
+ * reintroduces a colliding field, at test time instead of mid-game.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class FloatingEffectSerializationRoundTripTest : FunSpec({
+
+    // Same discriminator the game server's persistenceJson uses (also kotlinx's default).
+    val json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        classDiscriminator = "type"
+        allowStructuredMapKeys = true
+        serializersModule = engineSerializersModule
+    }
+
+    fun sealedLeaves(klass: KClass<*>): List<KClass<*>> =
+        klass.sealedSubclasses.flatMap { sub ->
+            if (sub.sealedSubclasses.isEmpty()) listOf(sub) else sealedLeaves(sub)
+        }
+
+    test("no SerializableModification leaf has a JSON field colliding with the 'type' class discriminator") {
+        val leaves = sealedLeaves(SerializableModification::class)
+        leaves.isNotEmpty() shouldBe true
+        leaves.forEach { leaf ->
+            val descriptor = serializer(leaf.createType()).descriptor
+            val fieldNames = (0 until descriptor.elementsCount).map { descriptor.getElementName(it) }
+            withClue("${leaf.simpleName} would throw JsonEncodingException on save — rename the field with @SerialName") {
+                fieldNames shouldNotContain "type"
+            }
+        }
+    }
+
+    test("an ActiveFloatingEffect carrying AddType round-trips through persistence-shaped JSON") {
+        val effect = ActiveFloatingEffect(
+            id = EntityId("floating-1"),
+            effect = FloatingEffectData(
+                layer = Layer.TYPE,
+                modification = SerializableModification.AddType("CREATURE"),
+                affectedEntities = setOf(EntityId("land-1"))
+            ),
+            duration = Duration.Permanent,
+            sourceId = EntityId("tendril-1"),
+            sourceName = "Tendril of the Mycotyrant",
+            controllerId = EntityId("player-1"),
+            timestamp = 42L
+        )
+        val encoded = json.encodeToString(ActiveFloatingEffect.serializer(), effect)
+        json.decodeFromString(ActiveFloatingEffect.serializer(), encoded) shouldBe effect
+    }
+
+    test("an ActiveFloatingEffect carrying RemoveType round-trips through persistence-shaped JSON") {
+        val effect = ActiveFloatingEffect(
+            id = EntityId("floating-2"),
+            effect = FloatingEffectData(
+                layer = Layer.TYPE,
+                modification = SerializableModification.RemoveType("CREATURE"),
+                affectedEntities = setOf(EntityId("perm-1"))
+            ),
+            duration = Duration.Permanent,
+            sourceId = null,
+            controllerId = EntityId("player-1"),
+            timestamp = 43L
+        )
+        val encoded = json.encodeToString(ActiveFloatingEffect.serializer(), effect)
+        json.decodeFromString(ActiveFloatingEffect.serializer(), encoded) shouldBe effect
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CostPaymentServiceTest.kt
@@ -340,14 +340,26 @@ class CostPaymentServiceTest : ScenarioTestBase() {
             game.state.getEntity(fodder)!!.has<TappedComponent>().shouldBeTrue()
         }
 
-        test("Tap: unaffordable when the only other permanent is already tapped") {
+        test("Tap: unaffordable when every permanent, including the source, is already tapped") {
+            val game = scenario().withPlayers()
+                .withCardOnBattlefield(1, "Goblin Guide", tapped = true)
+                .withCardOnBattlefield(1, "Savannah Lions", tapped = true)
+                .build()
+            val service = CostPaymentService(EngineServices(cardRegistry))
+            val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
+            service.canAfford(game.state, game.player1Id, Costs.pay.Tap(GameObjectFilter.Any, 1), source).shouldBeFalse()
+        }
+
+        test("Tap: the source itself is an eligible candidate when the cost doesn't say 'another'") {
+            // "Tap an untapped permanent you control" (Command Bridge, Sunshot Militia's cost
+            // shape) has no "other" — the untapped source may pay its own cost.
             val game = scenario().withPlayers()
                 .withCardOnBattlefield(1, "Goblin Guide")
                 .withCardOnBattlefield(1, "Savannah Lions", tapped = true)
                 .build()
             val service = CostPaymentService(EngineServices(cardRegistry))
             val source = bfCardByName(game.state, game.player1Id, "Goblin Guide")
-            service.canAfford(game.state, game.player1Id, Costs.pay.Tap(GameObjectFilter.Any, 1), source).shouldBeFalse()
+            service.canAfford(game.state, game.player1Id, Costs.pay.Tap(GameObjectFilter.Any, 1), source).shouldBeTrue()
         }
 
         // -----------------------------------------------------------------------------------------

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SunshotMilitiaScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SunshotMilitiaScenarioTest.kt
@@ -1,0 +1,141 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SunshotMilitia
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Sunshot Militia (LCI #168).
+ *
+ * Sunshot Militia {1}{R}
+ * Creature — Human Soldier 1/3
+ * Tap two untapped artifacts and/or creatures you control: This creature deals 1 damage to each
+ * opponent. Activate only as a sorcery.
+ *
+ * Covers:
+ *  - Happy path: tapping two creatures deals 1 damage to the opponent and taps both permanents.
+ *  - Self-tap: the Militia itself may be one of the two (its cost has no "other").
+ *  - Sorcery-speed gate: activation is rejected outside a main phase with an empty stack.
+ *  - Cost gate: activation is rejected without two matching untapped permanents.
+ */
+class SunshotMilitiaScenarioTest : FunSpec({
+
+    val abilityId = SunshotMilitia.activatedAbilities.first().id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SunshotMilitia))
+        return driver
+    }
+
+    test("tapping two creatures deals 1 damage to each opponent") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val militia = driver.putCreatureOnBattlefield(activePlayer, "Sunshot Militia")
+        driver.removeSummoningSickness(militia)
+        val bear1 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+        val bear2 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear2)
+
+        driver.getLifeTotal(opponent) shouldBe 20
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = militia,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1, bear2))
+            )
+        )
+        driver.bothPass() // resolve the ability
+
+        driver.isTapped(bear1) shouldBe true
+        driver.isTapped(bear2) shouldBe true
+        driver.getLifeTotal(opponent) shouldBe 19
+    }
+
+    test("the Militia itself may be one of the two tapped permanents (no \"other\" in the cost)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val militia = driver.putCreatureOnBattlefield(activePlayer, "Sunshot Militia")
+        driver.removeSummoningSickness(militia)
+        val bear = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = militia,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(militia, bear))
+            )
+        )
+        driver.bothPass() // resolve the ability
+
+        driver.isTapped(militia) shouldBe true
+        driver.isTapped(bear) shouldBe true
+        driver.getLifeTotal(opponent) shouldBe 19
+    }
+
+    test("cannot be activated at instant speed (sorcery-speed gate)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+
+        val militia = driver.putCreatureOnBattlefield(activePlayer, "Sunshot Militia")
+        driver.removeSummoningSickness(militia)
+        val bear1 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear1)
+        val bear2 = driver.putCreatureOnBattlefield(activePlayer, "Grizzly Bears")
+        driver.removeSummoningSickness(bear2)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = militia,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(bear1, bear2))
+            )
+        )
+    }
+
+    test("cannot be activated without two matching untapped permanents") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val activePlayer = driver.activePlayer!!
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val militia = driver.putCreatureOnBattlefield(activePlayer, "Sunshot Militia")
+        driver.removeSummoningSickness(militia)
+        // Only Sunshot Militia itself is untapped — cost requires two matching permanents.
+
+        driver.submitExpectFailure(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = militia,
+                abilityId = abilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(militia))
+            )
+        )
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SynapseNecromageScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SynapseNecromageScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SynapseNecromage
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Synapse Necromage (LCI #125): {2}{B} 3/1 Fungus Wizard
+ *
+ * "When this creature dies, create two 1/1 black Fungus creature tokens with
+ * 'This token can't block.'"
+ *
+ * Tests:
+ * 1. When Synapse Necromage dies, exactly two 1/1 black Fungus tokens are created,
+ *    each with the "can't block" static ability.
+ */
+class SynapseNecromageScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(SynapseNecromage))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    fun GameTestDriver.fungusTokens(playerId: EntityId): List<EntityId> =
+        getCreatures(playerId).filter { getCardName(it) == "Fungus Token" }
+
+    test("dying Synapse Necromage creates two 1/1 black Fungus can't-block tokens") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val necromage = driver.putCreatureOnBattlefield(player, "Synapse Necromage")
+        val tokensBefore = driver.fungusTokens(player).size
+
+        // Kill the 3/1 Necromage with a Lightning Bolt so it dies through the real
+        // damage/SBA path → the dies trigger is detected and queued.
+        driver.giveMana(player, Color.RED, 1)
+        val bolt = driver.putCardInHand(player, "Lightning Bolt")
+        driver.castSpellWithTargets(player, bolt, listOf(ChosenTarget.Permanent(necromage)))
+        driver.bothPass() // resolve the bolt -> Necromage dies, queuing its dies trigger
+        driver.bothPass() // resolve the dies trigger -> creates the two Fungus tokens
+
+        val tokensAfter = driver.fungusTokens(player)
+        tokensAfter.size shouldBe tokensBefore + 2
+
+        tokensAfter.forEach { token ->
+            driver.state.projectedState.getPower(token) shouldBe 1
+            driver.state.projectedState.getToughness(token) shouldBe 1
+            driver.state.projectedState.cantBlock(token) shouldBe true
+        }
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TarriansSoulcleaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TarriansSoulcleaverScenarioTest.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SynapseNecromage
 import com.wingedsheep.mtg.sets.definitions.lci.cards.TarriansSoulcleaver
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.CounterType
@@ -29,6 +30,10 @@ import io.kotest.matchers.shouldBe
  *  2. Another creature dying (any controller) puts a +1/+1 counter on the equipped creature.
  *  3. An artifact dying puts a +1/+1 counter on the equipped creature (artifact branch of the OR).
  *  4. When the Soulcleaver is unattached, the death trigger resolves as a harmless no-op.
+ *  5. A TOKEN dying puts a +1/+1 counter on the equipped creature — regression for the
+ *     TriggerMatcher LKI gap: the union filter collapses to CardPredicate.Or, and the token
+ *     entity is swept by CR 704.5d before trigger matching, so the composite must be evaluated
+ *     against the event's last-known type line, not the live (gone) CardComponent.
  */
 class TarriansSoulcleaverScenarioTest : FunSpec({
 
@@ -36,7 +41,7 @@ class TarriansSoulcleaverScenarioTest : FunSpec({
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(TarriansSoulcleaver))
+        driver.registerCards(TestCards.all + listOf(TarriansSoulcleaver, SynapseNecromage))
         return driver
     }
 
@@ -145,5 +150,40 @@ class TarriansSoulcleaverScenarioTest : FunSpec({
 
         // No creature to receive the counter — the bear stays at zero and nothing crashes.
         plusOneCounters(driver, bear) shouldBe 0
+    }
+
+    test("a token dying puts a +1/+1 counter on the equipped creature (LKI regression)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putEquipmentAttached(driver.player1, "Tarrian's Soulcleaver", bear)
+        // Opponent's Synapse Necromage: killing it creates two Fungus tokens through the real
+        // token-creation path, so the tokens carry a genuine TokenComponent.
+        val necromage = driver.putCreatureOnBattlefield(driver.player2, "Synapse Necromage")
+
+        driver.advanceToPlayer1Main()
+
+        driver.giveMana(driver.player1, Color.RED, 1)
+        val bolt1 = driver.putCardInHand(driver.player1, "Lightning Bolt")
+        driver.castSpell(driver.player1, bolt1, targets = listOf(necromage)).isSuccess shouldBe true
+        driver.bothPass() // resolve the bolt -> Necromage dies, queuing both players' triggers
+        driver.bothPass() // resolve one trigger (APNAP)
+        driver.bothPass() // resolve the other trigger
+
+        // The Necromage (a real card) dying already grew the bear by one and left two tokens.
+        plusOneCounters(driver, bear) shouldBe 1
+        val fungusTokens = driver.getCreatures(driver.player2).filter { driver.getCardName(it) == "Fungus Token" }
+        fungusTokens.size shouldBe 2
+
+        // Kill a token: it dies AND is swept from the game by 704.5d in the same SBA pass, so
+        // the Soulcleaver's `Artifact or Creature` union must match on last-known info.
+        driver.giveMana(driver.player1, Color.RED, 1)
+        val bolt2 = driver.putCardInHand(driver.player1, "Lightning Bolt")
+        driver.castSpell(driver.player1, bolt2, targets = listOf(fungusTokens.first())).isSuccess shouldBe true
+        driver.bothPass() // resolve the bolt -> token dies and is swept
+        driver.bothPass() // resolve the Soulcleaver trigger
+
+        plusOneCounters(driver, bear) shouldBe 2
     }
 })

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TarriansSoulcleaverScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TarriansSoulcleaverScenarioTest.kt
@@ -1,0 +1,149 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.battlefield.AttachmentsComponent
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TarriansSoulcleaver
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tarrian's Soulcleaver (LCI #264) — {1} Legendary Artifact — Equipment.
+ *
+ * Equipped creature has vigilance.
+ * Whenever another artifact or creature is put into a graveyard from the battlefield,
+ * put a +1/+1 counter on equipped creature.
+ * Equip {2}
+ *
+ * Tests:
+ *  1. Equipped creature has vigilance (static GrantKeyword).
+ *  2. Another creature dying (any controller) puts a +1/+1 counter on the equipped creature.
+ *  3. An artifact dying puts a +1/+1 counter on the equipped creature (artifact branch of the OR).
+ *  4. When the Soulcleaver is unattached, the death trigger resolves as a harmless no-op.
+ */
+class TarriansSoulcleaverScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TarriansSoulcleaver))
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.putEquipmentAttached(
+        playerId: EntityId,
+        cardName: String,
+        targetCreatureId: EntityId,
+    ): EntityId {
+        val equipmentId = putPermanentOnBattlefield(playerId, cardName)
+        var newState = state.updateEntity(equipmentId) { c -> c.with(AttachedToComponent(targetCreatureId)) }
+        val existing = newState.getEntity(targetCreatureId)
+            ?.get<AttachmentsComponent>()?.attachedIds ?: emptyList()
+        newState = newState.updateEntity(targetCreatureId) { c ->
+            c.with(AttachmentsComponent(existing + equipmentId))
+        }
+        replaceState(newState)
+        return equipmentId
+    }
+
+    // Player 1 may not be active at game start (random turn order) — advance until it is.
+    fun GameTestDriver.advanceToPlayer1Main() {
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        var safety = 0
+        while (activePlayer != player1 && safety < 50) {
+            bothPass()
+            passPriorityUntil(Step.PRECOMBAT_MAIN)
+            safety++
+        }
+    }
+
+    test("equipped creature has vigilance") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putEquipmentAttached(driver.player1, "Tarrian's Soulcleaver", bear)
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(bear, Keyword.VIGILANCE) shouldBe true
+    }
+
+    test("another creature dying (any controller) puts a +1/+1 counter on the equipped creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putEquipmentAttached(driver.player1, "Tarrian's Soulcleaver", bear)
+        // A different creature the opponent controls — "another artifact or creature", any controller.
+        val victim = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+
+        driver.advanceToPlayer1Main()
+        plusOneCounters(driver, bear) shouldBe 0
+
+        // Destroy the victim for real so its dies (battlefield -> graveyard) trigger fires.
+        val doomBlade = driver.putCardInHand(driver.player1, "Doom Blade")
+        driver.giveMana(driver.player1, Color.BLACK, 2)
+        driver.castSpell(driver.player1, doomBlade, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // resolve Doom Blade -> victim dies, queuing the Soulcleaver trigger
+        driver.state.getBattlefield().contains(victim) shouldBe false
+        driver.bothPass() // resolve the Soulcleaver "another ... is put into a graveyard" trigger
+
+        plusOneCounters(driver, bear) shouldBe 1
+    }
+
+    test("an artifact dying puts a +1/+1 counter on the equipped creature") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        driver.putEquipmentAttached(driver.player1, "Tarrian's Soulcleaver", bear)
+        // A colorless artifact creature — matches the "artifact" branch of the trigger filter.
+        val artifact = driver.putCreatureOnBattlefield(driver.player1, "Artifact Creature")
+
+        driver.advanceToPlayer1Main()
+
+        val doomBlade = driver.putCardInHand(driver.player1, "Doom Blade")
+        driver.giveMana(driver.player1, Color.BLACK, 2)
+        driver.castSpell(driver.player1, doomBlade, targets = listOf(artifact)).isSuccess shouldBe true
+        driver.bothPass() // resolve Doom Blade -> artifact dies
+        driver.state.getBattlefield().contains(artifact) shouldBe false
+        driver.bothPass() // resolve the Soulcleaver trigger
+
+        plusOneCounters(driver, bear) shouldBe 1
+    }
+
+    test("unattached Soulcleaver: a creature dying resolves as a no-op") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Swamp" to 40), startingLife = 20)
+
+        val bear = driver.putCreatureOnBattlefield(driver.player1, "Grizzly Bears")
+        // Soulcleaver on the battlefield but attached to nothing.
+        driver.putPermanentOnBattlefield(driver.player1, "Tarrian's Soulcleaver")
+        val victim = driver.putCreatureOnBattlefield(driver.player2, "Grizzly Bears")
+
+        driver.advanceToPlayer1Main()
+
+        val doomBlade = driver.putCardInHand(driver.player1, "Doom Blade")
+        driver.giveMana(driver.player1, Color.BLACK, 2)
+        driver.castSpell(driver.player1, doomBlade, targets = listOf(victim)).isSuccess shouldBe true
+        driver.bothPass() // resolve Doom Blade
+        driver.bothPass() // resolve (or fizzle) the Soulcleaver trigger with no equipped creature
+
+        // No creature to receive the counter — the bear stays at zero and nothing crashes.
+        plusOneCounters(driver, bear) shouldBe 0
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TectonicHazardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TectonicHazardScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TectonicHazard
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tectonic Hazard (LCI #169) — {R} Sorcery.
+ *
+ * "Tectonic Hazard deals 1 damage to each opponent and each creature they control."
+ *
+ * Two damage sub-effects composed: 1 damage to each opponent (the player) and 1 damage
+ * to each creature that opponent controls. The caster and the caster's own creatures are
+ * untouched.
+ */
+class TectonicHazardScenarioTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCards(PredefinedTokens.allTokens)
+        driver.registerCard(TectonicHazard)
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    test("deals 1 to the opponent and 1 to each of their creatures, sparing the caster's side") {
+        val driver = newDriver()
+        val me = driver.player1
+        val opp = driver.player2
+
+        // Opponent's board: a 2/2 (survives 1 damage) and a 1/1 (dies to 1 damage).
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")     // 2/2
+        driver.putCreatureOnBattlefield(opp, "Llanowar Elves")    // 1/1
+        // Caster's own creatures must be untouched.
+        val myBears = driver.putCreatureOnBattlefield(me, "Grizzly Bears")   // 2/2
+
+        val hazard = driver.putCardInHand(me, "Tectonic Hazard")
+        driver.giveMana(me, Color.RED, 1)
+        driver.castSpell(me, hazard).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Opponent (the only opponent) took 1 damage; caster untouched.
+        driver.getLifeTotal(opp) shouldBe 19
+        driver.getLifeTotal(me) shouldBe 20
+
+        // The opponent's 1/1 died; their 2/2 and the caster's 2/2 survived.
+        driver.findPermanent(opp, "Llanowar Elves") shouldBe null
+        (driver.findPermanent(opp, "Grizzly Bears") != null) shouldBe true
+        (myBears == driver.findPermanent(me, "Grizzly Bears")) shouldBe true
+        driver.getCreatures(me).size shouldBe 1
+        driver.getCreatures(opp).size shouldBe 1
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TendrilOfTheMycotyrantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TendrilOfTheMycotyrantScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TendrilOfTheMycotyrant
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario tests for Tendril of the Mycotyrant (LCI #215) — {1}{G} 2/2 Creature — Fungus Wizard.
+ *
+ * "{5}{G}{G}: Put seven +1/+1 counters on target noncreature land you control. It becomes a
+ *  0/0 Fungus creature with haste. It's still a land."
+ *
+ * Covered:
+ *  1. Activating the ability on a noncreature land you control puts seven +1/+1 counters on it
+ *     and permanently animates it into a 0/0 Fungus creature — a 7/7 while the counters remain —
+ *     that is still a land.
+ */
+class TendrilOfTheMycotyrantScenarioTest : FunSpec({
+
+    val abilityId = TendrilOfTheMycotyrant.activatedAbilities.first().id
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TendrilOfTheMycotyrant)
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    fun plusOneCounters(driver: GameTestDriver, entityId: EntityId): Int =
+        driver.state.getEntity(entityId)
+            ?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("animating a noncreature land adds seven +1/+1 counters and makes it a 0/0 Fungus creature that is still a land") {
+        val driver = newDriver()
+        val me = driver.player1
+
+        // The Tendril on the battlefield provides the activated ability.
+        val tendril = driver.putPermanentOnBattlefield(me, "Tendril of the Mycotyrant")
+
+        // A noncreature land you control to target.
+        val land = driver.putLandOnBattlefield(me, "Forest")
+
+        // {5}{G}{G}: 5 generic + 2 green.
+        driver.giveColorlessMana(me, 5)
+        driver.giveMana(me, Color.GREEN, 2)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = me,
+                sourceId = tendril,
+                abilityId = abilityId,
+                targets = listOf(ChosenTarget.Permanent(land))
+            )
+        )
+        result.isSuccess shouldBe true
+
+        driver.bothPass()
+
+        // Seven +1/+1 counters landed on the target land.
+        plusOneCounters(driver, land) shouldBe 7
+
+        // The land is now a creature (permanent BecomeCreature) and still on the battlefield.
+        driver.findPermanent(me, "Forest") shouldNotBe null
+        driver.state.projectedState.isCreature(land) shouldBe true
+
+        // It's still a land.
+        driver.state.projectedState.hasType(land, "LAND") shouldBe true
+
+        // Base 0/0 plus seven +1/+1 counters => a 7/7 body.
+        driver.state.projectedState.getPower(land) shouldBe 7
+        driver.state.projectedState.getToughness(land) shouldBe 7
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheBelligerentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheBelligerentScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.core.DeclareAttackers
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TheBelligerent
+import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Tests for The Belligerent.
+ *
+ * The Belligerent: {2}{U}{R}
+ * Legendary Artifact — Vehicle
+ * 5/5
+ * Whenever The Belligerent attacks, create a Treasure token. Until end of turn, you may look at the
+ * top card of your library any time, and you may play lands and cast spells from the top of your
+ * library.
+ * Crew 3
+ *
+ * The attack trigger creates the Treasure token; the "until end of turn" play window is modeled as
+ * two conditional statics gated on "attacked this turn" (the Lunar Whale pattern). These tests
+ * exercise both halves: the Treasure fires on attack, and the play-from-top permission is dormant
+ * until the Vehicle is crewed and attacks, then active for the rest of the turn.
+ */
+class TheBelligerentScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(TheBelligerent)
+        // The attack trigger's CreateTreasure looks up the "Treasure" token definition in the
+        // registry, so it must be registered alongside the card.
+        driver.registerCard(PredefinedTokens.Treasure)
+        return driver
+    }
+
+    test("cannot play the top card of library before The Belligerent attacks") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        // Belligerent present but it has not attacked this turn — the conditional gate is false.
+        driver.putPermanentOnBattlefield(you, "The Belligerent")
+        val mountainOnTop = driver.putCardOnTopOfLibrary(you, "Mountain")
+
+        // A land on top of library can only be played via the (currently inactive) permission.
+        driver.playLand(you, mountainOnTop).isSuccess shouldBe false
+        driver.findPermanent(you, "Mountain") shouldBe null
+    }
+
+    test("attacking creates a Treasure token and opens the play-from-top window") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+
+        // Crew partner: Centaur Courser (power 3 satisfies Crew 3).
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val belligerent = driver.putPermanentOnBattlefield(you, "The Belligerent")
+        driver.removeSummoningSickness(belligerent)
+
+        // Crew the Belligerent (it becomes a creature) and declare it as an attacker.
+        driver.submitSuccess(CrewVehicle(you, belligerent, listOf(courser)))
+        driver.bothPass() // resolve the crew activation
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.submitSuccess(DeclareAttackers(you, mapOf(belligerent to opponent)))
+        driver.bothPass() // resolve the attack trigger (creates the Treasure token)
+
+        // The attack trigger created a Treasure token.
+        driver.findPermanent(you, "Treasure") shouldNotBe null
+
+        // Move to the postcombat main phase — the Belligerent "attacked this turn", gate is open.
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        val mountainOnTop = driver.putCardOnTopOfLibrary(you, "Mountain")
+        driver.playLand(you, mountainOnTop).isSuccess shouldBe true
+        driver.findPermanent(you, "Mountain") shouldNotBe null
+    }
+
+    test("can cast a spell from the top of library after The Belligerent attacks") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Island" to 20, "Mountain" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+        val opponent = driver.state.turnOrder.first { it != you }
+
+        val courser = driver.putCreatureOnBattlefield(you, "Centaur Courser")
+        val belligerent = driver.putPermanentOnBattlefield(you, "The Belligerent")
+        driver.removeSummoningSickness(belligerent)
+
+        driver.submitSuccess(CrewVehicle(you, belligerent, listOf(courser)))
+        driver.bothPass()
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.submitSuccess(DeclareAttackers(you, mapOf(belligerent to opponent)))
+        driver.bothPass()
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        // Frogmite (an artifact creature) on top — any spell type may be cast from the top.
+        val frogmiteOnTop = driver.putCardOnTopOfLibrary(you, "Frogmite")
+        driver.giveMana(you, Color.BLUE, 4)
+
+        driver.castSpell(you, frogmiteOnTop).isSuccess shouldBe true
+        driver.bothPass()
+        driver.state.getBattlefield(you).contains(frogmiteOnTop) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheBelligerentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheBelligerentScenarioTest.kt
@@ -4,12 +4,14 @@ import com.wingedsheep.engine.core.CrewVehicle
 import com.wingedsheep.engine.core.DeclareAttackers
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
-import com.wingedsheep.mtg.sets.definitions.lci.cards.TheBelligerent
+import com.wingedsheep.engine.view.ClientStateTransformer
 import com.wingedsheep.mtg.sets.tokens.PredefinedTokens
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
@@ -34,12 +36,14 @@ class TheBelligerentScenarioTest : FunSpec({
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
         driver.registerCards(TestCards.all)
-        driver.registerCard(TheBelligerent)
-        // The attack trigger's CreateTreasure looks up the "Treasure" token definition in the
-        // registry, so it must be registered alongside the card.
+        // TestCards.all covers every catalog card but not tokens; the attack trigger's
+        // CreateTreasure looks up the "Treasure" token definition in the registry.
         driver.registerCard(PredefinedTokens.Treasure)
         return driver
     }
+
+    fun transformer(d: GameTestDriver): ClientStateTransformer =
+        ClientStateTransformer(cardRegistry = d.cardRegistry)
 
     test("cannot play the top card of library before The Belligerent attacks") {
         val driver = createDriver()
@@ -54,6 +58,10 @@ class TheBelligerentScenarioTest : FunSpec({
         // A land on top of library can only be played via the (currently inactive) permission.
         driver.playLand(you, mountainOnTop).isSuccess shouldBe false
         driver.findPermanent(you, "Mountain") shouldBe null
+
+        // The client view mirrors the gate: the top card is not revealed to the controller yet.
+        val view = transformer(driver).transform(driver.state, viewingPlayerId = you)
+        view.cards.keys shouldNotContain mountainOnTop
     }
 
     test("attacking creates a Treasure token and opens the play-from-top window") {
@@ -82,6 +90,14 @@ class TheBelligerentScenarioTest : FunSpec({
         driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
 
         val mountainOnTop = driver.putCardOnTopOfLibrary(you, "Mountain")
+
+        // The look permission is active: the client view reveals the top card to the
+        // controller privately — the defender still must not see it.
+        transformer(driver).transform(driver.state, viewingPlayerId = you)
+            .cards.keys shouldContain mountainOnTop
+        transformer(driver).transform(driver.state, viewingPlayerId = opponent)
+            .cards.keys shouldNotContain mountainOnTop
+
         driver.playLand(you, mountainOnTop).isSuccess shouldBe true
         driver.findPermanent(you, "Mountain") shouldNotBe null
     }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMycotyrantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMycotyrantScenarioTest.kt
@@ -1,0 +1,129 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.BroodrageMycoid
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TheMycotyrant
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Mycotyrant (LCI #235): {1}{B}{G} Legendary Creature — Elder Fungus, mythic.
+ *
+ * - Trample
+ * - Its power and toughness are each equal to the number of creatures you control that
+ *   are Fungi and/or Saprolings (characteristic-defining ability — counts itself, since
+ *   it is a Fungus).
+ * - At the beginning of your end step, create X 1/1 black Fungus tokens with "This token
+ *   can't block," where X = the number of times you descended this turn.
+ *
+ * Tests:
+ * 1. Trample is present.
+ * 2. The CDA sets P/T to the count of Fungi/Saprolings you control (itself + another
+ *    Fungus), and excludes creatures of other types.
+ * 3. The end-step trigger creates exactly X Fungus tokens = the descend count (2 here).
+ * 4. No tokens are created when you have not descended this turn (X = 0).
+ */
+class TheMycotyrantScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(TheMycotyrant, BroodrageMycoid))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    /**
+     * Move a card to the graveyard via [ZoneTransitionService] to fire the zone-change
+     * event and increment the descend counter (CR 700.11).
+     */
+    fun GameTestDriver.descend(entityId: EntityId) {
+        val result = ZoneTransitionService.moveToZone(
+            state = state,
+            entityId = entityId,
+            destinationZone = Zone.GRAVEYARD
+        )
+        replaceState(result.state)
+    }
+
+    fun GameTestDriver.fungusTokens(playerId: EntityId): List<EntityId> =
+        getCreatures(playerId).filter { getCardName(it) == "Fungus Token" }
+
+    test("The Mycotyrant has trample") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val mycotyrant = driver.putCreatureOnBattlefield(player, "The Mycotyrant")
+
+        driver.state.projectedState.hasKeyword(mycotyrant, Keyword.TRAMPLE) shouldBe true
+    }
+
+    test("power and toughness equal the number of Fungi/Saprolings you control") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Alone: only The Mycotyrant itself (an Elder Fungus) counts → 1/1.
+        val mycotyrant = driver.putCreatureOnBattlefield(player, "The Mycotyrant")
+        driver.state.projectedState.getPower(mycotyrant) shouldBe 1
+        driver.state.projectedState.getToughness(mycotyrant) shouldBe 1
+
+        // Add another Fungus (Broodrage Mycoid) → 2 Fungi → 2/2.
+        driver.putCreatureOnBattlefield(player, "Broodrage Mycoid")
+        driver.state.projectedState.getPower(mycotyrant) shouldBe 2
+        driver.state.projectedState.getToughness(mycotyrant) shouldBe 2
+
+        // Add a non-Fungus, non-Saproling creature → count unchanged, still 2/2.
+        driver.putCreatureOnBattlefield(player, "Grizzly Bears")
+        driver.state.projectedState.getPower(mycotyrant) shouldBe 2
+        driver.state.projectedState.getToughness(mycotyrant) shouldBe 2
+    }
+
+    test("end step creates X Fungus tokens equal to the number of times you descended") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(player, "The Mycotyrant")
+
+        // Descend twice: two permanent (creature) cards put into the graveyard.
+        val bears1 = driver.putCardInHand(player, "Grizzly Bears")
+        val bears2 = driver.putCardInHand(player, "Grizzly Bears")
+        driver.descend(bears1)
+        driver.descend(bears2)
+
+        val tokensBefore = driver.fungusTokens(player).size
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass() // end-step trigger resolves, creating X = 2 tokens
+
+        val tokensAfter = driver.fungusTokens(player)
+        tokensAfter.size shouldBe tokensBefore + 2
+
+        // Each token is a 1/1 that can't block.
+        val token = tokensAfter.first()
+        driver.state.projectedState.getPower(token) shouldBe 1
+        driver.state.projectedState.getToughness(token) shouldBe 1
+        driver.state.projectedState.cantBlock(token) shouldBe true
+    }
+
+    test("no Fungus tokens are created at end step when you have not descended") {
+        val driver = createDriver()
+        val player = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.putCreatureOnBattlefield(player, "The Mycotyrant")
+
+        val tokensBefore = driver.fungusTokens(player).size
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.fungusTokens(player).size shouldBe tokensBefore
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMycotyrantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TheMycotyrantScenarioTest.kt
@@ -3,8 +3,6 @@ package com.wingedsheep.engine.scenarios
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
-import com.wingedsheep.mtg.sets.definitions.lci.cards.BroodrageMycoid
-import com.wingedsheep.mtg.sets.definitions.lci.cards.TheMycotyrant
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
@@ -34,7 +32,7 @@ class TheMycotyrantScenarioTest : FunSpec({
 
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(TheMycotyrant, BroodrageMycoid))
+        driver.registerCards(TestCards.all)
         driver.initMirrorMatch(
             deck = Deck.of("Swamp" to 20, "Grizzly Bears" to 20),
             skipMulligans = true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThousandMoonsCrackshotScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThousandMoonsCrackshotScenarioTest.kt
@@ -1,0 +1,98 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thousand Moons Crackshot ({1}{W} 2/2 Creature — Human Soldier) — Lost Caverns of Ixalan.
+ *
+ * "Whenever this creature attacks, you may pay {2}{W}. When you do, tap target creature."
+ *
+ * Modelled as a `ReflexiveTriggerEffect` whose optional action is the {2}{W} payment: after the
+ * attack trigger resolves, the engine offers the optional payment first (yes/no + mana sources),
+ * then — only if paid — the reflexive "tap target creature" goes on the stack and asks for its
+ * target. Paying taps the chosen creature; declining leaves it untapped.
+ */
+class ThousandMoonsCrackshotScenarioTest : FunSpec({
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+    }
+
+    fun GameTestDriver.isTapped(id: com.wingedsheep.sdk.model.EntityId): Boolean =
+        state.getEntity(id)?.get<TappedComponent>() != null
+
+    test("paying {2}{W} taps target creature") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val crackshot = d.putCreatureOnBattlefield(you, "Thousand Moons Crackshot")
+        d.removeSummoningSickness(crackshot)
+        // Three Plains provide the {2}{W} for the optional payment.
+        repeat(3) { d.putLandOnBattlefield(you, "Plains") }
+        val victim = d.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(you, listOf(crackshot), opponent)
+
+        // Answer in the engine's order: pay (yes) -> auto-pay mana sources -> choose target.
+        var targeted = false
+        var guard = 0
+        while (!targeted && guard++ < 40) {
+            when (d.pendingDecision) {
+                is YesNoDecision -> d.submitYesNo(you, true)
+                is SelectManaSourcesDecision -> d.submitManaAutoPayOrDecline(you, true)
+                is ChooseTargetsDecision -> {
+                    d.submitTargetSelection(you, listOf(victim)); targeted = true
+                }
+                else -> d.bothPass()
+            }
+        }
+        targeted shouldBe true
+
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.isTapped(victim) shouldBe true
+    }
+
+    test("declining the {2}{W} payment leaves the creature untapped") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = if (you == d.player1) d.player2 else d.player1
+
+        val crackshot = d.putCreatureOnBattlefield(you, "Thousand Moons Crackshot")
+        d.removeSummoningSickness(crackshot)
+        repeat(3) { d.putLandOnBattlefield(you, "Plains") }
+        val victim = d.putCreatureOnBattlefield(opponent, "Grizzly Bears") // 2/2
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(you, listOf(crackshot), opponent)
+
+        // The pay choice is genuinely offered (mana is available) — decline it. No target is chosen.
+        var answered = false
+        var guard = 0
+        while (!answered && guard++ < 40) {
+            when (d.pendingDecision) {
+                is YesNoDecision -> {
+                    d.submitYesNo(you, false); answered = true
+                }
+                else -> d.bothPass()
+            }
+        }
+        answered shouldBe true
+
+        while (!d.isPaused && d.state.stack.isNotEmpty()) d.bothPass()
+
+        d.isTapped(victim) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThousandMoonsInfantryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThousandMoonsInfantryScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.ThousandMoonsInfantry
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Thousand Moons Infantry — {2}{W} Creature — Human Soldier, 2/4.
+ *   "Untap this creature during each other player's untap step."
+ *
+ * Covers the self-scoped [UntapSelfDuringOtherUntapSteps] static: the creature untaps on a
+ * *non-controller's* untap step, while a plain creature the same player controls stays tapped
+ * through it.
+ */
+class ThousandMoonsInfantryScenarioTest : FunSpec({
+
+    // A vanilla creature (no self-untap static) — the negative control for the untap test.
+    val PlainSoldier = card("Thousand Moons Test Plain Soldier") {
+        manaCost = "{2}{W}"
+        typeLine = "Creature — Human Soldier"
+        power = 2
+        toughness = 2
+    }
+
+    fun driver(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all + listOf(ThousandMoonsInfantry, PlainSoldier))
+        initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
+    }
+
+    test("untaps during another player's untap step, while a plain creature stays tapped") {
+        val d = driver()
+        val you = d.activePlayer!!
+        val opponent = d.getOpponent(you)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val infantry = d.putPermanentOnBattlefield(you, "Thousand Moons Infantry")
+        val plainSoldier = d.putPermanentOnBattlefield(you, "Thousand Moons Test Plain Soldier")
+
+        // Tap both on your own turn.
+        d.tapPermanent(infantry)
+        d.tapPermanent(plainSoldier)
+        d.isTapped(infantry) shouldBe true
+        d.isTapped(plainSoldier) shouldBe true
+
+        // Advance into the opponent's turn — their untap step runs along the way.
+        d.passPriorityUntil(Step.UPKEEP)
+        d.activePlayer shouldBe opponent
+
+        // The infantry untapped during the opponent's untap step; the plain soldier did not.
+        d.isTapped(infantry) shouldBe false
+        d.isTapped(plainSoldier) shouldBe true
+    }
+
+    test("stays untapped through its own controller's untap step (no double-untap issue)") {
+        val d = driver()
+        val you = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val infantry = d.putPermanentOnBattlefield(you, "Thousand Moons Infantry")
+        d.tapPermanent(infantry)
+        d.isTapped(infantry) shouldBe true
+
+        // Advance into the opponent's turn — their untap step untaps the infantry via the static.
+        d.passPriorityUntil(Step.UPKEEP)
+        d.activePlayer shouldBe d.getOpponent(you)
+        // Loop through the rest of the opponent's turn back to your own turn: the opponent's
+        // precombat main first, then your next upkeep (past your own untap step, where the
+        // infantry untaps as normal — no double-untap issue).
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.passPriorityUntil(Step.UPKEEP)
+        d.activePlayer shouldBe you
+        d.isTapped(infantry) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThousandMoonsInfantryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThousandMoonsInfantryScenarioTest.kt
@@ -2,7 +2,6 @@ package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
-import com.wingedsheep.mtg.sets.definitions.lci.cards.ThousandMoonsInfantry
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
@@ -28,7 +27,9 @@ class ThousandMoonsInfantryScenarioTest : FunSpec({
     }
 
     fun driver(): GameTestDriver = GameTestDriver().apply {
-        registerCards(TestCards.all + listOf(ThousandMoonsInfantry, PlainSoldier))
+        // TestCards.all already includes the catalog's LCI cards; only the test-local
+        // vanilla control needs explicit registration.
+        registerCards(TestCards.all + listOf(PlainSoldier))
         initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20)
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThreefoldThunderhulkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThreefoldThunderhulkScenarioTest.kt
@@ -1,0 +1,148 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.mtg.sets.definitions.lci.cards.ThreefoldThunderhulk
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Threefold Thunderhulk (LCI #265) — {7} Artifact Creature — Gnome 0/0.
+ *
+ * "This creature enters with three +1/+1 counters on it.
+ *  Whenever this creature enters or attacks, create a number of 1/1 colorless Gnome artifact
+ *    creature tokens equal to its power.
+ *  {2}, Sacrifice another artifact: Put a +1/+1 counter on this creature."
+ *
+ * Exercises:
+ *  - [EntersWithCounters] replacement: the Thunderhulk arrives with three +1/+1 counters, making
+ *    it a 3/3 on entry.
+ *  - Enters trigger: creating tokens equal to its power (3) as it enters.
+ *  - Attacks trigger: creating tokens equal to its power when it attacks (post-pump count).
+ *  - Activated ability: {2}, Sacrifice another artifact → one +1/+1 counter on the Thunderhulk.
+ */
+class ThreefoldThunderhulkScenarioTest : ScenarioTestBase() {
+
+    init {
+        // Threefold Thunderhulk is auto-discovered from the LCI cards package, so it is already
+        // present in the shared cardRegistry. No explicit registration needed.
+        val activateAbilityId = ThreefoldThunderhulk.activatedAbilities.first().id
+        val projector = StateProjector()
+
+        fun plusOne(game: TestGame, id: EntityId): Int =
+            game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+        /** Directly add +1/+1 counters to a battlefield entity without going through the stack. */
+        fun addPlusOne(game: TestGame, id: EntityId, count: Int) {
+            game.state = game.state.updateEntity(id) { container ->
+                val existing = container.get<CountersComponent>() ?: CountersComponent()
+                container.with(existing.withAdded(CounterType.PLUS_ONE_PLUS_ONE, count))
+            }
+        }
+
+        /** All Gnome tokens controlled by player 1. */
+        fun gnomeTokens(game: TestGame): List<EntityId> =
+            game.state.getBattlefield().filter { id ->
+                val e = game.state.getEntity(id) ?: return@filter false
+                e.has<TokenComponent>() && e.get<CardComponent>()?.name == "Gnome Token"
+            }
+
+        context("Threefold Thunderhulk") {
+
+            test("enters with three +1/+1 counters and creates three Gnome tokens equal to its power") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardInHand(1, "Threefold Thunderhulk")
+                    .withLandsOnBattlefield(1, "Forest", 7)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Threefold Thunderhulk").error shouldBe null
+                game.resolveStack()
+
+                val hulk = game.findPermanent("Threefold Thunderhulk")!!
+                withClue("enters with three +1/+1 counters (0/0 base → 3/3)") {
+                    plusOne(game, hulk) shouldBe 3
+                    projector.getProjectedPower(game.state, hulk) shouldBe 3
+                }
+                withClue("enters trigger creates tokens equal to its power (3)") {
+                    gnomeTokens(game).size shouldBe 3
+                }
+
+                // Each token is a 1/1 colorless Gnome artifact creature.
+                val token = gnomeTokens(game).first()
+                val card = game.state.getEntity(token)!!.get<CardComponent>()!!
+                card.typeLine.isArtifact shouldBe true
+                card.typeLine.isCreature shouldBe true
+                card.typeLine.subtypes.map { it.value } shouldBe listOf("Gnome")
+                card.colors shouldBe emptySet()
+                projector.getProjectedPower(game.state, token) shouldBe 1
+                projector.getProjectedToughness(game.state, token) shouldBe 1
+            }
+
+            test("attacks trigger creates tokens equal to its power") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Threefold Thunderhulk")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hulk = game.findPermanent("Threefold Thunderhulk")!!
+                // Placed directly (no ETB replacement), so simulate the three entry counters → 3/3.
+                addPlusOne(game, hulk, 3)
+                withClue("no tokens before combat") { gnomeTokens(game).size shouldBe 0 }
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Threefold Thunderhulk" to 2))
+                game.resolveStack()
+
+                withClue("attacks trigger creates tokens equal to its power (3)") {
+                    gnomeTokens(game).size shouldBe 3
+                }
+            }
+
+            test("{2}, Sacrifice another artifact: put a +1/+1 counter on this creature") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Threefold Thunderhulk")
+                    .withCardOnBattlefield(1, "Artifact Creature")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val hulk = game.findPermanent("Threefold Thunderhulk")!!
+                addPlusOne(game, hulk, 3)
+                val fodder = game.findPermanent("Artifact Creature")!!
+
+                withClue("three counters before activation") { plusOne(game, hulk) shouldBe 3 }
+
+                val result = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = hulk, abilityId = activateAbilityId)
+                )
+                result.error shouldBe null
+                if (game.getPendingDecision() is com.wingedsheep.engine.core.SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("Thunderhulk gains a +1/+1 counter (3 → 4)") {
+                    plusOne(game, hulk) shouldBe 4
+                }
+                withClue("the other artifact was sacrificed") {
+                    game.state.getBattlefield().contains(fodder) shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## LCI cards — batch 18 (5 cards) + a client-view fix surfaced by playtest

Eighteenth batch of Lost Caverns of Ixalan cards, each with a scenario test. **Stacked on `lci-cards-17`** — please review only the difference to that branch (the two commits listed below); everything under it is reviewed on the earlier batch PRs.

### Cards (commit `1028b433e`)

- **The Belligerent** — {2}{U}{R} Legendary Artifact Vehicle 5/5; attacks → create a Treasure and, until end of turn, look at / play lands and cast spells from the top of your library; Crew 3. Modeled as the Lunar Whale pattern: conditional statics gated on "attacked this turn" (the approximation vs the printed until-end-of-turn one-shot is documented in the card comment).
- **The Mycotyrant** — {1}{B}{G} Legendary Elder Fungus \*/\*; trample; P/T = number of Fungi/Saprolings you control (CDA, counts itself); your end step → create X 1/1 black can't-block Fungus tokens, X = times you descended this turn (CR 700.11 count, not the boolean).
- **Thousand Moons Crackshot** — {1}{W} Human Soldier 2/2; attacks → you may pay {2}{W}; when you do, tap target creature (reflexive trigger, target chosen when the reflexive ability goes on the stack).
- **Thousand Moons Infantry** — {2}{W} Human Soldier 2/4; untap during each other player's untap step.
- **Threefold Thunderhulk** — {7} Artifact Creature Gnome 0/0; enters with three +1/+1 counters; enters or attacks → create 1/1 colorless Gnome artifact tokens equal to its power (evaluated at resolution, so post-pump attacks mint more); {2}, sacrifice another artifact → +1/+1 counter.

No new SDK types — all five compose existing primitives. Includes a manual self-play scenario (`manual-scenarios/sets/lci/cards-18.json`) with all five in hand and mana to cast them.

### Client-view fix (commit `3c081a894` — found by playtesting this batch; latent bug, not a new capability)

**Reveal top-of-library behind conditional static gates in client view.** `ClientStateTransformer`'s visibility checks matched statics by bare type, so a `ConditionalStaticAbility`-wrapped `LookAtTopOfLibrary` (The Belligerent is the first such card) never revealed the controller's top card — the play permission was legal server-side (`CastPermissionUtils` already unwraps conditionals) while the client had no visible card to act on. The transformer's four visibility checks (private look at top, public top reveal, look at face-down creatures, opponents' hands revealed) now resolve conditional gates through the same unwrap-and-evaluate helper, keeping what a player *sees* in sync with what the legal-actions layer lets them *do*. View-layer assertions added: top card hidden pre-attack, revealed post-attack to the controller only.

### Verification

All 5 scenario test classes pass, plus regression tests for every other transformer path touched (Goblin Spy, Seer's Vision, Future Sight, The Lunar Whale); `:mtg-sets:test` snapshot + lint green via `gradle-locked`; `just check-card-printing` clean for all five cards; oracle text verified against Scryfall; CR 700.11 citation verified against the Comprehensive Rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
