### PR TITLE
fix: auto-tap prefers free colorless over painful colored mana for generic costs

### DIFF
--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/mana/ManaSolver.kt
@@ -34,6 +34,7 @@ import com.wingedsheep.sdk.scripting.effects.AddDynamicManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddManaOfChoiceEffect
 import com.wingedsheep.sdk.scripting.effects.CompositeEffect
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
 import com.wingedsheep.sdk.scripting.effects.Effect
 import com.wingedsheep.sdk.scripting.effects.Gate
 import com.wingedsheep.sdk.scripting.effects.GatedEffect
@@ -48,6 +49,8 @@ import com.wingedsheep.sdk.scripting.DampLandManaProduction
 import com.wingedsheep.sdk.scripting.GrantActivatedAbility
 import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.predicates.CardPredicate
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
 import com.wingedsheep.engine.state.components.identity.FaceDownComponent
 import com.wingedsheep.sdk.scripting.values.DynamicAmount
 
@@ -122,6 +125,22 @@ data class ManaSource(
      * Colors not present in this map can be produced for free (or not at all).
      */
     val colorActivationManaCost: Map<Color, Int> = emptyMap(),
+    /**
+     * Life required to produce each color, from the *cheapest* ability producing that color.
+     * Covers both pain modeled as a cost atom (Starting Town's "{T}, Pay 1 life: Add one mana
+     * of any color") and pain modeled as a self-damage side effect (Battlefield Forge's
+     * "{T}: Add {R} or {W}. This land deals 1 damage to you."). Colors not in this map are
+     * pain-free. Unlike the source-level [hasPainCost]/[painAmount] pair — which only flags a
+     * source whose *every* ability pains — this lets the solver see that a mixed source (free
+     * "{T}: Add {C}" alongside a painful colored ability) charges life for its colors but not
+     * for colorless, so auto-pay can route generic pips through the free ability.
+     */
+    val colorPainCost: Map<Color, Int> = emptyMap(),
+    /**
+     * Life required to produce colorless via the cheapest colorless-producing ability
+     * (0 = free, the overwhelmingly common case). Only meaningful when [producesColorless].
+     */
+    val colorlessPainCost: Int = 0,
     /**
      * Tapping this source also requires sacrificing it (e.g. Treasure tokens —
      * "{T}, Sacrifice this artifact: Add one mana of any color"). The auto-pay
@@ -560,8 +579,10 @@ class ManaSolver(
                         source2 == null -> source1
                         else -> {
                             // Pick the source with lower priority (tap it first)
-                            val priority1 = calculateTapPriority(source1, handRequirements, availableSourcesByColor)
-                            val priority2 = calculateTapPriority(source2, handRequirements, availableSourcesByColor)
+                            val priority1 = calculateTapPriority(source1, handRequirements, availableSourcesByColor) +
+                                painPenalty(source1, source1.colorPainCost[symbol.color1] ?: 0)
+                            val priority2 = calculateTapPriority(source2, handRequirements, availableSourcesByColor) +
+                                painPenalty(source2, source2.colorPainCost[symbol.color2] ?: 0)
                             if (priority1 <= priority2) source1 else source2
                         }
                     }
@@ -595,7 +616,10 @@ class ManaSolver(
                     // Sort colorless sources by priority
                     val source = remainingSources
                         .filter { it.producesColorless }
-                        .minByOrNull { calculateTapPriority(it, handRequirements, availableSourcesByColor) }
+                        .minByOrNull {
+                            calculateTapPriority(it, handRequirements, availableSourcesByColor) +
+                                painPenalty(it, it.colorlessPainCost)
+                        }
                         ?: return null
 
                     manaProduced[source.entityId] = ManaProduction(colorless = source.manaAmount)
@@ -726,9 +750,22 @@ class ManaSolver(
                 remainingSources.minByOrNull { calculateTapPriority(it, handRequirements, availableSourcesByColor) }
             } ?: return null
 
-            // For generic costs, prefer unrestricted colors, then colorless
-            val colorToUse = source.availableColorsFor(spellContext).firstOrNull()
-                ?: source.producesColors.firstOrNull()
+            // For generic costs any mana works, so pick the cheapest production: prefer
+            // unrestricted colors, then colorless — but never pay a color's extra cost
+            // (pain or activation mana) when a cheaper colorless ability exists. Without
+            // this, a Starting Town tapped for generic would route through "{T}, Pay
+            // 1 life: Add one mana of any color" instead of its free "{T}: Add {C}".
+            fun coloredExtraCost(color: Color): Int =
+                (source.colorPainCost[color] ?: 0) + (source.colorActivationManaCost[color] ?: 0)
+            val cheapestColor = source.availableColorsFor(spellContext)
+                .ifEmpty { source.producesColors }
+                .minByOrNull(::coloredExtraCost)
+            val colorToUse = when {
+                cheapestColor == null -> null
+                source.producesColorless &&
+                    coloredExtraCost(cheapestColor) > source.colorlessPainCost -> null
+                else -> cheapestColor
+            }
             manaProduced[source.entityId] = if (colorToUse != null) {
                 ManaProduction(color = colorToUse, amount = source.manaAmount)
             } else {
@@ -1019,6 +1056,10 @@ class ManaSolver(
             val perColorRestrictions = mutableMapOf<Color, ManaRestriction?>()
             // Track the minimum mana-cost-to-activate per color (cheapest ability producing it)
             val perColorActivationCost = mutableMapOf<Color, Int>()
+            // Track the minimum life cost (pain) per color, and for colorless production,
+            // across the abilities producing each — see ManaSource.colorPainCost.
+            val perColorPainCost = mutableMapOf<Color, Int>()
+            var cheapestColorlessPain = Int.MAX_VALUE
             // Track which colors are produceable WITHOUT sacrificing the source. A color is
             // sacrifice-free if any accepted ability producing it has no SacrificeSelf cost.
             // Colors in `combinedColors` but not here can only be made by sacrificing — the
@@ -1037,7 +1078,10 @@ class ManaSolver(
             landSubtypeSeedColors?.let { seed ->
                 combinedColors.addAll(seed)
                 sacrificeFreeColors.addAll(seed)
-                for (color in seed) perColorRestrictions[color] = null
+                for (color in seed) {
+                    perColorRestrictions[color] = null
+                    perColorPainCost[color] = 0
+                }
                 hasUnrestrictedAbility = true
             }
 
@@ -1140,6 +1184,15 @@ class ManaSolver(
                     }
                 }
 
+                // Pain modeled as a self-damage side effect in the ability's effect chain
+                // (Battlefield Forge: "{T}: Add {R} or {W}. This land deals 1 damage to you.")
+                // counts the same as a PayLife cost atom.
+                val effectPain = selfDamageAmount(ability.effect)
+                if (effectPain > 0) {
+                    abilityHasPainCost = true
+                    abilityPainAmount += effectPain
+                }
+
                 if (!abilityHasPainCost) anyAbilityHasNoPainCost = true
                 if (abilityHasPainCost) minPainAmount = minOf(minPainAmount, abilityPainAmount)
 
@@ -1238,6 +1291,16 @@ class ManaSolver(
                     else minOf(existing, abilityActivationManaCost)
                 }
 
+                // Record the cheapest pain per color / for colorless this ability produces.
+                for (color in effectColors) {
+                    val existing = perColorPainCost[color]
+                    perColorPainCost[color] = if (existing == null) abilityPainAmount
+                    else minOf(existing, abilityPainAmount)
+                }
+                if (manaEffect is AddColorlessManaEffect) {
+                    cheapestColorlessPain = minOf(cheapestColorlessPain, abilityPainAmount)
+                }
+
                 // Record which colors this ability can produce without sacrifice.
                 if (!abilityRequiresSacrifice) {
                     sacrificeFreeColors.addAll(effectColors)
@@ -1297,6 +1360,10 @@ class ManaSolver(
                 val colorActivationCosts = perColorActivationCost
                     .filter { (_, cost) -> cost > 0 }
 
+                // Only record pain > 0 (the default is "pain-free").
+                val colorPainCosts = perColorPainCost
+                    .filter { (_, pain) -> pain > 0 }
+
                 // Mark the source as sacrifice-required only when every accepted ability
                 // demanded sacrifice. If any non-sac ability was accepted, that path is
                 // preferred and the source is offered without sacrifice.
@@ -1348,6 +1415,10 @@ class ManaSolver(
                     colorRiders = perColorRiders.mapValues { (_, v) -> v.toSet() },
                     colorRestrictions = restrictedColors,
                     colorActivationManaCost = colorActivationCosts,
+                    colorPainCost = colorPainCosts,
+                    colorlessPainCost = if (producesColorless && cheapestColorlessPain != Int.MAX_VALUE) {
+                        cheapestColorlessPain
+                    } else 0,
                     requiresSacrifice = requiresSacrifice,
                     colorsRequiringSacrifice = colorsRequiringSacrifice,
                     hasContextSensitiveAbilities = hasMixedRestrictions,
@@ -1490,6 +1561,22 @@ class ManaSolver(
             else -> effect
         }
         else -> effect
+    }
+
+    /**
+     * Total fixed self-damage a mana ability's effect chain deals to its controller
+     * (Battlefield Forge: `AddMana(RED).then(DealDamage(1, PlayerRef(You)))`). Dynamic
+     * amounts are ignored (no printed mana ability self-damages a dynamic amount).
+     */
+    private fun selfDamageAmount(effect: Effect): Int = when (effect) {
+        is CompositeEffect -> effect.effects.sumOf { selfDamageAmount(it) }
+        is DealDamageEffect -> {
+            val target = effect.target
+            if (target is EffectTarget.PlayerRef && target.player == Player.You) {
+                (effect.amount as? DynamicAmount.Fixed)?.amount ?: 0
+            } else 0
+        }
+        else -> 0
     }
 
     private fun extractManaRestriction(
@@ -1816,8 +1903,21 @@ class ManaSolver(
     ): ManaSource? {
         return sources
             .filter { it.availableColorsFor(spellContext).contains(color) }
-            .minByOrNull { calculateTapPriority(it, handRequirements, availableSourcesByColor) }
+            .minByOrNull {
+                calculateTapPriority(it, handRequirements, availableSourcesByColor) +
+                    painPenalty(it, it.colorPainCost[color] ?: 0)
+            }
     }
+
+    /**
+     * Extra tap-priority penalty for producing mana that costs [pain] life from [source].
+     * Mirrors the pain-land rule in [calculateTapPriority], which already charges a source
+     * whose *every* ability pains ([ManaSource.hasPainCost]) — such sources are skipped here
+     * so the penalty isn't applied twice. This covers mixed sources (a free colorless ability
+     * alongside painful colored ones) where the demanded color specifically costs life.
+     */
+    private fun painPenalty(source: ManaSource, pain: Int): Int =
+        if (pain > 0 && !source.hasPainCost) 15 + pain else 0
 
     /**
      * Checks if a player can pay a mana cost (from floating mana pool + auto-pay).

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AutoTapPainAndBonusReproTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AutoTapPainAndBonusReproTest.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.components.player.ManaPoolComponent
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.apc.cards.BattlefieldForge
 import com.wingedsheep.mtg.sets.definitions.fin.cards.StartingTown
 import com.wingedsheep.mtg.sets.definitions.tla.AvatarTheLastAirbenderSet
 import com.wingedsheep.mtg.sets.definitions.tla.cards.BadgermoleCub
@@ -65,12 +66,21 @@ class AutoTapPainAndBonusReproTest : FunSpec({
         spell { effect = Effects.DrawCards(1) }
     }
 
+    // A {2}{G} sorcery used to force an auto-tap with generic pips (the Surrak repro shape).
+    val twoGenericGreenSpell = card("Generic Green Test Spell") {
+        manaCost = "{2}{G}"
+        colorIdentity = "G"
+        typeLine = "Sorcery"
+        oracleText = "Draw a card."
+        spell { effect = Effects.DrawCards(1) }
+    }
+
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
         driver.registerCards(
             TestCards.all + AvatarTheLastAirbenderSet.cards + listOf(
-                TestForest, BadgermoleCub, StartingTown,
-                tapForGreenCreature, greenGreenSpell, whiteSpell
+                TestForest, BadgermoleCub, StartingTown, BattlefieldForge,
+                tapForGreenCreature, greenGreenSpell, whiteSpell, twoGenericGreenSpell
             )
         )
         return driver
@@ -80,8 +90,8 @@ class AutoTapPainAndBonusReproTest : FunSpec({
         val registry = CardRegistry()
         registry.register(
             TestCards.all + AvatarTheLastAirbenderSet.cards + listOf(
-                TestForest, BadgermoleCub, StartingTown,
-                tapForGreenCreature, greenGreenSpell, whiteSpell
+                TestForest, BadgermoleCub, StartingTown, BattlefieldForge,
+                tapForGreenCreature, greenGreenSpell, whiteSpell, twoGenericGreenSpell
             )
         )
         return registry
@@ -103,6 +113,72 @@ class AutoTapPainAndBonusReproTest : FunSpec({
         result.isSuccess shouldBe true
 
         driver.isTapped(town) shouldBe true
+        driver.getLifeTotal(activePlayer) shouldBe (before - 1)
+    }
+
+    test("Starting Town generic: auto-paying generic pips uses the free colorless ability, no life loss") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Forest" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        // The Surrak repro: Forest pays the {G}, the two Starting Towns pay the {2}.
+        // Generic mana must flow through "{T}: Add {C}", not "{T}, Pay 1 life: Add one
+        // mana of any color".
+        val forest = driver.putLandOnBattlefield(activePlayer, "Forest")
+        val town1 = driver.putPermanentOnBattlefield(activePlayer, "Starting Town")
+        val town2 = driver.putPermanentOnBattlefield(activePlayer, "Starting Town")
+        val spell = driver.putCardInHand(activePlayer, "Generic Green Test Spell")
+
+        val before = driver.getLifeTotal(activePlayer)
+        val result = driver.castSpell(activePlayer, spell)
+        result.isSuccess shouldBe true
+
+        driver.isTapped(forest) shouldBe true
+        driver.isTapped(town1) shouldBe true
+        driver.isTapped(town2) shouldBe true
+        driver.getLifeTotal(activePlayer) shouldBe before
+    }
+
+    test("Battlefield Forge generic: auto-paying generic pips uses the free colorless ability, no damage") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Forest" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        // Same shape as Starting Town but with pain modeled as a self-damage side effect
+        // ("{T}: Add {R} or {W}. This land deals 1 damage to you.") instead of a cost atom.
+        val forest = driver.putLandOnBattlefield(activePlayer, "Forest")
+        val forge1 = driver.putPermanentOnBattlefield(activePlayer, "Battlefield Forge")
+        val forge2 = driver.putPermanentOnBattlefield(activePlayer, "Battlefield Forge")
+        val spell = driver.putCardInHand(activePlayer, "Generic Green Test Spell")
+
+        val before = driver.getLifeTotal(activePlayer)
+        val result = driver.castSpell(activePlayer, spell)
+        result.isSuccess shouldBe true
+
+        driver.isTapped(forest) shouldBe true
+        driver.isTapped(forge1) shouldBe true
+        driver.isTapped(forge2) shouldBe true
+        driver.getLifeTotal(activePlayer) shouldBe before
+    }
+
+    test("Battlefield Forge colored pip: pain still applies when the colored ability is required") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 20, "Forest" to 20), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val activePlayer = driver.activePlayer!!
+        // The forge is the only white source, so its painful "{T}: Add {R} or {W}" ability
+        // must be used — and its self-damage side effect must still land.
+        val forge = driver.putPermanentOnBattlefield(activePlayer, "Battlefield Forge")
+        val spell = driver.putCardInHand(activePlayer, "White Test Spell")
+
+        val before = driver.getLifeTotal(activePlayer)
+        val result = driver.castSpell(activePlayer, spell)
+        result.isSuccess shouldBe true
+
+        driver.isTapped(forge) shouldBe true
         driver.getLifeTotal(activePlayer) shouldBe (before - 1)
     }
 


### PR DESCRIPTION
## Problem

Auto-tap routed generic mana pips through a mixed source's *painful* colored ability even when the same source has a free `{T}: Add {C}` ability. Casting Surrak with two Starting Towns paying the generic portion cost 2 life for no reason; the same happened with painlands like Battlefield Forge (pain modeled as a self-damage side effect rather than a `PayLife` cost atom).

The solver's existing `hasPainCost`/`painAmount` fields are source-level and only flag a source whose *every* ability pains — a mixed source (free colorless alongside painful colored) looked entirely pain-free.

## Fix

- **`ManaSource.colorPainCost` / `colorlessPainCost`** — per-color (and colorless) life cost from the *cheapest* ability producing that mana, mirroring the existing `colorActivationManaCost` pattern. Built during source analysis.
- **`selfDamageAmount`** — pain modeled as a fixed self-damage effect in the ability's effect chain (Battlefield Forge: `AddMana(RED).then(DealDamage(1, You))`) now counts the same as a `PayLife` cost atom, feeding both the new per-color fields and the existing source-level pain fields.
- **Generic pass** — picks the cheapest production: prefers unrestricted colors, but never pays a color's extra cost (pain *or* activation mana) when a cheaper colorless ability exists. This also fixes filter-land shapes (free `{T}: Add {C}` alongside `{1}, {T}: Add {W}{U}`) wasting an extra tap on generic.
- **Colored / hybrid / `{C}` pip passes** — add a `painPenalty` (15 + pain, matching the pain-land rule in `calculateTapPriority`, with a guard against double-counting `hasPainCost` sources) so pips prefer pain-free sources when alternatives exist, while still using the painful ability when it's the only way to pay.

Execution was already consistent: `ManaAbilitySideEffectExecutor` matches the activated ability by produced color, so colorless production runs the free ability (no side effects) and colored production runs the painful one (side effects + life payment).

## Tests

New in `AutoTapPainAndBonusReproTest` (all green, alongside the existing pain/bonus repros):

- Starting Town ×2 paying `{2}` of a `{2}{G}` spell → free colorless ability, no life loss.
- Battlefield Forge ×2 paying `{2}` → free colorless ability, no damage (effect-modeled pain).
- Battlefield Forge as the only white source for a `{W}` spell → painful ability still used, damage still lands.

Also verified green: `MonocolorHybridManaSolverTest`, `SmartTapTest`, `ConditionalManaAbilityAutoTapTest`, `MultiManaSourceTest` (no pinned auto-tap ordering shifted).

A self-review (per the repo's review-changes flow) is attached as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
