### PR TITLE
Match becomes-target trigger filters against projected types

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -1194,48 +1194,20 @@ class TriggerMatcher(
         // Valiant: check if this is the first time this turn
         if (trigger.firstTimeEachTurn && !event.firstTimeByThisController) return false
 
-        // Check targetFilter against the targeted entity
+        // Check targetFilter against the targeted entity. The target is live (a battlefield
+        // permanent, or a spell on the stack for includeSpellTargets), so evaluate the whole
+        // filter through PredicateEvaluator: card predicates read projected types when the
+        // entity has a battlefield projection — an animated land IS "a creature you control"
+        // while the effect lasts — and fall back to base card data for stack objects; the
+        // controller predicate likewise falls back to the spell's caster (Surrak, Elusive
+        // Hunter). Targeted abilities on the stack carry no card data and never match.
         if (trigger.targetFilter != GameObjectFilter.Any) {
-            val projected = state.projectedState
             val targetContainer = state.getEntity(event.targetEntityId) ?: return false
-            val targetCard = targetContainer.get<CardComponent>() ?: return false
-
-            // Check card predicates
-            for (predicate in trigger.targetFilter.cardPredicates) {
-                if (!matchesCardPredicate(predicate, targetCard, projected, event.targetEntityId)) return false
-            }
-
-            // Check state predicates (e.g. "with a +1/+1 counter on it" — Elrond, Master of
-            // Healing). The targeted permanent is on the battlefield, so projected/base state
-            // applies. (A spell-on-stack target has no such state, so the filter simply won't match.)
-            if (trigger.targetFilter.statePredicates.isNotEmpty()) {
-                val predicateContext = com.wingedsheep.engine.handlers.PredicateContext(
-                    controllerId = controllerId, sourceId = sourceId
-                )
-                val statePredicateEvaluator = PredicateEvaluator()
-                for (predicate in trigger.targetFilter.statePredicates) {
-                    if (!statePredicateEvaluator.matchesStatePredicate(
-                            state, event.targetEntityId, predicate, predicateContext
-                        )) return false
-                }
-            }
-
-            // Check controller predicate. Spells on the stack aren't in projected state
-            // (only battlefield permanents are), so fall back to the spell's own controller
-            // component for spell-target events (Surrak, Elusive Hunter).
-            trigger.targetFilter.controllerPredicate?.let { pred ->
-                val targetController = projected.getController(event.targetEntityId)
-                    ?: targetContainer.get<SpellOnStackComponent>()?.casterId
-                    ?: return false
-                val controllerMatches = pred.evaluateWith { leaf ->
-                    when (leaf) {
-                        is ControllerPredicate.ControlledByYou -> targetController == controllerId
-                        is ControllerPredicate.ControlledByOpponent -> targetController != controllerId
-                        else -> null // leaf kinds this site can't evaluate don't constrain
-                    }
-                }
-                if (!controllerMatches) return false
-            }
+            if (!targetContainer.has<CardComponent>()) return false
+            val predicateContext = PredicateContext(controllerId = controllerId, sourceId = sourceId)
+            if (!PredicateEvaluator().matches(
+                    state, state.projectedState, event.targetEntityId, trigger.targetFilter, predicateContext
+                )) return false
         }
 
         return true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PawpatchRecruitTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PawpatchRecruitTest.kt
@@ -1,5 +1,6 @@
 package com.wingedsheep.engine.scenarios
 
+import com.wingedsheep.engine.core.ActivateAbility
 import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
@@ -7,6 +8,7 @@ import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.mtg.sets.definitions.blb.cards.BrightbladeStoat
 import com.wingedsheep.mtg.sets.definitions.blb.cards.PawpatchRecruit
 import com.wingedsheep.mtg.sets.definitions.ons.cards.GlorySeeker
+import com.wingedsheep.mtg.sets.definitions.ons.cards.KamahlFistOfKrosa
 import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.model.Deck
@@ -75,5 +77,57 @@ class PawpatchRecruitTest : FunSpec({
         legalTargets shouldContain pawpatch
         legalTargets shouldContain seeker
         legalTargets shouldNotContain stoat
+    }
+
+    test("triggers when an opponent targets an animated land creature you control") {
+        val driver = createDriver()
+        driver.initMirrorMatch(
+            deck = Deck.of("Forest" to 20, "Mountain" to 20),
+            startingLife = 20
+        )
+
+        val activePlayer = driver.activePlayer!!
+        val opponent = driver.getOpponent(activePlayer)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val pawpatch = driver.putCreatureOnBattlefield(activePlayer, "Pawpatch Recruit")
+        val kamahl = driver.putCreatureOnBattlefield(activePlayer, "Kamahl, Fist of Krosa")
+        val forest = driver.putLandOnBattlefield(activePlayer, "Forest")
+        driver.removeSummoningSickness(kamahl)
+
+        // Animate the Forest into a 1/1 creature (it's still a land).
+        driver.giveMana(activePlayer, Color.GREEN, 1)
+        val animate = driver.submit(
+            ActivateAbility(
+                playerId = activePlayer,
+                sourceId = kamahl,
+                abilityId = KamahlFistOfKrosa.activatedAbilities[0].id,
+                targets = listOf(ChosenTarget.Permanent(forest))
+            )
+        )
+        animate.isSuccess shouldBe true
+        driver.bothPass()
+
+        // Opponent bolts the animated Forest — a creature the active player controls,
+        // so Pawpatch Recruit's trigger must fire even though the Forest is only a
+        // creature via a continuous effect.
+        driver.giveMana(opponent, Color.RED, 1)
+        val bolt = driver.putCardInHand(opponent, "Lightning Bolt")
+        driver.passPriority(activePlayer)
+        val cast = driver.castSpellWithTargets(
+            opponent, bolt, listOf(ChosenTarget.Permanent(forest))
+        )
+        cast.error shouldBe null
+
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        decision.playerId shouldBe activePlayer
+        val legalTargets = decision.legalTargets[0] ?: emptyList()
+
+        // "Other than that creature" excludes the animated Forest; Pawpatch and
+        // Kamahl are legal.
+        legalTargets shouldContain pawpatch
+        legalTargets shouldContain kamahl
+        legalTargets shouldNotContain forest
     }
 })


