### PR TITLE
Fix enters-with-counter cards using a trigger instead of a replacement effect

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6225,6 +6225,19 @@ replacementEffect {
     `DistinctColorsManaSpent` reads the new creature's own cast (and a token / reanimated creature that
     wasn't cast spent no mana → 0). Player-scoped counts (`TurnTracking(Player.You)`, Gev) still read
     the replacement source's controller.
+- `EntersWithKeywords(keywords, condition?, selfOnly?, appliesTo?)` — "[permanent] enters with
+  [keywords]" (CR 614.1c), the keyword counterpart of `EntersWithCounters`. The grant happens as the
+  permanent enters — no trigger, no stack, no response window — as a permanent, entry-timestamped
+  Layer-6 floating effect: a later "loses all abilities" removes it, it does not re-apply if stripped,
+  and it is cleaned up when the permanent leaves the battlefield (new object, CR 400.7). Kicker riders
+  are the canonical use (Kavu Titan "If this creature was kicked, it enters with three +1/+1 counters
+  on it and with trample" = an `EntersWithCounters` **plus** an `EntersWithKeywords`, both
+  `selfOnly = true, condition = WasKicked`; also Benalish Lancer / Duskwalker / Faerie Squadron /
+  Pouncing Kavu). `condition` is evaluated at the moment of entry against the entering permanent
+  (cast-choice conditions like `WasKicked` read the durable cast-choices bag, so a token copy or
+  reanimated body — never kicked — correctly gets nothing). Like `EntersWithCounters`, a
+  non-`selfOnly` instance stamped on a battlefield permanent applies to *other* permanents matching
+  `appliesTo` as they enter.
 - `EntersWithDevour(multiplier, sacrificeFilter, counterType, variant)` — Devour (CR 702.82) and its
   printed variants. As the permanent resolves from the stack, the controller is prompted to pick any
   number of their own permanents matching `sacrificeFilter`. Those permanents are sacrificed and the

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ReplacementEffect.kt
@@ -443,6 +443,50 @@ data class EntersWithDynamicCounters(
     }
 }
 
