### PR TITLE
fix: AI soft-lock casting Spree spells — gate cast-time mode picks on stacked mana affordability

### DIFF
--- a/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
+++ b/game-server/src/main/kotlin/com/wingedsheep/gameserver/handler/GamePlayHandler.kt
@@ -1251,6 +1251,24 @@ class GamePlayHandler(
         gameSession: GameSession,
         aiPlayerId: EntityId
     ): List<com.wingedsheep.engine.core.GameAction> {
+        // A pending decision blocks every priority action (pass included), and a decision
+        // response that was just rejected is deterministic — re-submitting it can't succeed.
+        // Cancelling the decision is the only fallback that can unwedge the game: cancellable
+        // decisions (cast-time mode/target pauses) abort cleanly with no side effects, and
+        // non-cancellable ones reject the cancel without state change, falling through to the
+        // remaining fallbacks. Without this, an AI whose decision answer keeps failing (e.g. a
+        // mid-cast pause whose eventual payment is impossible) loops forever.
+        val pendingDecision = gameSession.getStateForTesting()?.pendingDecision
+        val cancelPending = if (pendingDecision?.playerId == aiPlayerId) {
+            listOf<com.wingedsheep.engine.core.GameAction>(
+                com.wingedsheep.engine.core.SubmitDecision(
+                    aiPlayerId,
+                    com.wingedsheep.engine.core.CancelDecisionResponse(pendingDecision.id)
+                )
+            )
+        } else {
+            emptyList()
+        }
         val pass = com.wingedsheep.engine.core.PassPriority(aiPlayerId)
         // If PassPriority is currently a legal action, we're in a priority window (e.g. after
         // blockers/attackers were already declared), not the actual declare-step decision. In that
@@ -1261,7 +1279,7 @@ class GamePlayHandler(
         val passIsLegal = gameSession.getLegalActions(aiPlayerId).any {
             it.action is com.wingedsheep.engine.core.PassPriority
         }
-        return when (gameSession.getStateForTesting()?.step) {
+        return cancelPending + when (gameSession.getStateForTesting()?.step) {
             com.wingedsheep.sdk.core.Step.DECLARE_BLOCKERS -> {
                 val declare = com.wingedsheep.engine.core.DeclareBlockers(aiPlayerId, emptyMap())
                 if (passIsLegal) listOf(pass, declare) else listOf(declare, pass)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -3317,6 +3317,47 @@ class CastSpellHandler(
     }
 
     /**
+     * Mana-affordability gate for cast-time mode selection: can the caster still pay
+     * the spell's total cost if [chosenIndices] end up being the chosen modes? Chosen
+     * modes' additional mana costs stack (rule 700.2h), so a pick that is affordable
+     * alone can become unpayable combined with earlier picks — and by the time payment
+     * runs (after target selection) the only way out is cancelling the whole cast.
+     *
+     * Uses the plain effective-cost pipeline for the base cost; a "without paying its
+     * mana cost" cast still owes the stacked per-mode additional costs (CR 601.2b,
+     * 601.2f — additional costs apply on top of an alternative cost).
+     */
+    private fun canPayModeSelection(
+        state: GameState,
+        action: CastSpell,
+        modes: List<com.wingedsheep.sdk.scripting.effects.Mode>,
+        chosenIndices: List<Int>
+    ): Boolean {
+        val extraCosts = chosenIndices.mapNotNull { modes.getOrNull(it)?.additionalManaCost }
+        // Nothing stacks — base-cost affordability was already validated on the cast action.
+        if (extraCosts.isEmpty()) return true
+        val cardComponent = state.getEntity(action.cardId)?.get<CardComponent>() ?: return true
+        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return true
+        val playForFree = zoneResolver.hasPlayWithoutPayingCost(state, action.playerId, action.cardId) ||
+            action.useWithoutPayingManaCost
+        var cost = if (playForFree) {
+            ManaCost.ZERO
+        } else {
+            costCalculator.calculateEffectiveCost(
+                state,
+                cardDef,
+                action.playerId,
+                action.targets.map { it.toEntityId() },
+                fromZone = castSourceZone(state, action.cardId)
+            )
+        }
+        for (extra in extraCosts) {
+            cost = cost + ManaCost.parse(extra)
+        }
+        return validatePayment(state, action, cost) == null
+    }
+
+    /**
      * Build a ChooseOptionDecision + CastModalModeSelectionContinuation for the next
      * mode pick. Shared between the initial pause (here) and the iterative resumer.
      */
@@ -3331,7 +3372,20 @@ class CastSpellHandler(
         availableIndices: List<Int>?,
         repeatAvailableIndices: List<Int>?
     ): ExecutionResult {
-        val offerIndices = availableIndices ?: repeatAvailableIndices ?: modalEffect.modes.indices.toList()
+        val candidateIndices = availableIndices ?: repeatAvailableIndices ?: modalEffect.modes.indices.toList()
+        // Rule 700.2h — only offer a mode the caster can still pay for on top of the
+        // modes already picked. Without this gate an unpayable combination sails
+        // through mode + target selection and dead-ends at payment, where the pending
+        // decision can never be answered legally (only cancelled).
+        val offerIndices = candidateIndices.filter { candidate ->
+            canPayModeSelection(state, baseCastAction, modalEffect.modes, selectedModeIndices + candidate)
+        }
+        if (offerIndices.isEmpty() && selectedModeIndices.size < modalEffect.minChooseCount) {
+            return ExecutionResult.error(
+                state,
+                "Cannot afford the additional cost of any remaining mode for $cardName"
+            )
+        }
         val doneOffered = selectedModeIndices.size >= modalEffect.minChooseCount &&
             selectedModeIndices.size < modalEffect.chooseCount
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/actions/spell/CastSpellHandler.kt
@@ -424,243 +424,9 @@ class CastSpellHandler(
             }
         }
         val playForFree = playForFreeFromComponent || action.useWithoutPayingManaCost
-        // Split-layout (CR 709.3a) — only the chosen half is evaluated for legality. When
-        // `faceIndex` is set, the cost is the face's printed mana cost passed through the
-        // standard battlefield cost-modifier pipeline (CR 118.9a applies cost modifiers to
-        // the chosen half just like to a normal cast).
-        val faceManaCostOverride: ManaCost? = action.faceIndex?.let { idx ->
-            cardDef?.cardFaces?.getOrNull(idx)?.manaCost
-        }
-        var effectiveCost = if (playForFree) {
-            ManaCost.ZERO
-        } else if (faceManaCostOverride != null && cardDef != null) {
-            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, faceManaCostOverride, action.playerId)
-        } else if (action.useAlternativeCost && cardDef != null) {
-            // Check flashback cost first (printed, granted per-entity by Archmage's Newt, or
-            // granted to the whole graveyard by a battlefield static — Iroh, Grand Lotus).
-            val flashbackAbility = FlashbackGrants.effectiveFlashback(
-                state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
-            )
-            // Harmonize may be printed on the card or granted at runtime (Songcrafter Mage).
-            val harmonizeAbility = HarmonizeGrants.effectiveHarmonize(state, action.cardId, cardDef)
-            // Each branch is gated by [CastSpell.altAllows] so an explicit player choice (e.g.
-            // evoke) isn't overridden by a higher-priority cost that also happens to be legal
-            // (e.g. a granted warp). With no choice recorded, every gate is open and this falls
-            // back to the original priority order.
-            if (action.altAllows(AlternativeCostType.FLASHBACK) && flashbackAbility != null && zoneResolver.hasFlashbackPermission(state, action.playerId, action.cardId)) {
-                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, flashbackAbility.cost, action.playerId)
-            } else if (action.altAllows(AlternativeCostType.HARMONIZE) && harmonizeAbility != null && zoneResolver.hasHarmonizePermission(state, action.playerId, action.cardId)) {
-                // Harmonize cost (printed or granted). The per-creature power reduction is
-                // applied afterward via alternativePayment.
-                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, harmonizeAbility.cost, action.playerId)
-            } else {
-                // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular
-                // mana cost. Printed warp wins; a battlefield grant ([GrantWarpToCardsInHand])
-                // supplies the cost when the card has no printed warp.
-                val warpAbility = WarpGrants.effectiveWarp(
-                    state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
-                )
-                if (action.altAllows(AlternativeCostType.WARP) && warpAbility != null && zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)) {
-                    costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, warpAbility.cost, action.playerId)
-                } else {
-                    // Check sneak cost (CR 702.190 — mana portion; the bounce is paid separately).
-                    // The effective sneak cost is the printed Sneak, or a granted graveyard sneak
-                    // (Ninja Teen: "creature cards in your graveyard have sneak {3}{B}").
-                    val sneakCost = SneakWindow.effectiveSneakCost(state, cardDef, action.cardId, action.playerId, cardRegistry)
-                    // Check evoke cost
-                    val evokeAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Evoke>().firstOrNull()
-                    if (action.altAllows(AlternativeCostType.SNEAK) && sneakCost != null) {
-                        costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, sneakCost, action.playerId)
-                    } else if (action.altAllows(AlternativeCostType.EVOKE) && evokeAbility != null) {
-                        costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, evokeAbility.cost, action.playerId)
-                    } else {
-                        // Check impending cost
-                        val impendingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Impending>().firstOrNull()
-                        // Check miracle cost (CR 702.94 — printed or granted in hand, window-gated).
-                        // The window component must be present (opened when drawn as the first card
-                        // this turn); without it, the miracle alternative cost is unavailable.
-                        val miracleWindowOpen = state.getEntity(action.cardId)
-                            ?.has<com.wingedsheep.engine.state.components.identity.MiracleWindowComponent>() == true
-                        val miracleAbility = if (miracleWindowOpen) MiracleGrants.effectiveMiracle(
-                            state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
-                        ) else null
-                        if (action.altAllows(AlternativeCostType.IMPENDING) && impendingAbility != null) {
-                            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, impendingAbility.cost, action.playerId)
-                        } else if (action.altAllows(AlternativeCostType.MIRACLE) && miracleAbility != null) {
-                            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, miracleAbility.cost, action.playerId)
-                        } else {
-                            // Check self-alternative cost (e.g., Zahid's {3}{U} + tap artifact)
-                            val selfAltCost = cardDef.script.selfAlternativeCost
-                            if (action.altAllows(AlternativeCostType.SELF_ALTERNATIVE) && selfAltCost != null) {
-                                val altMana = selfAltCost.manaCost
-                                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altMana, action.playerId)
-                            } else {
-                                // Fall back to battlefield-granted alternative cost (e.g., Jodah's {W}{U}{B}{R}{G})
-                                val altCosts = costCalculator.findAlternativeCastingCosts(state, action.playerId)
-                                if (altCosts.isEmpty()) return "No alternative casting cost available"
-                                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altCosts.first())
-                            }
-                        }
-                    }
-                }
-            }
-        } else if (cardDef != null) {
-            costCalculator.calculateEffectiveCost(
-                state,
-                cardDef,
-                action.playerId,
-                action.targets.map { it.toEntityId() },
-                fromZone = if (hasCommanderCast) Zone.COMMAND else castSourceZone(state, action.cardId),
-            )
-        } else {
-            cardComponent.manaCost
-        }
-
-        // Add kicker/offspring mana cost if kicked (only for mana-based kicker/offspring)
-        if (action.wasKicked && !playForFree && !action.useAlternativeCost && cardDef != null) {
-            val kickerManaCost = cardDef.keywordAbilities
-                .filterIsInstance<KeywordAbility.OptionalAdditionalCost>()
-                .firstOrNull { it.manaCost != null }
-                ?.manaCost
-            if (kickerManaCost != null) {
-                effectiveCost = ManaCost(effectiveCost.symbols + kickerManaCost.symbols)
-            }
-        }
-
-        // Apply BlightOrPay "pay mana" adjustment in validation
-        if (cardDef != null && !playForFree) {
-            val blightOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.BlightOrPay>()
-                .firstOrNull()
-            if (blightOrPay != null) {
-                val choseBlight = action.additionalCostPayment?.blightTargets?.isNotEmpty() == true
-                if (!choseBlight) {
-                    effectiveCost = effectiveCost + ManaCost.parse(blightOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply BeholdOrPay "pay mana" adjustment in validation
-        if (cardDef != null && !playForFree) {
-            val beholdOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.BeholdOrPay>()
-                .firstOrNull()
-            if (beholdOrPay != null) {
-                val choseBehold = action.additionalCostPayment?.beheldCards?.isNotEmpty() == true
-                if (!choseBehold) {
-                    effectiveCost = effectiveCost + ManaCost.parse(beholdOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply ExileFromGraveyardOrPay "pay mana" adjustment in validation
-        if (cardDef != null && !playForFree) {
-            val exileOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.ExileFromGraveyardOrPay>()
-                .firstOrNull()
-            if (exileOrPay != null) {
-                val choseExile = action.additionalCostPayment?.exiledCards?.isNotEmpty() == true
-                if (!choseExile) {
-                    effectiveCost = effectiveCost + ManaCost.parse(exileOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply SacrificeOrPay "pay mana" adjustment in validation
-        if (cardDef != null && !playForFree) {
-            val sacOrPay = cardDef.script.additionalCosts
-                .filterIsInstance<AdditionalCost.SacrificeOrPay>()
-                .firstOrNull()
-            if (sacOrPay != null) {
-                val choseSacrifice = action.additionalCostPayment?.sacrificedPermanents?.isNotEmpty() == true
-                if (!choseSacrifice) {
-                    effectiveCost = effectiveCost + ManaCost.parse(sacOrPay.alternativeManaCost)
-                }
-            }
-        }
-
-        // Apply spell-level waterbend additional cost (Avatar: The Last Airbender). Adds the
-        // waterbend amount {N} (or {X}) as generic mana; the tapped artifacts/creatures in
-        // alternativePayment reduce that generic below, capped at N.
-        if (cardDef != null && !playForFree) {
-            val waterbendAmount = spellWaterbendAmount(cardDef, action)
-            if (waterbendAmount > 0) {
-                effectiveCost = effectiveCost + ManaCost.parse("{$waterbendAmount}")
-            }
-        }
-
-        // Airbend: a fixed alternative cost ({2}) is paid *instead of* the printed cost — it
-        // replaces the base. A cost increase (e.g. Soul Partition's tax, or a Thalia-style "costs
-        // {1} more") is not part of the cost it replaces, so it still applies on top: an airbended
-        // card cast under a {1}-tax costs {3}, not {2}.
-        if (!playForFree) {
-            val fixedAltCost = state.getEntity(action.cardId)
-                ?.get<PlayWithFixedAlternativeManaCostComponent>()
-                ?.takeIf { it.controllerId == action.playerId }
-            if (fixedAltCost != null) {
-                effectiveCost = fixedAltCost.fixedCost
-            }
-            // Apply runtime mana tax from exile permissions (e.g., Soul Partition) on top of
-            // whichever base applies (printed cost, or the fixed alternative above).
-            val runtimeCostIncrease = state.getEntity(action.cardId)
-                ?.get<PlayWithCostIncreaseComponent>()
-                ?.takeIf { it.controllerId == action.playerId }
-            if (runtimeCostIncrease != null) {
-                effectiveCost = effectiveCost + ManaCost.parse("{${runtimeCostIncrease.amount}}")
-            }
-        }
-
-        // Apply sacrifice-for-cost-reduction before validating payment
-        if (cardDef != null && action.additionalCostPayment != null) {
-            for (cost in cardDef.script.additionalCosts) {
-                if (cost is AdditionalCost.SacrificeCreaturesForCostReduction) {
-                    val sacrificeCount = action.additionalCostPayment.sacrificedPermanents.size
-                    val reduction = sacrificeCount * cost.costReductionPerCreature
-                    if (reduction > 0) {
-                        effectiveCost = effectiveCost.reduceGeneric(reduction)
-                    }
-                }
-            }
-        }
-
-        // Account for Delve/Convoke reduction before validating payment
-        val costAfterAltPayment = if (action.alternativePayment != null && !action.alternativePayment.isEmpty && cardDef != null) {
-            alternativePaymentHandler.calculateReducedCost(
-                effectiveCost,
-                action.alternativePayment,
-                cardDef,
-                state,
-                action.playerId,
-                action.cardId
-            )
-        } else {
-            effectiveCost
-        }
-
-        // Account for waterbend (Avatar): tapped artifacts/creatures reduce the waterbend generic,
-        // capped at the waterbend amount. Two sources: a spell-level `waterbend {N}` additional cost
-        // (capped so taps never eat the printed generic) and Hama's fixed-alternative waterbend cost
-        // (the whole {mana value} is reducible). Only one is ever non-zero for a given cast.
-        val validateWaterbendCap = (if (cardDef != null) spellWaterbendAmount(cardDef, action) else 0) +
-            fixedAltWaterbendAmount(state, action, playForFree)
-        val costAfterWaterbend = if (!playForFree && action.alternativePayment != null &&
-            action.alternativePayment.waterbendPermanents.isNotEmpty() && validateWaterbendCap > 0
-        ) {
-            alternativePaymentHandler.calculateReducedCostForWaterbend(
-                costAfterAltPayment, action.alternativePayment, validateWaterbendCap
-            )
-        } else {
-            costAfterAltPayment
-        }
-
-        // Validate payment. For an X-cost Harmonize cast where a creature is tapped, the
-        // creature's power reduces generic mana — and {X} is generic (TDM release notes) —
-        // so the leftover reduction beyond any printed generic comes off the X mana paid.
-        // For a "waterbend {X}" spell the X is already materialized as generic in the cost
-        // (and reduced by the waterbend taps), so it must NOT also be charged as {X} mana.
-        val paymentXValue = if (cardDef?.script?.spellWaterbend?.isX == true) 0
-            else harmonizePaymentXValue(state, action, cardDef, effectiveCost)
-        val paymentError = validatePayment(state, action, costAfterWaterbend, paymentXValue)
+        val computedCost = computeTotalCastCost(state, action, cardDef, cardComponent, playForFree, hasCommanderCast)
+            ?: return "No alternative casting cost available"
+        val paymentError = validatePayment(state, action, computedCost.cost, computedCost.paymentXValue)
         if (paymentError != null) {
             return paymentError
         }
@@ -883,6 +649,268 @@ class CastSpellHandler(
         val leftover = (power - harmonizeCost.genericAmount).coerceAtLeast(0)
         val xCount = harmonizeCost.xCount.coerceAtLeast(1)
         return ((xValue * xCount - leftover).coerceAtLeast(0)) / xCount
+    }
+
+    /** The [cost] and adjusted X actually charged as mana at payment time for a cast. */
+    private data class ComputedCastCost(val cost: ManaCost, val paymentXValue: Int)
+
+    /**
+     * The full mana-cost pipeline for a cast (CR 601.2f): alternative-cost base selection
+     * (flashback/harmonize/warp/sneak/evoke/impending/miracle/…), kicker, Or-Pay additional
+     * costs, waterbend, airbend fixed-alternative plus runtime cost increases,
+     * sacrifice-for-reduction, and delve/convoke/waterbend alternative-payment reductions —
+     * plus the harmonize/waterbend adjustment to the X actually paid as mana.
+     *
+     * Shared by [validate] and the cast-time modal affordability gate
+     * ([canPayModeSelection]) so mode offers can never diverge from what payment will
+     * actually charge. Returns null when the action requests an alternative cost but none
+     * is available.
+     */
+    private fun computeTotalCastCost(
+        state: GameState,
+        action: CastSpell,
+        cardDef: com.wingedsheep.sdk.model.CardDefinition?,
+        cardComponent: CardComponent,
+        playForFree: Boolean,
+        castingFromCommandZone: Boolean
+    ): ComputedCastCost? {
+        // Split-layout (CR 709.3a) — only the chosen half is evaluated for legality. When
+        // `faceIndex` is set, the cost is the face's printed mana cost passed through the
+        // standard battlefield cost-modifier pipeline (CR 118.9a applies cost modifiers to
+        // the chosen half just like to a normal cast).
+        val faceManaCostOverride: ManaCost? = action.faceIndex?.let { idx ->
+            cardDef?.cardFaces?.getOrNull(idx)?.manaCost
+        }
+        var effectiveCost = if (playForFree) {
+            ManaCost.ZERO
+        } else if (faceManaCostOverride != null && cardDef != null) {
+            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, faceManaCostOverride, action.playerId)
+        } else if (action.useAlternativeCost && cardDef != null) {
+            // Check flashback cost first (printed, granted per-entity by Archmage's Newt, or
+            // granted to the whole graveyard by a battlefield static — Iroh, Grand Lotus).
+            val flashbackAbility = FlashbackGrants.effectiveFlashback(
+                state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
+            )
+            // Harmonize may be printed on the card or granted at runtime (Songcrafter Mage).
+            val harmonizeAbility = HarmonizeGrants.effectiveHarmonize(state, action.cardId, cardDef)
+            // Each branch is gated by [CastSpell.altAllows] so an explicit player choice (e.g.
+            // evoke) isn't overridden by a higher-priority cost that also happens to be legal
+            // (e.g. a granted warp). With no choice recorded, every gate is open and this falls
+            // back to the original priority order.
+            if (action.altAllows(AlternativeCostType.FLASHBACK) && flashbackAbility != null && zoneResolver.hasFlashbackPermission(state, action.playerId, action.cardId)) {
+                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, flashbackAbility.cost, action.playerId)
+            } else if (action.altAllows(AlternativeCostType.HARMONIZE) && harmonizeAbility != null && zoneResolver.hasHarmonizePermission(state, action.playerId, action.cardId)) {
+                // Harmonize cost (printed or granted). The per-creature power reduction is
+                // applied afterward via alternativePayment.
+                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, harmonizeAbility.cost, action.playerId)
+            } else {
+                // Check warp cost (hand only — CR 702.185a). Re-casts from exile pay the regular
+                // mana cost. Printed warp wins; a battlefield grant ([GrantWarpToCardsInHand])
+                // supplies the cost when the card has no printed warp.
+                val warpAbility = WarpGrants.effectiveWarp(
+                    state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
+                )
+                if (action.altAllows(AlternativeCostType.WARP) && warpAbility != null && zoneResolver.hasWarpPermission(state, action.playerId, action.cardId)) {
+                    costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, warpAbility.cost, action.playerId)
+                } else {
+                    // Check sneak cost (CR 702.190 — mana portion; the bounce is paid separately).
+                    // The effective sneak cost is the printed Sneak, or a granted graveyard sneak
+                    // (Ninja Teen: "creature cards in your graveyard have sneak {3}{B}").
+                    val sneakCost = SneakWindow.effectiveSneakCost(state, cardDef, action.cardId, action.playerId, cardRegistry)
+                    // Check evoke cost
+                    val evokeAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Evoke>().firstOrNull()
+                    if (action.altAllows(AlternativeCostType.SNEAK) && sneakCost != null) {
+                        costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, sneakCost, action.playerId)
+                    } else if (action.altAllows(AlternativeCostType.EVOKE) && evokeAbility != null) {
+                        costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, evokeAbility.cost, action.playerId)
+                    } else {
+                        // Check impending cost
+                        val impendingAbility = cardDef.keywordAbilities.filterIsInstance<KeywordAbility.Impending>().firstOrNull()
+                        // Check miracle cost (CR 702.94 — printed or granted in hand, window-gated).
+                        // The window component must be present (opened when drawn as the first card
+                        // this turn); without it, the miracle alternative cost is unavailable.
+                        val miracleWindowOpen = state.getEntity(action.cardId)
+                            ?.has<com.wingedsheep.engine.state.components.identity.MiracleWindowComponent>() == true
+                        val miracleAbility = if (miracleWindowOpen) MiracleGrants.effectiveMiracle(
+                            state, action.cardId, cardDef, action.playerId, cardRegistry, predicateEvaluator
+                        ) else null
+                        if (action.altAllows(AlternativeCostType.IMPENDING) && impendingAbility != null) {
+                            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, impendingAbility.cost, action.playerId)
+                        } else if (action.altAllows(AlternativeCostType.MIRACLE) && miracleAbility != null) {
+                            costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, miracleAbility.cost, action.playerId)
+                        } else {
+                            // Check self-alternative cost (e.g., Zahid's {3}{U} + tap artifact)
+                            val selfAltCost = cardDef.script.selfAlternativeCost
+                            if (action.altAllows(AlternativeCostType.SELF_ALTERNATIVE) && selfAltCost != null) {
+                                val altMana = selfAltCost.manaCost
+                                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altMana, action.playerId)
+                            } else {
+                                // Fall back to battlefield-granted alternative cost (e.g., Jodah's {W}{U}{B}{R}{G})
+                                val altCosts = costCalculator.findAlternativeCastingCosts(state, action.playerId)
+                                if (altCosts.isEmpty()) return null
+                                costCalculator.calculateEffectiveCostWithAlternativeBase(state, cardDef, altCosts.first())
+                            }
+                        }
+                    }
+                }
+            }
+        } else if (cardDef != null) {
+            costCalculator.calculateEffectiveCost(
+                state,
+                cardDef,
+                action.playerId,
+                action.targets.map { it.toEntityId() },
+                fromZone = if (castingFromCommandZone) Zone.COMMAND else castSourceZone(state, action.cardId),
+            )
+        } else {
+            cardComponent.manaCost
+        }
+
+        // Add kicker/offspring mana cost if kicked (only for mana-based kicker/offspring)
+        if (action.wasKicked && !playForFree && !action.useAlternativeCost && cardDef != null) {
+            val kickerManaCost = cardDef.keywordAbilities
+                .filterIsInstance<KeywordAbility.OptionalAdditionalCost>()
+                .firstOrNull { it.manaCost != null }
+                ?.manaCost
+            if (kickerManaCost != null) {
+                effectiveCost = ManaCost(effectiveCost.symbols + kickerManaCost.symbols)
+            }
+        }
+
+        // Apply BlightOrPay "pay mana" adjustment in validation
+        if (cardDef != null && !playForFree) {
+            val blightOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.BlightOrPay>()
+                .firstOrNull()
+            if (blightOrPay != null) {
+                val choseBlight = action.additionalCostPayment?.blightTargets?.isNotEmpty() == true
+                if (!choseBlight) {
+                    effectiveCost = effectiveCost + ManaCost.parse(blightOrPay.alternativeManaCost)
+                }
+            }
+        }
+
+        // Apply BeholdOrPay "pay mana" adjustment in validation
+        if (cardDef != null && !playForFree) {
+            val beholdOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.BeholdOrPay>()
+                .firstOrNull()
+            if (beholdOrPay != null) {
+                val choseBehold = action.additionalCostPayment?.beheldCards?.isNotEmpty() == true
+                if (!choseBehold) {
+                    effectiveCost = effectiveCost + ManaCost.parse(beholdOrPay.alternativeManaCost)
+                }
+            }
+        }
+
+        // Apply ExileFromGraveyardOrPay "pay mana" adjustment in validation
+        if (cardDef != null && !playForFree) {
+            val exileOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.ExileFromGraveyardOrPay>()
+                .firstOrNull()
+            if (exileOrPay != null) {
+                val choseExile = action.additionalCostPayment?.exiledCards?.isNotEmpty() == true
+                if (!choseExile) {
+                    effectiveCost = effectiveCost + ManaCost.parse(exileOrPay.alternativeManaCost)
+                }
+            }
+        }
+
+        // Apply SacrificeOrPay "pay mana" adjustment in validation
+        if (cardDef != null && !playForFree) {
+            val sacOrPay = cardDef.script.additionalCosts
+                .filterIsInstance<AdditionalCost.SacrificeOrPay>()
+                .firstOrNull()
+            if (sacOrPay != null) {
+                val choseSacrifice = action.additionalCostPayment?.sacrificedPermanents?.isNotEmpty() == true
+                if (!choseSacrifice) {
+                    effectiveCost = effectiveCost + ManaCost.parse(sacOrPay.alternativeManaCost)
+                }
+            }
+        }
+
+        // Apply spell-level waterbend additional cost (Avatar: The Last Airbender). Adds the
+        // waterbend amount {N} (or {X}) as generic mana; the tapped artifacts/creatures in
+        // alternativePayment reduce that generic below, capped at N.
+        if (cardDef != null && !playForFree) {
+            val waterbendAmount = spellWaterbendAmount(cardDef, action)
+            if (waterbendAmount > 0) {
+                effectiveCost = effectiveCost + ManaCost.parse("{$waterbendAmount}")
+            }
+        }
+
+        // Airbend: a fixed alternative cost ({2}) is paid *instead of* the printed cost — it
+        // replaces the base. A cost increase (e.g. Soul Partition's tax, or a Thalia-style "costs
+        // {1} more") is not part of the cost it replaces, so it still applies on top: an airbended
+        // card cast under a {1}-tax costs {3}, not {2}.
+        if (!playForFree) {
+            val fixedAltCost = state.getEntity(action.cardId)
+                ?.get<PlayWithFixedAlternativeManaCostComponent>()
+                ?.takeIf { it.controllerId == action.playerId }
+            if (fixedAltCost != null) {
+                effectiveCost = fixedAltCost.fixedCost
+            }
+            // Apply runtime mana tax from exile permissions (e.g., Soul Partition) on top of
+            // whichever base applies (printed cost, or the fixed alternative above).
+            val runtimeCostIncrease = state.getEntity(action.cardId)
+                ?.get<PlayWithCostIncreaseComponent>()
+                ?.takeIf { it.controllerId == action.playerId }
+            if (runtimeCostIncrease != null) {
+                effectiveCost = effectiveCost + ManaCost.parse("{${runtimeCostIncrease.amount}}")
+            }
+        }
+
+        // Apply sacrifice-for-cost-reduction before validating payment
+        if (cardDef != null && action.additionalCostPayment != null) {
+            for (cost in cardDef.script.additionalCosts) {
+                if (cost is AdditionalCost.SacrificeCreaturesForCostReduction) {
+                    val sacrificeCount = action.additionalCostPayment.sacrificedPermanents.size
+                    val reduction = sacrificeCount * cost.costReductionPerCreature
+                    if (reduction > 0) {
+                        effectiveCost = effectiveCost.reduceGeneric(reduction)
+                    }
+                }
+            }
+        }
+
+        // Account for Delve/Convoke reduction before validating payment
+        val costAfterAltPayment = if (action.alternativePayment != null && !action.alternativePayment.isEmpty && cardDef != null) {
+            alternativePaymentHandler.calculateReducedCost(
+                effectiveCost,
+                action.alternativePayment,
+                cardDef,
+                state,
+                action.playerId,
+                action.cardId
+            )
+        } else {
+            effectiveCost
+        }
+
+        // Account for waterbend (Avatar): tapped artifacts/creatures reduce the waterbend generic,
+        // capped at the waterbend amount. Two sources: a spell-level `waterbend {N}` additional cost
+        // (capped so taps never eat the printed generic) and Hama's fixed-alternative waterbend cost
+        // (the whole {mana value} is reducible). Only one is ever non-zero for a given cast.
+        val validateWaterbendCap = (if (cardDef != null) spellWaterbendAmount(cardDef, action) else 0) +
+            fixedAltWaterbendAmount(state, action, playForFree)
+        val costAfterWaterbend = if (!playForFree && action.alternativePayment != null &&
+            action.alternativePayment.waterbendPermanents.isNotEmpty() && validateWaterbendCap > 0
+        ) {
+            alternativePaymentHandler.calculateReducedCostForWaterbend(
+                costAfterAltPayment, action.alternativePayment, validateWaterbendCap
+            )
+        } else {
+            costAfterAltPayment
+        }
+
+        // For an X-cost Harmonize cast where a creature is tapped, the
+        // creature's power reduces generic mana — and {X} is generic (TDM release notes) —
+        // so the leftover reduction beyond any printed generic comes off the X mana paid.
+        // For a "waterbend {X}" spell the X is already materialized as generic in the cost
+        // (and reduced by the waterbend taps), so it must NOT also be charged as {X} mana.
+        val paymentXValue = if (cardDef?.script?.spellWaterbend?.isX == true) 0
+            else harmonizePaymentXValue(state, action, cardDef, effectiveCost)
+        return ComputedCastCost(costAfterWaterbend, paymentXValue)
     }
 
     private fun validatePayment(state: GameState, action: CastSpell, cost: ManaCost, paymentXValue: Int = action.xValue ?: 0): String? {
@@ -3323,9 +3351,11 @@ class CastSpellHandler(
      * alone can become unpayable combined with earlier picks — and by the time payment
      * runs (after target selection) the only way out is cancelling the whole cast.
      *
-     * Uses the plain effective-cost pipeline for the base cost; a "without paying its
-     * mana cost" cast still owes the stacked per-mode additional costs (CR 601.2b,
-     * 601.2f — additional costs apply on top of an alternative cost).
+     * The base cost comes from [computeTotalCastCost] — the same pipeline payment uses —
+     * so alternative costs, cost modifiers, and alternative payments (convoke/delve)
+     * can't make the gate disagree with payment. A "without paying its mana cost" cast
+     * still owes the stacked per-mode additional costs (CR 601.2b, 601.2f — additional
+     * costs apply on top of an alternative cost).
      */
     private fun canPayModeSelection(
         state: GameState,
@@ -3340,21 +3370,19 @@ class CastSpellHandler(
         val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return true
         val playForFree = zoneResolver.hasPlayWithoutPayingCost(state, action.playerId, action.cardId) ||
             action.useWithoutPayingManaCost
-        var cost = if (playForFree) {
-            ManaCost.ZERO
-        } else {
-            costCalculator.calculateEffectiveCost(
-                state,
-                cardDef,
-                action.playerId,
-                action.targets.map { it.toEntityId() },
-                fromZone = castSourceZone(state, action.cardId)
-            )
-        }
+        val computed = computeTotalCastCost(
+            state,
+            action,
+            cardDef,
+            cardComponent,
+            playForFree,
+            castingFromCommandZone = zoneResolver.hasCommanderCastPermission(state, action.playerId, action.cardId)
+        ) ?: return false
+        var cost = computed.cost
         for (extra in extraCosts) {
             cost = cost + ManaCost.parse(extra)
         }
-        return validatePayment(state, action, cost) == null
+        return validatePayment(state, action, cost, computed.paymentXValue) == null
     }
 
     /**

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalCastTimeModeAffordabilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalCastTimeModeAffordabilityTest.kt
@@ -1,0 +1,181 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.identity.LifeTotalComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.otj.cards.UnfortunateAccident
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Cast-time mode selection must respect stacked per-mode additional mana costs
+ * (rule 700.2h): each iterative mode pick may only offer modes the caster can still
+ * pay for *on top of* the modes already picked. Without the gate, a caster (notably
+ * the AI, which drives the iterative decision flow) can lock in an unpayable mode
+ * combination, sail through target selection, and dead-end at payment — leaving a
+ * pending decision that can never be answered legally (the production Unfortunate
+ * Accident soft-lock).
+ *
+ * The up-front `chosenModes` path is covered by [ModalPerModeAdditionalCostTest];
+ * this covers the interactive decision flow in
+ * [com.wingedsheep.engine.handlers.actions.spell.CastSpellHandler.presentCastModalModeDecision].
+ */
+class ModalCastTimeModeAffordabilityTest : FunSpec({
+
+    // Mode 0: free "Gain 1 life"; Mode 1: +{1} "Draw a card"; Mode 2: +{2} "Lose 1 life".
+    val StackingCostsModal = CardDefinition(
+        name = "Test Stacking Costs Modal",
+        manaCost = ManaCost.parse("{R}"),
+        typeLine = TypeLine.sorcery(),
+        oracleText = "Choose one or more —\n• Gain 1 life\n• {1}: Draw a card\n• {2}: You lose 1 life",
+        script = CardScript.spell(
+            effect = ModalEffect(
+                modes = listOf(
+                    Mode.noTarget(
+                        GainLifeEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
+                        "Gain 1 life"
+                    ),
+                    Mode(
+                        effect = DrawCardsEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
+                        description = "Pay {1}: Draw a card",
+                        additionalManaCost = "{1}"
+                    ),
+                    Mode(
+                        effect = LoseLifeEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
+                        description = "Pay {2}: You lose 1 life",
+                        additionalManaCost = "{2}"
+                    )
+                ),
+                chooseCount = 3,
+                minChooseCount = 1
+            )
+        )
+    )
+
+    fun driver(): GameTestDriver {
+        val d = GameTestDriver()
+        d.registerCards(TestCards.all + StackingCostsModal + UnfortunateAccident)
+        return d
+    }
+
+    test("a mode whose stacked cost is unpayable is not offered on the next pick") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // {R} + {2}: can afford base + either costed mode alone, not both stacked.
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 2)
+
+        val lifeBefore = d.state.getEntity(p1)!!.get<LifeTotalComponent>()!!.life
+        val spell = d.putCardInHand(p1, "Test Stacking Costs Modal")
+        d.submit(
+            CastSpell(playerId = p1, cardId = spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isPaused shouldBe true
+
+        // Pick 1: every mode is individually affordable, so all three are offered.
+        val firstPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        firstPick.options shouldBe listOf("Gain 1 life", "Pay {1}: Draw a card", "Pay {2}: You lose 1 life")
+        d.submitDecision(p1, OptionChosenResponse(firstPick.id, 2)) // take the {2} mode
+
+        // Pick 2: the {1} mode would stack to {R}{3} (unpayable with {R}{2}) — it must
+        // be withheld. The free mode and "Done" remain.
+        val secondPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        secondPick.options shouldBe listOf("Gain 1 life", "Done")
+        d.submitDecision(p1, OptionChosenResponse(secondPick.id, 1)) // Done
+
+        d.bothPass()
+
+        // Only the {2} mode resolved: lose 1 life, no draw, and the cast never soft-locked.
+        d.state.pendingDecision shouldBe null
+        d.state.getEntity(p1)!!.get<LifeTotalComponent>()!!.life shouldBe (lifeBefore - 1)
+    }
+
+    test("with enough mana the same pick still offers every mode") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // {R} + {3}: both costed modes stack to {R}{3} — affordable.
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 3)
+
+        val spell = d.putCardInHand(p1, "Test Stacking Costs Modal")
+        d.submit(
+            CastSpell(playerId = p1, cardId = spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isPaused shouldBe true
+
+        val firstPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        d.submitDecision(p1, OptionChosenResponse(firstPick.id, 2)) // the {2} mode
+
+        val secondPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        secondPick.options shouldContain "Pay {1}: Draw a card"
+    }
+
+    test("Unfortunate Accident with 4 mana: destroy mode picked, token mode withheld, cast completes") {
+        // Reproduces the production soft-lock: Spree base {B}, +{2}{B} destroy, +{1} token.
+        // With {B}{B}{2} the destroy mode alone ({2}{B}{B}) is exactly affordable; adding
+        // the token mode ({3}{B}{B}) is not. The old flow offered it anyway and the cast
+        // dead-ended at payment after target selection.
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Swamp" to 40))
+        val p1 = d.activePlayer!!
+        val p2 = d.getOpponent(p1)
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val victim = d.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        d.giveMana(p1, Color.BLACK, 2)
+        d.giveColorlessMana(p1, 2)
+
+        val spell = d.putCardInHand(p1, "Unfortunate Accident")
+        d.submit(
+            CastSpell(playerId = p1, cardId = spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isPaused shouldBe true
+
+        // Pick 1: both spree modes are individually affordable.
+        val firstPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        firstPick.options.size shouldBe 2
+        val destroyIndex = firstPick.options.indexOfFirst { it.contains("Destroy") }
+        destroyIndex shouldNotBe -1
+        d.submitDecision(p1, OptionChosenResponse(firstPick.id, destroyIndex))
+
+        // Pick 2: the token mode would stack past the available mana — only "Done" is left.
+        val secondPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        secondPick.options shouldBe listOf("Done")
+        d.submitDecision(p1, OptionChosenResponse(secondPick.id, 0))
+
+        // Target selection for the destroy mode, then the cast must complete (no payment
+        // dead-end) and resolve.
+        d.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        d.submitTargetSelection(p1, listOf(victim))
+        d.bothPass()
+
+        d.state.pendingDecision shouldBe null
+        d.findPermanent(p2, "Grizzly Bears") shouldBe null
+        d.getGraveyardCardNames(p2) shouldContain "Grizzly Bears"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalCastTimeModeAffordabilityTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ModalCastTimeModeAffordabilityTest.kt
@@ -13,9 +13,14 @@ import com.wingedsheep.sdk.core.Color
 import com.wingedsheep.sdk.core.ManaCost
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.TypeLine
+import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.CardScript
 import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.CostModification
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifySpellCost
+import com.wingedsheep.sdk.scripting.SpellCostTarget
 import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
 import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
 import com.wingedsheep.sdk.scripting.effects.LoseLifeEffect
@@ -74,9 +79,51 @@ class ModalCastTimeModeAffordabilityTest : FunSpec({
         )
     )
 
+    // Base {1}{R}; Mode 0: free "Gain 1 life"; Mode 1: +{2} "Lose 1 life". Cast under
+    // the reducer below so the gate must price mode picks through the reduced effective
+    // cost, not the printed one.
+    val ReducedCostModal = CardDefinition(
+        name = "Test Reduced Cost Modal",
+        manaCost = ManaCost.parse("{1}{R}"),
+        typeLine = TypeLine.sorcery(),
+        oracleText = "Choose one or more —\n• Gain 1 life\n• {2}: You lose 1 life",
+        script = CardScript.spell(
+            effect = ModalEffect(
+                modes = listOf(
+                    Mode.noTarget(
+                        GainLifeEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
+                        "Gain 1 life"
+                    ),
+                    Mode(
+                        effect = LoseLifeEffect(DynamicAmount.Fixed(1), EffectTarget.Controller),
+                        description = "Pay {2}: You lose 1 life",
+                        additionalManaCost = "{2}"
+                    )
+                ),
+                chooseCount = 2,
+                minChooseCount = 1
+            )
+        )
+    )
+
+    val SpellCostReducer = card("Test Spell Cost Reducer") {
+        manaCost = "{1}"
+        colorIdentity = ""
+        typeLine = "Artifact"
+        oracleText = "Spells you cast cost {1} less to cast."
+        staticAbility {
+            ability = ModifySpellCost(
+                target = SpellCostTarget.YouCast(GameObjectFilter.Any),
+                modification = CostModification.ReduceGeneric(1),
+            )
+        }
+    }
+
     fun driver(): GameTestDriver {
         val d = GameTestDriver()
-        d.registerCards(TestCards.all + StackingCostsModal + UnfortunateAccident)
+        d.registerCards(
+            TestCards.all + StackingCostsModal + ReducedCostModal + SpellCostReducer + UnfortunateAccident
+        )
         return d
     }
 
@@ -134,6 +181,40 @@ class ModalCastTimeModeAffordabilityTest : FunSpec({
 
         val secondPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
         secondPick.options shouldContain "Pay {1}: Draw a card"
+    }
+
+    test("a mode affordable only through a cost-reduction static is still offered") {
+        val d = driver()
+        d.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        val p1 = d.activePlayer!!
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        d.putPermanentOnBattlefield(p1, "Test Spell Cost Reducer")
+        // {R} + {2}: the reduced base ({1}{R} less {1} = {R}) plus the {2} mode is exactly
+        // affordable. Priced at the printed {1}{R} the mode would (wrongly) be withheld —
+        // the gate must use the same cost pipeline payment does.
+        d.giveMana(p1, Color.RED, 1)
+        d.giveColorlessMana(p1, 2)
+
+        val lifeBefore = d.state.getEntity(p1)!!.get<LifeTotalComponent>()!!.life
+        val spell = d.putCardInHand(p1, "Test Reduced Cost Modal")
+        d.submit(
+            CastSpell(playerId = p1, cardId = spell, paymentStrategy = PaymentStrategy.FromPool)
+        ).isPaused shouldBe true
+
+        val firstPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        firstPick.options shouldBe listOf("Gain 1 life", "Pay {2}: You lose 1 life")
+        d.submitDecision(p1, OptionChosenResponse(firstPick.id, 1)) // the {2} mode
+
+        val secondPick = d.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        secondPick.options shouldBe listOf("Gain 1 life", "Done")
+        d.submitDecision(p1, OptionChosenResponse(secondPick.id, 1)) // Done
+
+        d.bothPass()
+
+        // The {2} mode resolved, paid through the reduced cost — no payment dead-end.
+        d.state.pendingDecision shouldBe null
+        d.state.getEntity(p1)!!.get<LifeTotalComponent>()!!.life shouldBe (lifeBefore - 1)
     }
 
     test("Unfortunate Accident with 4 mana: destroy mode picked, token mode withheld, cast completes") {


### PR DESCRIPTION
## Summary

Fixes an AI soft-lock when casting a Spree spell it can't fully pay for.

**Repro (from a live game):** the AI cast Unfortunate Accident ({B}, Spree: + {2}{B} destroy / + {1} token) with 4 mana available, chose **both** modes ({3}{B}{B} total — unpayable), picked targets, and the cast dead-ended at payment with `Not enough mana to auto-pay`. The pending `ChooseTargetsDecision` could never be answered legally, `PassPriority` is blocked while a decision is pending, and the AI retried the same response forever:

```
WARN  AI action failed: Not enough mana to auto-pay — trying safe fallbacks
WARN  AI fallback PassPriority also failed: Cannot pass priority while there's a pending decision …
(repeats indefinitely)
```

## Root cause

Cast-time mode selection for choose-N modal spells (`CastSpellHandler.pauseForCastTimeModeSelection` → `presentCastModalModeDecision`) filtered mode options only by **target legality**, never by mana. Per-mode additional costs stack when several modes are chosen (CR 700.2h), and each mode is only affordability-checked *individually* at enumeration time — nobody checked the cumulative combination until payment, which runs after target selection. By then the only legal way out is cancelling, which the AI never does.

## Changes

**rules-engine** — `presentCastModalModeDecision` now offers only modes the caster can still pay for *on top of* the modes already picked (base effective cost + stacked `additionalManaCost`s, validated through the same `validatePayment` path the final cast uses). "Done" remains available once `minChooseCount` is satisfied. Early-returns when no chosen/candidate mode carries a mana cost, so Confluence-style choose-N picks are completely unaffected. Free casts (Cascade-style, which also hit this pause) still owe the stacked additional costs per CR 601.2b/601.2f and are gated on those alone.

**rules-engine (follow-up commit)** — the gate prices picks through the *full* cost pipeline, not a bare `calculateEffectiveCost`. `validate()`'s cost computation (alternative-cost bases — flashback/warp/evoke/harmonize/…, kicker, Or-Pay additional costs, waterbend, airbend fixed-alternative + runtime cost increases, sacrifice-for-reduction, convoke/delve/waterbend alternative-payment reductions, and the harmonize/waterbend payment-X adjustment) is extracted into a shared `computeTotalCastCost` helper used by both `validate()` and the gate. Without this, a mode affordable only through a cost-reduction static or a cheaper alternative cost would have been silently withheld (and vice versa the gate could over-offer). Mode offers now can't diverge from what payment actually charges, and validate's ~230-line pipeline is deduplicated rather than copied a third time.

**game-server** — `GamePlayHandler.safeFallbackActions` now tries `SubmitDecision(CancelDecisionResponse)` first whenever the AI holds the pending decision. A pending decision blocks every priority action, and a rejected decision response is deterministic — re-submitting can't succeed — so cancelling is the only fallback that can unwedge the game. Cancellable decisions (cast-time mode/target pauses) abort cleanly with no side effects; non-cancellable ones reject the cancel without state change and fall through to the existing fallbacks. Belt-and-braces net for any future soft-lock of this class.

## Tests

New `ModalCastTimeModeAffordabilityTest` (4 tests):
- synthetic stacking-cost modal: an unpayable stacked mode is withheld on the next pick; the cast still completes via "Done"
- same card with enough mana: the mode is still offered
- a mode affordable only through a `ModifySpellCost` cost-reduction static is still offered (pins the full-pipeline pricing)
- **Unfortunate Accident end-to-end repro**: 4 mana, destroy mode picked, token mode withheld, target chosen, creature destroyed — no payment dead-end

All existing modal/Spree suites pass: `ModalCastTimeCancelTest`, `ModalCastTimeDeferredTargetsTest`, `ModalPerModeAdditionalCostTest`, `ModalMinChooseCountTest`, `OtjUnfortunateAccidentScenarioTest`, `SmugglersSurpriseScenarioTest`, `ThreeStepsAheadScenarioTest`, `TrashTheTownScenarioTest`, `GreatTrainHeistTest`, `LivelyDirgeScenarioTest`. Full `:rules-engine:test` run green after each commit (6919 passed, 0 failed on the follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