### PR DESCRIPTION
## Summary

"Becomes the target" triggers (Pawpatch Recruit, Surrak Elusive Hunter, King of the Oathbreakers, …) never fired when the targeted permanent only matched the trigger's type filter via a continuous effect — e.g. an animated land.

Observed in play: Singing Bell Strike legally enchanted an animated Forest (target validation uses the projection), but the defender's Pawpatch Recruit — "whenever a **creature you control** becomes the target of a spell or ability an opponent controls" — never triggered, because `TriggerMatcher.matchesBecomesTargetTrigger` checked the target's card predicates against the **base** type line (`cardComponent.typeLine.isCreature`). The two sides of the engine disagreed about whether the Forest was a creature.

## Fix

`matchesBecomesTargetTrigger` now evaluates the whole target filter through the projection-aware `PredicateEvaluator.matches()`, replacing its hand-rolled per-predicate loops (card predicates, state predicates, and a bespoke controller check):

- Battlefield permanents are matched against their **projected** types, so type-changing effects count (an animated land *is* "a creature you control" while the effect lasts). Changeling permanents now also correctly match subtype filters, and face-down permanents match only their 2/2-creature projection (Rule 708.2a) instead of their base card types.
- Stack objects have no battlefield projection and fall back to base card data — and to the spell's caster for the controller predicate — preserving the Surrak "…or a creature spell you control" behavior (`includeSpellTargets`).
- The collapse deletes ~30 lines of duplicated predicate evaluation and picks up filter-level `anyOf` support, which the old loops silently ignored.

The zone-change/LKI trigger path intentionally keeps `TriggerMatcher`'s own predicate matcher — for permanents that already left the battlefield, last-known info is the correct source, not the current projection.

## Testing

- New regression test in `PawpatchRecruitTest`: Kamahl, Fist of Krosa animates a Forest, the opponent bolts it → Pawpatch Recruit's trigger must fire and must exclude the targeted Forest from its "other than that creature" counter targets. Fails without the fix, passes with it.
- Related becomes-target suites pass: Surrak (permanent + spell-target + non-creature cases), Cactarantula, Manifold Mouse (Valiant), King of the Oathbreakers, both Elrond, Master of Healing target-trigger tests, Kamahl.
- Full `just test-rules` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