+/**
+ * Permanent enters the battlefield with [keywords] (CR 614.1c) — the keyword counterpart of
+ * [EntersWithCounters]. Example: Kavu Titan "If this creature was kicked, it enters with three
+ * +1/+1 counters on it and with trample" — an [EntersWithCounters] plus an [EntersWithKeywords],
+ * both gated on the same [condition].
+ *
+ * The grant happens as the permanent enters: no trigger, no stack, no response window. It is
+ * entry-timestamped for Rule 613 layer ordering (a later "loses all abilities" effect removes
+ * it) and lasts as long as the permanent remains on the battlefield — it is cleaned up when the
+ * permanent leaves (a new object per CR 400.7) and does NOT re-apply if the keyword is removed.
+ *
+ * @param keywords The keywords the entering permanent has from the moment it enters.
+ * @param condition When non-null, the keywords are only granted if this condition evaluates true
+ *                  at the moment the permanent enters (e.g. [conditions.WasKicked], read from the
+ *                  durable cast-choices bag).
+ * @param selfOnly When true, only applies to the permanent carrying this effect as it enters,
+ *                 never to other permanents matching [appliesTo] (mirrors [EntersWithCounters]).
+ */
+@SerialName("EntersWithKeywords")
+@Serializable
+data class EntersWithKeywords(
+    val keywords: List<Keyword>,
+    val condition: Condition? = null,
+    val selfOnly: Boolean = false,
+    override val appliesTo: EventPattern = EventPattern.ZoneChangeEvent(
+        filter = GameObjectFilter.Creature.youControl(),
+        to = Zone.BATTLEFIELD
+    )
+) : ReplacementEffect {
+    override val description: String = buildString {
+        append("If ${appliesTo.description}, it enters with ")
+        append(keywords.joinToString(" and ") { it.displayName.lowercase() })
+        if (condition != null) append(" if ${condition.description}")
+    }
+
+    override fun applyTextReplacement(replacer: TextReplacer): ReplacementEffect {
+        val newAppliesTo = appliesTo.applyTextReplacement(replacer)
+        val newCondition = condition?.applyTextReplacement(replacer)
+        return if (newAppliesTo !== appliesTo || newCondition !== condition)
+            copy(appliesTo = newAppliesTo, condition = newCondition)
+        else this
+    }
+}
+
 // =============================================================================
 // Damage Replacement Effects
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CinderingCutthroat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/blb/cards/CinderingCutthroat.kt
@@ -1,14 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.blb.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Costs
 import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -29,12 +28,13 @@ val CinderingCutthroat = card("Cindering Cutthroat") {
     power = 3
     toughness = 2
 
-    // Conditional ETB: enters with +1/+1 if opponent lost life this turn
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = Conditions.OpponentLostLifeThisTurn
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true,
+        condition = Conditions.OpponentLostLifeThisTurn
+    ))
 
     // {1}{B/R}: This creature gains menace until end of turn
     activatedAbility {

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/AcademyDrake.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/AcademyDrake.kt
@@ -1,14 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Academy Drake
@@ -30,11 +28,13 @@ val AcademyDrake = card("Academy Drake") {
     keywordAbility(KeywordAbility.kicker("{4}"))
     keywords(Keyword.FLYING)
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 2,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/BalothGorger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/BalothGorger.kt
@@ -1,13 +1,11 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
-import com.wingedsheep.sdk.core.Counters
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Baloth Gorger
@@ -27,11 +25,13 @@ val BalothGorger = card("Baloth Gorger") {
 
     keywordAbility(KeywordAbility.kicker("{4}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 3,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/GrunnTheLonelyKing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/GrunnTheLonelyKing.kt
@@ -1,15 +1,15 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
-import com.wingedsheep.sdk.core.Counters
-import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
 import com.wingedsheep.sdk.scripting.events.AttackPredicate
-import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -31,11 +31,13 @@ val GrunnTheLonelyKing = card("Grunn, the Lonely King") {
 
     keywordAbility(KeywordAbility.kicker("{3}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 5, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 5,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     triggeredAbility {
         trigger = Triggers.attacks(requires = setOf(AttackPredicate.Alone))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/StrongholdConfessor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/StrongholdConfessor.kt
@@ -1,14 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Stronghold Confessor
@@ -30,11 +28,13 @@ val StrongholdConfessor = card("Stronghold Confessor") {
     keywordAbility(KeywordAbility.kicker("{3}"))
     keywords(Keyword.MENACE)
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 2,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/UntamedKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/dom/cards/UntamedKavu.kt
@@ -1,14 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.dom.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Untamed Kavu
@@ -30,11 +28,13 @@ val UntamedKavu = card("Untamed Kavu") {
     keywordAbility(KeywordAbility.kicker("{3}"))
     keywords(Keyword.VIGILANCE, Keyword.TRAMPLE)
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 3,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.UNCOMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GoblinBoarders.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/fdn/cards/GoblinBoarders.kt
@@ -1,12 +1,10 @@
 package com.wingedsheep.mtg.sets.definitions.fdn.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.dsl.Conditions
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Goblin Boarders
@@ -16,9 +14,9 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *
  * Raid — This creature enters with a +1/+1 counter on it if you attacked this turn.
  *
- * Raid enters-with-counter follows the engine's established convention (War-Name
- * Aspirant): an enters-the-battlefield trigger gated by the intervening-if condition
- * [Conditions.YouAttackedThisTurn], adding one +1/+1 counter to itself.
+ * "Enters with a counter" is a replacement effect (rule 614.1c), not a trigger:
+ * it never uses the stack and the creature is a 4/3 from the moment it enters
+ * (Frilled Sparkshooter follows the same pattern).
  */
 val GoblinBoarders = card("Goblin Boarders") {
     manaCost = "{2}{R}"
@@ -28,11 +26,12 @@ val GoblinBoarders = card("Goblin Boarders") {
     toughness = 2
     oracleText = "Raid — This creature enters with a +1/+1 counter on it if you attacked this turn."
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = Conditions.YouAttackedThisTurn
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
-    }
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true,
+        condition = Conditions.YouAttackedThisTurn
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArdentSoldier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/ArdentSoldier.kt
@@ -1,14 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Ardent Soldier
@@ -32,11 +30,13 @@ val ArdentSoldier = card("Ardent Soldier") {
     keywords(Keyword.VIGILANCE)
     keywordAbility(KeywordAbility.kicker("{2}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BenalishLancer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/BenalishLancer.kt
@@ -1,15 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.EntersWithKeywords
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Benalish Lancer
@@ -30,14 +28,19 @@ val BenalishLancer = card("Benalish Lancer") {
 
     keywordAbility(KeywordAbility.kicker("{2}{W}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.Composite(
-            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
-            Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self, Duration.Permanent),
-        )
-    }
+    // "Enters with … counters … and with first strike" is a replacement
+    // effect (rule 614.1c), not an ETB trigger — no stack, present the moment it enters.
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 2,
+        selfOnly = true,
+        condition = WasKicked
+    ))
+    replacementEffect(EntersWithKeywords(
+        keywords = listOf(Keyword.FIRST_STRIKE),
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Duskwalker.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/Duskwalker.kt
@@ -1,15 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.EntersWithKeywords
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Duskwalker
@@ -31,14 +29,19 @@ val Duskwalker = card("Duskwalker") {
 
     keywordAbility(KeywordAbility.kicker("{3}{B}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.Composite(
-            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
-            Effects.GrantKeyword(Keyword.FEAR, EffectTarget.Self, Duration.Permanent),
-        )
-    }
+    // "Enters with … counters … and with fear" is a replacement
+    // effect (rule 614.1c), not an ETB trigger — no stack, present the moment it enters.
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 2,
+        selfOnly = true,
+        condition = WasKicked
+    ))
+    replacementEffect(EntersWithKeywords(
+        keywords = listOf(Keyword.FEAR),
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FaerieSquadron.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/FaerieSquadron.kt
@@ -1,15 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.EntersWithKeywords
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Faerie Squadron
@@ -30,14 +28,19 @@ val FaerieSquadron = card("Faerie Squadron") {
 
     keywordAbility(KeywordAbility.kicker("{3}{U}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.Composite(
-            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
-            Effects.GrantKeyword(Keyword.FLYING, EffectTarget.Self, Duration.Permanent)
-        )
-    }
+    // "Enters with … counters … and with flying" is a replacement
+    // effect (rule 614.1c), not an ETB trigger — no stack, present the moment it enters.
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 2,
+        selfOnly = true,
+        condition = WasKicked
+    ))
+    replacementEffect(EntersWithKeywords(
+        keywords = listOf(Keyword.FLYING),
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuAggressor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuAggressor.kt
@@ -1,14 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Kavu Aggressor
@@ -35,11 +33,13 @@ val KavuAggressor = card("Kavu Aggressor") {
         ability = CantBlock()
     }
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuTitan.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/KavuTitan.kt
@@ -1,15 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.EntersWithKeywords
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Kavu Titan
@@ -30,14 +28,19 @@ val KavuTitan = card("Kavu Titan") {
 
     keywordAbility(KeywordAbility.kicker("{2}{G}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.Composite(
-            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 3, EffectTarget.Self),
-            Effects.GrantKeyword(Keyword.TRAMPLE, EffectTarget.Self, Duration.Permanent),
-        )
-    }
+    // "Enters with … counters … and with trample" is a replacement effect (rule 614.1c),
+    // not an ETB trigger: a kicked Titan is a 5/5 trampler from the moment it enters.
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 3,
+        selfOnly = true,
+        condition = WasKicked
+    ))
+    replacementEffect(EntersWithKeywords(
+        keywords = listOf(Keyword.TRAMPLE),
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.RARE

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LlanowarElite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/LlanowarElite.kt
@@ -1,14 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Llanowar Elite
@@ -32,11 +30,13 @@ val LlanowarElite = card("Llanowar Elite") {
     keywordAbility(KeywordAbility.kicker("{8}"))
     keywords(Keyword.TRAMPLE)
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 5, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 5,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PincerSpider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PincerSpider.kt
@@ -1,14 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Pincer Spider
@@ -32,11 +30,13 @@ val PincerSpider = card("Pincer Spider") {
     keywords(Keyword.REACH)
     keywordAbility(KeywordAbility.kicker("{3}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PouncingKavu.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PouncingKavu.kt
@@ -1,15 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
-import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.EntersWithKeywords
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Pouncing Kavu
@@ -33,14 +31,19 @@ val PouncingKavu = card("Pouncing Kavu") {
     keywordAbility(KeywordAbility.kicker("{2}{R}"))
     keywords(Keyword.FIRST_STRIKE)
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.Composite(
-            Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 2, EffectTarget.Self),
-            Effects.GrantKeyword(Keyword.HASTE, EffectTarget.Self, Duration.Permanent)
-        )
-    }
+    // "Enters with … counters … and with haste" is a replacement
+    // effect (rule 614.1c), not an ETB trigger — no stack, present the moment it enters.
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 2,
+        selfOnly = true,
+        condition = WasKicked
+    ))
+    replacementEffect(EntersWithKeywords(
+        keywords = listOf(Keyword.HASTE),
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PrisonBarricade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/PrisonBarricade.kt
@@ -1,17 +1,14 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.dsl.Conditions
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.CanAttackDespiteDefender
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
  * Prison Barricade
@@ -41,11 +38,13 @@ val PrisonBarricade = card("Prison Barricade") {
     keywords(Keyword.DEFENDER)
     keywordAbility(KeywordAbility.kicker("{1}{W}"))
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     staticAbility {
         ability = CanAttackDespiteDefender(

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrborgSkeleton.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/UrborgSkeleton.kt
@@ -1,14 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.scripting.KeywordAbility
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.dsl.Costs
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersWithCounters
+import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
 import com.wingedsheep.sdk.scripting.effects.RegenerateEffect
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
 
 /**
@@ -35,11 +34,13 @@ val UrborgSkeleton = card("Urborg Skeleton") {
         effect = RegenerateEffect(EffectTarget.Self)
     }
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianSerpent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/inv/cards/VodalianSerpent.kt
@@ -1,15 +1,13 @@
 package com.wingedsheep.mtg.sets.definitions.inv.cards
 
-import com.wingedsheep.sdk.core.Counters
 import com.wingedsheep.sdk.dsl.Conditions
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.CantAttackUnless
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.KeywordAbility
 import com.wingedsheep.sdk.scripting.conditions.WasKicked
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * Vodalian Serpent
@@ -36,11 +34,13 @@ val VodalianSerpent = card("Vodalian Serpent") {
         ability = CantAttackUnless(Conditions.DefendingPlayerControlsLandType("Island"))
     }
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = WasKicked
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 4, EffectTarget.Self)
-    }
+    // "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 4,
+        selfOnly = true,
+        condition = WasKicked
+    ))
 
     metadata {
         rarity = Rarity.COMMON

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ktk/cards/WarNameAspirant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/ktk/cards/WarNameAspirant.kt
@@ -1,15 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.ktk.cards
 
 import com.wingedsheep.sdk.dsl.Conditions
-
-import com.wingedsheep.sdk.core.Counters
-import com.wingedsheep.sdk.dsl.Effects
-import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.CantBeBlockedBy
+import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.GameObjectFilter
-import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
  * War-Name Aspirant
@@ -28,11 +25,12 @@ val WarNameAspirant = card("War-Name Aspirant") {
     toughness = 1
     oracleText = "Raid — This creature enters with a +1/+1 counter on it if you attacked this turn.\nThis creature can't be blocked by creatures with power 1 or less."
 
-    triggeredAbility {
-        trigger = Triggers.EntersBattlefield
-        triggerCondition = Conditions.YouAttackedThisTurn
-        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
-    }
+    replacementEffect(EntersWithCounters(
+        counterType = CounterTypeFilter.PlusOnePlusOne,
+        count = 1,
+        selfOnly = true,
+        condition = Conditions.YouAttackedThisTurn
+    ))
 
     staticAbility {
         ability = CantBeBlockedBy(GameObjectFilter.Creature.powerAtMost(1))

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonstormGlobe.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/tdm/cards/DragonstormGlobe.kt
@@ -33,7 +33,7 @@ val DragonstormGlobe = card("Dragonstorm Globe") {
         EntersWithDynamicCounters(
             count = DynamicAmount.Fixed(1),
             // otherOnly = true routes this through the battlefield-scan path in
-            // EntersWithCountersHelper, so the artifact grants counters to *other*
+            // EntersWithReplacements, so the artifact grants counters to *other*
             // permanents (Dragons you control) as they enter, not to itself.
             otherOnly = true,
             appliesTo = EventPattern.ZoneChangeEvent(

--- a/mtg-sets/src/test/resources/snapshots/cards/BLB.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/BLB.json
@@ -3052,37 +3052,9 @@
         "toughness": 2
     },
     "script": {
-        "triggeredAbilities": [
-            {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "triggerCondition": {
-                    "type": "Compare",
-                    "left": {
-                        "type": "TurnTracking",
-                        "player": "EachOpponent",
-                        "tracker": "LIFE_LOST"
-                    },
-                    "operator": "GTE",
-                    "right": {
-                        "type": "Fixed",
-                        "amount": 1
-                    }
-                }
-            }
-        ],
         "activatedAbilities": [
             {
-                "id": "ability_2",
+                "id": "ability_1",
                 "cost": {
                     "type": "CostAtomWrapper",
                     "atom": {
@@ -3094,6 +3066,26 @@
                     "type": "GrantKeyword",
                     "keyword": "MENACE",
                     "target": "Self"
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "EachOpponent",
+                        "tracker": "LIFE_LOST"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
                 }
             }
         ]

--- a/mtg-sets/src/test/resources/snapshots/cards/DOM.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/DOM.json
@@ -18,20 +18,12 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 2,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -855,20 +847,12 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 3,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 3,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -5134,20 +5118,6 @@
             {
                 "id": "ability_1",
                 "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 5,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
-            },
-            {
-                "id": "ability_2",
-                "trigger": {
                     "type": "AttackEvent",
                     "requires": [
                         "AttacksAlone"
@@ -5167,6 +5137,14 @@
                     },
                     "target": "Self"
                 }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 5,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -11417,20 +11395,12 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 2,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -13497,20 +13467,12 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 3,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 3,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/FDN.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/FDN.json
@@ -2896,20 +2896,12 @@
         "toughness": 2
     },
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "triggerCondition": {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
                     "type": "Compare",
                     "left": {
                         "type": "TurnTracking",

--- a/mtg-sets/src/test/resources/snapshots/cards/INV.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/INV.json
@@ -765,20 +765,12 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -1519,31 +1511,20 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "AddCounters",
-                            "counterType": "+1/+1",
-                            "count": 2,
-                            "target": "Self"
-                        },
-                        {
-                            "type": "GrantKeyword",
-                            "keyword": "FIRST_STRIKE",
-                            "target": "Self",
-                            "duration": "Permanent"
-                        }
-                    ]
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true,
+                "condition": "WasKicked"
+            },
+            {
+                "type": "EntersWithKeywords",
+                "keywords": [
+                    "FIRST_STRIKE"
+                ],
+                "condition": "WasKicked",
+                "selfOnly": true
             }
         ]
     },
@@ -4469,31 +4450,20 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "AddCounters",
-                            "counterType": "+1/+1",
-                            "count": 2,
-                            "target": "Self"
-                        },
-                        {
-                            "type": "GrantKeyword",
-                            "keyword": "FEAR",
-                            "target": "Self",
-                            "duration": "Permanent"
-                        }
-                    ]
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true,
+                "condition": "WasKicked"
+            },
+            {
+                "type": "EntersWithKeywords",
+                "keywords": [
+                    "FEAR"
+                ],
+                "condition": "WasKicked",
+                "selfOnly": true
             }
         ]
     },
@@ -5047,31 +5017,20 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "AddCounters",
-                            "counterType": "+1/+1",
-                            "count": 2,
-                            "target": "Self"
-                        },
-                        {
-                            "type": "GrantKeyword",
-                            "keyword": "FLYING",
-                            "target": "Self",
-                            "duration": "Permanent"
-                        }
-                    ]
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true,
+                "condition": "WasKicked"
+            },
+            {
+                "type": "EntersWithKeywords",
+                "keywords": [
+                    "FLYING"
+                ],
+                "condition": "WasKicked",
+                "selfOnly": true
             }
         ]
     },
@@ -6535,24 +6494,16 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
-            {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
-            }
-        ],
         "staticAbilities": [
             "CantBlock"
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": "WasKicked"
+            }
         ]
     },
     "metadata": {
@@ -6835,31 +6786,20 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "AddCounters",
-                            "counterType": "+1/+1",
-                            "count": 3,
-                            "target": "Self"
-                        },
-                        {
-                            "type": "GrantKeyword",
-                            "keyword": "TRAMPLE",
-                            "target": "Self",
-                            "duration": "Permanent"
-                        }
-                    ]
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 3,
+                "selfOnly": true,
+                "condition": "WasKicked"
+            },
+            {
+                "type": "EntersWithKeywords",
+                "keywords": [
+                    "TRAMPLE"
+                ],
+                "condition": "WasKicked",
+                "selfOnly": true
             }
         ]
     },
@@ -7127,20 +7067,12 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 5,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 5,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -9164,20 +9096,12 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -9497,31 +9421,20 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
+        "replacementEffects": [
             {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "Composite",
-                    "effects": [
-                        {
-                            "type": "AddCounters",
-                            "counterType": "+1/+1",
-                            "count": 2,
-                            "target": "Self"
-                        },
-                        {
-                            "type": "GrantKeyword",
-                            "keyword": "HASTE",
-                            "target": "Self",
-                            "duration": "Permanent"
-                        }
-                    ]
-                },
-                "triggerCondition": "WasKicked"
+                "type": "EntersWithCounters",
+                "count": 2,
+                "selfOnly": true,
+                "condition": "WasKicked"
+            },
+            {
+                "type": "EntersWithKeywords",
+                "keywords": [
+                    "HASTE"
+                ],
+                "condition": "WasKicked",
+                "selfOnly": true
             }
         ]
     },
@@ -9617,22 +9530,6 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
-            {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
-            }
-        ],
         "staticAbilities": [
             {
                 "type": "CanAttackDespiteDefender",
@@ -9645,6 +9542,14 @@
                         ]
                     }
                 }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -16504,25 +16409,9 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
-            {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
-            }
-        ],
         "activatedAbilities": [
             {
-                "id": "ability_2",
+                "id": "ability_1",
                 "cost": {
                     "type": "CostAtomWrapper",
                     "atom": {
@@ -16534,6 +16423,14 @@
                     "type": "Regenerate",
                     "target": "Self"
                 }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },
@@ -17257,22 +17154,6 @@
         }
     ],
     "script": {
-        "triggeredAbilities": [
-            {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 4,
-                    "target": "Self"
-                },
-                "triggerCondition": "WasKicked"
-            }
-        ],
         "staticAbilities": [
             {
                 "type": "CantAttackUnless",
@@ -17282,6 +17163,14 @@
                     "zone": "Battlefield",
                     "filter": "land Island"
                 }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 4,
+                "selfOnly": true,
+                "condition": "WasKicked"
             }
         ]
     },

--- a/mtg-sets/src/test/resources/snapshots/cards/KTK.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/KTK.json
@@ -13227,34 +13227,6 @@
         "toughness": 1
     },
     "script": {
-        "triggeredAbilities": [
-            {
-                "id": "ability_1",
-                "trigger": {
-                    "type": "ZoneChangeEvent",
-                    "to": "Battlefield"
-                },
-                "effect": {
-                    "type": "AddCounters",
-                    "counterType": "+1/+1",
-                    "count": 1,
-                    "target": "Self"
-                },
-                "triggerCondition": {
-                    "type": "Compare",
-                    "left": {
-                        "type": "TurnTracking",
-                        "player": "You",
-                        "tracker": "PLAYER_ATTACKED"
-                    },
-                    "operator": "GTE",
-                    "right": {
-                        "type": "Fixed",
-                        "amount": 1
-                    }
-                }
-            }
-        ],
         "staticAbilities": [
             {
                 "type": "CantBeBlockedBy",
@@ -13266,6 +13238,26 @@
                             "max": 1
                         }
                     ]
+                }
+            }
+        ],
+        "replacementEffects": [
+            {
+                "type": "EntersWithCounters",
+                "count": 1,
+                "selfOnly": true,
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "PLAYER_ATTACKED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
                 }
             }
         ]

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ManaCountersAndState.kt
@@ -35,7 +35,11 @@ internal fun BridgeBuilder.manaCountersAndState() {
     // addition to its other types"): set base power/toughness (Layer 7b) and add a creature subtype
     // (Layer 4). Both map to standing SDK effects with Duration.Permanent. Capability-only — the
     // EntersWithLayerEffect/PutEachExiledCardOntoTheBattlefield host shape is card-specific, so the
-    // emitter declines -> SCAFFOLD.
+    // emitter declines -> SCAFFOLD. (A *plain-keyword* AddAbility under EntersWithLayerEffect is now
+    // expressible as the EntersWithKeywords replacement — the INV/DOM kicker "enters with … and with
+    // trample" cycle — but every corpus card with this tag also carries SetPT / activated-ability /
+    // until-EOT riders the shape doesn't cover, so there is no calibrated card to render and the
+    // emitter keeps declining.)
     effect("SetPT", "SetBasePowerToughness", "set base power/toughness via an enters-with layer effect (Ghost Vacuum)")
     effect("AddCreatureType", "AddCreatureType", "add a creature subtype in addition to other types (Ghost Vacuum)")
     // The mtgish IR routes every put-counter action through a `PutCounters` envelope whose nested

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/continuations/MiscContinuationResumer.kt
@@ -584,7 +584,7 @@ class MiscContinuationResumer(
             return ExecutionResult.error(state, "Expected number response for convert-counters-to-tokens")
         }
 
-        val counterType = com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+        val counterType = com.wingedsheep.engine.handlers.effects.EntersWithReplacements
             .resolveCounterType(continuation.counterType)
         val available = state.getEntity(continuation.sourceId)
             ?.get<com.wingedsheep.engine.state.components.battlefield.CountersComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/EntersWithReplacements.kt
@@ -2,10 +2,14 @@ package com.wingedsheep.engine.handlers.effects
 
 import com.wingedsheep.engine.core.CountersAddedEvent
 import com.wingedsheep.engine.core.GameEvent
+import com.wingedsheep.engine.core.KeywordGrantedEvent
 import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
+import com.wingedsheep.engine.mechanics.layers.Layer
+import com.wingedsheep.engine.mechanics.layers.SerializableModification
+import com.wingedsheep.engine.mechanics.layers.addFloatingEffect
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
@@ -16,99 +20,62 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.model.CardDefinition
 import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.Duration
 import com.wingedsheep.sdk.scripting.EntersWithCounters
 import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
+import com.wingedsheep.sdk.scripting.EntersWithKeywords
 import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 
 /**
- * Applies "enters with counters" replacement effects sourced from *other* battlefield
- * permanents (e.g., Gev, Scaled Scorch granting +1/+1 counters to creatures you control
- * that enter the battlefield).
+ * Applies "enters with …" replacement effects (CR 614.1c) — counters
+ * ([EntersWithCounters] / [EntersWithDynamicCounters]) and keywords ([EntersWithKeywords]) —
+ * both the entering permanent's own effects and global ones sourced from *other* battlefield
+ * permanents (e.g., Gev, Scaled Scorch granting +1/+1 counters to creatures you control that
+ * enter the battlefield).
  *
- * Used both by [com.wingedsheep.engine.mechanics.stack.StackResolver] when a spell
- * resolves onto the battlefield, and by token-creation executors when tokens enter
- * (tokens have no cast step but Rule 614 replacement effects still apply to them).
+ * Used by [com.wingedsheep.engine.mechanics.stack.StackResolver] when a spell resolves onto the
+ * battlefield, by token-creation executors when tokens enter (tokens have no cast step but
+ * Rule 614 replacement effects still apply to them), and by non-stack entry paths such as
+ * [com.wingedsheep.engine.handlers.effects.zones.MoveToZoneEffectExecutor] (reanimation).
  */
-object EntersWithCountersHelper {
+object EntersWithReplacements {
 
     private val dynamicAmountEvaluator = DynamicAmountEvaluator()
     private val predicateEvaluator = PredicateEvaluator()
     private val conditionEvaluator = com.wingedsheep.engine.handlers.ConditionEvaluator()
 
     /**
-     * Apply both the entering entity's own [EntersWithCounters] / [EntersWithDynamicCounters]
-     * replacement effects (from its [CardDefinition]) and any global ones sourced from other
+     * Apply both the entering entity's own enters-with replacement effects (from its
+     * [CardDefinition], looked up via [cardRegistry]) and any global ones sourced from other
      * battlefield permanents. Used by callers that put a permanent on the battlefield from a
-     * non-stack zone (e.g., [com.wingedsheep.engine.handlers.effects.zones.MoveToZoneEffectExecutor]
-     * when reanimating from graveyard).
+     * non-stack zone.
      *
      * Stack resolution has its own pre-battlefield application path
-     * ([com.wingedsheep.engine.mechanics.stack.StackResolver.applyEntersWithCounters]) and should
-     * not call this method; it would double-apply.
+     * ([com.wingedsheep.engine.mechanics.stack.StackResolver.applyEntersWithReplacements],
+     * which passes the resolving spell's card definition and cast context explicitly) and
+     * should not call this method; it would double-apply.
      */
-    fun applyEntersWithCounters(
+    fun applyOnEntry(
         state: GameState,
         enteringEntityId: EntityId,
         enteringControllerId: EntityId,
         cardRegistry: CardRegistry,
         xValue: Int? = null
     ): Pair<GameState, List<GameEvent>> {
+        val container = state.getEntity(enteringEntityId) ?: return state to emptyList()
+        val cardComponent = container.get<CardComponent>() ?: return state to emptyList()
+        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return state to emptyList()
+
         var newState = state
         val events = mutableListOf<GameEvent>()
-        val container = newState.getEntity(enteringEntityId) ?: return newState to events
-        val cardComponent = container.get<CardComponent>() ?: return newState to events
-        val cardDef = cardRegistry.getCard(cardComponent.cardDefinitionId) ?: return newState to events
-        val entityName = cardComponent.name
 
-        for (effect in cardDef.script.replacementEffects) {
-            when (effect) {
-                is EntersWithCounters -> {
-                    if (effect.condition != null) {
-                        val condContext = EffectContext(
-                            sourceId = enteringEntityId,
-                            controllerId = enteringControllerId,
-                        )
-                        if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
-                    }
-                    val counterType = resolveCounterType(effect.counterType)
-                    val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
-                        newState, enteringEntityId, counterType, effect.count, placerId = enteringControllerId
-                    )
-                    val current = newState.getEntity(enteringEntityId)?.get<CountersComponent>() ?: CountersComponent()
-                    newState = newState.updateEntity(enteringEntityId) { c ->
-                        c.with(current.withAdded(counterType, modifiedCount))
-                    }
-                    val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, enteringEntityId)
-                    newState = afterMark
-                    events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = enteringControllerId))
-                }
-                is EntersWithDynamicCounters -> {
-                    if (effect.otherOnly) continue
-                    val counterType = resolveCounterType(effect.counterType)
-                    val context = EffectContext(
-                        sourceId = enteringEntityId,
-                        controllerId = enteringControllerId,
-                        xValue = xValue
-                    )
-                    val count = dynamicAmountEvaluator.evaluate(newState, effect.count, context)
-                    if (count > 0) {
-                        val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
-                            newState, enteringEntityId, counterType, count, placerId = enteringControllerId
-                        )
-                        val current = newState.getEntity(enteringEntityId)?.get<CountersComponent>() ?: CountersComponent()
-                        newState = newState.updateEntity(enteringEntityId) { c ->
-                            c.with(current.withAdded(counterType, modifiedCount))
-                        }
-                        val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, enteringEntityId)
-                        newState = afterMark
-                        events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = enteringControllerId))
-                    }
-                }
-                else -> { /* Other replacement effects handled elsewhere */ }
-            }
-        }
+        val (ownState, ownEvents) = applyFromDefinition(
+            newState, enteringEntityId, cardDef, enteringControllerId, xValue
+        )
+        newState = ownState
+        events.addAll(ownEvents)
 
-        val (globalState, globalEvents) = applyGlobalEntersWithCounters(
+        val (globalState, globalEvents) = applyGlobal(
             newState, enteringEntityId, enteringControllerId
         )
         newState = globalState
@@ -118,14 +85,95 @@ object EntersWithCountersHelper {
     }
 
     /**
-     * Scan battlefield permanents for [EntersWithCounters] / [EntersWithDynamicCounters]
-     * replacement effects that apply to the entering entity, and add the counters.
+     * Apply the entering entity's *own* enters-with replacement effects from [cardDef].
+     * Shared by [applyOnEntry] and the stack-resolution path (which has the resolving
+     * spell's definition and cast context — [xValue] / [totalManaSpent] — at hand).
+     */
+    fun applyFromDefinition(
+        state: GameState,
+        entityId: EntityId,
+        cardDef: CardDefinition,
+        controllerId: EntityId,
+        xValue: Int? = null,
+        totalManaSpent: Int = 0
+    ): Pair<GameState, List<GameEvent>> {
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        val entityName = newState.getEntity(entityId)?.get<CardComponent>()?.name ?: ""
+
+        for (effect in cardDef.script.replacementEffects) {
+            when (effect) {
+                is EntersWithCounters -> {
+                    if (effect.condition != null) {
+                        val condContext = EffectContext(
+                            sourceId = entityId,
+                            controllerId = controllerId,
+                        )
+                        if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
+                    }
+                    val counterType = resolveCounterType(effect.counterType)
+                    val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
+                        newState, entityId, counterType, effect.count, placerId = controllerId
+                    )
+                    val current = newState.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
+                    newState = newState.updateEntity(entityId) { c ->
+                        c.with(current.withAdded(counterType, modifiedCount))
+                    }
+                    val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
+                    newState = afterMark
+                    events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = controllerId))
+                }
+                is EntersWithDynamicCounters -> {
+                    // Skip "other only" effects when applying to self (e.g., Gev)
+                    if (effect.otherOnly) continue
+                    val counterType = resolveCounterType(effect.counterType)
+                    val context = EffectContext(
+                        sourceId = entityId,
+                        controllerId = controllerId,
+                        xValue = xValue,
+                        totalManaSpent = totalManaSpent
+                    )
+                    val count = dynamicAmountEvaluator.evaluate(newState, effect.count, context)
+                    if (count > 0) {
+                        val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
+                            newState, entityId, counterType, count, placerId = controllerId
+                        )
+                        val current = newState.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
+                        newState = newState.updateEntity(entityId) { c ->
+                            c.with(current.withAdded(counterType, modifiedCount))
+                        }
+                        val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
+                        newState = afterMark
+                        events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = controllerId))
+                    }
+                }
+                is EntersWithKeywords -> {
+                    val context = EffectContext(
+                        sourceId = entityId,
+                        controllerId = controllerId,
+                    )
+                    if (effect.condition != null &&
+                        !conditionEvaluator.evaluate(newState, effect.condition!!, context)
+                    ) continue
+                    val (grantState, grantEvents) = grantKeywords(newState, effect, entityId, entityName, context)
+                    newState = grantState
+                    events.addAll(grantEvents)
+                }
+                else -> { /* Other replacement effects handled elsewhere */ }
+            }
+        }
+        return newState to events
+    }
+
+    /**
+     * Scan battlefield permanents for enters-with replacement effects that apply to the
+     * entering entity, and apply them (counters added / keywords granted).
      *
      * @param state The game state after the entering entity has been added to the battlefield.
      * @param enteringEntityId The entity that just entered the battlefield.
      * @param enteringControllerId The controller of the entering entity.
      */
-    fun applyGlobalEntersWithCounters(
+    fun applyGlobal(
         state: GameState,
         enteringEntityId: EntityId,
         enteringControllerId: EntityId,
@@ -177,10 +225,10 @@ object EntersWithCountersHelper {
                         // An "enters with N counters" count always describes the ENTERING object,
                         // not the replacement source — the counters go on the entering permanent and
                         // any "it" in the count refers to it (CR 121.6 / 614). Mirror the self path
-                        // (StackResolver.applyEntersWithCounters uses sourceId = the entering entity)
-                        // so amounts like DistinctColorsManaSpent ("...colors of mana spent to cast
-                        // IT") read the entering creature's own cast, not the source's. controllerId
-                        // stays the source's controller so player-scoped counts (Gev's
+                        // (StackResolver.applyEntersWithReplacements uses sourceId = the entering
+                        // entity) so amounts like DistinctColorsManaSpent ("...colors of mana spent
+                        // to cast IT") read the entering creature's own cast, not the source's.
+                        // controllerId stays the source's controller so player-scoped counts (Gev's
                         // TurnTracking(Player.You)) keep reading the source controller's trackers.
                         val context = EffectContext(
                             sourceId = enteringEntityId,
@@ -201,9 +249,70 @@ object EntersWithCountersHelper {
                             events.add(CountersAddedEvent(enteringEntityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = enteringControllerId))
                         }
                     }
+                    is EntersWithKeywords -> {
+                        if (effect.selfOnly) continue
+                        if (!matchesEnterFilter(effect.appliesTo, enteringEntityId, sourceControllerId, newState)) continue
+                        // Like the counters branch above: the condition describes the ENTERING
+                        // permanent; controllerId stays the source's controller.
+                        if (effect.condition != null) {
+                            val condContext = EffectContext(
+                                sourceId = enteringEntityId,
+                                controllerId = sourceControllerId,
+                                affectedEntityId = enteringEntityId,
+                            )
+                            if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
+                        }
+                        // The grant itself is credited to the replacement's source permanent.
+                        val grantContext = EffectContext(
+                            sourceId = sourceId,
+                            controllerId = sourceControllerId,
+                            affectedEntityId = enteringEntityId,
+                        )
+                        val (grantState, grantEvents) = grantKeywords(newState, effect, enteringEntityId, entityName, grantContext)
+                        newState = grantState
+                        events.addAll(grantEvents)
+                    }
                     else -> { /* Other replacement effects handled elsewhere */ }
                 }
             }
+        }
+        return newState to events
+    }
+
+    /**
+     * Grant [effect]'s keywords to [enteringEntityId] as permanent floating effects. The grant
+     * is entry-timestamped (Rule 613 layer ordering: a later "loses all abilities" removes it)
+     * and cleaned up when the permanent leaves the battlefield
+     * ([ZoneMovementUtils.removeFloatingEffectsTargeting], CR 400.7).
+     */
+    private fun grantKeywords(
+        state: GameState,
+        effect: EntersWithKeywords,
+        enteringEntityId: EntityId,
+        enteringEntityName: String,
+        context: EffectContext,
+    ): Pair<GameState, List<GameEvent>> {
+        var newState = state
+        val events = mutableListOf<GameEvent>()
+        val sourceName = context.sourceId
+            ?.let { newState.getEntity(it)?.get<CardComponent>()?.name }
+            ?: enteringEntityName
+        for (keyword in effect.keywords) {
+            newState = newState.addFloatingEffect(
+                layer = Layer.ABILITY,
+                modification = SerializableModification.GrantKeyword(keyword.name),
+                affectedEntities = setOf(enteringEntityId),
+                duration = Duration.Permanent,
+                context = context
+            )
+            events.add(
+                KeywordGrantedEvent(
+                    targetId = enteringEntityId,
+                    targetName = enteringEntityName,
+                    keyword = keyword.name.lowercase().replace('_', ' '),
+                    sourceName = sourceName
+                )
+            )
         }
         return newState to events
     }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/library/MoveCollectionExecutor.kt
@@ -4,7 +4,7 @@ import com.wingedsheep.engine.core.*
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.handlers.effects.TargetResolutionUtils
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.registry.CardRegistry
@@ -686,7 +686,7 @@ class MoveCollectionExecutor(
             // play, Hideaway's free-cast pile). Face-down entries skip this — morphed creatures
             // enter as 2/2 nameless with no replacement effects from their face-up identity.
             if (destZone == Zone.BATTLEFIELD && faceDown == null) {
-                val (counterState, counterEvents) = EntersWithCountersHelper.applyEntersWithCounters(
+                val (counterState, counterEvents) = EntersWithReplacements.applyOnEntry(
                     newState, cardId, actualDestPlayerId, cardRegistry
                 )
                 newState = counterState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/ConvertCountersToTokensExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/permanent/counters/ConvertCountersToTokensExecutor.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.core.EffectResult
 import com.wingedsheep.engine.handlers.DecisionHandler
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.state.GameState
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
@@ -35,7 +35,7 @@ class ConvertCountersToTokensExecutor(
         val sourceId = context.sourceId ?: return EffectResult.success(state)
         val sourceEntity = state.getEntity(sourceId) ?: return EffectResult.success(state)
 
-        val counterType = EntersWithCountersHelper.resolveCounterType(effect.counterType)
+        val counterType = EntersWithReplacements.resolveCounterType(effect.counterType)
         val available = sourceEntity.get<CountersComponent>()?.getCount(counterType) ?: 0
         if (available <= 0) return EffectResult.success(state)
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfChosenPermanentExecutor.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.effects.BattlefieldFilterUtils
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.ComponentContainer
@@ -157,7 +157,7 @@ class CreateTokenCopyOfChosenPermanentExecutor(
 
             // Apply "enters with counters" replacement effects from other battlefield permanents
             // (e.g., Gev, Scaled Scorch granting +1/+1 counters to token copies).
-            val (stateWithCounters, counterEvents) = EntersWithCountersHelper.applyGlobalEntersWithCounters(
+            val (stateWithCounters, counterEvents) = EntersWithReplacements.applyGlobal(
                 newState, tokenId, controllerId
             )
 

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenCopyOfSourceExecutor.kt
@@ -5,7 +5,7 @@ import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.event.DelayedTriggeredAbility
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.Component
@@ -142,7 +142,7 @@ class CreateTokenCopyOfSourceExecutor(
         // (e.g., Gev, Scaled Scorch granting +1/+1 counters to Offspring token copies).
         val counterEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
         for (tokenId in createdTokens) {
-            val (nextState, events) = EntersWithCountersHelper.applyGlobalEntersWithCounters(
+            val (nextState, events) = EntersWithReplacements.applyGlobal(
                 newState, tokenId, controllerId
             )
             newState = nextState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/CreateTokenExecutor.kt
@@ -6,7 +6,7 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.state.Component
 import com.wingedsheep.engine.state.ComponentContainer
 import com.wingedsheep.engine.state.GameState
@@ -244,7 +244,7 @@ class CreateTokenExecutor(
         // (e.g., Gev, Scaled Scorch granting +1/+1 counters to tokens entering under your control).
         val counterEvents = mutableListOf<com.wingedsheep.engine.core.GameEvent>()
         for (tokenId in createdTokens) {
-            val (nextState, events) = EntersWithCountersHelper.applyGlobalEntersWithCounters(
+            val (nextState, events) = EntersWithReplacements.applyGlobal(
                 newState, tokenId, tokenControllerId
             )
             newState = nextState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenCreationReplacementHelper.kt
@@ -8,7 +8,7 @@ import com.wingedsheep.engine.core.TokenCreationReplacementContinuation
 import com.wingedsheep.engine.core.YesNoDecision
 import com.wingedsheep.engine.core.ZoneChangeEvent
 import com.wingedsheep.engine.handlers.EffectContext
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
 import com.wingedsheep.engine.registry.CardRegistry
 import com.wingedsheep.engine.state.Component
@@ -343,7 +343,7 @@ object TokenCreationReplacementHelper {
      * exactly what was printed on the attached permanent. That includes printed
      * "enters with N counters" replacement effects (e.g., Burdened Stoneback's "this
      * creature enters with two -1/-1 counters"), applied via
-     * [EntersWithCountersHelper.applyEntersWithCounters]. Summoning sickness is added
+     * [EntersWithReplacements.applyOnEntry]. Summoning sickness is added
      * only when the copy is itself a creature (CR 302.6).
      */
     fun createAttachedPermanentCopies(
@@ -399,7 +399,7 @@ object TokenCreationReplacementHelper {
             // Apply the attached permanent's printed enters-with-counters replacement
             // effects (and any global ones from other permanents).
             if (cardRegistry != null) {
-                val (afterCounters, counterEvents) = EntersWithCountersHelper.applyEntersWithCounters(
+                val (afterCounters, counterEvents) = EntersWithReplacements.applyOnEntry(
                     newState, tokenId, controllerId, cardRegistry
                 )
                 newState = afterCounters

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/token/TokenFromDefinition.kt
@@ -7,7 +7,7 @@ import com.wingedsheep.engine.handlers.ConditionEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.BattlefieldEntry
 import com.wingedsheep.engine.handlers.effects.EnterTappedReplacements
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.handlers.effects.PermanentEntryReplacements
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
 import com.wingedsheep.engine.mechanics.layers.StaticAbilityHandler
@@ -47,7 +47,7 @@ import com.wingedsheep.sdk.scripting.EntersWithChoice
  *    `payLifeCost` form is land-only, so a minted creature only ever has the simple form.
  *  - **self + global [EntersWithCounters]/[EntersWithDynamicCounters]** add counters (a creature
  *    that "enters with N +1/+1 counters", plus grants from other permanents) via
- *    [EntersWithCountersHelper].
+ *    [EntersWithReplacements].
  *  - **[EntersWithChoice]** (Alloy Golem, "as this enters, choose a color") pauses for a player
  *    decision via [PermanentEntryReplacements]; the chosen value is recorded in
  *    `CastChoicesComponent` and the token's ETB triggers fire from the resumer afterward.
@@ -121,7 +121,7 @@ object TokenFromDefinition {
         )
 
         // As-enters: the token's own + global "enters with counters" (CR 614).
-        val (stateWithCounters, counterEvents) = EntersWithCountersHelper.applyEntersWithCounters(
+        val (stateWithCounters, counterEvents) = EntersWithReplacements.applyOnEntry(
             newState, tokenId, controllerId, cardRegistry
         )
         newState = stateWithCounters

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/MoveToZoneEffectExecutor.kt
@@ -10,7 +10,7 @@ import com.wingedsheep.engine.core.TargetRequirementInfo
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.TargetFinder
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.handlers.effects.LibraryPlacement
 import com.wingedsheep.engine.handlers.effects.ZoneEntryOptions
 import com.wingedsheep.engine.handlers.effects.ZoneMovementUtils
@@ -110,7 +110,7 @@ class MoveToZoneEffectExecutor(
         // creatures with no replacement effects from their face-up identity.
         val actualDestZone = transitionResult.actualDestination
         if (actualDestZone == Zone.BATTLEFIELD && effect.faceDown == null) {
-            val (counterState, counterEvents) = EntersWithCountersHelper.applyEntersWithCounters(
+            val (counterState, counterEvents) = EntersWithReplacements.applyOnEntry(
                 resultState, targetId, controllerId, cardRegistry
             )
             resultState = counterState

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/layers/StaticAbilityHandler.kt
@@ -999,6 +999,7 @@ class StaticAbilityHandler(
             is com.wingedsheep.sdk.scripting.DoubleCounterPlacement,
             is com.wingedsheep.sdk.scripting.EntersWithCounters,
             is com.wingedsheep.sdk.scripting.EntersWithDynamicCounters,
+            is com.wingedsheep.sdk.scripting.EntersWithKeywords,
             // "Lands you control enter untapped" (The Wandering Minstrel): a static effect
             // consulted from the battlefield against OTHER permanents as they enter.
             is com.wingedsheep.sdk.scripting.EntersUntapped,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -51,18 +51,13 @@ import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
 import com.wingedsheep.sdk.scripting.effects.WarpExileEffect
 import com.wingedsheep.sdk.model.EntityId
-import com.wingedsheep.sdk.scripting.events.CounterTypeFilter
 import com.wingedsheep.sdk.scripting.EntersAsCopy
-import com.wingedsheep.engine.handlers.effects.EntersWithCountersHelper
+import com.wingedsheep.engine.handlers.effects.EntersWithReplacements
 import com.wingedsheep.engine.handlers.effects.permanent.types.returnDfcFaceFromExile
-import com.wingedsheep.engine.handlers.effects.DamageUtils
 import com.wingedsheep.engine.handlers.effects.ReplacementEffectUtils
 import com.wingedsheep.sdk.scripting.EntersTapped
 import com.wingedsheep.sdk.scripting.EntersWithChoice
-import com.wingedsheep.sdk.scripting.EntersWithCounters
-import com.wingedsheep.sdk.scripting.EntersWithDynamicCounters
 import com.wingedsheep.sdk.scripting.ChoiceType
-import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.PredicateContext
 import com.wingedsheep.engine.handlers.PredicateEvaluator
 import com.wingedsheep.engine.handlers.TargetingSourceType
@@ -1379,7 +1374,7 @@ class StackResolver(
             val totalManaSpent = spellComponent.manaSpentWhite + spellComponent.manaSpentBlue +
                 spellComponent.manaSpentBlack + spellComponent.manaSpentRed +
                 spellComponent.manaSpentGreen + spellComponent.manaSpentColorless
-            val (counterState, events) = applyEntersWithCounters(
+            val (counterState, events) = applyEntersWithReplacements(
                 newState, spellId, cardDef, controllerId, spellComponent.xValue, totalManaSpent
             )
             newState = counterState
@@ -2335,19 +2330,17 @@ class StackResolver(
     }
 
     // =========================================================================
-    // Enters With Counters
+    // Enters With Replacements ("enters with counters / keywords", CR 614.1c)
     // =========================================================================
 
-    private val dynamicAmountEvaluator = DynamicAmountEvaluator()
-    private val conditionEvaluator = com.wingedsheep.engine.handlers.ConditionEvaluator()
-
     /**
-     * Apply "enters with counters" replacement effects to a permanent.
-     * Handles both fixed count (EntersWithCounters) and dynamic count (EntersWithDynamicCounters).
-     * Also checks other battlefield permanents for replacement effects that modify entering creatures
-     * (e.g., Gev, Scaled Scorch: "Other creatures you control enter with additional +1/+1 counters").
+     * Apply the resolving permanent's "enters with …" replacement effects — counters
+     * (EntersWithCounters / EntersWithDynamicCounters) and keywords (EntersWithKeywords) —
+     * plus any global ones sourced from other battlefield permanents (e.g., Gev, Scaled
+     * Scorch: "Other creatures you control enter with additional +1/+1 counters").
+     * Thin wrapper over [EntersWithReplacements] carrying the cast context (X, mana spent).
      */
-    internal fun applyEntersWithCounters(
+    internal fun applyEntersWithReplacements(
         state: GameState,
         entityId: EntityId,
         cardDef: com.wingedsheep.sdk.model.CardDefinition,
@@ -2357,61 +2350,14 @@ class StackResolver(
     ): Pair<GameState, List<GameEvent>> {
         var newState = state
         val events = mutableListOf<GameEvent>()
-        val entityName = newState.getEntity(entityId)?.get<CardComponent>()?.name ?: ""
-        // Apply the entering creature's own replacement effects
-        for (effect in cardDef.script.replacementEffects) {
-            when (effect) {
-                is EntersWithCounters -> {
-                    if (effect.condition != null) {
-                        val condContext = EffectContext(
-                            sourceId = entityId,
-                            controllerId = controllerId,
-                        )
-                        if (!conditionEvaluator.evaluate(newState, effect.condition!!, condContext)) continue
-                    }
-                    val counterType = resolveCounterType(effect.counterType)
-                    val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
-                        newState, entityId, counterType, effect.count, placerId = controllerId
-                    )
-                    val current = newState.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
-                    newState = newState.updateEntity(entityId) { c ->
-                        c.with(current.withAdded(counterType, modifiedCount))
-                    }
-                    val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
-                    newState = afterMark
-                    events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = controllerId))
-                }
-                is EntersWithDynamicCounters -> {
-                    // Skip "other only" effects when applying to self (e.g., Gev)
-                    if (effect.otherOnly) continue
-                    val counterType = resolveCounterType(effect.counterType)
-                    val context = EffectContext(
-                        sourceId = entityId,
-                        controllerId = controllerId,
-                        xValue = xValue,
-                        totalManaSpent = totalManaSpent
-                    )
-                    val count = dynamicAmountEvaluator.evaluate(newState, effect.count, context)
-                    if (count > 0) {
-                        val modifiedCount = ReplacementEffectUtils.applyCounterPlacementModifiers(
-                            newState, entityId, counterType, count, placerId = controllerId
-                        )
-                        val current = newState.getEntity(entityId)?.get<CountersComponent>() ?: CountersComponent()
-                        newState = newState.updateEntity(entityId) { c ->
-                            c.with(current.withAdded(counterType, modifiedCount))
-                        }
-                        val (afterMark, firstThisTurn) = DamageUtils.recordCounterPlacement(newState, entityId)
-                        newState = afterMark
-                        events.add(CountersAddedEvent(entityId, effect.counterType.description, modifiedCount, entityName, firstThisTurn, placedBy = controllerId))
-                    }
-                }
-                else -> { /* Other replacement effects handled elsewhere */ }
-            }
-        }
 
-        // Apply "enters with counters" replacement effects from other battlefield permanents
-        // (e.g., Gev: "Other creatures you control enter with additional +1/+1 counters")
-        val (globalState, globalEvents) = EntersWithCountersHelper.applyGlobalEntersWithCounters(
+        val (ownState, ownEvents) = EntersWithReplacements.applyFromDefinition(
+            newState, entityId, cardDef, controllerId, xValue, totalManaSpent
+        )
+        newState = ownState
+        events.addAll(ownEvents)
+
+        val (globalState, globalEvents) = EntersWithReplacements.applyGlobal(
             newState, entityId, controllerId
         )
         newState = globalState
@@ -2419,9 +2365,6 @@ class StackResolver(
 
         return newState to events
     }
-
-    private fun resolveCounterType(filter: CounterTypeFilter): CounterType =
-        EntersWithCountersHelper.resolveCounterType(filter)
 
     // =========================================================================
     // Countering

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinBoardersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GoblinBoardersScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.fdn.cards.GoblinBoarders
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Goblin Boarders {2}{R} — Creature — Goblin Pirate 3/2
+ *   Raid — This creature enters with a +1/+1 counter on it if you attacked this turn.
+ *
+ * "Enters with a counter" is a replacement effect (rule 614.1c), not an ETB trigger:
+ * nothing goes on the stack, and with Raid satisfied the creature is a 4/3 from the
+ * moment it hits the battlefield.
+ */
+class GoblinBoardersScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(GoblinBoarders))
+        return driver
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    test("raid active: enters as a 4/3 with the counter already on it, no trigger on the stack") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+        val opponent = driver.getOpponent(you)
+
+        // Attack this turn to satisfy Raid.
+        val goblin = driver.putCreatureOnBattlefield(you, "Goblin Guide")
+        driver.removeSummoningSickness(goblin)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(goblin), defendingPlayer = opponent).error shouldBe null
+        driver.passPriorityUntil(Step.POSTCOMBAT_MAIN)
+
+        driver.giveMana(you, Color.RED, 3)
+        val boarders = driver.putCardInHand(you, "Goblin Boarders")
+        driver.castSpell(you, boarders).error shouldBe null
+        driver.bothPass() // resolve onto the battlefield
+
+        // Replacement effect: the counter is there immediately and nothing triggered.
+        driver.stackSize shouldBe 0
+        val perm = driver.findPermanent(you, "Goblin Boarders")!!
+        driver.plusOneCounters(perm) shouldBe 1
+        driver.state.projectedState.getPower(perm) shouldBe 4
+        driver.state.projectedState.getToughness(perm) shouldBe 3
+    }
+
+    test("no attack this turn: enters as a plain 3/2") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val you = driver.activePlayer!!
+
+        driver.giveMana(you, Color.RED, 3)
+        val boarders = driver.putCardInHand(you, "Goblin Boarders")
+        driver.castSpell(you, boarders).error shouldBe null
+        driver.bothPass() // resolve onto the battlefield
+
+        driver.stackSize shouldBe 0
+        val perm = driver.findPermanent(you, "Goblin Boarders")!!
+        driver.plusOneCounters(perm) shouldBe 0
+        driver.state.projectedState.getPower(perm) shouldBe 3
+        driver.state.projectedState.getToughness(perm) shouldBe 2
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KickedEntersWithReplacementScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KickedEntersWithReplacementScenarioTest.kt
@@ -1,0 +1,140 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.core.PaymentStrategy
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Kicker "enters with …" riders are replacement effects (CR 614.1c), not ETB triggers:
+ * nothing goes on the stack, and the counters/keywords are present from the moment the
+ * permanent enters. Exercised through Kavu Titan ({1}{G} 2/2, Kicker {2}{G} — "If this
+ * creature was kicked, it enters with three +1/+1 counters on it and with trample") and
+ * Pouncing Kavu ({1}{R} 1/1 first strike, Kicker {2}{R} — "… enters with two +1/+1
+ * counters on it and with haste").
+ */
+class KickedEntersWithReplacementScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    fun GameTestDriver.castKicked(playerId: EntityId, cardId: EntityId) =
+        submit(
+            CastSpell(
+                playerId = playerId,
+                cardId = cardId,
+                wasKicked = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+
+    test("kicked Kavu Titan enters as a 5/5 with trample, with no trigger on the stack") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        driver.giveMana(you, Color.GREEN, 6)
+        val titan = driver.putCardInHand(you, "Kavu Titan")
+        driver.castKicked(you, titan).error shouldBe null
+        driver.bothPass() // resolve onto the battlefield
+
+        // Replacement effect: counters and trample are there immediately, nothing triggered.
+        driver.stackSize shouldBe 0
+        val perm = driver.findPermanent(you, "Kavu Titan")!!
+        driver.plusOneCounters(perm) shouldBe 3
+        driver.state.projectedState.getPower(perm) shouldBe 5
+        driver.state.projectedState.getToughness(perm) shouldBe 5
+        driver.state.projectedState.hasKeyword(perm, Keyword.TRAMPLE) shouldBe true
+    }
+
+    test("unkicked Kavu Titan enters as a plain 2/2 without trample") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        driver.giveMana(you, Color.GREEN, 2)
+        val titan = driver.putCardInHand(you, "Kavu Titan")
+        driver.castSpell(you, titan).error shouldBe null
+        driver.bothPass()
+
+        driver.stackSize shouldBe 0
+        val perm = driver.findPermanent(you, "Kavu Titan")!!
+        driver.plusOneCounters(perm) shouldBe 0
+        driver.state.projectedState.getPower(perm) shouldBe 2
+        driver.state.projectedState.getToughness(perm) shouldBe 2
+        driver.state.projectedState.hasKeyword(perm, Keyword.TRAMPLE) shouldBe false
+    }
+
+    test("kicked Pouncing Kavu has haste from the moment it enters") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        driver.giveMana(you, Color.RED, 5) // {1}{R} base + {2}{R} kicker
+        val kavu = driver.putCardInHand(you, "Pouncing Kavu")
+        driver.castKicked(you, kavu).error shouldBe null
+        driver.bothPass()
+
+        driver.stackSize shouldBe 0
+        val perm = driver.findPermanent(you, "Pouncing Kavu")!!
+        driver.plusOneCounters(perm) shouldBe 2
+        driver.state.projectedState.hasKeyword(perm, Keyword.HASTE) shouldBe true
+        // The printed keyword is untouched by the entry grant.
+        driver.state.projectedState.hasKeyword(perm, Keyword.FIRST_STRIKE) shouldBe true
+
+        // Haste is real: it can attack the turn it entered.
+        val opponent = driver.getOpponent(you)
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(you, listOf(perm), defendingPlayer = opponent).error shouldBe null
+    }
+
+    test("bounced and recast without kicker: enters as a fresh 2/2 (CR 400.7)") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Forest" to 40))
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val you = driver.activePlayer!!
+
+        driver.giveMana(you, Color.GREEN, 6)
+        val titan = driver.putCardInHand(you, "Kavu Titan")
+        driver.castKicked(you, titan).error shouldBe null
+        driver.bothPass()
+        val kicked = driver.findPermanent(you, "Kavu Titan")!!
+        driver.state.projectedState.hasKeyword(kicked, Keyword.TRAMPLE) shouldBe true
+
+        // Bounce it: the new object has no memory of being kicked (CR 400.7) —
+        // the keyword grant and counters must not survive the round trip.
+        driver.giveMana(you, Color.BLUE, 1)
+        val unsummon = driver.putCardInHand(you, "Unsummon")
+        driver.castSpell(you, unsummon, targets = listOf(kicked)).error shouldBe null
+        driver.bothPass()
+        driver.findPermanent(you, "Kavu Titan") shouldBe null
+
+        driver.giveMana(you, Color.GREEN, 2)
+        val again = driver.findCardInHand(you, "Kavu Titan")!!
+        driver.castSpell(you, again).error shouldBe null
+        driver.bothPass()
+
+        val perm = driver.findPermanent(you, "Kavu Titan")!!
+        driver.plusOneCounters(perm) shouldBe 0
+        driver.state.projectedState.getPower(perm) shouldBe 2
+        driver.state.projectedState.hasKeyword(perm, Keyword.TRAMPLE) shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeonardoSewerSamuraiScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LeonardoSewerSamuraiScenarioTest.kt
@@ -14,7 +14,7 @@ import io.kotest.matchers.shouldBe
  *
  * Exercises the non-self `EntersWithCounters(FINALITY, condition = WasCastFromGraveyard)`:
  * Leonardo's `selfOnly = false` replacement must evaluate the cast-from-graveyard status of the
- * *entering* creature (the fix in EntersWithCountersHelper.applyGlobalEntersWithCounters).
+ * *entering* creature (the fix in EntersWithReplacements.applyGlobal).
  */
 class LeonardoSewerSamuraiScenarioTest : ScenarioTestBase() {
 


### PR DESCRIPTION
## Summary

"This creature **enters with** a +1/+1 counter on it if \<condition\>" is a **replacement effect (CR 614.1c)**, not an ETB trigger: nothing goes on the stack, there is no response window, and the counters (and any "and with \<keyword\>" rider) are present from the moment the permanent enters. Two groups of cards implemented this as a condition-gated ETB trigger instead:

- **3 conditional enters-with-counter cards** — Goblin Boarders and War-Name Aspirant (Raid), Cindering Cutthroat (opponent lost life). With the trigger version, the creature entered as its base size and opponents could respond before the counter arrived.
- **17 Invasion/Dominaria kicker cards** — "If this creature was kicked, it enters with N +1/+1 counters on it [and with \<keyword\>]". A kicked Kavu Titan was killable as a 2/2 in response to its own trigger, and Torpor-Orb-style effects would wrongly suppress the counters.

## Changes

**Commit 1 — conditional (Raid / lost-life) cards**

Convert Goblin Boarders, War-Name Aspirant, and Cindering Cutthroat to the existing `EntersWithCounters(condition = …, selfOnly = true)` replacement, following the Frilled Sparkshooter precedent. No SDK changes.

**Commit 2 — kicker cards, plus the SDK/engine capability the keyword riders needed**

- **New SDK replacement effect `EntersWithKeywords(keywords, condition?, selfOnly?, appliesTo?)`** — the keyword counterpart of `EntersWithCounters`. Keywords are granted as an entry-timestamped, permanent Layer-6 floating effect: a later "loses all abilities" removes it, it does not re-apply if stripped, and it is cleaned up when the permanent leaves the battlefield (CR 400.7). Applied on both entry paths (stack resolution and non-stack zone moves) and by the global battlefield scan, mirroring `EntersWithCounters` semantics including `selfOnly`. Reuses the existing `KeywordGrantedEvent` — no new client/server surface.
- **Renamed `EntersWithCountersHelper` → `EntersWithReplacements`** (it now applies counters *and* keywords, matching the `EnterTappedReplacements` sibling naming) and collapsed `StackResolver`'s duplicated self-path into the shared `applyFromDefinition` core.
- **12 counter-only cards** → `EntersWithCounters(condition = WasKicked)`, following the Gnarlid Colony precedent: Ardent Soldier, Kavu Aggressor, Llanowar Elite, Pincer Spider, Prison Barricade, Urborg Skeleton, Vodalian Serpent (INV); Academy Drake, Baloth Gorger, Grunn the Lonely King, Stronghold Confessor, Untamed Kavu (DOM).
- **5 keyword-rider cards** → `EntersWithCounters` + `EntersWithKeywords`: Benalish Lancer (first strike), Duskwalker (fear), Faerie Squadron (flying), Kavu Titan (trample), Pouncing Kavu (haste).
- SDK reference documents the new type; the mtgish bridge note explains why the emitter still declines `EntersWithLayerEffect` (every corpus card with that tag carries SetPT / activated-grant / until-EOT riders beyond the plain-keyword shape — no calibrated card to render).

`WasKicked` needed no engine change: the KICKED cast-choice is stamped on the spell entity before the entry replacements apply, and a token copy or reanimated body (never kicked) correctly gets nothing.

## Tests

- `GoblinBoardersScenarioTest` — Raid satisfied: enters as a 4/3 with the counter already on it and **an empty stack** (the discriminating assertions the trigger version fails); no attack: plain 3/2.
- `KickedEntersWithReplacementScenarioTest` — kicked Kavu Titan enters as a 5/5 with trample and an empty stack; unkicked baseline 2/2; kicked Pouncing Kavu has haste from the moment it enters and attacks the same turn; bounced and recast without kicker enters as a fresh 2/2 (CR 400.7 new-object reset).
- Full `rules-engine` suite, `mtg-sdk` suite, `CardDefinitionSnapshotTest` (BLB/FDN/KTK/INV/DOM re-blessed — the diff is exactly the 20 trigger→replacement conversions) and `CardLintTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
