### PR TITLE
fix: sagas create from TokenFromDefinition apply SagaEntry

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.handlers.effects.BattlefieldEntry
 import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
 import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
 import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
+import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
@@ -149,6 +150,12 @@ object TokenFromDefinition {
                 if (paused != null) return EffectResult.from(paused)
             }
         }
+        // CR 714.2b/714.3a: a token copy of a Saga enters as a Saga and gets its on-enter lore
+        // counter (chapter I then triggers). BattlefieldEntry.place is the ad-hoc insertion path
+        // and intentionally skips enters-with-counters setup, so apply the shared Saga-entry
+        // helper here — the same one the standard moveToZone pipeline uses. No-op for non-Sagas.
+        val (sagaState, sagaEvents) = ZoneMovementUtils.applySagaEntryIfNeeded(newState, tokenId)
+        newState = sagaState
 
         val event = ZoneChangeEvent(
             entityId = tokenId,
@@ -158,6 +165,6 @@ object TokenFromDefinition {
             ownerId = controllerId
         )
 
-        return EffectResult.success(newState, listOf(event) + counterEvents)
+        return EffectResult.success(newState, listOf(event) + counterEvents + sagaEvents)
     }
 }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomirBasicScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MomirBasicScenarioTest.kt
@@ -223,6 +223,25 @@ class MomirBasicScenarioTest : ScenarioTestBase() {
             game.state.projectedState.getToughness(token) shouldBe 1
         }
 
+        test("a minted saga token applies its own enters effects (Summon: Knights of Round)") {
+            val game = scenario()
+                .withPlayers()
+                .withFormat(Format.MomirBasic(eligibleCreatureNames = listOf("Summon: Knights of Round")))
+                .withCardInCommandZone(1, avatar)
+                .withLandsOnBattlefield(1, "Plains", 8)
+                .withCardsInHand(1, "Mountain", 2)
+                .build()
+
+            game.execute(game.momirAction(xValue = 8)).error shouldBe null
+            game.resolveStack()
+
+            val token = game.findPermanents("Summon: Knights of Round").single()
+            game.state.projectedState.getPower(token) shouldBe 3
+            game.state.projectedState.getToughness(token) shouldBe 3
+            // The saga's on-enter chapter I trigger fired, creating three 2/2 white Knight tokens.
+            game.findPermanents("Knight Token") shouldHaveSize 3
+        }
+
         test("a minted token prompts its as-enters choice and becomes the chosen color (Alloy Golem)") {
             val game = scenario()
                 .withPlayers()


### PR DESCRIPTION
fixes an issue with sagas that are created using `TokenFromDefiniton` don't have their chapter effects applied. Test case also added to `MomirBasicScenarioTest` using Summon: Knights of Round to verify token etb creation.