### PR TITLE
Fix discover/cascade free-casting of targeted spells

### DIFF
--- a/manual-scenarios/bugs/cascade-targeted-spell-target-prompt.json
+++ b/manual-scenarios/bugs/cascade-targeted-spell-target-prompt.json
@@ -1,0 +1,34 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Quandrix, the Proof"],
+    "battlefield": [
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Island"},
+      {"name": "Island"}
+    ],
+    "graveyard": ["Grizzly Bears"],
+    "library": ["Zombify", "Forest", "Forest"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Forest", "Forest"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/bugs/discover-no-legal-targets-free-cast-leak.json
+++ b/manual-scenarios/bugs/discover-no-legal-targets-free-cast-leak.json
@@ -1,0 +1,41 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Trumpeting Carnosaur"],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": ["Grizzly Bears"],
+    "library": ["Zombify", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Hill Giant"}
+    ],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/bugs/discover-targeted-spell-target-prompt.json
+++ b/manual-scenarios/bugs/discover-targeted-spell-target-prompt.json
@@ -1,0 +1,33 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Trumpeting Carnosaur"],
+    "battlefield": [
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Mountain"}
+    ],
+    "graveyard": ["Grizzly Bears"],
+    "library": ["Zombify", "Mountain", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Mountain", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LibraryAndZoneContinuations.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/LibraryAndZoneContinuations.kt
@@ -358,6 +358,11 @@ data class DiscoverMayCastContinuation(
  * @property casterId The controller of the effect (also the decision-maker)
  * @property storeCastTo When set, the cast card's id is published to this pipeline collection
  *   once the cast initiates, so an enclosing `IfYouDoEffect` can gate a follow-up.
+ * @property grantedPermissionId The [com.wingedsheep.engine.state.permissions.MayPlayPermission]
+ *   created for this synthesized cast, so a failed cast can revoke exactly that grant (a blanket
+ *   per-card removal could clobber an unrelated permission covering the same card).
+ * @property onCastFailure Where the card goes if the cast still can't initiate with the chosen
+ *   targets. The free-cast grant is revoked either way.
  */
 @Serializable
 data class CastFromCollectionTargetsContinuation(
@@ -365,7 +370,25 @@ data class CastFromCollectionTargetsContinuation(
     val cardId: EntityId,
     val casterId: EntityId,
     val storeCastTo: String? = null,
+    val grantedPermissionId: EntityId? = null,
+    val onCastFailure: FreeCastFallback = FreeCastFallback.LEAVE,
 ) : ContinuationFrame
+
+/**
+ * Disposition of the card when a synthesized free cast fails to initiate after target
+ * selection ([CastFromCollectionTargetsContinuation.onCastFailure]).
+ */
+@Serializable
+enum class FreeCastFallback {
+    /** The card stays where it is (CastFromCollection effects — the card simply stays put). */
+    LEAVE,
+
+    /** Discover (CR 701.57a) — "If you don't cast it, put that card into your hand." */
+    HAND,
+
+    /** Cascade (CR 702.85a) — uncast exiled cards go to the bottom of the library. */
+    BOTTOM_OF_LIBRARY,
+}
 
 /**
  * Resume after the controller picks (or declines) the next card to cast for free during a

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -15,7 +15,6 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.OwnerComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
-import com.wingedsheep.engine.state.permissions.addMayPlayPermission
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CastAnyNumberFromCollectionWithoutPayingCostEffect
@@ -802,44 +801,43 @@ class LibraryAndZoneContinuationResumer(
             cards = others
         ) { afterBottom = it }
 
-        // Grant free-cast permission so the synthesized cast pays nothing.
-        var stateWithGrant = afterBottom.updateEntity(continuation.cascadeCardId) { container ->
-            container.with(PlayWithoutPayingCostComponent(controllerId = continuation.playerId))
-        }
-        val (permId, stateWithPerm) = stateWithGrant.newEntity()
-        stateWithGrant = stateWithPerm.addMayPlayPermission(
-            MayPlayPermission(
-                id = permId,
-                cardIds = setOf(continuation.cascadeCardId),
-                controllerId = continuation.playerId,
-                sourceId = continuation.sourceId,
-                timestamp = stateWithGrant.timestamp,
-            )
-        )
-
         // A non-modal targeted spell can't carry targets through the synthesized CastSpell —
         // surface the ChooseTargetsDecision first, exactly as
         // CastFromCollectionWithoutPayingCostExecutor does. If a required slot has no legal
-        // targets the cast can't initiate (CR 601.2c) and the cascade card is bottomed.
+        // targets the cast can't initiate (CR 601.2c) and the cascade card is bottomed. Checked
+        // *before* granting so the bottomed card carries no lingering free-cast grant.
         val targetPrep = CastFromCollectionWithoutPayingCostExecutor.prepareTargetSelection(
-            state = stateWithGrant,
+            state = afterBottom,
             cardId = continuation.cascadeCardId,
             casterId = continuation.playerId,
             cardRegistry = services.cardRegistry,
             targetFinder = targetFinder,
         )
         if (targetPrep is CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NoLegalTargets) {
-            var finalState = stateWithGrant
+            var finalState = afterBottom
             val tailEvents = CascadeExecutor.bottomRandomize(
-                state = stateWithGrant,
+                state = afterBottom,
                 playerId = continuation.playerId,
                 cards = listOf(continuation.cascadeCardId)
             ) { finalState = it }
             return checkForMore(finalState, bottomEvents + tailEvents)
         }
+
+        // Grant free-cast permission so the synthesized cast pays nothing.
+        val (permId, stateWithGrant) = CastFromCollectionWithoutPayingCostExecutor.grantFreeCast(
+            state = afterBottom,
+            cardId = continuation.cascadeCardId,
+            controllerId = continuation.playerId,
+            sourceId = continuation.sourceId,
+        )
+
         if (targetPrep is CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NeedsTargets) {
+            val targetsContinuation = targetPrep.continuation.copy(
+                grantedPermissionId = permId,
+                onCastFailure = FreeCastFallback.BOTTOM_OF_LIBRARY,
+            )
             val pausedState = stateWithGrant
-                .pushContinuation(targetPrep.continuation)
+                .pushContinuation(targetsContinuation)
                 .withPendingDecision(targetPrep.decision)
                 .withPriority(continuation.playerId)
             return ExecutionResult.paused(pausedState, targetPrep.decision, bottomEvents + targetPrep.event)
@@ -853,17 +851,23 @@ class LibraryAndZoneContinuationResumer(
         val castResult = castSpellHandler.execute(stateForCast, castAction)
 
         if (castResult.error != null) {
-            // Cast couldn't initiate (no legal targets, etc.) — the cascade card
-            // wasn't cast, so it joins the leftovers on the bottom of the library.
-            var finalState = stateWithGrant
+            // Cast couldn't initiate (no legal targets, etc.) — revoke the unused free-cast
+            // grant; the cascade card wasn't cast, so it joins the leftovers on the bottom
+            // of the library.
+            val revoked = CastFromCollectionWithoutPayingCostExecutor.revokeFreeCast(
+                stateWithGrant, continuation.cascadeCardId, permId
+            )
+            var finalState = revoked
             val tailEvents = CascadeExecutor.bottomRandomize(
-                state = stateWithGrant,
+                state = revoked,
                 playerId = continuation.playerId,
                 cards = listOf(continuation.cascadeCardId)
             ) { finalState = it }
             return checkForMore(finalState, bottomEvents + tailEvents)
         }
 
+        // CastSpellHandler already detected + stacked this cast's triggers; propagate the flag
+        // so SubmitDecisionHandler doesn't re-scan the SpellCastEvent and double-fire them.
         if (castResult.pendingDecision != null) {
             // The cast paused (for target / X / mode selection). The leftover
             // bottoming is already done; let the cast's own continuations finish
@@ -872,10 +876,11 @@ class LibraryAndZoneContinuationResumer(
                 castResult.state,
                 castResult.pendingDecision,
                 bottomEvents + castResult.events
-            )
+            ).copy(triggersAlreadyProcessed = castResult.triggersAlreadyProcessed)
         }
 
         return checkForMore(castResult.state, bottomEvents + castResult.events)
+            .copy(triggersAlreadyProcessed = castResult.triggersAlreadyProcessed)
     }
 
     /**
@@ -935,38 +940,21 @@ class LibraryAndZoneContinuationResumer(
             )
         }
 
-        // Cast branch: grant a free cast and synthesize it through the normal cast machinery —
-        // mirroring CascadeExecutor's may-cast rather than the CastFromCollection effect, so the
-        // cast's "whenever you cast a spell (from exile)" triggers are stacked exactly once
-        // (Quintorius Kand).
-        var granted = afterBottom.updateEntity(discovered) { container ->
-            container.with(PlayWithoutPayingCostComponent(controllerId = continuation.playerId))
-        }
-        val (permId, stateWithPerm) = granted.newEntity()
-        granted = stateWithPerm.addMayPlayPermission(
-            MayPlayPermission(
-                id = permId,
-                cardIds = setOf(discovered),
-                controllerId = continuation.playerId,
-                sourceId = continuation.sourceId,
-                timestamp = stateWithPerm.timestamp,
-            )
-        )
-
         // A non-modal targeted spell (Zombify) can't carry targets through the synthesized
         // CastSpell — surface the ChooseTargetsDecision first, exactly as
         // CastFromCollectionWithoutPayingCostExecutor does. If a required slot has no legal
-        // targets the cast can't initiate (CR 601.2c) and the card goes to hand instead.
+        // targets the cast can't initiate (CR 601.2c) and the card goes to hand instead. Checked
+        // *before* granting so the card reaches hand without a lingering free-cast grant.
         val targetPrep = CastFromCollectionWithoutPayingCostExecutor.prepareTargetSelection(
-            state = granted,
+            state = afterBottom,
             cardId = discovered,
             casterId = continuation.playerId,
             cardRegistry = services.cardRegistry,
             targetFinder = targetFinder,
         )
         if (targetPrep is CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NoLegalTargets) {
-            val moveResult = ZoneMovementUtils.moveCardToZone(granted, discovered, Zone.HAND)
-            var afterHand = granted
+            val moveResult = ZoneMovementUtils.moveCardToZone(afterBottom, discovered, Zone.HAND)
+            var afterHand = afterBottom
             val handEvents = bottomEvents.toMutableList()
             if (moveResult.isSuccess) {
                 afterHand = moveResult.state
@@ -974,6 +962,17 @@ class LibraryAndZoneContinuationResumer(
             }
             return runDiscoverThenEffect(afterHand, continuation, discoveredCollections, handEvents, checkForMore)
         }
+
+        // Cast branch: grant a free cast and synthesize it through the normal cast machinery —
+        // mirroring CascadeExecutor's may-cast rather than the CastFromCollection effect, so the
+        // cast's "whenever you cast a spell (from exile)" triggers are stacked exactly once
+        // (Quintorius Kand).
+        val (permId, granted) = CastFromCollectionWithoutPayingCostExecutor.grantFreeCast(
+            state = afterBottom,
+            cardId = discovered,
+            controllerId = continuation.playerId,
+            sourceId = continuation.sourceId,
+        )
 
         // The follow-up [thenEffect] is pre-pushed as an EffectContinuation so it resolves after
         // the cast even if the cast pauses for targets / X.
@@ -994,8 +993,12 @@ class LibraryAndZoneContinuationResumer(
         }
 
         if (targetPrep is CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NeedsTargets) {
+            val targetsContinuation = targetPrep.continuation.copy(
+                grantedPermissionId = permId,
+                onCastFailure = FreeCastFallback.HAND,
+            )
             val pausedState = stateForCast
-                .pushContinuation(targetPrep.continuation)
+                .pushContinuation(targetsContinuation)
                 .withPendingDecision(targetPrep.decision)
                 .withPriority(continuation.playerId)
             return ExecutionResult.paused(pausedState, targetPrep.decision, bottomEvents + targetPrep.event)
@@ -1005,10 +1008,15 @@ class LibraryAndZoneContinuationResumer(
         val castResult = castSpellHandler.execute(stateReady, CastSpell(continuation.playerId, discovered))
 
         if (castResult.error != null) {
-            // The cast couldn't initiate — pop the pre-pushed follow-up, put the discovered card
-            // into hand ("If you don't cast it, put that card into your hand"), then run the
-            // follow-up (Hit the Mother Lode still makes its Treasures — a card was discovered).
-            val withoutThen = if (continuation.thenEffect != null) stateForCast.popContinuation().second else stateForCast
+            // The cast couldn't initiate — pop the pre-pushed follow-up, revoke the unused
+            // free-cast grant, put the discovered card into hand ("If you don't cast it, put
+            // that card into your hand"), then run the follow-up (Hit the Mother Lode still
+            // makes its Treasures — a card was discovered).
+            val withoutThen = CastFromCollectionWithoutPayingCostExecutor.revokeFreeCast(
+                if (continuation.thenEffect != null) stateForCast.popContinuation().second else stateForCast,
+                discovered,
+                permId,
+            )
             val moveResult = ZoneMovementUtils.moveCardToZone(withoutThen, discovered, Zone.HAND)
             var afterHand = withoutThen
             val handEvents = bottomEvents.toMutableList()
@@ -1090,9 +1098,34 @@ class LibraryAndZoneContinuationResumer(
 
         if (castResult.error != null) {
             // Cast still couldn't initiate (e.g., targets became illegal between selection
-            // and resolution). Treat as a no-op so the rest of the trigger's resolution
-            // doesn't lose its outer pipeline.
-            return checkForMore(state, emptyList())
+            // and resolution). Revoke the unused free-cast grant and send the card to the
+            // owning flow's fallback zone (discover → hand, cascade → bottom of library) so
+            // it isn't stranded in exile; checkForMore keeps the rest of the trigger's
+            // resolution (e.g. a discover follow-up frame) alive.
+            var cleaned = CastFromCollectionWithoutPayingCostExecutor.revokeFreeCast(
+                state, continuation.cardId, continuation.grantedPermissionId
+            )
+            val fallbackEvents = mutableListOf<GameEvent>()
+            when (continuation.onCastFailure) {
+                FreeCastFallback.LEAVE -> {}
+                FreeCastFallback.HAND -> {
+                    val moveResult = ZoneMovementUtils.moveCardToZone(cleaned, continuation.cardId, Zone.HAND)
+                    if (moveResult.isSuccess) {
+                        cleaned = moveResult.state
+                        fallbackEvents.addAll(moveResult.events)
+                    }
+                }
+                FreeCastFallback.BOTTOM_OF_LIBRARY -> {
+                    fallbackEvents.addAll(
+                        CascadeExecutor.bottomRandomize(
+                            state = cleaned,
+                            playerId = continuation.casterId,
+                            cards = listOf(continuation.cardId)
+                        ) { cleaned = it }
+                    )
+                }
+            }
+            return checkForMore(cleaned, fallbackEvents)
         }
 
         // The cast initiated. Publish the cast card so an enclosing IfYouDoEffect frame beneath

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/LibraryAndZoneContinuationResumer.kt
@@ -4,8 +4,10 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PipelineState
 import com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler
+import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.handlers.effects.library.CascadeExecutor
+import com.wingedsheep.engine.handlers.effects.library.CastFromCollectionWithoutPayingCostExecutor
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.ZoneKey
 import com.wingedsheep.engine.state.components.battlefield.TappedComponent
@@ -27,6 +29,7 @@ class LibraryAndZoneContinuationResumer(
 ) : ContinuationResumerModule {
 
     private val castSpellHandler: CastSpellHandler by lazy { CastSpellHandler.create(services) }
+    private val targetFinder = TargetFinder()
     private val effectRunner: EffectContinuationRunner by lazy {
         EffectContinuationRunner(services.effectExecutorRegistry)
     }
@@ -814,6 +817,34 @@ class LibraryAndZoneContinuationResumer(
             )
         )
 
+        // A non-modal targeted spell can't carry targets through the synthesized CastSpell —
+        // surface the ChooseTargetsDecision first, exactly as
+        // CastFromCollectionWithoutPayingCostExecutor does. If a required slot has no legal
+        // targets the cast can't initiate (CR 601.2c) and the cascade card is bottomed.
+        val targetPrep = CastFromCollectionWithoutPayingCostExecutor.prepareTargetSelection(
+            state = stateWithGrant,
+            cardId = continuation.cascadeCardId,
+            casterId = continuation.playerId,
+            cardRegistry = services.cardRegistry,
+            targetFinder = targetFinder,
+        )
+        if (targetPrep is CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NoLegalTargets) {
+            var finalState = stateWithGrant
+            val tailEvents = CascadeExecutor.bottomRandomize(
+                state = stateWithGrant,
+                playerId = continuation.playerId,
+                cards = listOf(continuation.cascadeCardId)
+            ) { finalState = it }
+            return checkForMore(finalState, bottomEvents + tailEvents)
+        }
+        if (targetPrep is CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NeedsTargets) {
+            val pausedState = stateWithGrant
+                .pushContinuation(targetPrep.continuation)
+                .withPendingDecision(targetPrep.decision)
+                .withPriority(continuation.playerId)
+            return ExecutionResult.paused(pausedState, targetPrep.decision, bottomEvents + targetPrep.event)
+        }
+
         // Hand priority to the cascade controller for the synthesized cast. The cast
         // happens *during* cascade resolution (CR 702.85a) rather than on a normal
         // priority window, so we override the priorityPlayerId for this single call.
@@ -907,9 +938,46 @@ class LibraryAndZoneContinuationResumer(
         // Cast branch: grant a free cast and synthesize it through the normal cast machinery —
         // mirroring CascadeExecutor's may-cast rather than the CastFromCollection effect, so the
         // cast's "whenever you cast a spell (from exile)" triggers are stacked exactly once
-        // (Quintorius Kand). The follow-up [thenEffect] is pre-pushed as an EffectContinuation so it
-        // resolves after the cast even if the cast pauses for targets / X.
-        var stateForCast = afterBottom
+        // (Quintorius Kand).
+        var granted = afterBottom.updateEntity(discovered) { container ->
+            container.with(PlayWithoutPayingCostComponent(controllerId = continuation.playerId))
+        }
+        val (permId, stateWithPerm) = granted.newEntity()
+        granted = stateWithPerm.addMayPlayPermission(
+            MayPlayPermission(
+                id = permId,
+                cardIds = setOf(discovered),
+                controllerId = continuation.playerId,
+                sourceId = continuation.sourceId,
+                timestamp = stateWithPerm.timestamp,
+            )
+        )
+
+        // A non-modal targeted spell (Zombify) can't carry targets through the synthesized
+        // CastSpell — surface the ChooseTargetsDecision first, exactly as
+        // CastFromCollectionWithoutPayingCostExecutor does. If a required slot has no legal
+        // targets the cast can't initiate (CR 601.2c) and the card goes to hand instead.
+        val targetPrep = CastFromCollectionWithoutPayingCostExecutor.prepareTargetSelection(
+            state = granted,
+            cardId = discovered,
+            casterId = continuation.playerId,
+            cardRegistry = services.cardRegistry,
+            targetFinder = targetFinder,
+        )
+        if (targetPrep is CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NoLegalTargets) {
+            val moveResult = ZoneMovementUtils.moveCardToZone(granted, discovered, Zone.HAND)
+            var afterHand = granted
+            val handEvents = bottomEvents.toMutableList()
+            if (moveResult.isSuccess) {
+                afterHand = moveResult.state
+                handEvents.addAll(moveResult.events)
+            }
+            return runDiscoverThenEffect(afterHand, continuation, discoveredCollections, handEvents, checkForMore)
+        }
+
+        // The follow-up [thenEffect] is pre-pushed as an EffectContinuation so it resolves after
+        // the cast even if the cast pauses for targets / X.
+        var stateForCast = granted
         if (continuation.thenEffect != null) {
             val thenCtx = EffectContext(
                 sourceId = continuation.sourceId,
@@ -925,27 +993,22 @@ class LibraryAndZoneContinuationResumer(
             )
         }
 
-        var granted = stateForCast.updateEntity(discovered) { container ->
-            container.with(PlayWithoutPayingCostComponent(controllerId = continuation.playerId))
+        if (targetPrep is CastFromCollectionWithoutPayingCostExecutor.TargetPrep.NeedsTargets) {
+            val pausedState = stateForCast
+                .pushContinuation(targetPrep.continuation)
+                .withPendingDecision(targetPrep.decision)
+                .withPriority(continuation.playerId)
+            return ExecutionResult.paused(pausedState, targetPrep.decision, bottomEvents + targetPrep.event)
         }
-        val (permId, stateWithPerm) = granted.newEntity()
-        granted = stateWithPerm.addMayPlayPermission(
-            MayPlayPermission(
-                id = permId,
-                cardIds = setOf(discovered),
-                controllerId = continuation.playerId,
-                sourceId = continuation.sourceId,
-                timestamp = stateWithPerm.timestamp,
-            )
-        )
-        val stateReady = granted.copy(priorityPlayerId = continuation.playerId)
+
+        val stateReady = stateForCast.copy(priorityPlayerId = continuation.playerId)
         val castResult = castSpellHandler.execute(stateReady, CastSpell(continuation.playerId, discovered))
 
         if (castResult.error != null) {
             // The cast couldn't initiate — pop the pre-pushed follow-up, put the discovered card
             // into hand ("If you don't cast it, put that card into your hand"), then run the
             // follow-up (Hit the Mother Lode still makes its Treasures — a card was discovered).
-            val withoutThen = if (continuation.thenEffect != null) granted.popContinuation().second else granted
+            val withoutThen = if (continuation.thenEffect != null) stateForCast.popContinuation().second else stateForCast
             val moveResult = ZoneMovementUtils.moveCardToZone(withoutThen, discovered, Zone.HAND)
             var afterHand = withoutThen
             val handEvents = bottomEvents.toMutableList()
@@ -1037,17 +1100,21 @@ class LibraryAndZoneContinuationResumer(
         val castCollections = continuation.storeCastTo?.let { mapOf(it to listOf(continuation.cardId)) }
             ?: emptyMap()
 
+        // CastSpellHandler already detected + stacked this cast's triggers (e.g. Quintorius Kand's
+        // "whenever you cast a spell from exile"); propagate the flag so SubmitDecisionHandler
+        // doesn't re-scan the SpellCastEvent and double-fire them.
         if (castResult.pendingDecision != null) {
             val exposed = exposeCollectionsToNextFrame(castResult.state, castCollections)
             return ExecutionResult.paused(
                 exposed,
                 castResult.pendingDecision,
                 castResult.events,
-            )
+            ).copy(triggersAlreadyProcessed = castResult.triggersAlreadyProcessed)
         }
 
         val exposed = exposeCollectionsToNextFrame(castResult.state, castCollections)
         return checkForMore(exposed, castResult.events)
+            .copy(triggersAlreadyProcessed = castResult.triggersAlreadyProcessed)
     }
 
     /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
@@ -18,6 +18,7 @@ import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
 import com.wingedsheep.engine.state.permissions.addMayPlayPermission
+import com.wingedsheep.engine.state.permissions.removeMayPlayPermission
 import com.wingedsheep.sdk.model.EntityId
 import com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect
 import com.wingedsheep.sdk.scripting.effects.ModalEffect
@@ -70,46 +71,43 @@ class CastFromCollectionWithoutPayingCostExecutor(
         val cardId = cards.first()
         val controllerId = context.controllerId
 
+        // Check targeting *before* granting: a grant made ahead of a cast that never happens
+        // would follow the card out of exile and stay live until end-of-turn cleanup.
+        val prep = prepareTargetSelection(state, cardId, controllerId, cardRegistry, targetFinder, effect.storeCastTo)
+        if (prep is TargetPrep.NoLegalTargets) {
+            // CR 601.2c — if no legal targets exist for a required slot, the cast can't
+            // initiate; the chosen card simply stays where it is.
+            return EffectResult.success(state)
+        }
+
         // payManaCost casts route through the normal cost (Kaervek, the Punisher — "you may cast
         // the copy"); only the free-cast path stamps PlayWithoutPayingCostComponent. Both grant a
         // MayPlayPermission so the card is castable from its current (e.g. exile) zone.
-        var newState = if (effect.payManaCost) state else state.updateEntity(cardId) { container ->
-            container.with(PlayWithoutPayingCostComponent(controllerId = controllerId))
-        }
-        val (permId, stateWithPerm) = newState.newEntity()
-        newState = stateWithPerm.addMayPlayPermission(
-            MayPlayPermission(
-                id = permId,
-                cardIds = setOf(cardId),
-                controllerId = controllerId,
-                sourceId = context.sourceId,
-                timestamp = newState.timestamp,
-            )
+        val (permId, newState) = grantFreeCast(
+            state = state,
+            cardId = cardId,
+            controllerId = controllerId,
+            sourceId = context.sourceId,
+            withoutPayingCost = !effect.payManaCost,
         )
 
-        when (val prep = prepareTargetSelection(newState, cardId, controllerId, cardRegistry, targetFinder, effect.storeCastTo)) {
-            TargetPrep.NoLegalTargets ->
-                // CR 601.2c — if no legal targets exist for a required slot, the cast can't
-                // initiate; the chosen card simply stays where it is.
-                return EffectResult.success(newState)
-            is TargetPrep.NeedsTargets -> {
-                val pausedState = newState
-                    .pushContinuation(prep.continuation)
-                    .withPendingDecision(prep.decision)
-                    .withPriority(controllerId)
-                return EffectResult.paused(pausedState, prep.decision, listOf(prep.event))
-            }
-            TargetPrep.NotNeeded -> {}
+        if (prep is TargetPrep.NeedsTargets) {
+            val pausedState = newState
+                .pushContinuation(prep.continuation.copy(grantedPermissionId = permId))
+                .withPendingDecision(prep.decision)
+                .withPriority(controllerId)
+            return EffectResult.paused(pausedState, prep.decision, listOf(prep.event))
         }
 
         // No targets needed (or modal — CastSpellHandler will handle per-mode targets).
-        return invokeCast(newState, controllerId, cardId, emptyList(), effect.storeCastTo)
+        return invokeCast(newState, controllerId, cardId, permId, emptyList(), effect.storeCastTo)
     }
 
     private fun invokeCast(
         state: GameState,
         casterId: EntityId,
         cardId: EntityId,
+        grantedPermissionId: EntityId,
         targets: List<com.wingedsheep.engine.state.components.stack.ChosenTarget>,
         storeCastTo: String?,
     ): EffectResult {
@@ -120,7 +118,7 @@ class CastFromCollectionWithoutPayingCostExecutor(
         )
 
         if (castResult.error != null) {
-            return EffectResult.success(state)
+            return EffectResult.success(revokeFreeCast(state, cardId, grantedPermissionId))
         }
 
         // The cast initiated (synchronously or pausing for X / further input). Publish the cast
@@ -165,6 +163,49 @@ class CastFromCollectionWithoutPayingCostExecutor(
     }
 
     companion object {
+        /**
+         * Grant [controllerId] a one-shot cast of [cardId] from its current zone: a
+         * [MayPlayPermission] covering the card and — unless [withoutPayingCost] is false
+         * (Kaervek's "you may cast the copy", paying its cost) — a [PlayWithoutPayingCostComponent]
+         * making the cast free. Returns the permission id so a cast that never happens can revoke
+         * exactly this grant via [revokeFreeCast].
+         *
+         * Callers must only grant once the cast is known to be attemptable
+         * ([prepareTargetSelection] first): the component is zone-agnostic and lives until
+         * end-of-turn cleanup, so a leftover grant would let the card be cast for free from
+         * wherever it lands (hand, library, exile).
+         */
+        fun grantFreeCast(
+            state: GameState,
+            cardId: EntityId,
+            controllerId: EntityId,
+            sourceId: EntityId?,
+            withoutPayingCost: Boolean = true,
+        ): Pair<EntityId, GameState> {
+            val stamped = if (!withoutPayingCost) state else state.updateEntity(cardId) { container ->
+                container.with(PlayWithoutPayingCostComponent(controllerId = controllerId))
+            }
+            val (permId, stateWithPerm) = stamped.newEntity()
+            val granted = stateWithPerm.addMayPlayPermission(
+                MayPlayPermission(
+                    id = permId,
+                    cardIds = setOf(cardId),
+                    controllerId = controllerId,
+                    sourceId = sourceId,
+                    timestamp = stateWithPerm.timestamp,
+                )
+            )
+            return permId to granted
+        }
+
+        /** Undo [grantFreeCast] when the synthesized cast didn't happen after all. */
+        fun revokeFreeCast(state: GameState, cardId: EntityId, permissionId: EntityId?): GameState {
+            val withoutPermission = permissionId?.let { state.removeMayPlayPermission(it) } ?: state
+            return withoutPermission.updateEntity(cardId) { container ->
+                container.without<PlayWithoutPayingCostComponent>()
+            }
+        }
+
         /**
          * Determine whether a synthesized cast of [cardId] must pause for target selection first.
          *

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/CastFromCollectionWithoutPayingCostExecutor.kt
@@ -87,86 +87,19 @@ class CastFromCollectionWithoutPayingCostExecutor(
             )
         )
 
-        val cardComponent = newState.getEntity(cardId)?.get<CardComponent>()
-        val cardDef = cardComponent?.let { cardRegistry.getCard(it.cardDefinitionId) }
-        val isModalSpell = cardDef?.script?.spellEffect is ModalEffect
-        // Include the aura's enchant target: an Aura carries its target in `auraTarget`, not in
-        // `targetRequirements`, so a free-cast Aura (Pacifism) would otherwise reach CastSpellHandler
-        // with no target — which it rejects ("No valid targets available"), stranding the card in
-        // exile. Mirror CastSpellHandler's own `targetRequirements + auraTarget` union here.
-        val targetRequirements = buildList {
-            addAll(cardDef?.script?.targetRequirements.orEmpty())
-            cardDef?.script?.auraTarget?.let { add(it) }
-        }
-
-        // Modal spells route through CastSpellHandler's own target-pause flow after mode
-        // selection. Non-modal targeted spells (including Auras) need us to surface a
-        // ChooseTargetsDecision first because CastSpellHandler.validate rejects `targets = []`
-        // for required slots.
-        if (!isModalSpell && targetRequirements.isNotEmpty()) {
-            val legalTargetsMap = mutableMapOf<Int, List<EntityId>>()
-            val requirementInfos = targetRequirements.mapIndexed { index, requirement ->
-                val legal = targetFinder.findLegalTargets(
-                    state = newState,
-                    requirement = requirement,
-                    controllerId = controllerId,
-                    sourceId = cardId,
-                )
-                legalTargetsMap[index] = legal
-                TargetRequirementInfo(
-                    index = index,
-                    description = requirement.description,
-                    minTargets = requirement.effectiveMinCount,
-                    maxTargets = requirement.count,
-                )
-            }
-            val mandatoryRequirementHasNoTargets = requirementInfos.any { info ->
-                info.minTargets > 0 && legalTargetsMap[info.index].isNullOrEmpty()
-            }
-            if (mandatoryRequirementHasNoTargets) {
+        when (val prep = prepareTargetSelection(newState, cardId, controllerId, cardRegistry, targetFinder, effect.storeCastTo)) {
+            TargetPrep.NoLegalTargets ->
                 // CR 601.2c — if no legal targets exist for a required slot, the cast can't
                 // initiate; the chosen card simply stays where it is.
                 return EffectResult.success(newState)
+            is TargetPrep.NeedsTargets -> {
+                val pausedState = newState
+                    .pushContinuation(prep.continuation)
+                    .withPendingDecision(prep.decision)
+                    .withPriority(controllerId)
+                return EffectResult.paused(pausedState, prep.decision, listOf(prep.event))
             }
-
-            val cardName = cardComponent?.name ?: "spell"
-            val decisionId = UUID.randomUUID().toString()
-            val decision = ChooseTargetsDecision(
-                id = decisionId,
-                playerId = controllerId,
-                prompt = "Choose targets for $cardName",
-                context = DecisionContext(
-                    sourceId = cardId,
-                    sourceName = cardName,
-                    phase = DecisionPhase.CASTING,
-                ),
-                targetRequirements = requirementInfos,
-                legalTargets = legalTargetsMap,
-                canCancel = false,
-            )
-            val continuation = CastFromCollectionTargetsContinuation(
-                decisionId = decisionId,
-                cardId = cardId,
-                casterId = controllerId,
-                storeCastTo = effect.storeCastTo,
-            )
-            val pausedState = newState
-                .pushContinuation(continuation)
-                .withPendingDecision(decision)
-                .withPriority(controllerId)
-
-            return EffectResult.paused(
-                pausedState,
-                decision,
-                listOf(
-                    DecisionRequestedEvent(
-                        decisionId = decisionId,
-                        playerId = controllerId,
-                        decisionType = "CHOOSE_TARGETS",
-                        prompt = decision.prompt,
-                    )
-                ),
-            )
+            TargetPrep.NotNeeded -> {}
         }
 
         // No targets needed (or modal — CastSpellHandler will handle per-mode targets).
@@ -215,7 +148,111 @@ class CastFromCollectionWithoutPayingCostExecutor(
             )
     }
 
+    /** Outcome of [prepareTargetSelection] for a synthesized free/granted cast. */
+    sealed interface TargetPrep {
+        /** Targetless or modal spell — invoke `CastSpellHandler` directly; it drives any further prompts. */
+        data object NotNeeded : TargetPrep
+
+        /** A required target slot has no legal targets — the cast can't initiate (CR 601.2c). */
+        data object NoLegalTargets : TargetPrep
+
+        /** Pause with [decision] and push [continuation]; the resumer performs the cast with the picks. */
+        data class NeedsTargets(
+            val decision: ChooseTargetsDecision,
+            val continuation: CastFromCollectionTargetsContinuation,
+            val event: DecisionRequestedEvent,
+        ) : TargetPrep
+    }
+
     companion object {
+        /**
+         * Determine whether a synthesized cast of [cardId] must pause for target selection first.
+         *
+         * Synthesized casts (Cascade, Discover, Sunbird's Invocation, …) can't carry targets
+         * through the `CastSpell` action — there is no client action to supply them — and
+         * `CastSpellHandler.validate` rejects `targets = []` for required slots (and `execute`,
+         * invoked directly, would silently put the spell on the stack untargeted). Non-modal
+         * spells with target requirements therefore need a [ChooseTargetsDecision] surfaced
+         * before the cast. Modal spells fall through to [TargetPrep.NotNeeded] because
+         * `CastSpellHandler` has its own per-mode target-selection pause after mode choice.
+         *
+         * Includes the aura's enchant target: an Aura carries its target in `auraTarget`, not in
+         * `targetRequirements`, so a free-cast Aura (Pacifism) would otherwise reach
+         * CastSpellHandler with no target. Mirrors CastSpellHandler's own
+         * `targetRequirements + auraTarget` union.
+         */
+        fun prepareTargetSelection(
+            state: GameState,
+            cardId: EntityId,
+            casterId: EntityId,
+            cardRegistry: CardRegistry,
+            targetFinder: TargetFinder,
+            storeCastTo: String? = null,
+        ): TargetPrep {
+            val cardComponent = state.getEntity(cardId)?.get<CardComponent>()
+            val cardDef = cardComponent?.let { cardRegistry.getCard(it.cardDefinitionId) }
+            val isModalSpell = cardDef?.script?.spellEffect is ModalEffect
+            val targetRequirements = buildList {
+                addAll(cardDef?.script?.targetRequirements.orEmpty())
+                cardDef?.script?.auraTarget?.let { add(it) }
+            }
+            if (isModalSpell || targetRequirements.isEmpty()) {
+                return TargetPrep.NotNeeded
+            }
+
+            val legalTargetsMap = mutableMapOf<Int, List<EntityId>>()
+            val requirementInfos = targetRequirements.mapIndexed { index, requirement ->
+                val legal = targetFinder.findLegalTargets(
+                    state = state,
+                    requirement = requirement,
+                    controllerId = casterId,
+                    sourceId = cardId,
+                )
+                legalTargetsMap[index] = legal
+                TargetRequirementInfo(
+                    index = index,
+                    description = requirement.description,
+                    minTargets = requirement.effectiveMinCount,
+                    maxTargets = requirement.count,
+                )
+            }
+            val mandatoryRequirementHasNoTargets = requirementInfos.any { info ->
+                info.minTargets > 0 && legalTargetsMap[info.index].isNullOrEmpty()
+            }
+            if (mandatoryRequirementHasNoTargets) {
+                return TargetPrep.NoLegalTargets
+            }
+
+            val cardName = cardComponent?.name ?: "spell"
+            val decisionId = UUID.randomUUID().toString()
+            val decision = ChooseTargetsDecision(
+                id = decisionId,
+                playerId = casterId,
+                prompt = "Choose targets for $cardName",
+                context = DecisionContext(
+                    sourceId = cardId,
+                    sourceName = cardName,
+                    phase = DecisionPhase.CASTING,
+                ),
+                targetRequirements = requirementInfos,
+                legalTargets = legalTargetsMap,
+                canCancel = false,
+            )
+            val continuation = CastFromCollectionTargetsContinuation(
+                decisionId = decisionId,
+                cardId = cardId,
+                casterId = casterId,
+                storeCastTo = storeCastTo,
+            )
+            val event = DecisionRequestedEvent(
+                decisionId = decisionId,
+                playerId = casterId,
+                decisionType = "CHOOSE_TARGETS",
+                prompt = decision.prompt,
+            )
+            return TargetPrep.NeedsTargets(decision, continuation, event)
+        }
+
         /**
          * Shared `state + targets → ExecutionResult` shim used by both the inline
          * (no-targets) path and the targets-continuation resumer.

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscoverCastTargetedSpellScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscoverCastTargetedSpellScenarioTest.kt
@@ -4,6 +4,7 @@ import com.wingedsheep.engine.core.ChooseTargetsDecision
 import com.wingedsheep.engine.core.TargetsResponse
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.state.components.identity.PlayWithoutPayingCostComponent
 import com.wingedsheep.engine.support.ScenarioTestBase
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldContain
@@ -103,6 +104,17 @@ class DiscoverCastTargetedSpellScenarioTest : ScenarioTestBase() {
                 withClue("Nothing named Zombify is on the stack or resolved") {
                     game.isInGraveyard(1, "Zombify") shouldBe false
                 }
+
+                // The abandoned cast must not leak its free-cast grant: the stamp is zone-agnostic
+                // and lives until end-of-turn cleanup, so a leftover one would let the player cast
+                // Zombify from hand for {0} later this turn.
+                val zombify = game.findCardsInHand(1, "Zombify").single()
+                withClue("The card in hand carries no free-cast stamp") {
+                    game.state.getEntity(zombify)?.has<PlayWithoutPayingCostComponent>() shouldBe false
+                }
+                withClue("No may-play permission is left covering the card") {
+                    game.state.mayPlayPermissions.none { zombify in it.cardIds } shouldBe true
+                }
             }
 
             test("cascade hitting a targeted spell prompts for a target too") {
@@ -136,7 +148,7 @@ class DiscoverCastTargetedSpellScenarioTest : ScenarioTestBase() {
                 withClue("Submitting the target should succeed: ${picked.error}") {
                     picked.error shouldBe null
                 }
-                game.resolveStack() // Zombify, then Annoyed Altisaur, resolve.
+                game.resolveStack() // Zombify, then Quandrix, resolve.
 
                 withClue("Zombify returned the targeted creature card to the battlefield") {
                     game.isOnBattlefield("Grizzly Bears") shouldBe true

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscoverCastTargetedSpellScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiscoverCastTargetedSpellScenarioTest.kt
@@ -1,0 +1,147 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.TargetsResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.core.YesNoResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Regression test: a discover (CR 701.57) free-cast of a non-modal *targeted* spell must pause
+ * for target selection.
+ *
+ * The discover resumer synthesizes a `CastSpell` with no targets and invoked
+ * `CastSpellHandler.execute` directly — bypassing `validate`, which is what normally rejects a
+ * targeted spell with `targets = []`. A discovered Zombify therefore went on the stack
+ * untargeted and resolved doing nothing. The fix surfaces the same `ChooseTargetsDecision` the
+ * synthesized-free-cast executor ([com.wingedsheep.sdk.scripting.effects.CastFromCollectionWithoutPayingCostEffect])
+ * uses; if a required slot has no legal targets, the cast can't initiate (CR 601.2c) and the
+ * discovered card goes to the controller's hand instead.
+ *
+ * Cascade (CR 702.85) shares the fixed code path; the last test pins it there too.
+ */
+class DiscoverCastTargetedSpellScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("discover free-casting a targeted spell") {
+
+            test("Trumpeting Carnosaur's discover 5 hitting Zombify prompts for a target and reanimates it") {
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Trumpeting Carnosaur")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    // Top of library: Zombify (mana value 4 <= 5) is the discover hit.
+                    .withCardInLibrary(1, "Zombify")
+                    .withCardInLibrary(1, "Mountain")
+                    .build()
+
+                val cast = game.castSpell(1, "Trumpeting Carnosaur")
+                withClue("Casting Trumpeting Carnosaur should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // Carnosaur resolves; its ETB discover 5 pauses on cast-or-hand.
+
+                val yesNo = game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                val chose = game.submitDecision(YesNoResponse(yesNo.id, choice = true))
+                withClue("Choosing to cast the discovered card should succeed: ${chose.error}") {
+                    chose.error shouldBe null
+                }
+
+                // The free cast must pause for Zombify's target — the bug was putting it on the
+                // stack untargeted, so it resolved doing nothing.
+                val targetDecision = game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                withClue("The creature card in the graveyard must be offered as a legal target") {
+                    targetDecision.legalTargets[0].orEmpty() shouldContain bears
+                }
+
+                val picked = game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(bears))))
+                withClue("Submitting the target should succeed: ${picked.error}") {
+                    picked.error shouldBe null
+                }
+                game.resolveStack() // Zombify resolves.
+
+                withClue("Zombify returned the targeted creature card to the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+                withClue("The cast Zombify went to the graveyard") {
+                    game.isInGraveyard(1, "Zombify") shouldBe true
+                }
+            }
+
+            test("discovering a targeted spell with no legal targets puts it into hand instead") {
+                // No creature card in any graveyard — Zombify has no legal target, so the cast
+                // can't initiate (CR 601.2c) and the discovered card falls back to hand.
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Trumpeting Carnosaur")
+                    .withLandsOnBattlefield(1, "Mountain", 6)
+                    .withCardInLibrary(1, "Zombify")
+                    .withCardInLibrary(1, "Mountain")
+                    .build()
+
+                val cast = game.castSpell(1, "Trumpeting Carnosaur")
+                withClue("Casting Trumpeting Carnosaur should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                val yesNo = game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                val chose = game.submitDecision(YesNoResponse(yesNo.id, choice = true))
+                withClue("Choosing to cast should succeed even when the cast can't initiate: ${chose.error}") {
+                    chose.error shouldBe null
+                }
+
+                withClue("With no legal target the discovered Zombify goes to hand") {
+                    game.isInHand(1, "Zombify") shouldBe true
+                }
+                withClue("Nothing named Zombify is on the stack or resolved") {
+                    game.isInGraveyard(1, "Zombify") shouldBe false
+                }
+            }
+
+            test("cascade hitting a targeted spell prompts for a target too") {
+                // Quandrix, the Proof — {4}{G}{U}, Cascade. Zombify (mana value 4 < 6) is the
+                // cascade hit. (Not Annoyed Altisaur: its bare CASCADE keyword is display-only.)
+                val game = scenario()
+                    .withPlayers()
+                    .withCardInHand(1, "Quandrix, the Proof")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Zombify")
+                    .withCardInLibrary(1, "Mountain")
+                    .build()
+
+                val cast = game.castSpell(1, "Quandrix, the Proof")
+                withClue("Casting Quandrix, the Proof should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack() // Cascade trigger resolves and pauses on may-cast.
+
+                val yesNo = game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                val chose = game.submitDecision(YesNoResponse(yesNo.id, choice = true))
+                withClue("Choosing to cast the cascade hit should succeed: ${chose.error}") {
+                    chose.error shouldBe null
+                }
+
+                val targetDecision = game.getPendingDecision().shouldBeInstanceOf<ChooseTargetsDecision>()
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                val picked = game.submitDecision(TargetsResponse(targetDecision.id, mapOf(0 to listOf(bears))))
+                withClue("Submitting the target should succeed: ${picked.error}") {
+                    picked.error shouldBe null
+                }
+                game.resolveStack() // Zombify, then Annoyed Altisaur, resolve.
+
+                withClue("Zombify returned the targeted creature card to the battlefield") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes discover (CR 701.57a) and cascade (CR 702.85a) free-casting a non-modal **targeted** spell. The resumers synthesized a `CastSpell` with no targets and invoked `CastSpellHandler.execute` directly — bypassing `validate`, which is what normally rejects a targeted spell with `targets = []`. A discovered Zombify therefore went on the stack untargeted and resolved doing nothing.

### Commit 1 — surface the target prompt

- Extracts `CastFromCollectionWithoutPayingCostExecutor`'s target-selection logic into a shared `prepareTargetSelection` (companion, sealed `TargetPrep` result) and calls it from both the cascade and discover may-cast resumers.
- Non-modal targeted spells now pause with the same `ChooseTargetsDecision` the synthesized-free-cast executor uses; modal spells still fall through to `CastSpellHandler`'s own per-mode target flow.
- If a required slot has no legal targets the cast can't initiate (CR 601.2c): the discovered card goes to the controller's hand ("If you don't cast it, put that card into your hand"), the cascade card is bottomed.
- `triggersAlreadyProcessed` is propagated through the targets-continuation resumer so "whenever you cast a spell (from exile)" triggers (Quintorius Kand) aren't double-fired on the new path.

### Commit 2 — self-review follow-ups

- **Free-cast grant leak**: target legality is now checked *before* granting. The grant (`PlayWithoutPayingCostComponent` + `MayPlayPermission`) is zone-agnostic and lives until end-of-turn cleanup, so granting first meant a discovered spell with no legal targets reached the hand still castable for {0} that turn. Applies to both resumers and to the executor's own pre-existing `NoLegalTargets` exit in exile.
- The grant is extracted into a shared `grantFreeCast` / `revokeFreeCast` helper pair (executor companion) instead of three copy-pasted blocks, and every cast-couldn't-initiate fallback revokes the grant it made.
- `CastFromCollectionTargetsContinuation` carries `grantedPermissionId` + `onCastFailure` (`LEAVE` / `HAND` / `BOTTOM_OF_LIBRARY`, defaulted for serialization compatibility) so a cast that fails after target selection revokes exactly its own permission and sends the card to the owning flow's fallback zone instead of stranding it in exile.
- Cascade's direct sync/paused cast paths now propagate `triggersAlreadyProcessed`, matching discover.

## Tests

- New `DiscoverCastTargetedSpellScenarioTest` (rules-engine):
  - Trumpeting Carnosaur's discover 5 hitting Zombify prompts for a target and reanimates it.
  - No legal targets → the discovered card goes to hand **with no leftover free-cast stamp or may-play permission** (the leak assertions fail against commit 1 alone).
  - Cascade (Quandrix, the Proof) prompts for a target through the same shared path.
- Full `just test-rules` and `just test-server` suites pass.
- Three manual scenarios under `manual-scenarios/bugs/` for UI-level verification of the discover/cascade target prompt and the free-cast leak.

No SDK types were added or changed, so no `card-sdk-language-reference.md` update is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
