### PR TITLE
Implement VOW cards with 1:1 scenario tests

### DIFF
--- a/backlog/sets/innistrad-crimson-vow/cards.md
+++ b/backlog/sets/innistrad-crimson-vow/cards.md
@@ -1,0 +1,277 @@
+# Innistrad: Crimson Vow (VOW) - Card Checklist
+
+**Set Size:** 272 booster cards (excluding basic lands and tokens)
+**Release Date:** November 19, 2021
+**Implemented:** 109 / 272
+- [x] Abrade
+- [x] Adamant Will
+- [ ] Aim for the Head
+- [ ] Alchemist's Gambit
+- [ ] Alchemist's Retrieval
+- [ ] Alluring Suitor
+- [x] Ancestral Anger
+- [ ] Ancient Lumberknot
+- [x] Angelic Quartermaster
+- [ ] Anje, Maid of Dishonor
+- [ ] Apprentice Sharpshooter
+- [ ] Archghoul of Thraben
+- [x] Arm the Cathars
+- [ ] Ascendant Packleader
+- [ ] Avabruck Caretaker
+- [ ] Ballista Watcher
+- [x] Belligerent Guest
+- [ ] Binding Geist
+- [ ] Biolume Egg
+- [x] Bleed Dry
+- [x] Blood Fountain
+- [ ] Blood Hypnotist
+- [x] Blood Petal Celebrant
+- [x] Blood Servitor
+- [x] Bloodcrazed Socialite
+- [ ] Bloodsworn Squire
+- [x] Bloodtithe Harvester
+- [ ] Bloodvial Purveyor
+- [x] Bloody Betrayal
+- [x] Boarded Window
+- [ ] Bramble Armor
+- [x] Bramble Wurm
+- [ ] Bride's Gown
+- [ ] Brine Comber
+- [ ] By Invitation Only
+- [ ] Cartographer's Survey
+- [ ] Catapult Fodder
+- [ ] Cemetery Desecrator
+- [ ] Cemetery Gatekeeper
+- [ ] Cemetery Illuminator
+- [ ] Cemetery Protector
+- [ ] Cemetery Prowler
+- [ ] Ceremonial Knife
+- [ ] Chandra, Dressed to Kill
+- [ ] Change of Fortune
+- [ ] Child of the Pack
+- [ ] Chill of the Grave
+- [ ] Circle of Confinement
+- [ ] Cloaked Cadet
+- [x] Cobbled Lancer
+- [ ] Concealing Curtains
+- [ ] Consuming Tide
+- [x] Courier Bat
+- [x] Cradle of Safety
+- [ ] Crawling Infestation
+- [ ] Creepy Puppeteer
+- [x] Cruel Witness
+- [ ] Crushing Canopy
+- [ ] Cultivator Colossus
+- [ ] Curse of Hospitality
+- [x] Dawnhart Disciple
+- [x] Dawnhart Geist
+- [x] Daybreak Combatants
+- [x] Deathcap Glade
+- [ ] Demonic Bargain
+- [ ] Desperate Farmer
+- [ ] Dig Up
+- [x] Diregraf Scavenger
+- [ ] Distracting Geist
+- [ ] Diver Skaab
+- [ ] Dollhouse of Horrors
+- [ ] Dominating Vampire
+- [ ] Doomed Dissenter
+- [ ] Dormant Grove
+- [ ] Dorothea, Vengeful Victim
+- [ ] Dread Fugue
+- [ ] Dreadfeast Demon
+- [ ] Dreadlight Monstrosity
+- [x] Dreamroot Cascade
+- [ ] Dreamshackle Geist
+- [ ] Drogskol Infantry
+- [ ] Dying to Serve
+- [ ] Edgar's Awakening
+- [ ] Edgar, Charmed Groom
+- [x] End the Festivities
+- [ ] Eruth, Tormented Prophet
+- [x] Estwald Shieldbasher
+- [x] Evolving Wilds
+- [ ] Faithbound Judge
+- [x] Falkenrath Celebrants
+- [x] Falkenrath Forebear
+- [x] Fear of Death
+- [ ] Fearful Villager
+- [ ] Fell Stinger
+- [ ] Fierce Retribution
+- [x] Flame-Blessed Bolt
+- [ ] Fleeting Spirit
+- [x] Flourishing Hunter
+- [ ] Foreboding Statue
+- [x] Forest
+- [x] Frenzied Devils
+- [x] Geistlight Snare
+- [ ] Geralf, Visionary Stitcher
+- [x] Gift of Fangs
+- [ ] Glorious Sunrise
+- [x] Gluttonous Guest
+- [ ] Graf Reaver
+- [x] Grisly Ritual
+- [ ] Grolnok, the Omnivore
+- [ ] Groom's Finery
+- [ ] Gryff Rider
+- [ ] Gryffwing Cavalry
+- [ ] Gutter Skulker
+- [x] Halana and Alena, Partners
+- [ ] Hallowed Haunting
+- [ ] Hamlet Vanguard
+- [x] Headless Rider
+- [ ] Henrika Domnathi
+- [x] Hero's Downfall
+- [ ] Heron of Hope
+- [x] Heron-Blessed Geist
+- [ ] Hiveheart Shaman
+- [ ] Honeymoon Hearse
+- [x] Honored Heirloom
+- [ ] Hookhand Mariner
+- [ ] Hopeful Initiate
+- [ ] Howling Moon
+- [ ] Howlpack Piper
+- [x] Hullbreaker Horror
+- [x] Hungry Ridgewolf
+- [ ] Ill-Tempered Loner
+- [ ] Infestation Expert
+- [ ] Innocent Traveler
+- [ ] Inspired Idea
+- [ ] Into the Night
+- [ ] Investigator's Journal
+- [x] Island
+- [ ] Jacob Hauken, Inspector
+- [ ] Katilda, Dawnhart Martyr
+- [ ] Kaya, Geist Hunter
+- [x] Kessig Flamebreather
+- [x] Kessig Wolfrider
+- [ ] Kindly Ancestor
+- [ ] Lacerate Flesh
+- [ ] Laid to Rest
+- [ ] Lambholt Raconteur
+- [ ] Lantern Bearer
+- [ ] Lantern Flare
+- [x] Lantern of the Lost
+- [x] Lightning Wolf
+- [ ] Lunar Rejection
+- [ ] Magma Pummeler
+- [ ] Manaform Hellkite
+- [x] Markov Purifier
+- [x] Markov Retribution
+- [x] Markov Waltzer
+- [x] Massive Might
+- [x] Militia Rallier
+- [ ] Mindleech Ghoul
+- [ ] Mirrorhall Mimic
+- [ ] Mischievous Catgeist
+- [x] Moldgraf Millipede
+- [x] Mountain
+- [ ] Mulch
+- [ ] Nature's Embrace
+- [x] Nebelgast Beguiler
+- [x] Necroduality
+- [ ] Nurturing Presence
+- [ ] Oakshade Stalker
+- [ ] Odric, Blood-Cursed
+- [ ] Old Rutstein
+- [ ] Olivia's Attendants
+- [ ] Olivia, Crimson Bride
+- [x] Ollenbock Escort
+- [ ] Overcharged Amalgam
+- [x] Packsong Pup
+- [ ] Panicked Bystander
+- [ ] Parasitic Grasp
+- [ ] Parish-Blade Trainee
+- [ ] Patchwork Crawler
+- [ ] Path of Peril
+- [x] Persistent Specimen
+- [x] Piercing Light
+- [x] Plains
+- [x] Pointed Discussion
+- [ ] Pyre Spawn
+- [ ] Radiant Grace
+- [ ] Ragged Recluse
+- [x] Reckless Impulse
+- [x] Reclusive Taxidermist
+- [x] Rending Flame
+- [ ] Repository Skaab
+- [x] Resistance Squad
+- [ ] Restless Bloodseeker
+- [x] Retrieve
+- [ ] Rot-Tide Gargantua
+- [x] Runebound Wolf
+- [ ] Runo Stromkirk
+- [ ] Rural Recruit
+- [x] Sanctify
+- [ ] Sanguine Statuette
+- [ ] Savior of Ollenbock
+- [x] Sawblade Slinger
+- [x] Scattered Thoughts
+- [ ] Screaming Swarm
+- [x] Selhoff Entomber
+- [ ] Serpentine Ambush
+- [x] Shattered Sanctum
+- [x] Sheltering Boughs
+- [x] Sigarda's Imprisonment
+- [ ] Sigarda's Summons
+- [ ] Sigardian Paladin
+- [ ] Skulking Killer
+- [ ] Skull Skaab
+- [x] Skywarp Skaab
+- [ ] Snarling Wolf
+- [ ] Sorin the Mirthless
+- [ ] Soulcipher Board
+- [ ] Spiked Ripsaw
+- [ ] Splendid Reclamation
+- [x] Spore Crawler
+- [x] Sporeback Wolf
+- [x] Steelclad Spirit
+- [ ] Stensia Uprising
+- [ ] Stitched Assistant
+- [x] Stormcarved Coast
+- [ ] Stormchaser Drake
+- [x] Sundown Pass
+- [ ] Supernatural Rescue
+- [x] Sure Strike
+- [x] Swamp
+- [x] Syncopate
+- [x] Syphon Essence
+- [ ] Thalia, Guardian of Thraben
+- [x] Thirst for Discovery
+- [ ] Torens, Fist of the Angels
+- [x] Toxic Scorpion
+- [ ] Toxrill, the Corrosive
+- [x] Traveling Minister
+- [ ] Twinblade Geist
+- [ ] Ulvenwald Oddity
+- [x] Undead Butler
+- [ ] Undying Malice
+- [x] Unhallowed Phalanx
+- [x] Unholy Officiant
+- [x] Valorous Stance
+- [ ] Vampire Slayer
+- [x] Vampire's Kiss
+- [x] Vampires' Vengeance
+- [x] Vilespawn Spider
+- [x] Voice of the Blessed
+- [ ] Volatile Arsonist
+- [ ] Voldaren Bloodcaster
+- [x] Voldaren Epicure
+- [ ] Voldaren Estate
+- [ ] Voltaic Visionary
+- [x] Wandering Mind
+- [x] Wanderlight Spirit
+- [ ] Wash Away
+- [ ] Weary Prisoner
+- [ ] Weaver of Blossoms
+- [ ] Wedding Announcement
+- [x] Wedding Invitation
+- [x] Wedding Security
+- [x] Welcoming Vampire
+- [x] Whispering Wizard
+- [ ] Winged Portent
+- [x] Witch's Web
+- [ ] Witness the Future
+- [ ] Wolf Strike
+- [ ] Wolfkin Outcast
+- [x] Wretched Throng

--- a/backlog/sets/innistrad-crimson-vow/mechanics.md
+++ b/backlog/sets/innistrad-crimson-vow/mechanics.md
@@ -1,0 +1,69 @@
+# Innistrad: Crimson Vow (VOW) — Mechanics
+
+Counts are over the 272 booster cards (excluding basic lands and tokens), detected by
+regex over front-face + back-face oracle text, so they are **approximate** — a payoff that
+merely mentions "Blood token" is counted alongside the cards that make one. "Unimpl" = not
+yet implemented as of this document (~77 cards done; see [`cards.md`](cards.md) for the live
+checklist). Counts predate the in-flight card batch and will drift.
+
+Engine-support column reflects whether the SDK/rules-engine already models the mechanic (so
+cards using *only* supported mechanics need **no backend change** — pure `add-card` work).
+
+## Set mechanics
+
+| Mechanic | Cards | Unimpl | Engine support | Notes |
+|----------|------:|-------:|----------------|-------|
+| **Blood token** | ~30 | ~19 | ✅ `Effects.CreateBlood` | Artifact token: `{1}, {T}, Discard a card, Sacrifice: Draw a card.` 11 already done (e.g. Blood Fountain, Voldaren Epicure). |
+| **Cleave** | 12 | 12 | ❌ **GAP → [#1259](https://github.com/wingedsheep/argentum-engine/issues/1259)** | CR 702.148 — text-modifying alternative cost on instants/sorceries. Implement as a cast-mode branch, not string mutation (see issue). Canonical: Dread Fugue. |
+| **Training** | 9 | 9 | ❌ **GAP → [#1261](https://github.com/wingedsheep/argentum-engine/issues/1261)** | CR 702.149 — attack trigger gated on a co-attacker with greater power → +1/+1 counter; plus a "when this creature trains" payoff hook (702.149c). Structural analog: Mentor + Decayed. |
+| **Exploit** | 9 | 9 | ❌ **GAP → [#1260](https://github.com/wingedsheep/argentum-engine/issues/1260)** | CR 702.110 — ETB "may sacrifice a creature" + a paired "when this creature exploits a creature" payoff (702.110b, the crux). Analog: Casualty's reflexive "when you do" trigger. Also surfaces as blocked trigger `WhenAPermanentExploitsAPermanent` (×9). |
+| **Disturb** | ~13 | ~13 | ⚠️ **GAP — no issue yet** | CR 702.146 — cast the back face from your graveyard, then exile. Transform machinery exists (`TransformEffects`), but there is no Disturb keyword or graveyard-cast-back-face DSL. All are DFCs (spirit front // enchantment or aura back). Not on the coverage leaderboard because these DFCs sit in the tool's "unmatched in mtgish" bucket. |
+| **Daybound / Nightbound** | ~14 | ~14 | ⚠️ **GAP — no issue yet** | CR 702.145 — day/night designation + werewolf-style DFC flips keyed on spells-cast-per-turn. **Zero** engine support: no day/night state tracker anywhere in main source, no keyword. All are DFCs. Also invisible to the coverage leaderboard (unmatched-in-mtgish bucket). |
+
+**Transform / DFC machinery** — ✅ present (`TransformEffect`, `ExileAndReturnTransformedEffect`,
+`ReturnSelfFromZoneTransformedEffect`). The *effect* layer that flips a permanent's face exists and is
+reused by other sets; what VOW is missing is the two *keyword layers* above (Disturb's graveyard-cast +
+Daybound/Nightbound's day/night trigger) that drive those flips.
+
+## Evergreen / returning keywords present
+
+Flying (~30), Menace (~8), Defender (~5), Reach (~4), Vigilance (~4), Flash (~4),
+Lifelink (~3), Deathtouch (~3), Haste (~3), First strike (~3), Ward (~2),
+Double strike (1), Hexproof (1). Plus Equip (~5), Mill (~8), Scry (~1), Investigate,
+Fight (~1), and +1/+1 counters (~29). **All engine-supported.**
+
+## Backend-change assessment
+
+Three headline VOW mechanics have open engine work items (route through `add-feature`):
+
+- **Cleave** ([#1259](https://github.com/wingedsheep/argentum-engine/issues/1259), CR 702.148) —
+  ×12 cards. New alternative-cost type + cast-mode condition; behaviour branch, not text mutation.
+- **Training** ([#1261](https://github.com/wingedsheep/argentum-engine/issues/1261), CR 702.149) —
+  ×9 cards. Attack trigger + power comparison + "when it trains" hook.
+- **Exploit** ([#1260](https://github.com/wingedsheep/argentum-engine/issues/1260), CR 702.110) —
+  ×9 cards (+ the `WhenAPermanentExploitsAPermanent` trigger, ×9). ETB optional sacrifice + paired
+  "when it exploits" payoff.
+
+These three are exactly the top entries on `just coverage-gaps --set VOW`'s BLOCKED leaderboard
+(Cleave ×12, Training ×9, Exploit ×9), so clearing them unlocks the most cards.
+
+**Two further gaps have no work item yet** — flagged here so they aren't mistaken for supported:
+
+- **Disturb** (CR 702.146, ~13 cards) — needs a graveyard-cast-back-face keyword layered on the
+  existing transform machinery.
+- **Daybound / Nightbound** (CR 702.145, ~14 cards) — needs a day/night game-state tracker plus the
+  werewolf-flip trigger; nothing exists today.
+
+Both are absent from the coverage leaderboard only because their DFCs land in the tool's
+"unmatched in mtgish" bucket (name-join misses), **not** because they're covered.
+
+**Smaller blocked capabilities** (from `coverage-gaps`, lower-volume — assess per card, may be pure
+`add-feature` one-offs): `SetPT` layer effect (×4), `RemoveCounters` cost/action (×3),
+`WhenAPlayerPlaysALand` trigger (×2), `PermanentDoesntUntapDuringControllersNextUntap` (×2),
+characteristic-defining `CDA_Power`/`CDA_Toughness` (×2 each), `AddCardtype` (×2), and a tail of ×1
+items.
+
+**Everything else is pure `add-card` authoring** — Blood-token cards, the returning/evergreen keyword
+cards, and standard effects. Suggested order: clear the Blood/evergreen single-faced cards first, then
+land the Cleave/Training/Exploit features (highest unlock), and defer the Disturb / Daybound DFCs until
+those two keyword layers are built.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/InnistradCrimsonVowSet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/InnistradCrimsonVowSet.kt
@@ -26,5 +26,9 @@ object InnistradCrimsonVowSet : MtgSet {
         CardDiscovery.findPrintingsIn(CARDS_PACKAGE)
     }
 
+    override val basicLands: List<CardDefinition> by lazy {
+        CardDiscovery.findBasicLandsIn(CARDS_PACKAGE, code)
+    }
+
     private const val CARDS_PACKAGE = "com.wingedsheep.mtg.sets.definitions.vow.cards"
 }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/AngelicQuartermaster.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/AngelicQuartermaster.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Angelic Quartermaster
+ * {3}{W}{W}
+ * Creature — Angel Soldier
+ * 3/3
+ *
+ * Flying
+ * When this creature enters, put a +1/+1 counter on each of up to two other target creatures.
+ *
+ * The ETB fans a 0–2 optional [TargetCreature] filtered to [TargetFilter.OtherCreature] (any
+ * controller, excludes itself) out with [ForEachTargetEffect] so each chosen creature receives
+ * one +1/+1 counter — the same shape as Felidar Savior, but with the wider "other creatures"
+ * filter (not restricted to creatures you control).
+ */
+val AngelicQuartermaster = card("Angelic Quartermaster") {
+    manaCost = "{3}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Angel Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "When this creature enters, put a +1/+1 counter on each of up to two other target creatures."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to two other target creatures",
+            TargetCreature(count = 2, optional = true, filter = TargetFilter.OtherCreature),
+        )
+        effect = ForEachTargetEffect(
+            listOf(Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.ContextTarget(0))),
+        )
+        description = "When this creature enters, put a +1/+1 counter on each of up to two other " +
+            "target creatures."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "2"
+        artist = "PINDURSKI"
+        flavorText = "\"Stand strong. We will reclaim the dawn.\""
+        imageUri = "https://cards.scryfall.io/normal/front/4/1/41d81b88-c19b-4148-89ba-ae8fb53843e1.jpg?1782703194"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ArmTheCathars.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ArmTheCathars.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Arm the Cathars
+ * {1}{W}{W}
+ * Sorcery
+ *
+ * Until end of turn, target creature gets +3/+3, up to one other target creature gets +2/+2, and
+ * up to one other target creature gets +1/+1. Those creatures gain vigilance until end of turn.
+ *
+ * Three targets (the second and third "other" and optional, per the Mabel's Mettle multi-target
+ * idiom): the primary +3/+3, then two [TargetOther] optional creatures at +2/+2 and +1/+1. Each
+ * pump is paired with a vigilance grant so a skipped optional target simply confers nothing.
+ */
+val ArmTheCathars = card("Arm the Cathars") {
+    manaCost = "{1}{W}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Until end of turn, target creature gets +3/+3, up to one other target creature " +
+        "gets +2/+2, and up to one other target creature gets +1/+1. Those creatures gain " +
+        "vigilance until end of turn."
+
+    spell {
+        val primary = target("target creature", Targets.Creature)
+        // Two distinct optional slots — the names must differ, because target bindings are keyed by
+        // name (EffectContext.buildNamedTargets). Reusing one name would make both BoundVariables
+        // resolve to the same (last-bound) target, so the middle creature would get no bonus.
+        val second = target("up to one other target creature (+2/+2)", TargetOther(TargetCreature(optional = true)))
+        val third = target("up to one other target creature (+1/+1)", TargetOther(TargetCreature(optional = true)))
+        effect = Effects.ModifyStats(3, 3, primary)
+            .then(Effects.GrantKeyword(Keyword.VIGILANCE, primary))
+            .then(Effects.ModifyStats(2, 2, second))
+            .then(Effects.GrantKeyword(Keyword.VIGILANCE, second))
+            .then(Effects.ModifyStats(1, 1, third))
+            .then(Effects.GrantKeyword(Keyword.VIGILANCE, third))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "3"
+        artist = "Zoltan Boros"
+        flavorText = "Faith is a cathar's greatest weapon, but a sword of blessed silver is a " +
+            "close second."
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/2004a20c-e434-4691-8ef2-740846ce6a51.jpg?1782703194"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BelligerentGuest.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BelligerentGuest.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Belligerent Guest
+ * {2}{R}
+ * Creature — Vampire
+ * 3/2
+ *
+ * Trample
+ * Whenever this creature deals combat damage to a player, create a Blood token.
+ */
+val BelligerentGuest = card("Belligerent Guest") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 2
+    oracleText = "Trample (This creature can deal excess combat damage to the player or planeswalker " +
+        "it's attacking.)\n" +
+        "Whenever this creature deals combat damage to a player, create a Blood token. (It's an " +
+        "artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")"
+
+    keywords(Keyword.TRAMPLE)
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.CreateBlood(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "301"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/9/2/924b1c15-811a-4d11-a481-f904002a6740.jpg?1782702983"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BleedDry.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BleedDry.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Bleed Dry
+ * {2}{B}{B}
+ * Instant
+ * Target creature gets -13/-13 until end of turn. If that creature would die this turn, exile it instead.
+ */
+val BleedDry = card("Bleed Dry") {
+    manaCost = "{2}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Target creature gets -13/-13 until end of turn. If that creature would die this turn, exile it instead."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(-13, -13, t),
+            MarkExileOnDeathEffect(t)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "94"
+        artist = "Jodie Muir"
+        flavorText = "\"Wipe your chin, child. We can't have Olivia thinking we're uncivilized.\"\n—Anje Falkenrath"
+        imageUri = "https://cards.scryfall.io/normal/front/3/d/3db65755-f104-4de9-bcc9-0a4a7bc66b51.jpg?1782703123"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BloodFountain.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BloodFountain.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ForEachTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Blood Fountain
+ * {B}
+ * Artifact
+ *
+ * When this artifact enters, create a Blood token.
+ * {3}{B}, {T}, Sacrifice this artifact: Return up to two target creature cards from your graveyard
+ * to your hand.
+ */
+val BloodFountain = card("Blood Fountain") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, create a Blood token. (It's an artifact with \"{1}, {T}, " +
+        "Discard a card, Sacrifice this token: Draw a card.\")\n" +
+        "{3}{B}, {T}, Sacrifice this artifact: Return up to two target creature cards from your " +
+        "graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateBlood(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{B}"), Costs.Tap, Costs.SacrificeSelf)
+        target = TargetObject(
+            count = 2,
+            optional = true,
+            filter = TargetFilter.CreatureInYourGraveyard
+        )
+        effect = ForEachTargetEffect(
+            effects = listOf(Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND))
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "95"
+        artist = "Evyn Fong"
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/dd03651e-ada0-41dc-8722-0eba476943e3.jpg?1782703122"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BloodServitor.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BloodServitor.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Blood Servitor
+ * {3}
+ * Artifact Creature — Construct
+ * 2/2
+ *
+ * When this creature enters, create a Blood token.
+ */
+val BloodServitor = card("Blood Servitor") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact Creature — Construct"
+    power = 2
+    toughness = 2
+    oracleText = "When this creature enters, create a Blood token. (It's an artifact with \"{1}, {T}, " +
+        "Discard a card, Sacrifice this token: Draw a card.\")"
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateBlood(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "252"
+        artist = "Jason A. Engle"
+        flavorText = "\"Please, my friends, help yourselves to the help.\"\n—Olivia Voldaren"
+        imageUri = "https://cards.scryfall.io/normal/front/8/7/87845cc2-bf5d-491d-bfa2-b33b034557a4.jpg?1782703017"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BloodcrazedSocialite.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BloodcrazedSocialite.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Bloodcrazed Socialite
+ * {3}{B}
+ * Creature — Vampire
+ * 3/3
+ *
+ * Menace
+ * When this creature enters, create a Blood token.
+ * Whenever this creature attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until
+ * end of turn.
+ */
+val BloodcrazedSocialite = card("Bloodcrazed Socialite") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 3
+    oracleText = "Menace\n" +
+        "When this creature enters, create a Blood token. (It's an artifact with \"{1}, {T}, " +
+        "Discard a card, Sacrifice this token: Draw a card.\")\n" +
+        "Whenever this creature attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 " +
+        "until end of turn."
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateBlood(1)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = GatedEffect(
+            gate = Gate.MayPay(SacrificeEffect(filter = GameObjectFilter.Artifact.withSubtype("Blood"))),
+            then = Effects.ModifyStats(2, 2, EffectTarget.Self)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "288"
+        artist = "Samuel Araya"
+        imageUri = "https://cards.scryfall.io/normal/front/9/d/9df22639-7e98-43a1-801e-cbf882558c53.jpg?1782702993"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BloodyBetrayal.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/BloodyBetrayal.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+
+/**
+ * Bloody Betrayal
+ * {2}{R}
+ * Sorcery
+ *
+ * Gain control of target creature until end of turn. Untap that creature. It gains haste until
+ * end of turn. Create a Blood token.
+ */
+val BloodyBetrayal = card("Bloody Betrayal") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Gain control of target creature until end of turn. Untap that creature. It gains " +
+        "haste until end of turn. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard " +
+        "a card, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        val t = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.GainControl(t, Duration.EndOfTurn),
+            Effects.Untap(t),
+            Effects.GrantKeyword(Keyword.HASTE, t),
+            Effects.CreateBlood(1),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "147"
+        artist = "Brian Valeza"
+        imageUri = "https://cards.scryfall.io/normal/front/8/9/8970a5d6-dcab-415a-851b-20e228ef7d16.jpg?1782703085"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CourierBat.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CourierBat.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Courier Bat
+ * {2}{B}
+ * Creature — Bat
+ * 2/2
+ * Flying
+ * When this creature enters, if you gained life this turn, return up to one target creature card
+ * from your graveyard to your hand.
+ */
+val CourierBat = card("Courier Bat") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Bat"
+    oracleText = "Flying\nWhen this creature enters, if you gained life this turn, return up to one target creature card from your graveyard to your hand."
+    power = 2
+    toughness = 2
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouGainedLifeThisTurn
+        val t = target("target", TargetObject(optional = true, filter = TargetFilter.CreatureInYourGraveyard))
+        effect = Effects.Move(t, Zone.HAND)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "102"
+        artist = "Ilse Gort"
+        flavorText = "Swarms of bats poured from Lurenbraum Fortress carrying wedding invitations to vampires of every bloodline."
+        imageUri = "https://cards.scryfall.io/normal/front/4/d/4d9a8dc7-1ee9-4731-bd72-3d02f4e7c6c4.jpg?1782703119"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CradleOfSafety.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CradleOfSafety.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Cradle of Safety
+ * {1}{U}
+ * Enchantment — Aura
+ *
+ * Flash
+ * Enchant creature you control
+ * When this Aura enters, enchanted creature gains hexproof until end of turn.
+ * Enchanted creature gets +1/+1.
+ */
+val CradleOfSafety = card("Cradle of Safety") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Flash\n" +
+        "Enchant creature you control\n" +
+        "When this Aura enters, enchanted creature gains hexproof until end of turn. (It can't be " +
+        "the target of spells or abilities your opponents control.)\n" +
+        "Enchanted creature gets +1/+1."
+
+    keywords(Keyword.FLASH)
+    auraTarget = Targets.CreatureYouControl
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GrantKeyword(Keyword.HEXPROOF, EffectTarget.EnchantedCreature)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "54"
+        artist = "Howard Lyon"
+        imageUri = "https://cards.scryfall.io/normal/front/4/2/42cbad81-152a-435f-9289-f4b6483a059b.jpg?1782703156"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CruelWitness.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CruelWitness.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Cruel Witness
+ * {2}{U}{U}
+ * Creature — Bird Horror
+ * 3/3
+ * Flying
+ * Whenever you cast a noncreature spell, surveil 1.
+ */
+val CruelWitness = card("Cruel Witness") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Bird Horror"
+    oracleText = "Flying\nWhenever you cast a noncreature spell, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)"
+    power = 3
+    toughness = 3
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Patterns.Library.surveil(1)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "55"
+        artist = "Vincent Proce"
+        flavorText = "\"I escaped, so why do I still feel like I'm being watched?\"\n—Gregel, militia leader"
+        imageUri = "https://cards.scryfall.io/normal/front/5/b/5bf2c686-efb0-46c7-b34e-c77987914b96.jpg?1782703154"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DawnhartGeist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DawnhartGeist.kt
@@ -1,0 +1,33 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+
+/**
+ * Dawnhart Geist
+ * {1}{W}
+ * Creature — Spirit Warlock
+ * 1/3
+ * Whenever you cast an enchantment spell, you gain 2 life.
+ */
+val DawnhartGeist = card("Dawnhart Geist") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit Warlock"
+    oracleText = "Whenever you cast an enchantment spell, you gain 2 life."
+    power = 1
+    toughness = 3
+    triggeredAbility {
+        trigger = Triggers.YouCastEnchantment
+        effect = GainLifeEffect(2)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "8"
+        artist = "Artur Treffner"
+        flavorText = "\"Our bodies may lie slain, but perhaps we can still complete the ritual. I'd rather not spend my afterlife in this wretched eternal night.\""
+        imageUri = "https://cards.scryfall.io/normal/front/a/1/a1d27617-2d3d-44a1-b93f-0694253b6774.jpg?1782703191"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DaybreakCombatants.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DaybreakCombatants.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Daybreak Combatants
+ * {2}{R}
+ * Creature — Human Warrior
+ * 2/2
+ * Haste
+ * When this creature enters, target creature gets +2/+0 until end of turn.
+ */
+val DaybreakCombatants = card("Daybreak Combatants") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Warrior"
+    oracleText = "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen this creature enters, target creature gets +2/+0 until end of turn."
+    power = 2
+    toughness = 2
+    keywords(Keyword.HASTE)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.ModifyStats(2, 0, t)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "153"
+        artist = "Joshua Raphael"
+        flavorText = "After weeks of unending darkness, a glimpse of dawn was all the people of Stensia needed to rekindle their will to fight."
+        imageUri = "https://cards.scryfall.io/normal/front/8/6/8697a861-0f67-4ed3-bed8-f264fc78565e.jpg?1782703080"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DiregrafScavenger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DiregrafScavenger.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.ConditionalOnCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Diregraf Scavenger
+ * {3}{B}
+ * Creature — Zombie Bear
+ * 2/3
+ *
+ * Deathtouch
+ * When this creature enters, exile up to one target card from a graveyard. If a creature card was
+ * exiled this way, each opponent loses 2 life and you gain 2 life.
+ *
+ * ETB gather-then-move-then-conditional (the Soul-Shackled Zombie idiom): the single optional
+ * target is gathered ([CardSource.ChosenTargets]) and exiled, then the drain is gated on the
+ * exiled pile actually containing a creature ([ConditionalOnCollectionEffect] filtered to
+ * [GameObjectFilter.Creature]) — so a whiffed or noncreature exile skips the life swing.
+ */
+val DiregrafScavenger = card("Diregraf Scavenger") {
+    manaCost = "{3}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Bear"
+    power = 2
+    toughness = 3
+    oracleText = "Deathtouch\n" +
+        "When this creature enters, exile up to one target card from a graveyard. If a creature " +
+        "card was exiled this way, each opponent loses 2 life and you gain 2 life."
+
+    keywords(Keyword.DEATHTOUCH)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        target(
+            "up to one target card from a graveyard",
+            TargetObject(
+                count = 1,
+                optional = true,
+                filter = TargetFilter.CardInGraveyard
+            )
+        )
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.ChosenTargets,
+                storeAs = "diregraf_exiled"
+            ),
+            MoveCollectionEffect(
+                from = "diregraf_exiled",
+                destination = CardDestination.ToZone(Zone.EXILE)
+            ),
+            ConditionalOnCollectionEffect(
+                collection = "diregraf_exiled",
+                filter = GameObjectFilter.Creature,
+                ifNotEmpty = Effects.Composite(
+                    Effects.LoseLife(2, EffectTarget.PlayerRef(Player.EachOpponent)),
+                    Effects.GainLife(2)
+                ),
+                ifEmpty = Effects.Composite(emptyList())
+            )
+        )
+        description = "When this creature enters, exile up to one target card from a graveyard. " +
+            "If a creature card was exiled this way, each opponent loses 2 life and you gain 2 life."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "105"
+        artist = "Manuel Castañón"
+        flavorText = "It can barely feel the sword anymore."
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f72eb127-3f4c-42ed-8ba6-b6d83ea18545.jpg?1782703116"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/EndTheFestivities.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/EndTheFestivities.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * End the Festivities
+ * {R}
+ * Sorcery
+ * End the Festivities deals 1 damage to each opponent and each creature and planeswalker they control.
+ */
+val EndTheFestivities = card("End the Festivities") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "End the Festivities deals 1 damage to each opponent and each creature and planeswalker they control."
+    spell {
+        effect = Effects.Composite(
+            // 1 damage to each opponent
+            Effects.DealDamage(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            // 1 damage to each creature and planeswalker those opponents control
+            Effects.ForEachInGroup(
+                GroupFilter(GameObjectFilter.CreatureOrPlaneswalker.opponentControls()),
+                DealDamageEffect(1, EffectTarget.Self)
+            )
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Chris Rallis"
+        flavorText = "When the defenses around Lurenbraum Fortress faltered, the Crimson Ballroom received some unexpected guests."
+        imageUri = "https://cards.scryfall.io/normal/front/b/e/bec748e6-7245-4a71-aeee-cefed8346948.jpg?1782703079"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/EstwaldShieldbasher.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/EstwaldShieldbasher.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Estwald Shieldbasher
+ * {3}{W}
+ * Creature — Human Soldier
+ * 4/2
+ *
+ * Whenever this creature attacks, you may pay {1}. If you do, it gains indestructible until end of
+ * turn.
+ *
+ * The attack trigger is a flat "you may pay {1}. If you do" gate ([MayPayManaEffect]); paying
+ * grants indestructible to the attacker itself for the turn.
+ */
+val EstwaldShieldbasher = card("Estwald Shieldbasher") {
+    manaCost = "{3}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 4
+    toughness = 2
+    oracleText = "Whenever this creature attacks, you may pay {1}. If you do, it gains " +
+        "indestructible until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{1}"),
+            effect = Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, EffectTarget.Self)
+        )
+        description = "Whenever this creature attacks, you may pay {1}. If you do, it gains " +
+            "indestructible until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "11"
+        artist = "Wayne Reynolds"
+        flavorText = "The door to her home survived the fires of the Malignus. Now it's her " +
+            "greatest weapon."
+        imageUri = "https://cards.scryfall.io/normal/front/6/1/61c7d889-8cc0-4e80-b6d5-d41961820224.jpg?1782703190"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FalkenrathCelebrants.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FalkenrathCelebrants.kt
@@ -1,0 +1,41 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Falkenrath Celebrants
+ * {4}{R}
+ * Creature — Vampire
+ * 4/4
+ *
+ * Menace
+ * When this creature enters, create two Blood tokens.
+ */
+val FalkenrathCelebrants = card("Falkenrath Celebrants") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Vampire"
+    power = 4
+    toughness = 4
+    oracleText = "Menace (This creature can't be blocked except by two or more creatures.)\n" +
+        "When this creature enters, create two Blood tokens. (They're artifacts with \"{1}, {T}, " +
+        "Discard a card, Sacrifice this token: Draw a card.\")"
+
+    keywords(Keyword.MENACE)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateBlood(2)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "306"
+        artist = "Zinna Du"
+        imageUri = "https://cards.scryfall.io/normal/front/6/a/6aacc8fa-9440-494b-a3d9-7b1678c5a9f6.jpg?1782702979"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FalkenrathForebear.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FalkenrathForebear.kt
@@ -1,0 +1,70 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Falkenrath Forebear
+ * {2}{B}
+ * Creature — Vampire
+ * 3/1
+ *
+ * Flying
+ * This creature can't block.
+ * Whenever this creature deals combat damage to a player, create a Blood token.
+ * {B}, Sacrifice two Blood tokens: Return this card from your graveyard to the battlefield.
+ *
+ * The recursion ability activates from the graveyard (like Persistent Specimen):
+ * [Effects.PutOntoBattlefield] on Self from [Zone.GRAVEYARD], its cost combining {B} with
+ * sacrificing two Blood tokens ([Costs.SacrificeMultiple] over the Blood-artifact filter).
+ */
+val FalkenrathForebear = card("Falkenrath Forebear") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire"
+    power = 3
+    toughness = 1
+    oracleText = "Flying\n" +
+        "This creature can't block.\n" +
+        "Whenever this creature deals combat damage to a player, create a Blood token. (It's an " +
+        "artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")\n" +
+        "{B}, Sacrifice two Blood tokens: Return this card from your graveyard to the battlefield."
+
+    keywords(Keyword.FLYING)
+
+    staticAbility {
+        ability = CantBlock(filter = GroupFilter.source())
+    }
+
+    triggeredAbility {
+        trigger = Triggers.DealsCombatDamageToPlayer
+        effect = Effects.CreateBlood(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{B}"),
+            Costs.SacrificeMultiple(2, GameObjectFilter.Artifact.withSubtype("Blood")),
+        )
+        effect = Effects.PutOntoBattlefield(EffectTarget.Self)
+        activateFromZone = Zone.GRAVEYARD
+        description = "{B}, Sacrifice two Blood tokens: Return this card from your graveyard to " +
+            "the battlefield."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "334"
+        artist = "Greg Staples"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48d43ab9-772d-4f4d-8536-3ea60e8f9f82.jpg?1782702954"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FearOfDeath.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FearOfDeath.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantDynamicStatsEffect
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Fear of Death
+ * {1}{U}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, mill two cards.
+ * Enchanted creature gets -X/-0, where X is the number of cards in your graveyard.
+ *
+ * ETB self-mill (Aura enters → mill 2) plus a continuous debuff scoped to the attached creature.
+ * The power penalty is a negated dynamic count of cards in your graveyard
+ * ([DynamicAmount.Multiply] of [DynamicAmounts.cardsInYourGraveyard] by -1); toughness bonus is a
+ * fixed 0 (the Exotic Curse dynamic-aura idiom).
+ */
+val FearOfDeath = card("Fear of Death") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, mill two cards. (Put the top two cards of your library into your " +
+        "graveyard.)\n" +
+        "Enchanted creature gets -X/-0, where X is the number of cards in your graveyard."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(2)
+    }
+
+    staticAbility {
+        ability = GrantDynamicStatsEffect(
+            filter = GroupFilter.attachedCreature(),
+            powerBonus = DynamicAmount.Multiply(DynamicAmounts.cardsInYourGraveyard(), -1),
+            toughnessBonus = DynamicAmount.Fixed(0)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "59"
+        artist = "Anato Finnstark"
+        imageUri = "https://cards.scryfall.io/normal/front/b/8/b81704d2-d555-4894-b36c-6b65d1ebe681.jpg?1782703150"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FlameBlessedBolt.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FlameBlessedBolt.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.effects.MarkExileOnDeathEffect
+import com.wingedsheep.sdk.scripting.targets.TargetCreatureOrPlaneswalker
+
+/**
+ * Flame-Blessed Bolt
+ * {R}
+ * Instant
+ * Flame-Blessed Bolt deals 2 damage to target creature or planeswalker. If that creature or
+ * planeswalker would die this turn, exile it instead.
+ */
+val FlameBlessedBolt = card("Flame-Blessed Bolt") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Flame-Blessed Bolt deals 2 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead."
+    spell {
+        val t = target("target", TargetCreatureOrPlaneswalker())
+        effect = Effects.Composite(
+            DealDamageEffect(2, t),
+            MarkExileOnDeathEffect(t)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "158"
+        artist = "Andreas Zafiratos"
+        flavorText = "\"I noticed you were short on party favors, so I brought my own.\"\n—Higa, slayer-captain of Gatstaf"
+        imageUri = "https://cards.scryfall.io/normal/front/b/1/b1771a8f-7bea-4bb0-9949-566ee6613b93.jpg?1782703077"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FlourishingHunter.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FlourishingHunter.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.values.Aggregation
+import com.wingedsheep.sdk.scripting.values.CardNumericProperty
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Flourishing Hunter
+ * {4}{G}{G}
+ * Creature — Wolf Spirit
+ * 6/6
+ *
+ * When this creature enters, you gain life equal to the greatest toughness among other creatures
+ * you control.
+ *
+ * ETB gain life keyed to a MAX-toughness [DynamicAmount.AggregateBattlefield] over creatures you
+ * control with `excludeSelf = true` — the "other creatures" wording drops Flourishing Hunter's own
+ * 6 toughness from the aggregate (Valley Rotcaller idiom).
+ */
+val FlourishingHunter = card("Flourishing Hunter") {
+    manaCost = "{4}{G}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf Spirit"
+    power = 6
+    toughness = 6
+    oracleText = "When this creature enters, you gain life equal to the greatest toughness among " +
+        "other creatures you control."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.GainLife(
+            DynamicAmount.AggregateBattlefield(
+                player = Player.You,
+                filter = GameObjectFilter.Creature,
+                aggregation = Aggregation.MAX,
+                property = CardNumericProperty.TOUGHNESS,
+                excludeSelf = true
+            )
+        )
+        description = "When this creature enters, you gain life equal to the greatest toughness " +
+            "among other creatures you control."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "199"
+        artist = "Ilse Gort"
+        flavorText = "\"I would welcome her into my pack with honor.\"\n—Arlinn Kord"
+        imageUri = "https://cards.scryfall.io/normal/front/2/a/2abc54df-773d-4f46-b241-e1f42af8ab95.jpg?1782703051"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FrenziedDevils.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/FrenziedDevils.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Frenzied Devils
+ * {4}{R}
+ * Creature — Devil
+ * 3/3
+ * Haste
+ * Whenever you cast a noncreature spell, this creature gets +2/+2 until end of turn.
+ */
+val FrenziedDevils = card("Frenzied Devils") {
+    manaCost = "{4}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Devil"
+    oracleText = "Haste\nWhenever you cast a noncreature spell, this creature gets +2/+2 until end of turn."
+    power = 3
+    toughness = 3
+    keywords(Keyword.HASTE)
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = Effects.ModifyStats(2, 2, EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "159"
+        artist = "Andrey Kuzinskiy"
+        flavorText = "\"Devils need no reason to stir up chaos. The chaos itself is their reward.\"\n—Rem Karolus, Fiendslayer"
+        imageUri = "https://cards.scryfall.io/normal/front/b/7/b7912206-6de3-4085-b5f6-a2e90ea55b90.jpg?1782703077"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GiftOfFangs.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GiftOfFangs.kt
@@ -1,0 +1,47 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.conditions.EnchantedCreatureHasSubtype
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Gift of Fangs
+ * {B}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature gets +2/+2 as long as it's a Vampire. Otherwise, it gets -2/-2.
+ */
+val GiftOfFangs = card("Gift of Fangs") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature gets +2/+2 as long as it's a Vampire. Otherwise, it gets -2/-2."
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = ModifyStats(2, 2, GroupFilter.attachedCreature())
+        condition = EnchantedCreatureHasSubtype(Subtype("Vampire"))
+    }
+
+    staticAbility {
+        ability = ModifyStats(-2, -2, GroupFilter.attachedCreature())
+        condition = Conditions.Not(EnchantedCreatureHasSubtype(Subtype("Vampire")))
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "113"
+        artist = "Dominik Mayer"
+        flavorText = "\"You are one of the few to whom we offer our blessing. What fool would reject " +
+            "immortality?\"\n—Runo Stromkirk"
+        imageUri = "https://cards.scryfall.io/normal/front/a/8/a864375f-99c3-4c68-9440-bc25ff6d0dc0.jpg?1782703111"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GrislyRitual.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GrislyRitual.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Grisly Ritual
+ * {5}{B}
+ * Sorcery
+ *
+ * Destroy target creature or planeswalker. Create two Blood tokens.
+ */
+val GrislyRitual = card("Grisly Ritual") {
+    manaCost = "{5}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target creature or planeswalker. Create two Blood tokens. (They're " +
+        "artifacts with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        val t = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Composite(
+            Effects.Destroy(t),
+            Effects.CreateBlood(2),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "116"
+        artist = "Anastasia Ovchinnikova"
+        flavorText = "\"You can always tell who's new from the screaming.\"\n—Tinua, Skirsdag cultist"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/53cdf2ab-3acd-49bd-8273-84c1cfc92883.jpg?1782703107"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HeadlessRider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HeadlessRider.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Headless Rider
+ * {2}{B}
+ * Creature — Zombie
+ * 3/1
+ *
+ * Whenever this creature or another nontoken Zombie you control dies, create a 2/2 black Zombie
+ * creature token.
+ *
+ * A dies trigger scoped to nontoken Zombies you control with [TriggerBinding.ANY] — Headless Rider
+ * is itself a nontoken Zombie you control, so the same filter covers both "this creature" and
+ * "another nontoken Zombie you control." (Zombie tokens it produces are excluded by `nontoken()`.)
+ */
+val HeadlessRider = card("Headless Rider") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 3
+    toughness = 1
+    oracleText = "Whenever this creature or another nontoken Zombie you control dies, create a 2/2 " +
+        "black Zombie creature token."
+
+    triggeredAbility {
+        trigger = Triggers.leavesBattlefield(
+            filter = GameObjectFilter.Creature.withSubtype("Zombie").youControl().nontoken(),
+            to = Zone.GRAVEYARD,
+            binding = TriggerBinding.ANY
+        )
+        effect = CreateTokenEffect(
+            power = 2,
+            toughness = 2,
+            colors = setOf(Color.BLACK),
+            creatureTypes = setOf("Zombie")
+        )
+        description = "Whenever this creature or another nontoken Zombie you control dies, create " +
+            "a 2/2 black Zombie creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "372"
+        artist = "E. M. Gist"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/544d7162-b78f-4a70-86e7-83cec7062039.jpg?1782702926"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HeronBlessedGeist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HeronBlessedGeist.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Heron-Blessed Geist
+ * {4}{W}
+ * Creature — Spirit
+ * 3/3
+ *
+ * Flying
+ * {3}{W}, Exile this card from your graveyard: Create two 1/1 white Spirit creature tokens with
+ * flying. Activate only if you control an enchantment and only as a sorcery.
+ *
+ * A graveyard-activated ability (the Suspicious Shambler idiom): `activateFromZone = GRAVEYARD`
+ * with a composite {3}{W} + [Costs.ExileSelf] cost, gated to sorcery speed
+ * ([TimingRule.SorcerySpeed]) and to controlling an enchantment
+ * ([ActivationRestriction.OnlyIfCondition] over [Conditions.ControlEnchantment]). Paying it
+ * makes two 1/1 white flying Spirit tokens.
+ */
+val HeronBlessedGeist = card("Heron-Blessed Geist") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 3
+    oracleText = "Flying\n" +
+        "{3}{W}, Exile this card from your graveyard: Create two 1/1 white Spirit creature tokens " +
+        "with flying. Activate only if you control an enchantment and only as a sorcery."
+
+    keywords(Keyword.FLYING)
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{3}{W}"), Costs.ExileSelf)
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING),
+            count = 2
+        )
+        timing = TimingRule.SorcerySpeed
+        activateFromZone = Zone.GRAVEYARD
+        restrictions = listOf(ActivationRestriction.OnlyIfCondition(Conditions.ControlEnchantment))
+        description = "{3}{W}, Exile this card from your graveyard: Create two 1/1 white Spirit " +
+            "creature tokens with flying. Activate only if you control an enchantment and only as " +
+            "a sorcery."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "19"
+        artist = "Jason A. Engle"
+        imageUri = "https://cards.scryfall.io/normal/front/8/3/83bacf4a-4e99-4008-97e4-3a82dddd4e45.jpg?1782703183"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HerosDownfallReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HerosDownfallReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Hero's Downfall reprint in VOW.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in THS's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * VOW-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val HerosDownfallReprint = Printing(
+    oracleId = "03df6a57-37c9-46d3-83b3-4a6240100714",
+    name = "Hero's Downfall",
+    setCode = "VOW",
+    collectorNumber = "120",
+    scryfallId = "c1b0751e-3a7e-4568-8c64-7429d6829687",
+    artist = "Chris Rallis",
+    imageUri = "https://cards.scryfall.io/normal/front/c/1/c1b0751e-3a7e-4568-8c64-7429d6829687.jpg?1782703105",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HonoredHeirloom.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/HonoredHeirloom.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Honored Heirloom
+ * {3}
+ * Artifact
+ * {T}: Add one mana of any color.
+ * {2}, {T}: Exile target card from a graveyard.
+ */
+val HonoredHeirloom = card("Honored Heirloom") {
+    manaCost = "{3}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "{T}: Add one mana of any color.\n{2}, {T}: Exile target card from a graveyard."
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddManaOfChoice()
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+    }
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{2}"), Costs.Tap)
+        val t = target("target", TargetObject(filter = TargetFilter.CardInGraveyard))
+        effect = Effects.Move(t, Zone.EXILE)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "257"
+        artist = "Leanna Crossan"
+        flavorText = "After the Travails, Runechanters set about repairing twisted symbols of Avacyn as the first step in restoring faith in the Church."
+        imageUri = "https://cards.scryfall.io/normal/front/d/3/d3390e4d-9137-40ff-b998-bdb19c90b7d5.jpg?1782703014"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/InnistradCrimsonVowBasicLands.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/InnistradCrimsonVowBasicLands.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.basicLand
+
+/**
+ * Innistrad: Crimson Vow Basic Lands
+ *
+ * One full-art variant of each basic land type, collector numbers 408-412.
+ */
+
+val VowPlains408 = basicLand("Plains") {
+    collectorNumber = "408"
+    artist = "Daria Khlebnikova"
+    imageUri = "https://cards.scryfall.io/normal/front/8/0/80897666-ade2-4f70-9c4d-235753b44a23.jpg?1782702899"
+}
+
+val VowIsland409 = basicLand("Island") {
+    collectorNumber = "409"
+    artist = "Rio Krisma"
+    imageUri = "https://cards.scryfall.io/normal/front/1/f/1fddf4cb-0680-4bc7-8bb3-cb15268aff46.jpg?1782702899"
+}
+
+val VowSwamp410 = basicLand("Swamp") {
+    collectorNumber = "410"
+    artist = "Kerby Rosanes"
+    imageUri = "https://cards.scryfall.io/normal/front/9/1/91afb4f0-70ef-4539-9081-dc130c7c63f5.jpg?1782702899"
+}
+
+val VowMountain411 = basicLand("Mountain") {
+    collectorNumber = "411"
+    artist = "Daria Khlebnikova"
+    imageUri = "https://cards.scryfall.io/normal/front/1/1/117716bf-43c8-4534-92da-d7948d4b5628.jpg?1782702898"
+}
+
+val VowForest412 = basicLand("Forest") {
+    collectorNumber = "412"
+    artist = "Pig Hands"
+    imageUri = "https://cards.scryfall.io/normal/front/a/7/a7279281-42d5-4226-b841-f1f4deff919b.jpg?1782702898"
+}
+
+/**
+ * All Innistrad: Crimson Vow basic land variants.
+ */
+val InnistradCrimsonVowBasicLands = listOf(
+    VowPlains408,
+    VowIsland409,
+    VowSwamp410,
+    VowMountain411,
+    VowForest412,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/KessigFlamebreather.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/KessigFlamebreather.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Kessig Flamebreather
+ * {1}{R}
+ * Creature — Human Shaman
+ * 1/3
+ * Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent.
+ */
+val KessigFlamebreather = card("Kessig Flamebreather") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Shaman"
+    oracleText = "Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent."
+    power = 1
+    toughness = 3
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        effect = DealDamageEffect(1, EffectTarget.PlayerRef(Player.EachOpponent))
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "164"
+        artist = "Lius Lasahido"
+        flavorText = "\"Hunter's fire\" was meant for slaying monsters in the Ulvenwald, but that never stopped Ralen from showing it off."
+        imageUri = "https://cards.scryfall.io/normal/front/3/0/303ad78a-b02a-44dc-afe6-7f95781a5062.jpg?1782703073"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/KessigWolfrider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/KessigWolfrider.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Kessig Wolfrider
+ * {R}
+ * Creature — Human Knight
+ * 1/2
+ *
+ * Menace
+ * {2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token.
+ *
+ * The activated ability composes {2}{R} + tap + exile-three-from-graveyard ([Costs.ExileFromGraveyard],
+ * the Mines of Moria cost idiom) and creates one 3/2 red Wolf token.
+ */
+val KessigWolfrider = card("Kessig Wolfrider") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Human Knight"
+    power = 1
+    toughness = 2
+    oracleText = "Menace\n" +
+        "{2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token."
+
+    keywords(Keyword.MENACE)
+
+    activatedAbility {
+        cost = Costs.Composite(
+            Costs.Mana("{2}{R}"),
+            Costs.Tap,
+            Costs.ExileFromGraveyard(3)
+        )
+        effect = Effects.CreateToken(
+            power = 3,
+            toughness = 2,
+            colors = setOf(Color.RED),
+            creatureTypes = setOf("Wolf")
+        )
+        description = "{2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf " +
+            "creature token."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "165"
+        artist = "Bram Sels"
+        flavorText = "\"It's a perfect partnership. My village is safe from wolf attacks, and she " +
+            "gets to eat any vampires we catch.\""
+        imageUri = "https://cards.scryfall.io/normal/front/1/8/180b1a4f-c071-4742-9c57-9d775be0ed4f.jpg?1782703072"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/LanternOfTheLost.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/LanternOfTheLost.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Lantern of the Lost
+ * {1}
+ * Artifact
+ *
+ * When this artifact enters, exile target card from a graveyard.
+ * {1}, {T}, Exile this artifact: Exile all cards from all graveyards, then draw a card.
+ */
+val LanternOfTheLost = card("Lantern of the Lost") {
+    manaCost = "{1}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, exile target card from a graveyard.\n" +
+        "{1}, {T}, Exile this artifact: Exile all cards from all graveyards, then draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val exiled = target("target card in a graveyard", Targets.CardInGraveyard)
+        effect = Effects.Move(exiled, Zone.EXILE)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{1}"), Costs.Tap, Costs.ExileSelf)
+        effect = Effects.Composite(
+            GatherCardsEffect(
+                source = CardSource.FromZone(
+                    zone = Zone.GRAVEYARD,
+                    player = Player.Each,
+                    filter = GameObjectFilter.Any,
+                ),
+                storeAs = "allGraveyards",
+            ),
+            MoveCollectionEffect(
+                from = "allGraveyards",
+                destination = CardDestination.ToZone(Zone.EXILE),
+            ),
+            Effects.DrawCards(1),
+        )
+        description = "{1}, {T}, Exile this artifact: Exile all cards from all graveyards, then draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "259"
+        artist = "Chris Cold"
+        imageUri = "https://cards.scryfall.io/normal/front/c/2/c2303f11-2c82-44d5-893a-8e71dece7746.jpg?1782703014"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/LightningWolf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/LightningWolf.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Lightning Wolf
+ * {3}{R}
+ * Creature — Wolf
+ * 4/3
+ * {1}{R}: This creature gains first strike until end of turn. Activate only as a sorcery.
+ */
+val LightningWolf = card("Lightning Wolf") {
+    manaCost = "{3}{R}"
+    colorIdentity = "R"
+    typeLine = "Creature — Wolf"
+    oracleText = "{1}{R}: This creature gains first strike until end of turn. Activate only as a sorcery."
+    power = 4
+    toughness = 3
+    activatedAbility {
+        cost = Costs.Mana("{1}{R}")
+        effect = Effects.GrantKeyword(Keyword.FIRST_STRIKE, EffectTarget.Self)
+        timing = TimingRule.SorcerySpeed
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "168"
+        artist = "Alessandra Pisano"
+        flavorText = "These thick-furred wolves have adapted to Stensia's storms, channeling their energy into bursts of supernatural speed."
+        imageUri = "https://cards.scryfall.io/normal/front/7/2/7211e4c3-e940-41da-88e4-4630eab447a6.jpg?1782703071"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MarkovPurifier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MarkovPurifier.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPayManaEffect
+
+/**
+ * Markov Purifier
+ * {1}{W}{B}
+ * Creature — Vampire Cleric
+ * 2/3
+ *
+ * Lifelink
+ * At the beginning of your end step, if you gained life this turn, you may pay {2}. If you do,
+ * draw a card.
+ *
+ * The end-step trigger uses an intervening-if ([Conditions.YouGainedLifeThisTurn]); on resolution
+ * it offers a flat "you may pay {2}. If you do, draw a card" gate ([MayPayManaEffect]).
+ */
+val MarkovPurifier = card("Markov Purifier") {
+    manaCost = "{1}{W}{B}"
+    colorIdentity = "WB"
+    typeLine = "Creature — Vampire Cleric"
+    power = 2
+    toughness = 3
+    oracleText = "Lifelink\n" +
+        "At the beginning of your end step, if you gained life this turn, you may pay {2}. If you " +
+        "do, draw a card."
+
+    keywords(Keyword.LIFELINK)
+
+    triggeredAbility {
+        trigger = Triggers.YourEndStep
+        triggerCondition = Conditions.YouGainedLifeThisTurn
+        effect = MayPayManaEffect(
+            cost = ManaCost.parse("{2}"),
+            effect = Effects.DrawCards(1)
+        )
+        description = "At the beginning of your end step, if you gained life this turn, you may " +
+            "pay {2}. If you do, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "312"
+        artist = "Samuel Araya"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/533673f3-5e18-4630-bd71-001774d698a8.jpg?1782702974"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MarkovRetribution.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MarkovRetribution.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetOther
+
+/**
+ * Markov Retribution
+ * {2}{R}
+ * Sorcery
+ *
+ * Choose one or both —
+ * • Creatures you control get +1/+0 until end of turn.
+ * • Target Vampire you control deals damage equal to its power to another target creature.
+ *
+ * "Choose one or both" is modeled as three modes (pump only / bite only / both) chosen with
+ * `chooseCount = 1` — the Winterflame / Overwhelming Surge shape. The pump is a group modify
+ * ([Patterns.Group.modifyStatsForAll] over `creaturesYouControl`). The bite is the Itzquinth
+ * idiom: the Vampire is target index 0, the victim is a [TargetOther] target creature, damage
+ * equals the Vampire's power ([DynamicAmounts.targetPower(0)]) and its source is the Vampire
+ * (`damageSource`). In the "both" mode the Vampire (0) and victim (1) are declared first so the
+ * dynamic power reference stays index-0.
+ */
+val MarkovRetribution = card("Markov Retribution") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Choose one or both —\n" +
+        "• Creatures you control get +1/+0 until end of turn.\n" +
+        "• Target Vampire you control deals damage equal to its power to another target creature."
+
+    val pumpAll = Patterns.Group.modifyStatsForAll(1, 0, Filters.Group.creaturesYouControl)
+
+    spell {
+        modal(chooseCount = 1) {
+            mode("Creatures you control get +1/+0 until end of turn") {
+                effect = pumpAll
+            }
+            mode("Target Vampire you control deals damage equal to its power to another target creature") {
+                val vampire = target(
+                    "target Vampire you control",
+                    TargetCreature(filter = TargetFilter.Creature.withSubtype("Vampire").youControl())
+                )
+                val victim = target("another target creature", TargetOther(TargetCreature()))
+                effect = DealDamageEffect(DynamicAmounts.targetPower(0), victim, damageSource = vampire)
+            }
+            mode(
+                "Creatures you control get +1/+0 until end of turn and target Vampire you " +
+                    "control deals damage equal to its power to another target creature"
+            ) {
+                val vampire = target(
+                    "target Vampire you control",
+                    TargetCreature(filter = TargetFilter.Creature.withSubtype("Vampire").youControl())
+                )
+                val victim = target("another target creature", TargetOther(TargetCreature()))
+                effect = Effects.Composite(
+                    listOf(
+                        pumpAll,
+                        DealDamageEffect(DynamicAmounts.targetPower(0), victim, damageSource = vampire)
+                    )
+                )
+            }
+        }
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "171"
+        artist = "Uriah Voth"
+        imageUri = "https://cards.scryfall.io/normal/front/4/8/48d3840c-db27-4512-bfe3-92249094e5b4.jpg?1782703070"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MassiveMight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MassiveMight.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Massive Might
+ * {G}
+ * Instant
+ * Target creature gets +2/+2 and gains trample until end of turn.
+ */
+val MassiveMight = card("Massive Might") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +2/+2 and gains trample until end of turn."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(2, 2, t),
+            Effects.GrantKeyword(Keyword.TRAMPLE, t)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "208"
+        artist = "Iris Compiet"
+        flavorText = "\"Run! It's coming for us! Eventually!\"\n—Yaster, Havengul shopkeeper"
+        imageUri = "https://cards.scryfall.io/normal/front/3/a/3a5cd50b-4825-4d85-b0f9-e2a51d2a7df1.jpg?1782703046"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MilitiaRallier.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MilitiaRallier.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttackUnlessCoAttacker
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Militia Rallier
+ * {2}{W}
+ * Creature — Human Soldier
+ * 3/3
+ *
+ * This creature can't attack alone.
+ * Whenever this creature attacks, untap target creature.
+ */
+val MilitiaRallier = card("Militia Rallier") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    power = 3
+    toughness = 3
+    oracleText = "This creature can't attack alone.\n" +
+        "Whenever this creature attacks, untap target creature."
+
+    // "Can't attack alone" — requires any other creature to also attack.
+    staticAbility {
+        ability = CantAttackUnlessCoAttacker(coAttackerFilter = GameObjectFilter.Creature)
+    }
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target("creature", Targets.Creature)
+        effect = Effects.Untap(creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "24"
+        artist = "Eelis Kyttanen"
+        flavorText = "\"We can wait like helpless children for a hero, or we can gather our courage " +
+            "and be the heroes. Who's with me?\""
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/51b3ff40-3185-4369-985e-17613bb6ad22.jpg?1782703178"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/NebelgastBeguiler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/NebelgastBeguiler.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Nebelgast Beguiler
+ * {4}{W}
+ * Creature — Spirit
+ * 2/5
+ * {W}, {T}: Tap target creature.
+ */
+val NebelgastBeguiler = card("Nebelgast Beguiler") {
+    manaCost = "{4}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Spirit"
+    oracleText = "{W}, {T}: Tap target creature."
+    power = 2
+    toughness = 5
+    activatedAbility {
+        cost = Costs.Composite(Costs.Mana("{W}"), Costs.Tap)
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Tap(t)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "25"
+        artist = "Andreas Zafiratos"
+        flavorText = "A moment of distraction, an hour off course."
+        imageUri = "https://cards.scryfall.io/normal/front/0/4/04c68dbd-e61b-49a7-aa17-da6b26c9fd29.jpg?1782703176"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/OllenbockEscort.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/OllenbockEscort.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Ollenbock Escort
+ * {W}
+ * Creature — Human Cleric
+ * 1/1
+ * Vigilance
+ * Sacrifice this creature: Target creature you control with a +1/+1 counter on it gains lifelink
+ * and indestructible until end of turn.
+ */
+val OllenbockEscort = card("Ollenbock Escort") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "Vigilance\nSacrifice this creature: Target creature you control with a +1/+1 counter on it gains lifelink and indestructible until end of turn."
+    power = 1
+    toughness = 1
+    keywords(Keyword.VIGILANCE)
+    activatedAbility {
+        cost = Costs.SacrificeSelf
+        val t = target(
+            "target",
+            TargetCreature(
+                filter = TargetFilter(GameObjectFilter.Creature.withCounter(Counters.PLUS_ONE_PLUS_ONE).youControl())
+            )
+        )
+        effect = Effects.Composite(
+            Effects.GrantKeyword(Keyword.LIFELINK, t),
+            Effects.GrantKeyword(Keyword.INDESTRUCTIBLE, t)
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "27"
+        artist = "Eric Wilkerson"
+        flavorText = "\"Stay in the light. I don't know what lurks in those shadows, and I'd like to keep it that way.\""
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7a659bf-9d85-4011-980e-c3a8dc4513e9.jpg?1782703176"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PacksongPup.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PacksongPup.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Packsong Pup
+ * {1}{G}
+ * Creature — Wolf
+ * 1/1
+ * At the beginning of combat on your turn, if you control another Wolf or Werewolf, put a +1/+1
+ * counter on this creature.
+ * When this creature dies, you gain life equal to its power.
+ */
+val PacksongPup = card("Packsong Pup") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    oracleText = "At the beginning of combat on your turn, if you control another Wolf or Werewolf, put a +1/+1 counter on this creature.\nWhen this creature dies, you gain life equal to its power."
+    power = 1
+    toughness = 1
+    triggeredAbility {
+        trigger = Triggers.BeginCombat
+        triggerCondition = Conditions.YouControl(
+            filter = GameObjectFilter.Creature.withAnyOfSubtypes(listOf(Subtype.WOLF, Subtype.WEREWOLF)),
+            excludeSelf = true
+        )
+        effect = AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 1, target = EffectTarget.Self)
+    }
+    triggeredAbility {
+        trigger = Triggers.Dies
+        effect = GainLifeEffect(DynamicAmounts.sourcePower())
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "213"
+        artist = "April Prime"
+        flavorText = "A wolf pup is always dangerous, because a wolf pup is never alone."
+        imageUri = "https://cards.scryfall.io/normal/front/d/4/d43d9686-a5e4-413b-8a34-3430788dd1b9.jpg?1782703044"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PersistentSpecimen.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PersistentSpecimen.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Persistent Specimen
+ * {B}
+ * Creature — Skeleton
+ * 1/1
+ * {2}{B}: Return this card from your graveyard to the battlefield tapped.
+ */
+val PersistentSpecimen = card("Persistent Specimen") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Skeleton"
+    oracleText = "{2}{B}: Return this card from your graveyard to the battlefield tapped."
+    power = 1
+    toughness = 1
+    activatedAbility {
+        cost = Costs.Mana("{2}{B}")
+        effect = Effects.PutOntoBattlefield(EffectTarget.Self, tapped = true)
+        activateFromZone = Zone.GRAVEYARD
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "125"
+        artist = "Scott Murphy"
+        flavorText = "\"The jaw bone's connected to the skull bone. The skull bone's connected to the . . . uh . . . hook thingy.\"\n—Garl, sticher's assistant"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7baf973-3202-4fea-8861-a4a5ec228640.jpg?1782703101"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PiercingLight.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PiercingLight.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.DealDamageEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Piercing Light
+ * {W}
+ * Instant
+ * Piercing Light deals 2 damage to target attacking or blocking creature. Scry 1.
+ */
+val PiercingLight = card("Piercing Light") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Instant"
+    oracleText = "Piercing Light deals 2 damage to target attacking or blocking creature. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)"
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.AttackingOrBlockingCreature))
+        effect = Effects.Composite(
+            DealDamageEffect(2, t),
+            Patterns.Library.scry(1)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "30"
+        artist = "Donato Giancola"
+        flavorText = "\"Creatures of the night dissolve like shadows in the light of faith.\"\n—Thalia, Guardian of Thraben"
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54cc4e2b-1497-4788-afb4-9e42b7683b5a.jpg?1782703174"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PointedDiscussion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/PointedDiscussion.kt
@@ -1,0 +1,37 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Pointed Discussion
+ * {2}{B}
+ * Sorcery
+ *
+ * You draw two cards, lose 2 life, then create a Blood token.
+ */
+val PointedDiscussion = card("Pointed Discussion") {
+    manaCost = "{2}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "You draw two cards, lose 2 life, then create a Blood token. (It's an artifact with " +
+        "\"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        effect = Effects.Composite(
+            Effects.DrawCards(2),
+            Effects.LoseLife(2, EffectTarget.Controller),
+            Effects.CreateBlood(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "126"
+        artist = "Jarel Threat"
+        flavorText = "Small talk is a dying art."
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/076deb63-f7e2-498f-a66a-8a190370a3b3.jpg?1782703101"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RecklessImpulse.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RecklessImpulse.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.MayPlayExpiry
+
+/**
+ * Reckless Impulse
+ * {1}{R}
+ * Sorcery
+ *
+ * Exile the top two cards of your library. Until the end of your next turn, you may play those cards.
+ */
+val RecklessImpulse = card("Reckless Impulse") {
+    manaCost = "{1}{R}"
+    colorIdentity = "R"
+    typeLine = "Sorcery"
+    oracleText = "Exile the top two cards of your library. Until the end of your next turn, you may " +
+        "play those cards."
+
+    spell {
+        effect = Patterns.Exile.impulse(2, MayPlayExpiry.UntilEndOfNextTurn)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "174"
+        artist = "Mathias Kollros"
+        flavorText = "A stitcher looks at their creation and sees the result of years of study and " +
+            "hours of toil. A devil sees a new plaything."
+        imageUri = "https://cards.scryfall.io/normal/front/6/9/6943c07f-ab0d-4f5a-bbe9-c0a83dc98546.jpg?1782703066"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ReclusiveTaxidermist.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ReclusiveTaxidermist.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Reclusive Taxidermist
+ * {1}{G}
+ * Creature — Human Druid
+ * 1/2
+ *
+ * This creature gets +3/+2 as long as there are four or more creature cards in your graveyard.
+ * {T}: Add one mana of any color.
+ *
+ * The buff is a [ConditionalStaticAbility] over [ModifyStats] on the source, gated by
+ * [Conditions.CreatureCardsInGraveyardAtLeast] (Basking Capybara idiom). The mana ability is a
+ * {T}: any-color mana ability.
+ */
+val ReclusiveTaxidermist = card("Reclusive Taxidermist") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Druid"
+    power = 1
+    toughness = 2
+    oracleText = "This creature gets +3/+2 as long as there are four or more creature cards in " +
+        "your graveyard.\n" +
+        "{T}: Add one mana of any color."
+
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = ModifyStats(powerBonus = 3, toughnessBonus = 2, filter = GroupFilter.source()),
+            condition = Conditions.CreatureCardsInGraveyardAtLeast(4)
+        )
+    }
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Effects.AddAnyColorMana(1)
+        manaAbility = true
+        timing = TimingRule.ManaAbility
+        description = "{T}: Add one mana of any color."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "214"
+        artist = "Wisnu Tan"
+        flavorText = "All druids seek to preserve nature, but some go about it in rather unusual ways."
+        imageUri = "https://cards.scryfall.io/normal/front/1/0/10edf37a-ee35-491d-b83a-39035f7df65a.jpg?1782703043"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RendingFlame.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RendingFlame.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rending Flame
+ * {2}{R}
+ * Instant
+ *
+ * Rending Flame deals 5 damage to target creature or planeswalker. If that permanent is a
+ * Spirit, Rending Flame also deals 2 damage to that permanent's controller.
+ *
+ * A single target ([Targets.CreatureOrPlaneswalker]) takes 5 damage; a
+ * [ConditionalEffect] gated on [Conditions.TargetMatchesFilter] (target is a Spirit) adds 2
+ * damage to that permanent's controller ([EffectTarget.TargetController]) — the YipYip
+ * "if that permanent is a [type]" rider idiom, with the controller-of-target damage sink
+ * from Heated Argument.
+ */
+val RendingFlame = card("Rending Flame") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Rending Flame deals 5 damage to target creature or planeswalker. If that " +
+        "permanent is a Spirit, Rending Flame also deals 2 damage to that permanent's controller."
+
+    spell {
+        val permanent = target("target creature or planeswalker", Targets.CreatureOrPlaneswalker)
+        effect = Effects.Composite(
+            Effects.DealDamage(5, permanent),
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(GameObjectFilter.Any.withSubtype(Subtype.SPIRIT)),
+                effect = Effects.DealDamage(2, EffectTarget.TargetController)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "175"
+        artist = "Olena Richards"
+        flavorText = "\"It is our duty to bring the Blessed Sleep to the dead, even if they resist " +
+            "that gift.\"\n—Grete, Order of Saint Traft"
+        imageUri = "https://cards.scryfall.io/normal/front/5/1/51332c31-41df-4379-aa63-6a734a4df618.jpg?1782703065"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ResistanceSquad.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ResistanceSquad.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+/**
+ * Resistance Squad
+ * {2}{W}
+ * Creature — Human Soldier
+ * 3/2
+ * When this creature enters, if you control another Human, draw a card.
+ */
+val ResistanceSquad = card("Resistance Squad") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Soldier"
+    oracleText = "When this creature enters, if you control another Human, draw a card."
+    power = 3
+    toughness = 2
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        triggerCondition = Conditions.YouControl(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.HUMAN),
+            excludeSelf = true
+        )
+        effect = DrawCardsEffect(1)
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "32"
+        artist = "Joshua Raphael"
+        flavorText = "\"It's not that I didn't expect some defiance, but I did hope it wouldn't be so heavily armed.\"\n—Olivia Voldaren"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/093ae747-350f-4253-b903-8c6892d78c83.jpg?1782703173"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/Retrieve.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/Retrieve.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Retrieve
+ * {2}{G}
+ * Sorcery
+ *
+ * Return up to one target creature card and up to one target noncreature permanent card from your
+ * graveyard to your hand. Exile Retrieve.
+ *
+ * Two independent "up to one target" graveyard slots (optional, minCount 0) — the first a creature
+ * card, the second a noncreature permanent card you own in your graveyard — each returned to hand.
+ * `selfExile()` routes the spell to exile instead of its owner's graveyard as it finishes resolving
+ * (Wisdom of Ages idiom).
+ */
+val Retrieve = card("Retrieve") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Sorcery"
+    oracleText = "Return up to one target creature card and up to one target noncreature permanent " +
+        "card from your graveyard to your hand. Exile Retrieve."
+
+    spell {
+        selfExile()
+        val creature = target(
+            "creature",
+            TargetObject(optional = true, filter = TargetFilter.CreatureInYourGraveyard)
+        )
+        val noncreature = target(
+            "noncreature permanent",
+            TargetObject(
+                optional = true,
+                filter = TargetFilter(
+                    GameObjectFilter.NoncreaturePermanent.ownedByYou(),
+                    zone = Zone.GRAVEYARD
+                )
+            )
+        )
+        effect = Effects.Composite(
+            listOf(
+                Effects.ReturnToHand(creature),
+                Effects.ReturnToHand(noncreature)
+            )
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "215"
+        artist = "Alix Branwyn"
+        flavorText = "The roots preserved the armor for a hundred years, safeguarding it for a " +
+            "traveler in need."
+        imageUri = "https://cards.scryfall.io/normal/front/9/e/9e997f78-22a2-4b66-ac10-1adc9a72ce3b.jpg?1782703042"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/Sanctify.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/Sanctify.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Sanctify
+ * {1}{W}
+ * Sorcery
+ * Destroy target artifact or enchantment. You gain 3 life.
+ */
+val Sanctify = card("Sanctify") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Sorcery"
+    oracleText = "Destroy target artifact or enchantment. You gain 3 life."
+    spell {
+        val t = target("target", TargetPermanent(filter = TargetFilter.ArtifactOrEnchantment))
+        effect = Effects.Composite(
+            Effects.Move(t, Zone.GRAVEYARD, byDestruction = true),
+            GainLifeEffect(3)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "33"
+        artist = "Kasia 'Kafis' Zielińska"
+        flavorText = "\"Olivia Voldaren has faith only in herself. We answer to a higher calling.\"\n—Thalia, Guardian of Thraben"
+        imageUri = "https://cards.scryfall.io/normal/front/8/8/880e071a-6d6c-41c4-b2eb-c9e6626d0c7f.jpg?1782703172"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SawbladeSlinger.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SawbladeSlinger.kt
@@ -1,0 +1,72 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Mode
+import com.wingedsheep.sdk.scripting.effects.ModalEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Sawblade Slinger
+ * {3}{G}
+ * Creature — Human Archer
+ * 4/3
+ *
+ * When this creature enters, choose up to one —
+ * • Destroy target artifact an opponent controls.
+ * • This creature fights target Zombie an opponent controls.
+ *
+ * ETB "choose up to one" modal — a [ModalEffect] with `chooseCount = 1, minChooseCount = 0`
+ * so the controller may decline both modes (the HighwayRobbery min-0 idiom). Mode 1 destroys
+ * an opponent's artifact; mode 2 is a self-fight against an opponent's Zombie (source is
+ * [EffectTarget.Self], the HivespineWolverine idiom). Both target restrictions use
+ * `opponentControls()` so only opposing permanents are legal.
+ */
+val SawbladeSlinger = card("Sawblade Slinger") {
+    manaCost = "{3}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Archer"
+    power = 4
+    toughness = 3
+    oracleText = "When this creature enters, choose up to one —\n" +
+        "• Destroy target artifact an opponent controls.\n" +
+        "• This creature fights target Zombie an opponent controls."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = ModalEffect(
+            modes = listOf(
+                Mode.withTarget(
+                    Effects.Destroy(EffectTarget.ContextTarget(0)),
+                    TargetPermanent(filter = TargetFilter(GameObjectFilter.Artifact.opponentControls())),
+                    "Destroy target artifact an opponent controls"
+                ),
+                Mode.withTarget(
+                    Effects.Fight(EffectTarget.Self, EffectTarget.ContextTarget(0)),
+                    TargetCreature(
+                        filter = TargetFilter(GameObjectFilter.Creature.withSubtype("Zombie").opponentControls())
+                    ),
+                    "This creature fights target Zombie an opponent controls"
+                )
+            ),
+            chooseCount = 1,
+            minChooseCount = 0,
+            countsAsModalSpell = false
+        )
+        description = "When this creature enters, choose up to one — Destroy target artifact an " +
+            "opponent controls, or this creature fights target Zombie an opponent controls."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "217"
+        artist = "Joshua Raphael"
+        imageUri = "https://cards.scryfall.io/normal/front/2/2/225773f9-1843-4ee0-8564-8e4a5dfef775.jpg?1782703040"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ScatteredThoughts.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ScatteredThoughts.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Scattered Thoughts
+ * {3}{U}
+ * Instant
+ * Look at the top four cards of your library. Put two of those cards into your hand and the rest
+ * into your graveyard.
+ */
+val ScatteredThoughts = card("Scattered Thoughts") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Look at the top four cards of your library. Put two of those cards into your hand and the rest into your graveyard."
+    spell {
+        effect = Patterns.Library.lookAtTopAndKeep(count = 4, keepCount = 2)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "74"
+        artist = "Brian Valeza"
+        flavorText = "Stitchers delegate the most important tasks to assistants with a good eye for detail."
+        imageUri = "https://cards.scryfall.io/normal/front/d/c/dc5c6675-6e0f-427d-9399-a6e7fc6215f1.jpg?1782703139"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SelhoffEntomber.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SelhoffEntomber.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Selhoff Entomber
+ * {1}{U}
+ * Creature — Zombie
+ * 1/3
+ *
+ * {T}, Discard a creature card: Draw a card.
+ */
+val SelhoffEntomber = card("Selhoff Entomber") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 3
+    oracleText = "{T}, Discard a creature card: Draw a card."
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.Discard(GameObjectFilter.Creature))
+        effect = Effects.DrawCards(1)
+        description = "{T}, Discard a creature card: Draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "76"
+        artist = "Johann Bodin"
+        flavorText = "It knows one fundamental truth: bodies belong in graves."
+        imageUri = "https://cards.scryfall.io/normal/front/f/8/f8805db2-5a26-43cf-9b74-f882c283e5e4.jpg?1782703138"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ShelteringBoughs.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ShelteringBoughs.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Sheltering Boughs
+ * {2}{G}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * When this Aura enters, draw a card.
+ * Enchanted creature gets +1/+3.
+ */
+val ShelteringBoughs = card("Sheltering Boughs") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "When this Aura enters, draw a card.\n" +
+        "Enchanted creature gets +1/+3."
+
+    auraTarget = Targets.Creature
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    staticAbility {
+        ability = ModifyStats(1, 3)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "218"
+        artist = "Anato Finnstark"
+        flavorText = "\"We're not at odds with the woods. How could we be, when we share so many enemies?\"\n—Marel, Dawnhart witch"
+        imageUri = "https://cards.scryfall.io/normal/front/9/1/915dd4c2-0e9f-440c-8e4c-80db351a5eba.jpg?1782703040"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SigardasImprisonment.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SigardasImprisonment.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantAttack
+import com.wingedsheep.sdk.scripting.CantBlock
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Sigarda's Imprisonment
+ * {2}{W}
+ * Enchantment — Aura
+ *
+ * Enchant creature
+ * Enchanted creature can't attack or block.
+ * {4}{W}: Exile enchanted creature. Create a Blood token.
+ *
+ * "Can't attack or block" is the two-static-ability Pacifism idiom ([CantAttack] + [CantBlock]
+ * over the attached creature). The activated ability exiles the enchanted creature and makes a
+ * Blood token.
+ */
+val SigardasImprisonment = card("Sigarda's Imprisonment") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Enchantment — Aura"
+    oracleText = "Enchant creature\n" +
+        "Enchanted creature can't attack or block.\n" +
+        "{4}{W}: Exile enchanted creature. Create a Blood token. (It's an artifact with \"{1}, " +
+        "{T}, Discard a card, Sacrifice this token: Draw a card.\")"
+
+    auraTarget = Targets.Creature
+
+    staticAbility {
+        ability = CantAttack(filter = GroupFilter.attachedCreature())
+    }
+
+    staticAbility {
+        ability = CantBlock(filter = GroupFilter.attachedCreature())
+    }
+
+    activatedAbility {
+        cost = Costs.Mana("{4}{W}")
+        effect = Effects.Composite(
+            Effects.Exile(EffectTarget.EnchantedCreature),
+            Effects.CreateBlood(1),
+        )
+        description = "{4}{W}: Exile enchanted creature. Create a Blood token."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "35"
+        artist = "Bryan Sola"
+        imageUri = "https://cards.scryfall.io/normal/front/1/1/118995a6-8471-47ac-9404-700ce7fc46f6.jpg?1782703171"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SkywarpSkaab.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SkywarpSkaab.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.IfYouDoEffect
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.SuccessCriterion
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Skywarp Skaab
+ * {3}{U}{U}
+ * Creature — Zombie Drake
+ * 2/5
+ *
+ * Flying
+ * When this creature enters, you may exile two creature cards from your graveyard. If you do,
+ * draw a card.
+ *
+ * The ETB is the "exile exactly two" pipeline gated by [IfYouDoEffect] (see Aegis Sculptor):
+ * gather creature cards from your graveyard, choose exactly two, move them to exile, and only
+ * draw when both were actually exiled ([SuccessCriterion.CollectionNonEmpty] with `min = 2`).
+ * With fewer than two creature cards the player can't complete the exile, so no card is drawn.
+ */
+val SkywarpSkaab = card("Skywarp Skaab") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Drake"
+    power = 2
+    toughness = 5
+    oracleText = "Flying\n" +
+        "When this creature enters, you may exile two creature cards from your graveyard. If you " +
+        "do, draw a card."
+
+    keywords(Keyword.FLYING)
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = MayEffect(
+            IfYouDoEffect(
+                action = Effects.Composite(
+                    listOf(
+                        GatherCardsEffect(
+                            source = CardSource.FromZone(
+                                zone = Zone.GRAVEYARD,
+                                filter = GameObjectFilter.Creature
+                            ),
+                            storeAs = "graveyardCreatures"
+                        ),
+                        SelectFromCollectionEffect(
+                            from = "graveyardCreatures",
+                            selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(2)),
+                            storeSelected = "toExile",
+                            selectedLabel = "Exile"
+                        ),
+                        MoveCollectionEffect(
+                            from = "toExile",
+                            destination = CardDestination.ToZone(Zone.EXILE)
+                        )
+                    )
+                ),
+                ifYouDo = Effects.DrawCards(1),
+                successCriterion = SuccessCriterion.CollectionNonEmpty("toExile", min = 2)
+            )
+        )
+        description = "When this creature enters, you may exile two creature cards from your " +
+            "graveyard. If you do, draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "78"
+        artist = "Steven Belledin"
+        flavorText = "\"If I wanted all the parts to match, I wouldn't have become a stitcher.\"\n" +
+            "—Barton, stitcher"
+        imageUri = "https://cards.scryfall.io/normal/front/7/3/73168804-3c22-4fcb-907a-2f08999c0cea.jpg?1782703137"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SporebackWolf.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SporebackWolf.kt
@@ -1,0 +1,34 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Sporeback Wolf
+ * {1}{G}
+ * Creature — Wolf
+ * 2/2
+ * During your turn, this creature gets +0/+2.
+ */
+val SporebackWolf = card("Sporeback Wolf") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Wolf"
+    oracleText = "During your turn, this creature gets +0/+2."
+    power = 2
+    toughness = 2
+    staticAbility {
+        ability = ConditionalStaticAbility(ability = ModifyStats(0, 2, Filters.Self), condition = Conditions.IsYourTurn)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "223"
+        artist = "Nicholas Elias"
+        flavorText = "The mushrooms growing in the wolves' fur possess curative properties incredible enough to tempt many alchemists into risking their lives to track one down."
+        imageUri = "https://cards.scryfall.io/normal/front/3/f/3fb04879-9348-4d4f-9a23-c82fd99d04c6.jpg?1782703036"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SteelcladSpirit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SteelcladSpirit.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+
+/**
+ * Steelclad Spirit
+ * {1}{U}
+ * Creature — Spirit
+ * 3/3
+ *
+ * Defender
+ * Whenever an enchantment you control enters, this creature can attack this turn as though it
+ * didn't have defender.
+ *
+ * Models the enchantment-enters toggle like Stalked Researcher: a triggered ability filtered to
+ * enchantments you control that grants [Effects.CanAttackDespiteDefenderThisTurn].
+ */
+val SteelcladSpirit = card("Steelclad Spirit") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    power = 3
+    toughness = 3
+    oracleText = "Defender\n" +
+        "Whenever an enchantment you control enters, this creature can attack this turn as though " +
+        "it didn't have defender."
+
+    keywords(Keyword.DEFENDER)
+
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Enchantment.youControl(),
+            binding = TriggerBinding.ANY,
+        )
+        effect = Effects.CanAttackDespiteDefenderThisTurn()
+        description = "Whenever an enchantment you control enters, this creature can attack this " +
+            "turn as though it didn't have defender."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "80"
+        artist = "Artur Treffner"
+        flavorText = "Some geists imitate the lives they left behind. Others follow the dreams they " +
+            "never realized."
+        imageUri = "https://cards.scryfall.io/normal/front/5/5/55fb1426-5a6f-48dd-938b-c64b1a28ee59.jpg?1782703135"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SureStrikeReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SureStrikeReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Sure Strike reprint in VOW.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in BFZ's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * VOW-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val SureStrikeReprint = Printing(
+    oracleId = "fb694e7e-f66e-4958-b6ed-aa74bc9ac43e",
+    name = "Sure Strike",
+    setCode = "VOW",
+    collectorNumber = "179",
+    scryfallId = "1d872736-fafb-44e8-a809-48c5436c665a",
+    artist = "Lie Setiawan",
+    imageUri = "https://cards.scryfall.io/normal/front/1/d/1d872736-fafb-44e8-a809-48c5436c665a.jpg?1782703064",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.COMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SyphonEssence.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/SyphonEssence.kt
@@ -1,0 +1,40 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetSpell
+
+/**
+ * Syphon Essence
+ * {2}{U}
+ * Instant
+ *
+ * Counter target creature or planeswalker spell. Create a Blood token.
+ */
+val SyphonEssence = card("Syphon Essence") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Counter target creature or planeswalker spell. Create a Blood token. (It's an " +
+        "artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        target = TargetSpell(
+            filter = TargetFilter(GameObjectFilter.CreatureOrPlaneswalker, zone = Zone.STACK)
+        )
+        effect = Effects.CounterSpell() then Effects.CreateBlood(1)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "84"
+        artist = "Sean Murray"
+        flavorText = "The third step in creating a skaab requires draining the body of blood and " +
+            "replacing it with viscus vitae, a mixture of angel's blood and lamp oil."
+        imageUri = "https://cards.scryfall.io/normal/front/4/3/435a2d31-ac2c-45aa-8369-6c2d6fbba4e4.jpg?1782703133"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ToxicScorpion.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ToxicScorpion.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Toxic Scorpion
+ * {1}{G}
+ * Creature — Scorpion
+ * 1/1
+ * Deathtouch
+ * When this creature enters, another target creature you control gains deathtouch until end of turn.
+ */
+val ToxicScorpion = card("Toxic Scorpion") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Scorpion"
+    oracleText = "Deathtouch\nWhen this creature enters, another target creature you control gains deathtouch until end of turn."
+    power = 1
+    toughness = 1
+    keywords(Keyword.DEATHTOUCH)
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val t = target("target", TargetCreature(filter = TargetFilter.OtherCreatureYouControl))
+        effect = Effects.GrantKeyword(Keyword.DEATHTOUCH, t)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "224"
+        artist = "Simon Dominic"
+        flavorText = "\"You want that venom? Collect it yourself! I'm not losing another pair of dragonhide gloves.\"\n—Old Rutstein"
+        imageUri = "https://cards.scryfall.io/normal/front/4/c/4cfca481-cf2d-435d-b4b6-07b1fe2a8e5d.jpg?1782703036"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/TravelingMinister.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/TravelingMinister.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Traveling Minister
+ * {W}
+ * Creature — Human Cleric
+ * 1/1
+ * {T}: Target creature gets +1/+0 until end of turn. You gain 1 life. Activate only as a sorcery.
+ */
+val TravelingMinister = card("Traveling Minister") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Cleric"
+    oracleText = "{T}: Target creature gets +1/+0 until end of turn. You gain 1 life. Activate only as a sorcery."
+    power = 1
+    toughness = 1
+    activatedAbility {
+        cost = Costs.Tap
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(1, 0, t),
+            GainLifeEffect(1)
+        )
+        timing = TimingRule.SorcerySpeed
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "39"
+        artist = "Slawomir Maniak"
+        flavorText = "Priests of the Sigardian Sect travel to the farthest reaches to spread hope and healing, even in the darkest times."
+        imageUri = "https://cards.scryfall.io/normal/front/e/6/e672a05c-5f1a-4aa6-9398-e33df01c7c96.jpg?1782703166"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/UndeadButler.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/UndeadButler.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Undead Butler
+ * {1}{B}
+ * Creature — Zombie
+ * 1/2
+ *
+ * When this creature enters, mill three cards.
+ * When this creature dies, you may exile it. When you do, return target creature card from your
+ * graveyard to your hand.
+ */
+val UndeadButler = card("Undead Butler") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 1
+    toughness = 2
+    oracleText = "When this creature enters, mill three cards. (Put the top three cards of your " +
+        "library into your graveyard.)\n" +
+        "When this creature dies, you may exile it. When you do, return target creature card from " +
+        "your graveyard to your hand."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.mill(3)
+    }
+
+    // Dies trigger functions from the graveyard so "exile it" can reference Self. Exiling is
+    // optional ("you may"); once it happens the reflexive trigger returns a targeted creature card.
+    triggeredAbility {
+        trigger = Triggers.Dies
+        triggerZone = Zone.GRAVEYARD
+        effect = ReflexiveTriggerEffect(
+            action = Effects.Exile(EffectTarget.Self),
+            optional = true,
+            reflexiveEffect = Effects.Move(EffectTarget.ContextTarget(0), Zone.HAND),
+            reflexiveTargetRequirements = listOf(
+                TargetObject(filter = TargetFilter.CreatureInYourGraveyard)
+            ),
+            descriptionOverride = "You may exile this creature. When you do, return target " +
+                "creature card from your graveyard to your hand."
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "133"
+        artist = "Néstor Ossandón Leal"
+        imageUri = "https://cards.scryfall.io/normal/front/2/c/2c9b8582-8887-4652-82e2-f9b11ee21545.jpg?1782703094"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/UnhallowedPhalanx.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/UnhallowedPhalanx.kt
@@ -1,0 +1,29 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.EntersTapped
+
+/**
+ * Unhallowed Phalanx
+ * {4}{B}
+ * Creature — Zombie Soldier
+ * 1/13
+ * This creature enters tapped.
+ */
+val UnhallowedPhalanx = card("Unhallowed Phalanx") {
+    manaCost = "{4}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Soldier"
+    oracleText = "This creature enters tapped."
+    power = 1
+    toughness = 13
+    replacementEffect(EntersTapped())
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "135"
+        artist = "Nicholas Gregory"
+        flavorText = "\"In case any of you new recruits were wondering, this is why we don't use mass graves anymore.\"\n—Kerren of the Mausoleum Guards"
+        imageUri = "https://cards.scryfall.io/normal/front/d/5/d5ec541b-1799-4c0e-a3fb-c008cf2eb911.jpg?1782703092"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/UnholyOfficiant.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/UnholyOfficiant.kt
@@ -1,0 +1,38 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Unholy Officiant
+ * {W}
+ * Creature — Vampire Cleric
+ * 1/2
+ * Vigilance
+ * {4}{W}: Put a +1/+1 counter on this creature.
+ */
+val UnholyOfficiant = card("Unholy Officiant") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Vampire Cleric"
+    oracleText = "Vigilance\n{4}{W}: Put a +1/+1 counter on this creature."
+    power = 1
+    toughness = 2
+    keywords(Keyword.VIGILANCE)
+    activatedAbility {
+        cost = Costs.Mana("{4}{W}")
+        effect = AddCountersEffect(counterType = Counters.PLUS_ONE_PLUS_ONE, count = 1, target = EffectTarget.Self)
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "41"
+        artist = "Campbell White"
+        flavorText = "\"Is this twisted ceremony simply a mockery of the human rite, or has Olivia fallen for her own charade?\"\n—Sorin Markov"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8a4c04a4-e68b-4d3d-89c8-29cdaaac36b2.jpg?1782703165"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ValorousStanceReprint.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ValorousStanceReprint.kt
@@ -1,0 +1,24 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.model.Printing
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Valorous Stance reprint in VOW.
+ *
+ * The canonical [com.wingedsheep.sdk.model.CardDefinition] (script, types) lives in FRF's
+ * `cards/` package (the card's earliest real printing). This file contributes only the
+ * VOW-specific presentation row — set, collector number, art — picked up automatically by
+ * `CardDiscovery.findPrintingsIn` and surfaced via the set's `printings`.
+ */
+val ValorousStanceReprint = Printing(
+    oracleId = "1f938353-9081-4dc1-b8e7-d18ece038bd4",
+    name = "Valorous Stance",
+    setCode = "VOW",
+    collectorNumber = "42",
+    scryfallId = "0e6b9a3b-8a19-4094-8dbb-08a0a9ca04a0",
+    artist = "Anato Finnstark",
+    imageUri = "https://cards.scryfall.io/normal/front/0/e/0e6b9a3b-8a19-4094-8dbb-08a0a9ca04a0.jpg?1782703164",
+    releaseDate = "2021-11-19",
+    rarity = Rarity.UNCOMMON,
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/VampiresKiss.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/VampiresKiss.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+
+/**
+ * Vampire's Kiss
+ * {1}{B}
+ * Sorcery
+ *
+ * Target player loses 2 life and you gain 2 life. Create two Blood tokens.
+ */
+val VampiresKiss = card("Vampire's Kiss") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Target player loses 2 life and you gain 2 life. Create two Blood tokens. (They're " +
+        "artifacts with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        val t = target("target", TargetPlayer())
+        effect = Effects.Composite(
+            Effects.LoseLife(2, t),
+            Effects.GainLife(2, EffectTarget.Controller),
+            Effects.CreateBlood(2)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "136"
+        artist = "Ilse Gort"
+        flavorText = "Young vampires gorge themselves at every meal, but their elders have learned to savor the smallest bite."
+        imageUri = "https://cards.scryfall.io/normal/front/9/7/974bf8cc-4259-48cc-8e7f-1580bb010d3f.jpg?1782703092"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/VampiresVengeance.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/VampiresVengeance.kt
@@ -1,0 +1,44 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Vampires' Vengeance
+ * {2}{R}
+ * Instant
+ *
+ * Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token.
+ */
+val VampiresVengeance = card("Vampires' Vengeance") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Instant"
+    oracleText = "Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood " +
+        "token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")"
+
+    spell {
+        effect = Effects.Composite(
+            Patterns.Group.dealDamageToAll(
+                2,
+                GroupFilter(GameObjectFilter.Creature.notSubtype(Subtype.VAMPIRE))
+            ),
+            Effects.CreateBlood(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "339"
+        artist = "Dave Kendall"
+        flavorText = "She was ghastly, chalkily pale; the red seemed to have gone even from her lips " +
+            "and gums, and the bones of her face stood out prominently; her breathing was painful " +
+            "to see or hear."
+        imageUri = "https://cards.scryfall.io/normal/front/9/f/9f4ba693-0323-415d-ad91-c083fbbab7f7.jpg?1782702951"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WanderlightSpirit.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WanderlightSpirit.kt
@@ -1,0 +1,35 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Wanderlight Spirit
+ * {2}{U}
+ * Creature — Spirit
+ * 2/3
+ * Flying
+ * This creature can block only creatures with flying.
+ */
+val WanderlightSpirit = card("Wanderlight Spirit") {
+    manaCost = "{2}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Spirit"
+    oracleText = "Flying\nThis creature can block only creatures with flying."
+    power = 2
+    toughness = 3
+    keywords(Keyword.FLYING)
+    staticAbility {
+        ability = CanOnlyBlockCreaturesWith(blockerFilter = GameObjectFilter.Creature.withKeyword(Keyword.FLYING))
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "86"
+        artist = "Andrew Mar"
+        flavorText = "The towers and catwalks of the Voldaren fortress are lit by the lanterns of geists endlessly seeking a way out."
+        imageUri = "https://cards.scryfall.io/normal/front/7/b/7bb3ce5d-330d-427e-a053-8cc4eeb2941b.jpg?1782703131"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WeddingInvitation.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WeddingInvitation.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.Duration
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.ConditionalEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wedding Invitation
+ * {2}
+ * Artifact
+ *
+ * When this artifact enters, draw a card.
+ * {T}, Sacrifice this artifact: Target creature can't be blocked this turn. If it's a Vampire,
+ * it also gains lifelink until end of turn.
+ */
+val WeddingInvitation = card("Wedding Invitation") {
+    manaCost = "{2}"
+    colorIdentity = ""
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, draw a card.\n" +
+        "{T}, Sacrifice this artifact: Target creature can't be blocked this turn. If it's a " +
+        "Vampire, it also gains lifelink until end of turn."
+
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.DrawCards(1)
+    }
+
+    activatedAbility {
+        cost = Costs.Composite(Costs.Tap, Costs.SacrificeSelf)
+        val creature = target("target creature", Targets.Creature)
+        effect = Effects.Composite(
+            Effects.GrantKeyword(AbilityFlag.CANT_BE_BLOCKED, creature, Duration.EndOfTurn),
+            ConditionalEffect(
+                condition = Conditions.TargetMatchesFilter(
+                    GameObjectFilter.Creature.withSubtype(Subtype("Vampire"))
+                ),
+                effect = Effects.GrantKeyword(Keyword.LIFELINK, creature, Duration.EndOfTurn),
+            ),
+        )
+        description = "{T}, Sacrifice this artifact: Target creature can't be blocked this turn. " +
+            "If it's a Vampire, it also gains lifelink until end of turn."
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "260"
+        artist = "Justyna Dura"
+        flavorText = "RSVP at your own risk."
+        imageUri = "https://cards.scryfall.io/normal/front/d/d/ddc22ff6-4081-47ce-bc8a-e063f5f4d044.jpg?1782703014"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WeddingSecurity.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WeddingSecurity.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.Gate
+import com.wingedsheep.sdk.scripting.effects.GatedEffect
+import com.wingedsheep.sdk.scripting.effects.SacrificeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Wedding Security
+ * {3}{B}{B}
+ * Creature — Vampire Soldier
+ * 4/4
+ *
+ * Whenever this creature attacks, you may sacrifice a Blood token. If you do, put a +1/+1 counter
+ * on this creature and draw a card.
+ *
+ * Attack trigger with an optional Blood-sacrifice gate ([Gate.MayPay] over a Blood
+ * [SacrificeEffect], the Bloodcrazed Socialite idiom); paying puts a +1/+1 counter on the attacker
+ * and draws a card.
+ */
+val WeddingSecurity = card("Wedding Security") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Vampire Soldier"
+    power = 4
+    toughness = 4
+    oracleText = "Whenever this creature attacks, you may sacrifice a Blood token. If you do, put " +
+        "a +1/+1 counter on this creature and draw a card."
+
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        effect = GatedEffect(
+            gate = Gate.MayPay(SacrificeEffect(filter = GameObjectFilter.Artifact.withSubtype("Blood"))),
+            then = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)
+                .then(Effects.DrawCards(1))
+        )
+        description = "Whenever this creature attacks, you may sacrifice a Blood token. If you do, " +
+            "put a +1/+1 counter on this creature and draw a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "299"
+        artist = "Vi Szendrey (Cashile)"
+        imageUri = "https://cards.scryfall.io/normal/front/2/0/20b1a617-96bf-4960-bffe-dddf3a3c1868.jpg?1782702985"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WelcomingVampire.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WelcomingVampire.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TriggerBinding
+import com.wingedsheep.sdk.scripting.effects.DrawCardsEffect
+
+/**
+ * Welcoming Vampire
+ * {2}{W}
+ * Creature — Vampire
+ * 2/3
+ * Flying
+ * Whenever one or more other creatures you control with power 2 or less enter, draw a card.
+ * This ability triggers only once each turn.
+ */
+val WelcomingVampire = card("Welcoming Vampire") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Vampire"
+    oracleText = "Flying\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn."
+    power = 2
+    toughness = 3
+    keywords(Keyword.FLYING)
+    triggeredAbility {
+        trigger = Triggers.entersBattlefield(
+            filter = GameObjectFilter.Creature.powerAtMost(2).youControl(),
+            binding = TriggerBinding.OTHER
+        )
+        oncePerTurn = true
+        effect = DrawCardsEffect(1)
+    }
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "46"
+        artist = "Lorenzo Mastroianni"
+        flavorText = "From the moment they arrived, wedding guests were met with a pageant of wealth and excess."
+        imageUri = "https://cards.scryfall.io/normal/front/d/8/d8f69cea-823c-482b-a605-8138b3d950e6.jpg?1782703161"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WhisperingWizard.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WhisperingWizard.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Whispering Wizard
+ * {3}{U}
+ * Creature — Human Wizard
+ * 3/2
+ * Whenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying.
+ * This ability triggers only once each turn.
+ */
+val WhisperingWizard = card("Whispering Wizard") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Human Wizard"
+    oracleText = "Whenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying. This ability triggers only once each turn."
+    power = 3
+    toughness = 2
+    triggeredAbility {
+        trigger = Triggers.YouCastNoncreature
+        oncePerTurn = true
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.WHITE),
+            creatureTypes = setOf("Spirit"),
+            keywords = setOf(Keyword.FLYING)
+        )
+    }
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "88"
+        artist = "E. M. Gist"
+        flavorText = "Ivold was aghast when his device revealed the full scope of the geist infestation."
+        imageUri = "https://cards.scryfall.io/normal/front/5/4/54fb422d-71f2-44ed-9589-32630ab87050.jpg?1782703130"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WitchsWeb.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WitchsWeb.kt
@@ -1,0 +1,36 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Witch's Web
+ * {1}{G}
+ * Instant
+ * Target creature gets +3/+3 and gains reach until end of turn. Untap it.
+ */
+val WitchsWeb = card("Witch's Web") {
+    manaCost = "{1}{G}"
+    colorIdentity = "G"
+    typeLine = "Instant"
+    oracleText = "Target creature gets +3/+3 and gains reach until end of turn. Untap it."
+    spell {
+        val t = target("target", TargetCreature(filter = TargetFilter.Creature))
+        effect = Effects.Composite(
+            Effects.ModifyStats(3, 3, t),
+            Effects.GrantKeyword(Keyword.REACH, t),
+            Effects.Untap(t)
+        )
+    }
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "227"
+        artist = "Yeong-Hao Han"
+        flavorText = "Ever since the ritual, Ryla didn't have an appetite at the dinner table, but her long walks in the forest always seemed to satiate her hunger."
+        imageUri = "https://cards.scryfall.io/normal/front/0/d/0d021207-76be-4bc9-bb71-df991a04d8d8.jpg?1782703032"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -70,6 +70,358 @@
     ]
 }
 
+// Angelic Quartermaster
+{
+    "name": "Angelic Quartermaster",
+    "manaCost": "{3}{W}{W}",
+    "typeLine": "Creature — Angel Soldier",
+    "oracleText": "Flying\nWhen this creature enters, put a +1/+1 counter on each of up to two other target creatures.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "AddCounters",
+                        "counterType": "+1/+1",
+                        "count": 1,
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "count": 2,
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature",
+                        "excludeSelf": true
+                    },
+                    "id": "up to two other target creatures"
+                },
+                "descriptionOverride": "When this creature enters, put a +1/+1 counter on each of up to two other target creatures."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "2",
+        "rarity": "UNCOMMON",
+        "artist": "PINDURSKI",
+        "flavorText": "\"Stand strong. We will reclaim the dawn.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/1/41d81b88-c19b-4148-89ba-ae8fb53843e1.jpg?1782703194"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Arm the Cathars
+{
+    "name": "Arm the Cathars",
+    "manaCost": "{1}{W}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Until end of turn, target creature gets +3/+3, up to one other target creature gets +2/+2, and up to one other target creature gets +1/+1. Those creatures gain vigilance until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one other target creature (+2/+2)"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one other target creature (+2/+2)"
+                    }
+                },
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one other target creature (+1/+1)"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "VIGILANCE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "up to one other target creature (+1/+1)"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            },
+            {
+                "type": "TargetOther",
+                "baseRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "id": "up to one other target creature (+2/+2)"
+            },
+            {
+                "type": "TargetOther",
+                "baseRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature"
+                    }
+                },
+                "id": "up to one other target creature (+1/+1)"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "3",
+        "rarity": "UNCOMMON",
+        "artist": "Zoltan Boros",
+        "flavorText": "Faith is a cathar's greatest weapon, but a sword of blessed silver is a close second.",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/2004a20c-e434-4691-8ef2-740846ce6a51.jpg?1782703194"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Belligerent Guest
+{
+    "name": "Belligerent Guest",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nWhenever this creature deals combat damage to a player, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAMPLE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "301",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/2/924b1c15-811a-4d11-a481-f904002a6740.jpg?1782702983"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Bleed Dry
+{
+    "name": "Bleed Dry",
+    "manaCost": "{2}{B}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets -13/-13 until end of turn. If that creature would die this turn, exile it instead.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": -13
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": -13
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "MarkExileOnDeath",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "94",
+        "artist": "Jodie Muir",
+        "flavorText": "\"Wipe your chin, child. We can't have Olivia thinking we're uncivilized.\"\n—Anje Falkenrath",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/d/3db65755-f104-4de9-bcc9-0a4a7bc66b51.jpg?1782703123"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Blood Fountain
+{
+    "name": "Blood Fountain",
+    "manaCost": "{B}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")\n{3}{B}, {T}, Sacrifice this artifact: Return up to two target creature cards from your graveyard to your hand.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{B}"
+                            }
+                        },
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "ForEach",
+                    "space": "IterationSpace.Targets",
+                    "body": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Hand"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "count": 2,
+                        "optional": true,
+                        "filter": {
+                            "baseFilter": "creature own:you",
+                            "zone": "Graveyard"
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "95",
+        "artist": "Evyn Fong",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/dd03651e-ada0-41dc-8722-0eba476943e3.jpg?1782703122"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Blood Petal Celebrant
 {
     "name": "Blood Petal Celebrant",
@@ -121,6 +473,104 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Blood Servitor
+{
+    "name": "Blood Servitor",
+    "manaCost": "{3}",
+    "typeLine": "Artifact Creature — Construct",
+    "oracleText": "When this creature enters, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "252",
+        "artist": "Jason A. Engle",
+        "flavorText": "\"Please, my friends, help yourselves to the help.\"\n—Olivia Voldaren",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/7/87845cc2-bf5d-491d-bfa2-b33b034557a4.jpg?1782703017"
+    },
+    "colorIdentityOverride": []
+}
+
+// Bloodcrazed Socialite
+{
+    "name": "Bloodcrazed Socialite",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Menace\nWhen this creature enters, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")\nWhenever this creature attacks, you may sacrifice a Blood token. If you do, it gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "artifact Blood"
+                        }
+                    },
+                    "then": {
+                        "type": "ModifyStats",
+                        "powerModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "toughnessModifier": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "288",
+        "artist": "Samuel Araya",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/d/9df22639-7e98-43a1-801e-cbf882558c53.jpg?1782702993"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -204,6 +654,66 @@
     },
     "colorIdentityOverride": [
         "BLACK",
+        "RED"
+    ]
+}
+
+// Bloody Betrayal
+{
+    "name": "Bloody Betrayal",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GainControl",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "duration": "EndOfTurn"
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    },
+                    "tap": false
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "HASTE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target creature"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "147",
+        "artist": "Brian Valeza",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/9/8970a5d6-dcab-415a-851b-20e228ef7d16.jpg?1782703085"
+    },
+    "colorIdentityOverride": [
         "RED"
     ]
 }
@@ -392,6 +902,163 @@
     ]
 }
 
+// Courier Bat
+{
+    "name": "Courier Bat",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Bat",
+    "oracleText": "Flying\nWhen this creature enters, if you gained life this turn, return up to one target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Hand"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature own:you",
+                        "zone": "Graveyard"
+                    },
+                    "id": "target"
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "102",
+        "artist": "Ilse Gort",
+        "flavorText": "Swarms of bats poured from Lurenbraum Fortress carrying wedding invitations to vampires of every bloodline.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/d/4d9a8dc7-1ee9-4731-bd72-3d02f4e7c6c4.jpg?1782703119"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Cradle of Safety
+{
+    "name": "Cradle of Safety",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Flash\nEnchant creature you control\nWhen this Aura enters, enchanted creature gains hexproof until end of turn. (It can't be the target of spells or abilities your opponents control.)\nEnchanted creature gets +1/+1.",
+    "keywords": [
+        "FLASH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "HEXPROOF",
+                    "target": "EnchantedCreature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature ctrl:you"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "54",
+        "artist": "Howard Lyon",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/2/42cbad81-152a-435f-9289-f4b6483a059b.jpg?1782703156"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Cruel Witness
+{
+    "name": "Cruel Witness",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Bird Horror",
+    "oracleText": "Flying\nWhenever you cast a noncreature spell, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Surveil",
+                    "count": 1
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "55",
+        "artist": "Vincent Proce",
+        "flavorText": "\"I escaped, so why do I still feel like I'm being watched?\"\n—Gregel, militia leader",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/b/5bf2c686-efb0-46c7-b34e-c77987914b96.jpg?1782703154"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dawnhart Disciple
 {
     "name": "Dawnhart Disciple",
@@ -435,6 +1102,108 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Dawnhart Geist
+{
+    "name": "Dawnhart Geist",
+    "manaCost": "{1}{W}",
+    "typeLine": "Creature — Spirit Warlock",
+    "oracleText": "Whenever you cast an enchantment spell, you gain 2 life.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsEnchantment"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "8",
+        "rarity": "UNCOMMON",
+        "artist": "Artur Treffner",
+        "flavorText": "\"Our bodies may lie slain, but perhaps we can still complete the ritual. I'd rather not spend my afterlife in this wretched eternal night.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/1/a1d27617-2d3d-44a1-b93f-0694253b6774.jpg?1782703191"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Daybreak Combatants
+{
+    "name": "Daybreak Combatants",
+    "manaCost": "{2}{R}",
+    "typeLine": "Creature — Human Warrior",
+    "oracleText": "Haste (This creature can attack and {T} as soon as it comes under your control.)\nWhen this creature enters, target creature gets +2/+0 until end of turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 0
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "153",
+        "artist": "Joshua Raphael",
+        "flavorText": "After weeks of unending darkness, a glimpse of dawn was all the people of Stensia needed to rekindle their will to fight.",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/6/8697a861-0f67-4ed3-bed8-f264fc78565e.jpg?1782703080"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -505,6 +1274,101 @@
     ]
 }
 
+// Diregraf Scavenger
+{
+    "name": "Diregraf Scavenger",
+    "manaCost": "{3}{B}",
+    "typeLine": "Creature — Zombie Bear",
+    "oracleText": "Deathtouch\nWhen this creature enters, exile up to one target card from a graveyard. If a creature card was exiled this way, each opponent loses 2 life and you gain 2 life.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": "ChosenTargets",
+                            "storeAs": "diregraf_exiled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "diregraf_exiled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "ConditionalOnCollection",
+                            "collection": "diregraf_exiled",
+                            "ifNotEmpty": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "LoseLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        },
+                                        "target": {
+                                            "type": "PlayerRef",
+                                            "player": "EachOpponent"
+                                        }
+                                    },
+                                    {
+                                        "type": "GainLife",
+                                        "amount": {
+                                            "type": "Fixed",
+                                            "amount": 2
+                                        }
+                                    }
+                                ]
+                            },
+                            "ifEmpty": {
+                                "type": "Composite",
+                                "effects": []
+                            },
+                            "filter": "creature"
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "up to one target card from a graveyard"
+                },
+                "descriptionOverride": "When this creature enters, exile up to one target card from a graveyard. If a creature card was exiled this way, each opponent loses 2 life and you gain 2 life."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "105",
+        "artist": "Manuel Castañón",
+        "flavorText": "It can barely feel the sword anymore.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f72eb127-3f4c-42ed-8ba6-b6d83ea18545.jpg?1782703116"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Dreamroot Cascade
 {
     "name": "Dreamroot Cascade",
@@ -572,6 +1436,442 @@
     ]
 }
 
+// End the Festivities
+{
+    "name": "End the Festivities",
+    "manaCost": "{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "End the Festivities deals 1 damage to each opponent and each creature and planeswalker they control.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                },
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": "creature|planeswalker ctrl:opponent"
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 1
+                        },
+                        "target": "Self"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Chris Rallis",
+        "flavorText": "When the defenses around Lurenbraum Fortress faltered, the Crimson Ballroom received some unexpected guests.",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/e/bec748e6-7245-4a71-aeee-cefed8346948.jpg?1782703079"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Estwald Shieldbasher
+{
+    "name": "Estwald Shieldbasher",
+    "manaCost": "{3}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "Whenever this creature attacks, you may pay {1}. If you do, it gains indestructible until end of turn.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{1}"
+                        }
+                    },
+                    "then": {
+                        "type": "GrantKeyword",
+                        "keyword": "INDESTRUCTIBLE",
+                        "target": "Self"
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may pay {1}. If you do, it gains indestructible until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "11",
+        "artist": "Wayne Reynolds",
+        "flavorText": "The door to her home survived the fires of the Malignus. Now it's her greatest weapon.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/1/61c7d889-8cc0-4e80-b6d5-d41961820224.jpg?1782703190"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Falkenrath Celebrants
+{
+    "name": "Falkenrath Celebrants",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Menace (This creature can't be blocked except by two or more creatures.)\nWhen this creature enters, create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood",
+                    "count": 2
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "306",
+        "artist": "Zinna Du",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/a/6aacc8fa-9440-494b-a3d9-7b1678c5a9f6.jpg?1782702979"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Falkenrath Forebear
+{
+    "name": "Falkenrath Forebear",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Flying\nThis creature can't block.\nWhenever this creature deals combat damage to a player, create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")\n{B}, Sacrifice two Blood tokens: Return this card from your graveyard to the battlefield.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "DealsDamageEvent",
+                    "damageType": "DamageCombat",
+                    "recipient": "AnyPlayer"
+                },
+                "effect": {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{B}"
+                            }
+                        },
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomSacrifice",
+                                "filter": "artifact Blood",
+                                "count": 2
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Battlefield"
+                },
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "{B}, Sacrifice two Blood tokens: Return this card from your graveyard to the battlefield."
+            }
+        ],
+        "staticAbilities": [
+            "CantBlock"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "334",
+        "rarity": "RARE",
+        "artist": "Greg Staples",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48d43ab9-772d-4f4d-8536-3ea60e8f9f82.jpg?1782702954"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Fear of Death
+{
+    "name": "Fear of Death",
+    "manaCost": "{1}{U}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, mill two cards. (Put the top two cards of your library into your graveyard.)\nEnchanted creature gets -X/-0, where X is the number of cards in your graveyard.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 2
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "GrantDynamicStats",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                },
+                "powerBonus": {
+                    "type": "Multiply",
+                    "amount": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard"
+                    },
+                    "multiplier": -1
+                },
+                "toughnessBonus": {
+                    "type": "Fixed",
+                    "amount": 0
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "59",
+        "artist": "Anato Finnstark",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/8/b81704d2-d555-4894-b36c-6b65d1ebe681.jpg?1782703150"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Flame-Blessed Bolt
+{
+    "name": "Flame-Blessed Bolt",
+    "manaCost": "{R}",
+    "typeLine": "Instant",
+    "oracleText": "Flame-Blessed Bolt deals 2 damage to target creature or planeswalker. If that creature or planeswalker would die this turn, exile it instead.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "MarkExileOnDeath",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "158",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "\"I noticed you were short on party favors, so I brought my own.\"\n—Higa, slayer-captain of Gatstaf",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/1/b1771a8f-7bea-4bb0-9949-566ee6613b93.jpg?1782703077"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Flourishing Hunter
+{
+    "name": "Flourishing Hunter",
+    "manaCost": "{4}{G}{G}",
+    "typeLine": "Creature — Wolf Spirit",
+    "oracleText": "When this creature enters, you gain life equal to the greatest toughness among other creatures you control.",
+    "creatureStats": {
+        "power": 6,
+        "toughness": 6
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "AggregateBattlefield",
+                        "player": "You",
+                        "filter": "creature",
+                        "aggregation": "MAX",
+                        "property": "TOUGHNESS",
+                        "excludeSelf": true
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you gain life equal to the greatest toughness among other creatures you control."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "199",
+        "artist": "Ilse Gort",
+        "flavorText": "\"I would welcome her into my pack with honor.\"\n—Arlinn Kord",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/a/2abc54df-773d-4f46-b241-e1f42af8ab95.jpg?1782703051"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Frenzied Devils
+{
+    "name": "Frenzied Devils",
+    "manaCost": "{4}{R}",
+    "typeLine": "Creature — Devil",
+    "oracleText": "Haste\nWhenever you cast a noncreature spell, this creature gets +2/+2 until end of turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "HASTE"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "159",
+        "rarity": "UNCOMMON",
+        "artist": "Andrey Kuzinskiy",
+        "flavorText": "\"Devils need no reason to stir up chaos. The chaos itself is their reward.\"\n—Rem Karolus, Fiendslayer",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/7/b7912206-6de3-4085-b5f6-a2e90ea55b90.jpg?1782703077"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Geistlight Snare
 {
     "name": "Geistlight Snare",
@@ -635,6 +1935,60 @@
     ]
 }
 
+// Gift of Fangs
+{
+    "name": "Gift of Fangs",
+    "manaCost": "{B}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature gets +2/+2 as long as it's a Vampire. Otherwise, it gets -2/-2.",
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2
+                },
+                "condition": {
+                    "type": "EnchantedCreatureHasSubtype",
+                    "subtype": "Vampire"
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": -2,
+                    "toughnessBonus": -2
+                },
+                "condition": {
+                    "type": "Not",
+                    "condition": {
+                        "type": "EnchantedCreatureHasSubtype",
+                        "subtype": "Vampire"
+                    }
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "113",
+        "artist": "Dominik Mayer",
+        "flavorText": "\"You are one of the few to whom we offer our blessing. What fool would reject immortality?\"\n—Runo Stromkirk",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/8/a864375f-99c3-4c68-9440-bc25ff6d0dc0.jpg?1782703111"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Gluttonous Guest
 {
     "name": "Gluttonous Guest",
@@ -679,6 +2033,50 @@
         "collectorNumber": "114",
         "artist": "Jesper Ejsing",
         "imageUri": "https://cards.scryfall.io/normal/front/1/8/18c07288-1c71-4e71-bdf5-910eb583a1d8.jpg?1782703110"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Grisly Ritual
+{
+    "name": "Grisly Ritual",
+    "manaCost": "{5}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target creature or planeswalker. Create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "116",
+        "artist": "Anastasia Ovchinnikova",
+        "flavorText": "\"You can always tell who's new from the screaming.\"\n—Tinua, Skirsdag cultist",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/53cdf2ab-3acd-49bd-8273-84c1cfc92883.jpg?1782703107"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -755,6 +2153,188 @@
         "RED",
         "GREEN"
     ]
+}
+
+// Headless Rider
+{
+    "name": "Headless Rider",
+    "manaCost": "{2}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Whenever this creature or another nontoken Zombie you control dies, create a 2/2 black Zombie creature token.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature Zombie nontoken ctrl:you",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 2,
+                    "toughness": 2,
+                    "colors": [
+                        "BLACK"
+                    ],
+                    "creatureTypes": [
+                        "Zombie"
+                    ]
+                },
+                "descriptionOverride": "Whenever this creature or another nontoken Zombie you control dies, create a 2/2 black Zombie creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "372",
+        "rarity": "RARE",
+        "artist": "E. M. Gist",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/544d7162-b78f-4a70-86e7-83cec7062039.jpg?1782702926"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Heron-Blessed Geist
+{
+    "name": "Heron-Blessed Geist",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\n{3}{W}, Exile this card from your graveyard: Create two 1/1 white Spirit creature tokens with flying. Activate only if you control an enchantment and only as a sorcery.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
+                        },
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "timing": "SorcerySpeed",
+                "restrictions": [
+                    {
+                        "type": "ActivationOnlyIfCondition",
+                        "condition": {
+                            "type": "Exists",
+                            "player": "You",
+                            "zone": "Battlefield",
+                            "filter": "enchantment"
+                        }
+                    }
+                ],
+                "activateFromZone": "Graveyard",
+                "descriptionOverride": "{3}{W}, Exile this card from your graveyard: Create two 1/1 white Spirit creature tokens with flying. Activate only if you control an enchantment and only as a sorcery."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "19",
+        "artist": "Jason A. Engle",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/3/83bacf4a-4e99-4008-97e4-3a82dddd4e45.jpg?1782703183"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Honored Heirloom
+{
+    "name": "Honored Heirloom",
+    "manaCost": "{3}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Add one mana of any color.\n{2}, {T}: Exile target card from a graveyard.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {},
+                            "zone": "Graveyard"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "257",
+        "artist": "Leanna Crossan",
+        "flavorText": "After the Travails, Runechanters set about repairing twisted symbols of Avacyn as the first step in restoring faith in the Church.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/3/d3390e4d-9137-40ff-b998-bdb19c90b7d5.jpg?1782703014"
+    },
+    "colorIdentityOverride": []
 }
 
 // Hullbreaker Horror
@@ -946,6 +2526,469 @@
     ]
 }
 
+// Kessig Flamebreather
+{
+    "name": "Kessig Flamebreather",
+    "manaCost": "{1}{R}",
+    "typeLine": "Creature — Human Shaman",
+    "oracleText": "Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "164",
+        "artist": "Lius Lasahido",
+        "flavorText": "\"Hunter's fire\" was meant for slaying monsters in the Ulvenwald, but that never stopped Ralen from showing it off.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/0/303ad78a-b02a-44dc-afe6-7f95781a5062.jpg?1782703073"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Kessig Wolfrider
+{
+    "name": "Kessig Wolfrider",
+    "manaCost": "{R}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Menace\n{2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "MENACE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomExileFrom",
+                                "zone": "Graveyard",
+                                "count": 3
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 3,
+                    "toughness": 2,
+                    "colors": [
+                        "RED"
+                    ],
+                    "creatureTypes": [
+                        "Wolf"
+                    ]
+                },
+                "descriptionOverride": "{2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "165",
+        "rarity": "RARE",
+        "artist": "Bram Sels",
+        "flavorText": "\"It's a perfect partnership. My village is safe from wolf attacks, and she gets to eat any vampires we catch.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/8/180b1a4f-c071-4742-9c57-9d775be0ed4f.jpg?1782703072"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Lantern of the Lost
+{
+    "name": "Lantern of the Lost",
+    "manaCost": "{1}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, exile target card from a graveyard.\n{1}, {T}, Exile this artifact: Exile all cards from all graveyards, then draw a card.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target card in a graveyard"
+                    },
+                    "destination": "Exile"
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": {},
+                        "zone": "Graveyard"
+                    },
+                    "id": "target card in a graveyard"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{1}"
+                            }
+                        },
+                        "CostTap",
+                        "CostExileSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "FromZone",
+                                "zone": "Graveyard",
+                                "player": "Each"
+                            },
+                            "storeAs": "allGraveyards"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "allGraveyards",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Exile"
+                            }
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "{1}, {T}, Exile this artifact: Exile all cards from all graveyards, then draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "259",
+        "rarity": "UNCOMMON",
+        "artist": "Chris Cold",
+        "imageUri": "https://cards.scryfall.io/normal/front/c/2/c2303f11-2c82-44d5-893a-8e71dece7746.jpg?1782703014"
+    },
+    "colorIdentityOverride": []
+}
+
+// Lightning Wolf
+{
+    "name": "Lightning Wolf",
+    "manaCost": "{3}{R}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "{1}{R}: This creature gains first strike until end of turn. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}{R}"
+                    }
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "FIRST_STRIKE",
+                    "target": "Self"
+                },
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "168",
+        "artist": "Alessandra Pisano",
+        "flavorText": "These thick-furred wolves have adapted to Stensia's storms, channeling their energy into bursts of supernatural speed.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/2/7211e4c3-e940-41da-88e4-4630eab447a6.jpg?1782703071"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Markov Purifier
+{
+    "name": "Markov Purifier",
+    "manaCost": "{1}{W}{B}",
+    "typeLine": "Creature — Vampire Cleric",
+    "oracleText": "Lifelink\nAt the beginning of your end step, if you gained life this turn, you may pay {2}. If you do, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "LIFELINK"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "END"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "PayManaCost",
+                            "cost": "{2}"
+                        }
+                    },
+                    "then": {
+                        "type": "DrawCards",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "TurnTracking",
+                        "player": "You",
+                        "tracker": "LIFE_GAINED"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "At the beginning of your end step, if you gained life this turn, you may pay {2}. If you do, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "312",
+        "rarity": "UNCOMMON",
+        "artist": "Samuel Araya",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/533673f3-5e18-4630-bd71-001774d698a8.jpg?1782702974"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLACK"
+    ]
+}
+
+// Markov Retribution
+{
+    "name": "Markov Retribution",
+    "manaCost": "{2}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Choose one or both —\n• Creatures you control get +1/+0 until end of turn.\n• Target Vampire you control deals damage equal to its power to another target creature.",
+    "script": {
+        "spellEffect": {
+            "type": "Modal",
+            "modes": [
+                {
+                    "effect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Group",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            }
+                        },
+                        "body": {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": "Self"
+                        }
+                    },
+                    "description": "Creatures you control get +1/+0 until end of turn"
+                },
+                {
+                    "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "EntityProperty",
+                            "entity": "Target",
+                            "numericProperty": "Power"
+                        },
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "another target creature"
+                        },
+                        "damageSource": {
+                            "type": "BoundVariable",
+                            "name": "target Vampire you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature Vampire ctrl:you"
+                            },
+                            "id": "target Vampire you control"
+                        },
+                        {
+                            "type": "TargetOther",
+                            "baseRequirement": {
+                                "type": "TargetObject",
+                                "filter": {
+                                    "baseFilter": "creature"
+                                }
+                            },
+                            "id": "another target creature"
+                        }
+                    ],
+                    "description": "Target Vampire you control deals damage equal to its power to another target creature"
+                },
+                {
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "ForEach",
+                                "space": {
+                                    "type": "IterationSpace.Group",
+                                    "filter": {
+                                        "baseFilter": "creature ctrl:you"
+                                    }
+                                },
+                                "body": {
+                                    "type": "ModifyStats",
+                                    "powerModifier": {
+                                        "type": "Fixed",
+                                        "amount": 1
+                                    },
+                                    "toughnessModifier": {
+                                        "type": "Fixed",
+                                        "amount": 0
+                                    },
+                                    "target": "Self"
+                                }
+                            },
+                            {
+                                "type": "DealDamage",
+                                "amount": {
+                                    "type": "EntityProperty",
+                                    "entity": "Target",
+                                    "numericProperty": "Power"
+                                },
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "another target creature"
+                                },
+                                "damageSource": {
+                                    "type": "BoundVariable",
+                                    "name": "target Vampire you control"
+                                }
+                            }
+                        ]
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature Vampire ctrl:you"
+                            },
+                            "id": "target Vampire you control"
+                        },
+                        {
+                            "type": "TargetOther",
+                            "baseRequirement": {
+                                "type": "TargetObject",
+                                "filter": {
+                                    "baseFilter": "creature"
+                                }
+                            },
+                            "id": "another target creature"
+                        }
+                    ],
+                    "description": "Creatures you control get +1/+0 until end of turn and target Vampire you control deals damage equal to its power to another target creature"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "171",
+        "rarity": "UNCOMMON",
+        "artist": "Uriah Voth",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/8/48d3840c-db27-4512-bfe3-92249094e5b4.jpg?1782703070"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // Markov Waltzer
 {
     "name": "Markov Waltzer",
@@ -1010,6 +3053,116 @@
     "colorIdentityOverride": [
         "WHITE",
         "RED"
+    ]
+}
+
+// Massive Might
+{
+    "name": "Massive Might",
+    "manaCost": "{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +2/+2 and gains trample until end of turn.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "208",
+        "artist": "Iris Compiet",
+        "flavorText": "\"Run! It's coming for us! Eventually!\"\n—Yaster, Havengul shopkeeper",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/a/3a5cd50b-4825-4d85-b0f9-e2a51d2a7df1.jpg?1782703046"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Militia Rallier
+{
+    "name": "Militia Rallier",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "This creature can't attack alone.\nWhenever this creature attacks, untap target creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "tap": false
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature"
+                    },
+                    "id": "creature"
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttackUnlessCoAttacker",
+                "coAttackerFilter": {
+                    "cardPredicates": [
+                        "IsCreature"
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "24",
+        "artist": "Eelis Kyttanen",
+        "flavorText": "\"We can wait like helpless children for a hero, or we can gather our courage and be the heroes. Who's with me?\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/51b3ff40-3185-4369-985e-17613bb6ad22.jpg?1782703178"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
     ]
 }
 
@@ -1086,6 +3239,63 @@
     ]
 }
 
+// Nebelgast Beguiler
+{
+    "name": "Nebelgast Beguiler",
+    "manaCost": "{4}{W}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "{W}, {T}: Tap target creature.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{W}"
+                            }
+                        },
+                        "CostTap"
+                    ]
+                },
+                "effect": {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "25",
+        "artist": "Andreas Zafiratos",
+        "flavorText": "A moment of distraction, an hour off course.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/4/04c68dbd-e61b-49a7-aa17-da6b26c9fd29.jpg?1782703176"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Necroduality
 {
     "name": "Necroduality",
@@ -1117,6 +3327,587 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Ollenbock Escort
+{
+    "name": "Ollenbock Escort",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "Vigilance\nSacrifice this creature: Target creature you control with a +1/+1 counter on it gains lifelink and indestructible until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostSacrificeSelf",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "LIFELINK",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "INDESTRUCTIBLE",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature"
+                                ],
+                                "statePredicates": [
+                                    {
+                                        "type": "HasCounter",
+                                        "counterType": "+1/+1"
+                                    }
+                                ],
+                                "controllerPredicate": "ControlledByYou"
+                            }
+                        },
+                        "id": "target"
+                    }
+                ]
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "27",
+        "rarity": "UNCOMMON",
+        "artist": "Eric Wilkerson",
+        "flavorText": "\"Stay in the light. I don't know what lurks in those shadows, and I'd like to keep it that way.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7a659bf-9d85-4011-980e-c3a8dc4513e9.jpg?1782703176"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Packsong Pup
+{
+    "name": "Packsong Pup",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "At the beginning of combat on your turn, if you control another Wolf or Werewolf, put a +1/+1 counter on this creature.\nWhen this creature dies, you gain life equal to its power.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "BEGIN_COMBAT"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Wolf",
+                                    "Werewolf"
+                                ]
+                            }
+                        ]
+                    },
+                    "excludeSelf": true
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "EntityProperty",
+                        "entity": "Source",
+                        "numericProperty": "Power"
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "213",
+        "rarity": "UNCOMMON",
+        "artist": "April Prime",
+        "flavorText": "A wolf pup is always dangerous, because a wolf pup is never alone.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/4/d43d9686-a5e4-413b-8a34-3430788dd1b9.jpg?1782703044"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Persistent Specimen
+{
+    "name": "Persistent Specimen",
+    "manaCost": "{B}",
+    "typeLine": "Creature — Skeleton",
+    "oracleText": "{2}{B}: Return this card from your graveyard to the battlefield tapped.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}{B}"
+                    }
+                },
+                "effect": {
+                    "type": "MoveToZone",
+                    "target": "Self",
+                    "destination": "Battlefield",
+                    "placement": "Tapped"
+                },
+                "activateFromZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "125",
+        "artist": "Scott Murphy",
+        "flavorText": "\"The jaw bone's connected to the skull bone. The skull bone's connected to the . . . uh . . . hook thingy.\"\n—Garl, sticher's assistant",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7baf973-3202-4fea-8861-a4a5ec228640.jpg?1782703101"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Piercing Light
+{
+    "name": "Piercing Light",
+    "manaCost": "{W}",
+    "typeLine": "Instant",
+    "oracleText": "Piercing Light deals 2 damage to target attacking or blocking creature. Scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "Scry",
+                    "count": 1
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ],
+                        "statePredicates": [
+                            {
+                                "type": "StateOr",
+                                "predicates": [
+                                    "IsAttacking",
+                                    "IsBlocking"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "30",
+        "artist": "Donato Giancola",
+        "flavorText": "\"Creatures of the night dissolve like shadows in the light of faith.\"\n—Thalia, Guardian of Thraben",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54cc4e2b-1497-4788-afb4-9e42b7683b5a.jpg?1782703174"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Pointed Discussion
+{
+    "name": "Pointed Discussion",
+    "manaCost": "{2}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "You draw two cards, lose 2 life, then create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": "Controller"
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "126",
+        "artist": "Jarel Threat",
+        "flavorText": "Small talk is a dying art.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/076deb63-f7e2-498f-a66a-8a190370a3b3.jpg?1782703101"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Reckless Impulse
+{
+    "name": "Reckless Impulse",
+    "manaCost": "{1}{R}",
+    "typeLine": "Sorcery",
+    "oracleText": "Exile the top two cards of your library. Until the end of your next turn, you may play those cards.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeAs": "impulseExiled"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "impulseExiled",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Exile"
+                    }
+                },
+                {
+                    "type": "GrantMayPlayFromExile",
+                    "from": "impulseExiled",
+                    "expiry": {
+                        "type": "UntilControllerStep",
+                        "step": "CLEANUP",
+                        "includeCurrentTurn": false
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "174",
+        "artist": "Mathias Kollros",
+        "flavorText": "A stitcher looks at their creation and sees the result of years of study and hours of toil. A devil sees a new plaything.",
+        "imageUri": "https://cards.scryfall.io/normal/front/6/9/6943c07f-ab0d-4f5a-bbe9-c0a83dc98546.jpg?1782703066"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Reclusive Taxidermist
+{
+    "name": "Reclusive Taxidermist",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Human Druid",
+    "oracleText": "This creature gets +3/+2 as long as there are four or more creature cards in your graveyard.\n{T}: Add one mana of any color.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": "AddManaOfChoice",
+                "timing": "ManaAbility",
+                "isManaAbility": true,
+                "descriptionOverride": "{T}: Add one mana of any color."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 3,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "creature"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "214",
+        "rarity": "UNCOMMON",
+        "artist": "Wisnu Tan",
+        "flavorText": "All druids seek to preserve nature, but some go about it in rather unusual ways.",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/0/10edf37a-ee35-491d-b83a-39035f7df65a.jpg?1782703043"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Rending Flame
+{
+    "name": "Rending Flame",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Rending Flame deals 5 damage to target creature or planeswalker. If that permanent is a Spirit, Rending Flame also deals 2 damage to that permanent's controller.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature or planeswalker"
+                    }
+                },
+                {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.WhenCondition",
+                        "condition": {
+                            "type": "EntityMatches",
+                            "entity": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            },
+                            "filter": "Spirit"
+                        }
+                    },
+                    "then": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "TargetController"
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetCreatureOrPlaneswalker",
+                "id": "target creature or planeswalker"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "175",
+        "rarity": "UNCOMMON",
+        "artist": "Olena Richards",
+        "flavorText": "\"It is our duty to bring the Blessed Sleep to the dead, even if they resist that gift.\"\n—Grete, Order of Saint Traft",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/1/51332c31-41df-4379-aa63-6a734a4df618.jpg?1782703065"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
+// Resistance Squad
+{
+    "name": "Resistance Squad",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Soldier",
+    "oracleText": "When this creature enters, if you control another Human, draw a card.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "triggerCondition": {
+                    "type": "Exists",
+                    "player": "You",
+                    "zone": "Battlefield",
+                    "filter": "creature Human",
+                    "excludeSelf": true
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "32",
+        "rarity": "UNCOMMON",
+        "artist": "Joshua Raphael",
+        "flavorText": "\"It's not that I didn't expect some defiance, but I did hope it wouldn't be so heavily armed.\"\n—Olivia Voldaren",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/093ae747-350f-4253-b903-8c6892d78c83.jpg?1782703173"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Retrieve
+{
+    "name": "Retrieve",
+    "manaCost": "{2}{G}",
+    "typeLine": "Sorcery",
+    "oracleText": "Return up to one target creature card and up to one target noncreature permanent card from your graveyard to your hand. Exile Retrieve.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "noncreature permanent"
+                    },
+                    "destination": "Hand"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "creature own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "creature"
+            },
+            {
+                "type": "TargetObject",
+                "optional": true,
+                "filter": {
+                    "baseFilter": "noncreature permanent own:you",
+                    "zone": "Graveyard"
+                },
+                "id": "noncreature permanent"
+            }
+        ],
+        "selfExileOnResolve": true
+    },
+    "metadata": {
+        "collectorNumber": "215",
+        "rarity": "UNCOMMON",
+        "artist": "Alix Branwyn",
+        "flavorText": "The roots preserved the armor for a hundred years, safeguarding it for a traveler in need.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/e/9e997f78-22a2-4b66-ac10-1adc9a72ce3b.jpg?1782703042"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -1209,6 +4000,249 @@
     ]
 }
 
+// Sanctify
+{
+    "name": "Sanctify",
+    "manaCost": "{1}{W}",
+    "typeLine": "Sorcery",
+    "oracleText": "Destroy target artifact or enchantment. You gain 3 life.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "destination": "Graveyard",
+                    "byDestruction": true
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "artifact|enchantment"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "33",
+        "artist": "Kasia 'Kafis' Zielińska",
+        "flavorText": "\"Olivia Voldaren has faith only in herself. We answer to a higher calling.\"\n—Thalia, Guardian of Thraben",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/8/880e071a-6d6c-41c4-b2eb-c9e6626d0c7f.jpg?1782703172"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Sawblade Slinger
+{
+    "name": "Sawblade Slinger",
+    "manaCost": "{3}{G}",
+    "typeLine": "Creature — Human Archer",
+    "oracleText": "When this creature enters, choose up to one —\n• Destroy target artifact an opponent controls.\n• This creature fights target Zombie an opponent controls.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 3
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Modal",
+                    "modes": [
+                        {
+                            "effect": {
+                                "type": "MoveToZone",
+                                "target": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                },
+                                "destination": "Graveyard",
+                                "byDestruction": true
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "artifact ctrl:opponent"
+                                    }
+                                }
+                            ],
+                            "description": "Destroy target artifact an opponent controls"
+                        },
+                        {
+                            "effect": {
+                                "type": "Fight",
+                                "target1": "Self",
+                                "target2": {
+                                    "type": "ContextTarget",
+                                    "index": 0
+                                }
+                            },
+                            "targetRequirements": [
+                                {
+                                    "type": "TargetObject",
+                                    "filter": {
+                                        "baseFilter": "creature Zombie ctrl:opponent"
+                                    }
+                                }
+                            ],
+                            "description": "This creature fights target Zombie an opponent controls"
+                        }
+                    ],
+                    "minChooseCount": 0,
+                    "countsAsModalSpell": false
+                },
+                "descriptionOverride": "When this creature enters, choose up to one — Destroy target artifact an opponent controls, or this creature fights target Zombie an opponent controls."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "217",
+        "rarity": "UNCOMMON",
+        "artist": "Joshua Raphael",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/2/225773f9-1843-4ee0-8564-8e4a5dfef775.jpg?1782703040"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Scattered Thoughts
+{
+    "name": "Scattered Thoughts",
+    "manaCost": "{3}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Look at the top four cards of your library. Put two of those cards into your hand and the rest into your graveyard.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "TopOfLibrary",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 4
+                        }
+                    },
+                    "storeAs": "looked"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "looked",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        }
+                    },
+                    "storeSelected": "kept",
+                    "storeRemainder": "rest",
+                    "selectedLabel": "Put in hand",
+                    "remainderLabel": "Put in graveyard"
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "kept",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Hand"
+                    }
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "rest",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard"
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "74",
+        "artist": "Brian Valeza",
+        "flavorText": "Stitchers delegate the most important tasks to assistants with a good eye for detail.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/c/dc5c6675-6e0f-427d-9399-a6e7fc6215f1.jpg?1782703139"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Selhoff Entomber
+{
+    "name": "Selhoff Entomber",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "{T}, Discard a creature card: Draw a card.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 3
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomDiscard",
+                                "filter": "creature"
+                            }
+                        }
+                    ]
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "descriptionOverride": "{T}, Discard a creature card: Draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "76",
+        "artist": "Johann Bodin",
+        "flavorText": "It knows one fundamental truth: bodies belong in graves.",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/8/f8805db2-5a26-43cf-9b74-f882c283e5e4.jpg?1782703138"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Shattered Sanctum
 {
     "name": "Shattered Sanctum",
@@ -1276,6 +4310,214 @@
     ]
 }
 
+// Sheltering Boughs
+{
+    "name": "Sheltering Boughs",
+    "manaCost": "{2}{G}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nWhen this Aura enters, draw a card.\nEnchanted creature gets +1/+3.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 3
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "218",
+        "artist": "Anato Finnstark",
+        "flavorText": "\"We're not at odds with the woods. How could we be, when we share so many enemies?\"\n—Marel, Dawnhart witch",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/1/915dd4c2-0e9f-440c-8e4c-80db351a5eba.jpg?1782703040"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Sigarda's Imprisonment
+{
+    "name": "Sigarda's Imprisonment",
+    "manaCost": "{2}{W}",
+    "typeLine": "Enchantment — Aura",
+    "oracleText": "Enchant creature\nEnchanted creature can't attack or block.\n{4}{W}: Exile enchanted creature. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "MoveToZone",
+                            "target": "EnchantedCreature",
+                            "destination": "Exile"
+                        },
+                        {
+                            "type": "CreatePredefinedToken",
+                            "tokenType": "Blood"
+                        }
+                    ]
+                },
+                "descriptionOverride": "{4}{W}: Exile enchanted creature. Create a Blood token."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "CantAttack",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            },
+            {
+                "type": "CantBlock",
+                "filter": {
+                    "baseFilter": "permanent",
+                    "scope": "AttachedTo"
+                }
+            }
+        ],
+        "auraTarget": {
+            "type": "TargetObject",
+            "filter": {
+                "baseFilter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "35",
+        "artist": "Bryan Sola",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/1/118995a6-8471-47ac-9404-700ce7fc46f6.jpg?1782703171"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Skywarp Skaab
+{
+    "name": "Skywarp Skaab",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Zombie Drake",
+    "oracleText": "Flying\nWhen this creature enters, you may exile two creature cards from your graveyard. If you do, draw a card.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 5
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Gated",
+                    "gate": "Gate.MayDecide",
+                    "then": {
+                        "type": "Gated",
+                        "gate": {
+                            "type": "Gate.DoAction",
+                            "action": {
+                                "type": "Composite",
+                                "effects": [
+                                    {
+                                        "type": "GatherCards",
+                                        "source": {
+                                            "type": "FromZone",
+                                            "zone": "Graveyard",
+                                            "filter": "creature"
+                                        },
+                                        "storeAs": "graveyardCreatures"
+                                    },
+                                    {
+                                        "type": "SelectFromCollection",
+                                        "from": "graveyardCreatures",
+                                        "selection": {
+                                            "type": "ChooseExactly",
+                                            "count": {
+                                                "type": "Fixed",
+                                                "amount": 2
+                                            }
+                                        },
+                                        "storeSelected": "toExile",
+                                        "selectedLabel": "Exile"
+                                    },
+                                    {
+                                        "type": "MoveCollection",
+                                        "from": "toExile",
+                                        "destination": {
+                                            "type": "ToZone",
+                                            "zone": "Exile"
+                                        }
+                                    }
+                                ]
+                            },
+                            "successCriterion": {
+                                "type": "SuccessCriterion.CollectionNonEmpty",
+                                "name": "toExile",
+                                "min": 2
+                            }
+                        },
+                        "then": {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    }
+                },
+                "descriptionOverride": "When this creature enters, you may exile two creature cards from your graveyard. If you do, draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "78",
+        "artist": "Steven Belledin",
+        "flavorText": "\"If I wanted all the parts to match, I wouldn't have become a stitcher.\"\n—Barton, stitcher",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/3/73168804-3c22-4fcb-907a-2f08999c0cea.jpg?1782703137"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Spore Crawler
 {
     "name": "Spore Crawler",
@@ -1313,6 +4555,83 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Sporeback Wolf
+{
+    "name": "Sporeback Wolf",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Wolf",
+    "oracleText": "During your turn, this creature gets +0/+2.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 0,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": "IsYourTurn"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "223",
+        "artist": "Nicholas Elias",
+        "flavorText": "The mushrooms growing in the wolves' fur possess curative properties incredible enough to tempt many alchemists into risking their lives to track one down.",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/f/3fb04879-9348-4d4f-9a23-c82fd99d04c6.jpg?1782703036"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Steelclad Spirit
+{
+    "name": "Steelclad Spirit",
+    "manaCost": "{1}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Defender\nWhenever an enchantment you control enters, this creature can attack this turn as though it didn't have defender.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "DEFENDER"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "enchantment ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "ANY",
+                "effect": "CanAttackDespiteDefenderThisTurn",
+                "descriptionOverride": "Whenever an enchantment you control enters, this creature can attack this turn as though it didn't have defender."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "80",
+        "artist": "Artur Treffner",
+        "flavorText": "Some geists imitate the lives they left behind. Others follow the dreams they never realized.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/5/55fb1426-5a6f-48dd-938b-c64b1a28ee59.jpg?1782703135"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -1450,6 +4769,44 @@
     ]
 }
 
+// Syphon Essence
+{
+    "name": "Syphon Essence",
+    "manaCost": "{2}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Counter target creature or planeswalker spell. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "Counter",
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature|planeswalker",
+                    "zone": "Stack"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "84",
+        "artist": "Sean Murray",
+        "flavorText": "The third step in creating a skaab requires draining the body of blood and replacing it with viscus vitae, a mixture of angel's blood and lamp oil.",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/3/435a2d31-ac2c-45aa-8369-6c2d6fbba4e4.jpg?1782703133"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Thirst for Discovery
 {
     "name": "Thirst for Discovery",
@@ -1521,6 +4878,392 @@
     },
     "colorIdentityOverride": [
         "BLUE"
+    ]
+}
+
+// Toxic Scorpion
+{
+    "name": "Toxic Scorpion",
+    "manaCost": "{1}{G}",
+    "typeLine": "Creature — Scorpion",
+    "oracleText": "Deathtouch\nWhen this creature enters, another target creature you control gains deathtouch until end of turn.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "keywords": [
+        "DEATHTOUCH"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "GrantKeyword",
+                    "keyword": "DEATHTOUCH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature ctrl:you",
+                        "excludeSelf": true
+                    },
+                    "id": "target"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "224",
+        "artist": "Simon Dominic",
+        "flavorText": "\"You want that venom? Collect it yourself! I'm not losing another pair of dragonhide gloves.\"\n—Old Rutstein",
+        "imageUri": "https://cards.scryfall.io/normal/front/4/c/4cfca481-cf2d-435d-b4b6-07b1fe2a8e5d.jpg?1782703036"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
+// Traveling Minister
+{
+    "name": "Traveling Minister",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Human Cleric",
+    "oracleText": "{T}: Target creature gets +1/+0 until end of turn. You gain 1 life. Activate only as a sorcery.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 1
+    },
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "ModifyStats",
+                            "powerModifier": {
+                                "type": "Fixed",
+                                "amount": 1
+                            },
+                            "toughnessModifier": {
+                                "type": "Fixed",
+                                "amount": 0
+                            },
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target"
+                            }
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target"
+                    }
+                ],
+                "timing": "SorcerySpeed"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "39",
+        "artist": "Slawomir Maniak",
+        "flavorText": "Priests of the Sigardian Sect travel to the farthest reaches to spread hope and healing, even in the darkest times.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/6/e672a05c-5f1a-4aa6-9398-e33df01c7c96.jpg?1782703166"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Undead Butler
+{
+    "name": "Undead Butler",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "When this creature enters, mill three cards. (Put the top three cards of your library into your graveyard.)\nWhen this creature dies, you may exile it. When you do, return target creature card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 3
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "from": "Battlefield",
+                    "to": "Graveyard"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "MoveToZone",
+                        "target": "Self",
+                        "destination": "Exile"
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Hand"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may exile this creature. When you do, return target creature card from your graveyard to your hand."
+                },
+                "activeZone": "Graveyard"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "133",
+        "rarity": "UNCOMMON",
+        "artist": "Néstor Ossandón Leal",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/c/2c9b8582-8887-4652-82e2-f9b11ee21545.jpg?1782703094"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Unhallowed Phalanx
+{
+    "name": "Unhallowed Phalanx",
+    "manaCost": "{4}{B}",
+    "typeLine": "Creature — Zombie Soldier",
+    "oracleText": "This creature enters tapped.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 13
+    },
+    "script": {
+        "replacementEffects": [
+            "EntersTapped"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "135",
+        "artist": "Nicholas Gregory",
+        "flavorText": "\"In case any of you new recruits were wondering, this is why we don't use mass graves anymore.\"\n—Kerren of the Mausoleum Guards",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/5/d5ec541b-1799-4c0e-a3fb-c008cf2eb911.jpg?1782703092"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Unholy Officiant
+{
+    "name": "Unholy Officiant",
+    "manaCost": "{W}",
+    "typeLine": "Creature — Vampire Cleric",
+    "oracleText": "Vigilance\n{4}{W}: Put a +1/+1 counter on this creature.",
+    "creatureStats": {
+        "power": 1,
+        "toughness": 2
+    },
+    "keywords": [
+        "VIGILANCE"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{4}{W}"
+                    }
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "41",
+        "artist": "Campbell White",
+        "flavorText": "\"Is this twisted ceremony simply a mockery of the human rite, or has Olivia fallen for her own charade?\"\n—Sorin Markov",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8a4c04a4-e68b-4d3d-89c8-29cdaaac36b2.jpg?1782703165"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Vampire's Kiss
+{
+    "name": "Vampire's Kiss",
+    "manaCost": "{1}{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Target player loses 2 life and you gain 2 life. Create two Blood tokens. (They're artifacts with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "LoseLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood",
+                    "count": 2
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetPlayer",
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "136",
+        "artist": "Ilse Gort",
+        "flavorText": "Young vampires gorge themselves at every meal, but their elders have learned to savor the smallest bite.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/7/974bf8cc-4259-48cc-8e7f-1580bb010d3f.jpg?1782703092"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Vampires' Vengeance
+{
+    "name": "Vampires' Vengeance",
+    "manaCost": "{2}{R}",
+    "typeLine": "Instant",
+    "oracleText": "Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token. (It's an artifact with \"{1}, {T}, Discard a card, Sacrifice this token: Draw a card.\")",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ForEach",
+                    "space": {
+                        "type": "IterationSpace.Group",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotSubtype",
+                                        "subtype": "Vampire"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "body": {
+                        "type": "DealDamage",
+                        "amount": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "target": "Self"
+                    }
+                },
+                {
+                    "type": "CreatePredefinedToken",
+                    "tokenType": "Blood"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "339",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Kendall",
+        "flavorText": "She was ghastly, chalkily pale; the red seemed to have gone even from her lips and gums, and the bones of her face stood out prominently; her breathing was painful to see or hear.",
+        "imageUri": "https://cards.scryfall.io/normal/front/9/f/9f4ba693-0323-415d-ad91-c083fbbab7f7.jpg?1782702951"
+    },
+    "colorIdentityOverride": [
+        "RED"
     ]
 }
 
@@ -1886,6 +5629,357 @@
     "colorIdentityOverride": [
         "BLUE",
         "RED"
+    ]
+}
+
+// Wanderlight Spirit
+{
+    "name": "Wanderlight Spirit",
+    "manaCost": "{2}{U}",
+    "typeLine": "Creature — Spirit",
+    "oracleText": "Flying\nThis creature can block only creatures with flying.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "CanOnlyBlockCreaturesWith",
+                "blockerFilter": {
+                    "cardPredicates": [
+                        "IsCreature",
+                        {
+                            "type": "HasKeyword",
+                            "keyword": "FLYING"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "86",
+        "artist": "Andrew Mar",
+        "flavorText": "The towers and catwalks of the Voldaren fortress are lit by the lanterns of geists endlessly seeking a way out.",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/b/7bb3ce5d-330d-427e-a053-8cc4eeb2941b.jpg?1782703131"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Wedding Invitation
+{
+    "name": "Wedding Invitation",
+    "manaCost": "{2}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, draw a card.\n{T}, Sacrifice this artifact: Target creature can't be blocked this turn. If it's a Vampire, it also gains lifelink until end of turn.",
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        "CostTap",
+                        "CostSacrificeSelf"
+                    ]
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GrantKeyword",
+                            "keyword": "CANT_BE_BLOCKED",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "target creature"
+                            }
+                        },
+                        {
+                            "type": "Gated",
+                            "gate": {
+                                "type": "Gate.WhenCondition",
+                                "condition": {
+                                    "type": "EntityMatches",
+                                    "entity": {
+                                        "type": "ContextTarget",
+                                        "index": 0
+                                    },
+                                    "filter": "creature Vampire"
+                                }
+                            },
+                            "then": {
+                                "type": "GrantKeyword",
+                                "keyword": "LIFELINK",
+                                "target": {
+                                    "type": "BoundVariable",
+                                    "name": "target creature"
+                                }
+                            }
+                        }
+                    ]
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature"
+                        },
+                        "id": "target creature"
+                    }
+                ],
+                "descriptionOverride": "{T}, Sacrifice this artifact: Target creature can't be blocked this turn. If it's a Vampire, it also gains lifelink until end of turn."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "260",
+        "artist": "Justyna Dura",
+        "flavorText": "RSVP at your own risk.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/d/ddc22ff6-4081-47ce-bc8a-e063f5f4d044.jpg?1782703014"
+    },
+    "colorIdentityOverride": []
+}
+
+// Wedding Security
+{
+    "name": "Wedding Security",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Vampire Soldier",
+    "oracleText": "Whenever this creature attacks, you may sacrifice a Blood token. If you do, put a +1/+1 counter on this creature and draw a card.",
+    "creatureStats": {
+        "power": 4,
+        "toughness": 4
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": "AttackEvent",
+                "effect": {
+                    "type": "Gated",
+                    "gate": {
+                        "type": "Gate.MayPay",
+                        "cost": {
+                            "type": "Sacrifice",
+                            "filter": "artifact Blood"
+                        }
+                    },
+                    "then": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            {
+                                "type": "DrawCards",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                "descriptionOverride": "Whenever this creature attacks, you may sacrifice a Blood token. If you do, put a +1/+1 counter on this creature and draw a card."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "299",
+        "rarity": "UNCOMMON",
+        "artist": "Vi Szendrey (Cashile)",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/0/20b1a617-96bf-4960-bffe-dddf3a3c1868.jpg?1782702985"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Welcoming Vampire
+{
+    "name": "Welcoming Vampire",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Vampire",
+    "oracleText": "Flying\nWhenever one or more other creatures you control with power 2 or less enter, draw a card. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLYING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "filter": "creature pow<=2 ctrl:you",
+                    "to": "Battlefield"
+                },
+                "binding": "OTHER",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "oncePerTurn": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "46",
+        "rarity": "RARE",
+        "artist": "Lorenzo Mastroianni",
+        "flavorText": "From the moment they arrived, wedding guests were met with a pageant of wealth and excess.",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/8/d8f69cea-823c-482b-a605-8138b3d950e6.jpg?1782703161"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
+// Whispering Wizard
+{
+    "name": "Whispering Wizard",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Human Wizard",
+    "oracleText": "Whenever you cast a noncreature spell, create a 1/1 white Spirit creature token with flying. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 2
+    },
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsNoncreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Spirit"
+                    ],
+                    "keywords": [
+                        "FLYING"
+                    ]
+                },
+                "oncePerTurn": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "88",
+        "rarity": "UNCOMMON",
+        "artist": "E. M. Gist",
+        "flavorText": "Ivold was aghast when his device revealed the full scope of the geist infestation.",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/4/54fb422d-71f2-44ed-9589-32630ab87050.jpg?1782703130"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Witch's Web
+{
+    "name": "Witch's Web",
+    "manaCost": "{1}{G}",
+    "typeLine": "Instant",
+    "oracleText": "Target creature gets +3/+3 and gains reach until end of turn. Untap it.",
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "ModifyStats",
+                    "powerModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "toughnessModifier": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "GrantKeyword",
+                    "keyword": "REACH",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    }
+                },
+                {
+                    "type": "TapUntap",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target"
+                    },
+                    "tap": false
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "target"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "227",
+        "artist": "Yeong-Hao Han",
+        "flavorText": "Ever since the ritual, Ryla didn't have an appetite at the dinner table, but her long walks in the forest always seemed to satiate her hunger.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/d/0d021207-76be-4bc9-bb71-df991a04d8d8.jpg?1782703032"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AngelicQuartermasterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AngelicQuartermasterScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Angelic Quartermaster (VOW #2) — {3}{W}{W} Creature — Angel Soldier, 3/3,
+ * Flying.
+ *
+ *   When this creature enters, put a +1/+1 counter on each of up to two other target creatures.
+ *
+ * Exercises the ETB fan-out: two other target creatures (any controller) each receive one
+ * +1/+1 counter; the Quartermaster itself is excluded from the target pool.
+ */
+class AngelicQuartermasterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Angelic Quartermaster ETB") {
+
+            test("entering puts a +1/+1 counter on each of two other target creatures") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Angelic Quartermaster")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val card = game.findCardsInHand(1, "Angelic Quartermaster").first()
+                game.execute(
+                    CastSpell(game.player1Id, card, emptyList())
+                ).error shouldBe null
+                game.resolveStack() // creature enters -> ETB trigger asks for up to two targets
+
+                game.selectTargets(listOf(bears, giant)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears (mine) gets a +1/+1 counter") {
+                    game.state.getEntity(bears)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+                withClue("Hill Giant (opponent's) gets a +1/+1 counter") {
+                    game.state.getEntity(giant)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+                withClue("Angelic Quartermaster is on the battlefield") {
+                    game.isOnBattlefield("Angelic Quartermaster") shouldBe true
+                }
+            }
+
+            test("declining targets puts no counters on anything") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Angelic Quartermaster")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Angelic Quartermaster").error shouldBe null
+                game.resolveStack()
+
+                game.skipTargets().error shouldBe null
+                game.resolveStack()
+
+                withClue("no counters placed when the optional targets are declined") {
+                    val counters = game.state.getEntity(bears)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArmTheCatharsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ArmTheCatharsScenarioTest.kt
@@ -1,0 +1,108 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Arm the Cathars (VOW #3) — {1}{W}{W} Sorcery.
+ *
+ *   Until end of turn, target creature gets +3/+3, up to one other target creature gets +2/+2,
+ *   and up to one other target creature gets +1/+1. Those creatures gain vigilance until end
+ *   of turn.
+ *
+ * Exercises the three-target pump (primary +3/+3, second +2/+2, third +1/+1), each paired with a
+ * vigilance grant, and confirms an untargeted (skipped optional) creature is unaffected.
+ */
+class ArmTheCatharsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Arm the Cathars") {
+
+            test("targeting all three creatures pumps each and grants vigilance") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Arm the Cathars")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2 primary
+                    .withCardOnBattlefield(1, "Savannah Lions", summoningSickness = false) // 1/1 second
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false) // 3/3 third
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val lions = game.findPermanent("Savannah Lions")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val card = game.findCardsInHand(1, "Arm the Cathars").first()
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        card,
+                        listOf(
+                            ChosenTarget.Permanent(bears),
+                            ChosenTarget.Permanent(lions),
+                            ChosenTarget.Permanent(giant),
+                        ),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("primary target (Grizzly Bears) gets +3/+3 (becomes 5/5)") {
+                    game.state.projectedState.getPower(bears) shouldBe 5
+                    game.state.projectedState.getToughness(bears) shouldBe 5
+                }
+                withClue("second target (Savannah Lions) gets +2/+2 (becomes 3/3)") {
+                    game.state.projectedState.getPower(lions) shouldBe 3
+                    game.state.projectedState.getToughness(lions) shouldBe 3
+                }
+                withClue("third target (Hill Giant) gets +1/+1 (becomes 4/4)") {
+                    game.state.projectedState.getPower(giant) shouldBe 4
+                    game.state.projectedState.getToughness(giant) shouldBe 4
+                }
+                withClue("all three gain vigilance") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.VIGILANCE) shouldBe true
+                    game.state.projectedState.hasKeyword(lions, Keyword.VIGILANCE) shouldBe true
+                    game.state.projectedState.hasKeyword(giant, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+
+            test("skipping the optional targets leaves only the primary target affected") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Arm the Cathars")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                val card = game.findCardsInHand(1, "Arm the Cathars").first()
+                game.execute(
+                    CastSpell(game.player1Id, card, listOf(ChosenTarget.Permanent(bears)))
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("primary target still gets +3/+3 (becomes 5/5)") {
+                    game.state.projectedState.getPower(bears) shouldBe 5
+                    game.state.projectedState.getToughness(bears) shouldBe 5
+                }
+                withClue("untargeted creature is unaffected") {
+                    game.state.projectedState.getPower(giant) shouldBe 3
+                    game.state.projectedState.getToughness(giant) shouldBe 3
+                    game.state.projectedState.hasKeyword(giant, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BelligerentGuestScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BelligerentGuestScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Belligerent Guest (VOW #301) — {2}{R} Creature — Vampire, 3/2, Trample.
+ *
+ *   Whenever this creature deals combat damage to a player, create a Blood token.
+ *
+ * Exercises the printed Trample keyword and the combat-damage-to-player trigger creating a
+ * Blood token when the attack connects unblocked.
+ */
+class BelligerentGuestScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Belligerent Guest") {
+
+            test("has printed trample") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Belligerent Guest", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val guest = game.findPermanent("Belligerent Guest")!!
+
+                withClue("Belligerent Guest has trample") {
+                    game.state.projectedState.hasKeyword(guest, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+
+            test("dealing combat damage to a player creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Belligerent Guest", summoningSickness = false)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Belligerent Guest" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                withClue("the opponent takes 3 combat damage (20 -> 17)") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+                withClue("a Blood token was created") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BleedDryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BleedDryScenarioTest.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Bleed Dry (VOW #94) — {2}{B}{B} Instant.
+ *
+ *   Target creature gets -13/-13 until end of turn. If that creature would die this turn,
+ *   exile it instead.
+ *
+ * Exercises the -13/-13 shrink and the exile-instead-of-die replacement: a 3/3 target is
+ * reduced to a lethally-negative toughness, dies to state-based actions, and ends up exiled
+ * rather than in its owner's graveyard.
+ */
+class BleedDryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bleed Dry -13/-13 and exile-on-death") {
+
+            test("shrinks the target to lethal toughness and exiles it instead of letting it die") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Bleed Dry")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false) // 3/3
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Bleed Dry", targetId = giant).error shouldBe null
+                game.resolveStack()
+
+                withClue("Hill Giant is no longer on the battlefield (it died to -13/-13)") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                }
+                withClue("It is exiled, not sent to the graveyard") {
+                    game.isInExile(2, "Hill Giant") shouldBe true
+                    game.isInGraveyard(2, "Hill Giant") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodFountainScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodFountainScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Blood Fountain (VOW #95) — {B} Artifact.
+ *
+ *   When this artifact enters, create a Blood token.
+ *   {3}{B}, {T}, Sacrifice this artifact: Return up to two target creature cards from your
+ *   graveyard to your hand.
+ *
+ * Exercises the ETB Blood token creation and the tap-sacrifice activated ability returning two
+ * targeted creature cards from the graveyard to hand.
+ */
+class BloodFountainScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Blood Fountain") {
+
+            test("entering the battlefield creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Blood Fountain")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Blood Fountain").error shouldBe null
+                game.resolveStack()
+
+                withClue("a Blood token is created on entering the battlefield") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+
+            test("the {3}{B}, tap, sacrifice ability returns two graveyard creatures to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Fountain")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val fountain = game.findPermanent("Blood Fountain")!!
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                val giant = game.findCardsInGraveyard(1, "Hill Giant").single()
+                val abilityId = cardRegistry.getCard("Blood Fountain")!!.activatedAbilities.first().id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = fountain,
+                        abilityId = abilityId,
+                        targets = listOf(
+                            ChosenTarget.Card(bears, game.player1Id, Zone.GRAVEYARD),
+                            ChosenTarget.Card(giant, game.player1Id, Zone.GRAVEYARD)
+                        )
+                    )
+                )
+                withClue("Activating the ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Blood Fountain was sacrificed to pay the cost") {
+                    game.isOnBattlefield("Blood Fountain") shouldBe false
+                    game.isInGraveyard(1, "Blood Fountain") shouldBe true
+                }
+                withClue("Both creature cards returned to hand") {
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                    game.isInHand(1, "Hill Giant") shouldBe true
+                }
+                withClue("Both are gone from the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                    game.isInGraveyard(1, "Hill Giant") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodPetalCelebrantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodPetalCelebrantScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Blood Petal Celebrant (VOW #146) — {1}{R} Creature — Vampire, 2/1.
+ *
+ *   This creature has first strike as long as it's attacking.
+ *   When this creature dies, create a Blood token.
+ *
+ * Exercises the conditional first strike (only while attacking, not while sitting on the
+ * battlefield) and the dies trigger creating a Blood token.
+ */
+class BloodPetalCelebrantScenarioTest : ScenarioTestBase() {
+
+    private val projector = StateProjector()
+
+    init {
+        context("Blood Petal Celebrant") {
+
+            test("has no first strike while not attacking") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Petal Celebrant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val celebrant = game.findPermanent("Blood Petal Celebrant")!!
+
+                withClue("no first strike while not attacking") {
+                    projector.getProjectedKeywords(game.state, celebrant).contains(Keyword.FIRST_STRIKE) shouldBe false
+                }
+            }
+
+            test("gains first strike while attacking") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Petal Celebrant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val celebrant = game.findPermanent("Blood Petal Celebrant")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Blood Petal Celebrant" to 2)).error shouldBe null
+
+                withClue("first strike is granted while attacking") {
+                    projector.getProjectedKeywords(game.state, celebrant).contains(Keyword.FIRST_STRIKE) shouldBe true
+                }
+            }
+
+            test("creates a Blood token when it dies") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Blood Petal Celebrant", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Blood Petal Celebrant" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+
+                val block = game.declareBlockers(mapOf("Hill Giant" to listOf("Blood Petal Celebrant")))
+                withClue("blocking should succeed: ${block.error}") { block.error shouldBe null }
+
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                withClue("Blood Petal Celebrant died to the 3/3 blocker") {
+                    game.isOnBattlefield("Blood Petal Celebrant") shouldBe false
+                    game.isInGraveyard(1, "Blood Petal Celebrant") shouldBe true
+                }
+                withClue("a Blood token was created on death") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodServitorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodServitorScenarioTest.kt
@@ -1,0 +1,43 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Blood Servitor (VOW #252) — {3} Artifact Creature — Construct, 2/2.
+ *
+ *   When this creature enters, create a Blood token.
+ *
+ * Exercises the ETB Blood token creation, the only thing this vanilla-bodied artifact creature
+ * does.
+ */
+class BloodServitorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Blood Servitor") {
+
+            test("entering the battlefield creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Blood Servitor")
+                    .withLandsOnBattlefield(1, "Wastes", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Blood Servitor").error shouldBe null
+                game.resolveStack()
+
+                withClue("Blood Servitor is on the battlefield") {
+                    game.isOnBattlefield("Blood Servitor") shouldBe true
+                }
+                withClue("a Blood token is created on entering the battlefield") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodcrazedSocialiteScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodcrazedSocialiteScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Bloodcrazed Socialite (VOW #288) — {3}{B} Creature — Vampire, 3/3.
+ *
+ *   Menace
+ *   When this creature enters, create a Blood token.
+ *   Whenever this creature attacks, you may sacrifice a Blood token. If you do, it gets +2/+2
+ *   until end of turn.
+ *
+ * Exercises the ETB Blood token creation and the attack-trigger gated sacrifice: paying by
+ * sacrificing the Blood token pumps the attacker +2/+2; declining leaves it unbuffed.
+ */
+class BloodcrazedSocialiteScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bloodcrazed Socialite") {
+
+            test("entering the battlefield creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Bloodcrazed Socialite")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Bloodcrazed Socialite").error shouldBe null
+                game.resolveStack()
+
+                withClue("a Blood token is created on entering the battlefield") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+
+            test("attacking and sacrificing the Blood token gives +2/+2 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bloodcrazed Socialite", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val socialite = game.findPermanent("Bloodcrazed Socialite")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Bloodcrazed Socialite" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the attack trigger offers a yes/no to sacrifice the Blood token") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("the Blood token was sacrificed") {
+                    game.findPermanents("Blood").size shouldBe 0
+                }
+                withClue("Bloodcrazed Socialite gets +2/+2 (becomes 5/5)") {
+                    game.state.projectedState.getPower(socialite) shouldBe 5
+                    game.state.projectedState.getToughness(socialite) shouldBe 5
+                }
+            }
+
+            test("declining the sacrifice leaves the attacker at its base stats") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bloodcrazed Socialite", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val socialite = game.findPermanent("Bloodcrazed Socialite")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Bloodcrazed Socialite" to 2)).error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("the Blood token is not sacrificed") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+                withClue("Bloodcrazed Socialite stays at 3/3") {
+                    game.state.projectedState.getPower(socialite) shouldBe 3
+                    game.state.projectedState.getToughness(socialite) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodtitheHarvesterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodtitheHarvesterScenarioTest.kt
@@ -1,0 +1,87 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Bloodtithe Harvester (VOW #232) — {B}{R} Creature — Vampire, 3/2.
+ *
+ *   When this creature enters, create a Blood token.
+ *   {T}, Sacrifice this creature: Target creature gets -X/-X until end of turn, where X is twice
+ *   the number of Blood tokens you control. Activate only as a sorcery.
+ *
+ * Exercises the ETB Blood token creation and the tap-sacrifice ability's -X/-X sizing: with two
+ * Blood tokens under the controller, X = 4, so the target gets -4/-4.
+ */
+class BloodtitheHarvesterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bloodtithe Harvester") {
+
+            test("entering the battlefield creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Bloodtithe Harvester")
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Bloodtithe Harvester").error shouldBe null
+                game.resolveStack()
+
+                withClue("a Blood token is created on entering the battlefield") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+
+            test("tap+sacrifice gives target -X/-X where X is twice the controller's Blood count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Bloodtithe Harvester", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withCardOnBattlefield(2, "Force of Nature", summoningSickness = false) // 5/5
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val harvester = game.findPermanent("Bloodtithe Harvester")!!
+                val target = game.findPermanent("Force of Nature")!!
+                val abilityId = cardRegistry.getCard("Bloodtithe Harvester")!!.activatedAbilities.first().id
+
+                withClue("two Blood tokens are on the battlefield before activation") {
+                    game.findPermanents("Blood").size shouldBe 2
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = harvester,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(target))
+                    )
+                )
+                withClue("activation should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Bloodtithe Harvester was sacrificed to pay the cost") {
+                    game.isOnBattlefield("Bloodtithe Harvester") shouldBe false
+                    game.isInGraveyard(1, "Bloodtithe Harvester") shouldBe true
+                }
+                withClue("X = 2 * 2 Blood tokens = 4, so Force of Nature (5/5) becomes 1/1") {
+                    game.state.projectedState.getPower(target) shouldBe 1
+                    game.state.projectedState.getToughness(target) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodyBetrayalScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BloodyBetrayalScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Bloody Betrayal (VOW #147) — {2}{R} Sorcery.
+ *
+ *   Gain control of target creature until end of turn. Untap that creature. It gains haste
+ *   until end of turn. Create a Blood token.
+ *
+ * Exercises the control-steal composite: control moves to the caster, the creature is untapped
+ * and gains haste, and a Blood token is created.
+ */
+class BloodyBetrayalScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bloody Betrayal") {
+
+            test("steals a tapped opponent's creature, untaps it, grants haste, and creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Bloody Betrayal")
+                    .withCardOnBattlefield(2, "Hill Giant", tapped = true)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                withClue("Hill Giant starts under Player2's control, tapped") {
+                    game.state.getBattlefield(game.player2Id).contains(giant) shouldBe true
+                    game.state.getEntity(giant)?.has<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() shouldBe true
+                }
+
+                game.castSpell(1, "Bloody Betrayal", targetId = giant).error shouldBe null
+                game.resolveStack()
+
+                withClue("Player1 gains control of Hill Giant") {
+                    game.state.projectedState.getController(giant) shouldBe game.player1Id
+                }
+                withClue("Hill Giant is untapped") {
+                    game.state.getEntity(giant)?.has<com.wingedsheep.engine.state.components.battlefield.TappedComponent>() shouldBe false
+                }
+                withClue("Hill Giant gains haste") {
+                    game.state.projectedState.hasKeyword(giant, Keyword.HASTE) shouldBe true
+                }
+                withClue("a Blood token is created") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoardedWindowScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BoardedWindowScenarioTest.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Boarded Window (VOW #253) — {3} Artifact.
+ *
+ *   Creatures attacking you get -1/-0.
+ *   At the beginning of each end step, if you were dealt 4 or more damage this turn, exile this
+ *   artifact.
+ *
+ * Exercises the static -1/-0 debuff on opponent's attackers and the end-step self-exile once the
+ * controller has taken 4+ damage this turn.
+ */
+class BoardedWindowScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Boarded Window") {
+
+            test("gives creatures attacking the controller -1/-0") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Boarded Window")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false) // 3/3
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hill Giant" to 1)).error shouldBe null
+
+                withClue("Hill Giant attacking the Boarded Window controller becomes 2/3") {
+                    game.state.projectedState.getPower(giant) shouldBe 2
+                    game.state.projectedState.getToughness(giant) shouldBe 3
+                }
+            }
+
+            test("does not affect creatures that are not attacking the controller") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Boarded Window")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                withClue("Hill Giant is unaffected while not attacking") {
+                    game.state.projectedState.getPower(giant) shouldBe 3
+                    game.state.projectedState.getToughness(giant) shouldBe 3
+                }
+            }
+
+            test("exiles itself at the end step once the controller took 4+ damage this turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Boarded Window")
+                    .withCardInHand(1, "Stoke the Flames")
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // The controller deals 4 damage to themself to cross the threshold this turn.
+                game.castSpellTargetingPlayer(1, "Stoke the Flames", 1).error shouldBe null
+                game.resolveStack()
+
+                withClue("the controller took 4 damage this turn") {
+                    game.getLifeTotal(1) shouldBe 16
+                }
+                withClue("Boarded Window is still on the battlefield before the end step") {
+                    game.isOnBattlefield("Boarded Window") shouldBe true
+                }
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("Boarded Window exiled itself at the end step") {
+                    game.isOnBattlefield("Boarded Window") shouldBe false
+                    game.isInExile(1, "Boarded Window") shouldBe true
+                }
+            }
+
+            test("stays on the battlefield at the end step with less than 4 damage taken") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Boarded Window")
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("no damage taken this turn -> Boarded Window is not exiled") {
+                    game.isOnBattlefield("Boarded Window") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrambleWurmScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/BrambleWurmScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Bramble Wurm (VOW #189) — {6}{G} Creature — Wurm, 7/6, Reach, Trample.
+ *
+ *   When this creature enters, you gain 5 life.
+ *   {2}{G}, Exile this card from your graveyard: You gain 5 life.
+ *
+ * Exercises the ETB lifegain and the graveyard-activated exile-self ability, both gaining 5 life.
+ */
+class BrambleWurmScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Bramble Wurm") {
+
+            test("entering the battlefield gains 5 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Bramble Wurm")
+                    .withLandsOnBattlefield(1, "Forest", 7)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Bramble Wurm").error shouldBe null
+                game.resolveStack()
+
+                withClue("Bramble Wurm resolved onto the battlefield") {
+                    game.isOnBattlefield("Bramble Wurm") shouldBe true
+                }
+                withClue("controller gained 5 life on entering the battlefield") {
+                    game.getLifeTotal(1) shouldBe 25
+                }
+            }
+
+            test("exiling it from the graveyard for {2}{G} gains 5 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Bramble Wurm")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wurm = game.findCardsInGraveyard(1, "Bramble Wurm").single()
+                val abilityId = cardRegistry.getCard("Bramble Wurm")!!.activatedAbilities.first().id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = wurm,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("activation from the graveyard should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the card is exiled from the graveyard") {
+                    game.isInGraveyard(1, "Bramble Wurm") shouldBe false
+                    game.isInExile(1, "Bramble Wurm") shouldBe true
+                }
+                withClue("controller gained 5 life") {
+                    game.getLifeTotal(1) shouldBe 25
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CobbledLancerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CobbledLancerScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Cobbled Lancer (VOW #52) — {U} Creature — Zombie Horse, 3/3.
+ *
+ *   As an additional cost to cast this spell, exile a creature card from your graveyard.
+ *   {3}{U}, Exile this card from your graveyard: Draw a card.
+ *
+ * Exercises the additional cast cost (must exile a creature card from the graveyard to cast it at
+ * all) and the graveyard-activated draw-a-card ability.
+ */
+class CobbledLancerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cobbled Lancer") {
+
+            test("casting it exiles a creature card from the graveyard as an additional cost") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cobbled Lancer")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lancerCard = game.findCardsInHand(1, "Cobbled Lancer").single()
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+
+                val cast = game.execute(
+                    CastSpell(
+                        playerId = game.player1Id,
+                        cardId = lancerCard,
+                        targets = emptyList(),
+                        additionalCostPayment = AdditionalCostPayment(exiledCards = listOf(bears))
+                    )
+                )
+                withClue("casting should succeed while exiling a creature card: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears was exiled to pay the additional cost") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                    game.isInExile(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Cobbled Lancer resolved onto the battlefield") {
+                    game.isOnBattlefield("Cobbled Lancer") shouldBe true
+                }
+            }
+
+            test("cannot be cast without a creature card in the graveyard to exile") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cobbled Lancer")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cast = game.castSpell(1, "Cobbled Lancer")
+                withClue("casting must fail — the additional cost requires a creature card to exile") {
+                    (cast.error != null) shouldBe true
+                }
+                withClue("Cobbled Lancer stays in hand") {
+                    game.isInHand(1, "Cobbled Lancer") shouldBe true
+                }
+            }
+
+            test("exiling it from the graveyard for {3}{U} draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Cobbled Lancer")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lancer = game.findCardsInGraveyard(1, "Cobbled Lancer").single()
+                val abilityId = cardRegistry.getCard("Cobbled Lancer")!!.activatedAbilities.first().id
+                val handSizeBefore = game.handSize(1)
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = lancer,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("activation from the graveyard should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the card is exiled from the graveyard") {
+                    game.isInGraveyard(1, "Cobbled Lancer") shouldBe false
+                    game.isInExile(1, "Cobbled Lancer") shouldBe true
+                }
+                withClue("a card was drawn") {
+                    game.handSize(1) shouldBe handSizeBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CourierBatScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CourierBatScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Courier Bat (VOW #102) — {2}{B} Creature — Bat, 2/2, Flying.
+ *
+ *   When this creature enters, if you gained life this turn, return up to one target creature
+ *   card from your graveyard to your hand.
+ *
+ * Exercises the intervening-if ETB trigger: without life gained this turn the trigger doesn't
+ * return anything; after gaining life this turn, it returns a targeted creature card from the
+ * graveyard to hand.
+ */
+class CourierBatScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A simple life-gain spell to turn the "if you gained life this turn" condition on.
+        cardRegistry.register(
+            CardDefinition.instant(
+                name = "Healing Salve Test",
+                manaCost = ManaCost.parse("{W}"),
+                oracleText = "You gain 3 life.",
+                script = CardScript.spell(effect = GainLifeEffect(3, EffectTarget.Controller)),
+            )
+        )
+
+        context("Courier Bat") {
+
+            test("without life gained this turn, the ETB trigger does not return a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Courier Bat")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Courier Bat").error shouldBe null
+                game.resolveStack()
+
+                withClue("Courier Bat resolved onto the battlefield") {
+                    game.isOnBattlefield("Courier Bat") shouldBe true
+                }
+                withClue("no life gained this turn -> Grizzly Bears stays in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("after gaining life this turn, returns a targeted creature card from the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Courier Bat")
+                    .withCardInHand(1, "Healing Salve Test")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Healing Salve Test").error shouldBe null
+                game.resolveStack()
+
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                game.castSpell(1, "Courier Bat").error shouldBe null
+                game.resolveStack() // Courier Bat enters -> ETB trigger asks for a target
+
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("life was gained this turn -> Grizzly Bears returned to hand") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CradleOfSafetyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CradleOfSafetyScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Cradle of Safety (VOW #54) — {1}{U} Enchantment — Aura.
+ *
+ *   Flash
+ *   Enchant creature you control
+ *   When this Aura enters, enchanted creature gains hexproof until end of turn.
+ *   Enchanted creature gets +1/+1.
+ *
+ * Exercises the ETB hexproof grant and the static +1/+1 buff on the enchanted creature.
+ */
+class CradleOfSafetyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cradle of Safety") {
+
+            test("has flash") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cradle of Safety")
+                    .build()
+
+                val cardDef = cardRegistry.getCard("Cradle of Safety")!!
+                withClue("Cradle of Safety has flash") {
+                    cardDef.keywords.contains(Keyword.FLASH) shouldBe true
+                }
+            }
+
+            test("enchanting a creature you control gives +1/+1 and hexproof until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Cradle of Safety")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Grizzly Bears does not start with hexproof") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HEXPROOF) shouldBe false
+                }
+
+                game.castSpell(1, "Cradle of Safety", targetId = bears).error shouldBe null
+                game.resolveStack() // Aura resolves and attaches -> ETB trigger grants hexproof
+
+                withClue("Cradle of Safety is attached to Grizzly Bears") {
+                    game.isOnBattlefield("Cradle of Safety") shouldBe true
+                }
+                withClue("Grizzly Bears gets +1/+1 (becomes 3/3)") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 3
+                }
+                withClue("Grizzly Bears gains hexproof until end of turn") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HEXPROOF) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CruelWitnessScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CruelWitnessScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ReorderLibraryDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Cruel Witness (VOW #55) — {2}{U}{U} Creature — Bird Horror, 3/3, Flying.
+ *
+ *   Whenever you cast a noncreature spell, surveil 1.
+ *
+ * Exercises the noncreature-cast trigger firing a Surveil 1 (a card-selection decision over the
+ * top card of the library), and confirms a creature spell does NOT trigger it.
+ */
+class CruelWitnessScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Cruel Witness") {
+
+            test("casting a noncreature spell triggers surveil 1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cruel Witness", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Mountain") // surveil fodder (top card)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("casting a noncreature spell triggers a surveil 1 look at the top card") {
+                    val decision = game.getPendingDecision()
+                    decision.shouldBeInstanceOf<SelectCardsDecision>()
+                    (decision as SelectCardsDecision).options.size shouldBe 1
+                }
+                game.skipSelection() // keep the card out of the graveyard...
+                // ...which leaves it to be put back on top; the surveil pipeline's "put the rest on
+                // top" step (CardOrder.ControllerChooses) then raises a ReorderLibraryDecision.
+                if (game.getPendingDecision() is ReorderLibraryDecision) game.keepLibraryOrder()
+
+                withClue("the surveil resolved without further decisions") {
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+
+            test("does not trigger when casting a creature spell") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Cruel Witness", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Mountain")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("a creature spell must not trigger a surveil") {
+                    game.hasPendingDecision() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DawnhartDiscipleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DawnhartDiscipleScenarioTest.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Dawnhart Disciple (VOW #196) — {1}{G} Creature — Human Warlock, 2/2.
+ *
+ *   Whenever another Human you control enters, this creature gets +1/+1 until end of turn.
+ *
+ * Exercises the "another Human enters" trigger: casting a second Human creature you control
+ * pumps Dawnhart Disciple +1/+1 until end of turn.
+ */
+class DawnhartDiscipleScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dawnhart Disciple — another Human entering pumps it") {
+
+            test("another Human you control entering gives Dawnhart Disciple +1/+1 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dawnhart Disciple", summoningSickness = false)
+                    .withCardInHand(1, "Glory Seeker") // another Human you control
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val disciple = game.findPermanent("Dawnhart Disciple")!!
+
+                withClue("Dawnhart Disciple starts at its base 2/2") {
+                    game.state.projectedState.getPower(disciple) shouldBe 2
+                    game.state.projectedState.getToughness(disciple) shouldBe 2
+                }
+
+                game.castSpell(1, "Glory Seeker").error shouldBe null
+                game.resolveStack() // Glory Seeker enters → triggers Dawnhart Disciple's pump
+
+                withClue("Dawnhart Disciple gets +1/+1 (becomes 3/3)") {
+                    game.state.projectedState.getPower(disciple) shouldBe 3
+                    game.state.projectedState.getToughness(disciple) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DawnhartGeistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DawnhartGeistScenarioTest.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Dawnhart Geist (VOW #8) — {1}{W} Creature — Spirit Warlock, 1/3.
+ *
+ *   Whenever you cast an enchantment spell, you gain 2 life.
+ *
+ * Exercises the "you cast an enchantment spell" trigger: casting an enchantment gains 2 life.
+ */
+class DawnhartGeistScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dawnhart Geist — casting an enchantment gains 2 life") {
+
+            test("casting an enchantment spell gains 2 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dawnhart Geist", summoningSickness = false)
+                    .withCardInHand(1, "Test Enchantment")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Enchantment").error shouldBe null
+                game.resolveStack() // the cast trigger (and then the enchantment spell) resolve
+
+                withClue("Player 1 gains 2 life (20 -> 22) from the cast trigger") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+
+                withClue("Test Enchantment resolves onto the battlefield") {
+                    game.isOnBattlefield("Test Enchantment") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DaybreakCombatantsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DaybreakCombatantsScenarioTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Daybreak Combatants (VOW #153) — {2}{R} Creature — Human Warrior, 2/2, haste.
+ *
+ *   When this creature enters, target creature gets +2/+0 until end of turn.
+ *
+ * Exercises the ETB targeted buff: the trigger asks for a target creature and applies +2/+0.
+ */
+class DaybreakCombatantsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Daybreak Combatants ETB buff") {
+
+            test("entering gives a target creature +2/+0 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Daybreak Combatants")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 target
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpell(1, "Daybreak Combatants").error shouldBe null
+                game.resolveStack() // creature enters → ETB trigger asks for a target
+
+                val result = game.selectTargets(listOf(bears))
+                withClue("Targeting a creature is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets +2/+0 (becomes 4/2)") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+                withClue("Daybreak Combatants is on the battlefield") {
+                    game.isOnBattlefield("Daybreak Combatants") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeathcapGladeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeathcapGladeScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Deathcap Glade (VOW #261) — Land.
+ *
+ *   This land enters tapped unless you control two or more other lands.
+ *   {T}: Add {B} or {G}.
+ *
+ * One of the "slow lands": enters untapped only with two or more other lands already in play
+ * (i.e. three or more lands total, counting itself). Exercises both the tapped-entry replacement
+ * and the two-mode {T} mana ability.
+ */
+class DeathcapGladeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Deathcap Glade — enters tapped unless you control two or more other lands") {
+
+            test("enters tapped as the very first land") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Deathcap Glade")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glade = game.findCardsInHand(1, "Deathcap Glade").first()
+                game.execute(PlayLand(game.player1Id, glade)).error shouldBe null
+
+                withClue("With no other lands, Deathcap Glade enters tapped") {
+                    game.state.getEntity(glade)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("enters untapped with two or more other lands already controlled") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Deathcap Glade")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glade = game.findCardsInHand(1, "Deathcap Glade").first()
+                game.execute(PlayLand(game.player1Id, glade)).error shouldBe null
+
+                withClue("With two other lands, Deathcap Glade enters untapped") {
+                    game.state.getEntity(glade)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("{T}: Add {B} or {G}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Deathcap Glade", tapped = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glade = game.findPermanent("Deathcap Glade")!!
+                val blackAbility = cardRegistry.getCard("Deathcap Glade")!!.activatedAbilities[0].id
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = blackAbility)
+                ).error shouldBe null
+
+                withClue("taps for black") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.black shouldBe 1
+                }
+            }
+
+            test("{T}: Add {G} on a second copy") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Deathcap Glade", tapped = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val glade = game.findPermanent("Deathcap Glade")!!
+                val greenAbility = cardRegistry.getCard("Deathcap Glade")!!.activatedAbilities[1].id
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = glade, abilityId = greenAbility)
+                ).error shouldBe null
+
+                withClue("taps for green") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.green shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiregrafScavengerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DiregrafScavengerScenarioTest.kt
@@ -1,0 +1,86 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Diregraf Scavenger (VOW #105) — {3}{B} Creature — Zombie Bear, 2/3,
+ * Deathtouch.
+ *
+ *   When this creature enters, exile up to one target card from a graveyard. If a creature card
+ *   was exiled this way, each opponent loses 2 life and you gain 2 life.
+ *
+ * Exercises both branches of the conditional drain: exiling a creature card triggers the life
+ * swing, exiling a noncreature card does not.
+ */
+class DiregrafScavengerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Diregraf Scavenger ETB") {
+
+            test("exiling a creature card from a graveyard drains each opponent for 2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Diregraf Scavenger")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInGraveyard(2, "Hill Giant") // creature
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("Diregraf Scavenger has deathtouch") {
+                    cardRegistry.getCard("Diregraf Scavenger")!!.keywords.contains(Keyword.DEATHTOUCH) shouldBe true
+                }
+
+                game.castSpell(1, "Diregraf Scavenger").error shouldBe null
+                game.resolveStack() // creature enters -> ETB trigger asks for a target
+
+                val creatureCard = game.findCardsInGraveyard(2, "Hill Giant").first()
+                game.selectTargets(listOf(creatureCard)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the creature card is exiled") {
+                    game.isInExile(2, "Hill Giant") shouldBe true
+                }
+                withClue("a creature was exiled -> opponent loses 2, you gain 2") {
+                    game.getLifeTotal(2) shouldBe 18
+                    game.getLifeTotal(1) shouldBe 22
+                }
+            }
+
+            test("exiling a noncreature card does not drain") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Diregraf Scavenger")
+                    .withLandsOnBattlefield(1, "Swamp", 4)
+                    .withCardInGraveyard(2, "Mountain") // noncreature
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Diregraf Scavenger").error shouldBe null
+                game.resolveStack()
+
+                val landCard = game.findCardsInGraveyard(2, "Mountain").first()
+                game.selectTargets(listOf(landCard)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the land card is exiled") {
+                    game.isInExile(2, "Mountain") shouldBe true
+                }
+                withClue("no creature exiled -> no life change") {
+                    game.getLifeTotal(2) shouldBe 20
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreamrootCascadeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DreamrootCascadeScenarioTest.kt
@@ -1,0 +1,102 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Dreamroot Cascade (VOW #262) — Land.
+ *
+ *   This land enters tapped unless you control two or more other lands.
+ *   {T}: Add {G} or {U}.
+ *
+ * One of the "slow lands": enters untapped only with two or more other lands already in play
+ * (i.e. three or more lands total, counting itself). Exercises both the tapped-entry replacement
+ * and the two-mode {T} mana ability.
+ */
+class DreamrootCascadeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Dreamroot Cascade — enters tapped unless you control two or more other lands") {
+
+            test("enters tapped as the very first land") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dreamroot Cascade")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cascade = game.findCardsInHand(1, "Dreamroot Cascade").first()
+                game.execute(PlayLand(game.player1Id, cascade)).error shouldBe null
+
+                withClue("With no other lands, Dreamroot Cascade enters tapped") {
+                    game.state.getEntity(cascade)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("enters untapped with two or more other lands already controlled") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Dreamroot Cascade")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cascade = game.findCardsInHand(1, "Dreamroot Cascade").first()
+                game.execute(PlayLand(game.player1Id, cascade)).error shouldBe null
+
+                withClue("With two other lands, Dreamroot Cascade enters untapped") {
+                    game.state.getEntity(cascade)?.has<TappedComponent>() shouldBe false
+                }
+            }
+
+            test("{T}: Add {G}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dreamroot Cascade", tapped = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cascade = game.findPermanent("Dreamroot Cascade")!!
+                val greenAbility = cardRegistry.getCard("Dreamroot Cascade")!!.activatedAbilities[0].id
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = cascade, abilityId = greenAbility)
+                ).error shouldBe null
+
+                withClue("taps for green") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.green shouldBe 1
+                }
+            }
+
+            test("{T}: Add {U} on a second copy") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Dreamroot Cascade", tapped = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val cascade = game.findPermanent("Dreamroot Cascade")!!
+                val blueAbility = cardRegistry.getCard("Dreamroot Cascade")!!.activatedAbilities[1].id
+
+                game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = cascade, abilityId = blueAbility)
+                ).error shouldBe null
+
+                withClue("taps for blue") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.blue shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EndTheFestivitiesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EndTheFestivitiesScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for End the Festivities (VOW #155) — {R} Sorcery.
+ *
+ *   End the Festivities deals 1 damage to each opponent and each creature and planeswalker they
+ *   control.
+ *
+ * Exercises the mass 1-damage sweep: the opponent takes 1 (life 20 -> 19), each of their creatures
+ * takes 1 marked damage (a 1-toughness creature dies; a tougher one survives), and the caster's own
+ * board is untouched.
+ */
+class EndTheFestivitiesScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("End the Festivities — 1 damage to each opponent and their permanents") {
+
+            test("opponent loses 1 life, their 1/1 dies, their 2/2 survives with 1 damage, own board untouched") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "End the Festivities")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    // Player1's own creature — must NOT be damaged.
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    // Opponent's board: a 1/1 that dies and a 2/2 that survives with 1 marked damage.
+                    .withCardOnBattlefield(2, "Savannah Lions", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ownBears = game.findPermanents("Grizzly Bears")
+                    .first { game.state.getBattlefield(game.player1Id).contains(it) }
+                val opponentBears = game.findPermanents("Grizzly Bears")
+                    .first { game.state.getBattlefield(game.player2Id).contains(it) }
+
+                game.castSpell(1, "End the Festivities").error shouldBe null
+                game.resolveStack()
+
+                withClue("Player 2 (opponent) takes 1 damage (20 -> 19)") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("Opponent's 1/1 Savannah Lions is destroyed by 1 damage") {
+                    game.isOnBattlefield("Savannah Lions") shouldBe false
+                    game.isInGraveyard(2, "Savannah Lions") shouldBe true
+                }
+                withClue("Opponent's 2/2 Grizzly Bears survives with 1 marked damage") {
+                    game.state.getBattlefield(game.player2Id).contains(opponentBears) shouldBe true
+                    val opponentDamage = game.state.getEntity(opponentBears)?.get<DamageComponent>()?.amount ?: 0
+                    opponentDamage shouldBe 1
+                }
+                withClue("Player 1's own Grizzly Bears is untouched (an opponent's permanents only)") {
+                    val ownDamage = game.state.getEntity(ownBears)?.get<DamageComponent>()?.amount ?: 0
+                    ownDamage shouldBe 0
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EstwaldShieldbasherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/EstwaldShieldbasherScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Estwald Shieldbasher (VOW #11) — {3}{W} Creature — Human Soldier, 4/2.
+ *
+ *   Whenever this creature attacks, you may pay {1}. If you do, it gains indestructible until
+ *   end of turn.
+ *
+ * Exercises the optional-mana attack trigger: paying {1} grants indestructible to the attacker;
+ * declining leaves it without indestructible.
+ */
+class EstwaldShieldbasherScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Estwald Shieldbasher — may pay {1} on attack") {
+
+            test("paying {1} grants indestructible until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Estwald Shieldbasher", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shieldbasher = game.findPermanent("Estwald Shieldbasher")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Estwald Shieldbasher" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the attack trigger offers a yes/no to pay {1}") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+
+                withClue("paying yes then prompts for mana sources") {
+                    game.getPendingDecision().shouldBeInstanceOf<SelectManaSourcesDecision>()
+                }
+                game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Estwald Shieldbasher gains indestructible") {
+                    game.state.projectedState.hasKeyword(shieldbasher, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+
+            test("declining the payment leaves it without indestructible") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Estwald Shieldbasher", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val shieldbasher = game.findPermanent("Estwald Shieldbasher")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Estwald Shieldbasher" to 2)).error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("declining leaves it without indestructible") {
+                    game.state.projectedState.hasKeyword(shieldbasher, Keyword.INDESTRUCTIBLE) shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FalkenrathCelebrantsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FalkenrathCelebrantsScenarioTest.kt
@@ -1,0 +1,46 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Falkenrath Celebrants (VOW #306) — {4}{R} Creature — Vampire, 4/4.
+ *
+ *   Menace
+ *   When this creature enters, create two Blood tokens.
+ *
+ * Exercises the ETB Blood-token creation (two tokens) and confirms the Menace keyword is present.
+ */
+class FalkenrathCelebrantsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Falkenrath Celebrants") {
+
+            test("entering the battlefield creates two Blood tokens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Falkenrath Celebrants")
+                    .withLandsOnBattlefield(1, "Mountain", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Falkenrath Celebrants").error shouldBe null
+                game.resolveStack()
+
+                withClue("two Blood tokens are created on entering the battlefield") {
+                    game.findPermanents("Blood").size shouldBe 2
+                }
+
+                val celebrants = game.findPermanent("Falkenrath Celebrants")!!
+                withClue("Falkenrath Celebrants has Menace") {
+                    game.state.projectedState.hasKeyword(celebrants, Keyword.MENACE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FalkenrathForebearScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FalkenrathForebearScenarioTest.kt
@@ -1,0 +1,127 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Falkenrath Forebear (VOW #334) — {2}{B} Creature — Vampire, 3/1, Flying.
+ *
+ *   Flying
+ *   This creature can't block.
+ *   Whenever this creature deals combat damage to a player, create a Blood token.
+ *   {B}, Sacrifice two Blood tokens: Return this card from your graveyard to the battlefield.
+ *
+ * Exercises the printed Flying/can't-block statics, the combat-damage-to-player -> Blood token
+ * trigger, and the graveyard-activated recursion ability paid with two sacrificed Blood tokens.
+ */
+class FalkenrathForebearScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Falkenrath Forebear") {
+
+            test("has flying and can't block") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Falkenrath Forebear", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val forebear = game.findPermanent("Falkenrath Forebear")!!
+
+                withClue("Falkenrath Forebear has flying") {
+                    game.state.projectedState.hasKeyword(forebear, Keyword.FLYING) shouldBe true
+                }
+                withClue("Falkenrath Forebear can't block") {
+                    game.state.projectedState.cantBlock(forebear) shouldBe true
+                }
+            }
+
+            test("dealing combat damage to a player creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Falkenrath Forebear", summoningSickness = false)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Falkenrath Forebear" to 2)).error shouldBe null
+                game.passUntilPhase(Phase.COMBAT, Step.END_COMBAT)
+                game.resolveStack()
+
+                withClue("the opponent takes 3 combat damage (20 -> 17)") {
+                    game.getLifeTotal(2) shouldBe 17
+                }
+                withClue("a Blood token was created") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+
+            test("{B}, Sacrifice two Blood tokens returns it from the graveyard to the battlefield") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Falkenrath Forebear")
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("Starts in the graveyard, not on the battlefield") {
+                    game.isInGraveyard(1, "Falkenrath Forebear") shouldBe true
+                    game.isOnBattlefield("Falkenrath Forebear") shouldBe false
+                }
+
+                val bloodTokens = game.findPermanents("Blood")
+                withClue("Two Blood tokens are on the battlefield to sacrifice") {
+                    bloodTokens.size shouldBe 2
+                }
+
+                val graveyardCard = game.state.getGraveyard(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Falkenrath Forebear"
+                }
+                val abilityId = cardRegistry.getCard("Falkenrath Forebear")!!
+                    .activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = graveyardCard,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(sacrificedPermanents = bloodTokens),
+                    )
+                )
+                withClue("Activating the {B}, sacrifice two Blood tokens ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+
+                withClue("Both Blood tokens were sacrificed as a cost") {
+                    game.findPermanents("Blood").size shouldBe 0
+                }
+
+                game.resolveStack()
+
+                withClue("Falkenrath Forebear is back on the battlefield") {
+                    game.isOnBattlefield("Falkenrath Forebear") shouldBe true
+                }
+                withClue("Falkenrath Forebear is no longer in the graveyard") {
+                    game.isInGraveyard(1, "Falkenrath Forebear") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfDeathScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FearOfDeathScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Fear of Death (VOW #59) — {1}{U} Enchantment — Aura.
+ *
+ *   Enchant creature
+ *   When this Aura enters, mill two cards.
+ *   Enchanted creature gets -X/-0, where X is the number of cards in your graveyard.
+ *
+ * Exercises the ETB self-mill and the continuous -X/-0 debuff on the enchanted creature scaling
+ * with the controller's graveyard size.
+ */
+class FearOfDeathScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Fear of Death") {
+
+            test("entering mills two cards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Fear of Death")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withCardInLibrary(1, "Swamp")
+                    .withCardInLibrary(1, "Swamp")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("starts with an empty graveyard") {
+                    game.graveyardSize(1) shouldBe 0
+                }
+
+                game.castSpell(1, "Fear of Death", targetId = bears).error shouldBe null
+                game.resolveStack() // Aura resolves and attaches -> ETB trigger mills two
+
+                withClue("Fear of Death is attached to Grizzly Bears") {
+                    game.isOnBattlefield("Fear of Death") shouldBe true
+                }
+                withClue("the ETB milled exactly two cards into the graveyard") {
+                    game.graveyardSize(1) shouldBe 2
+                }
+            }
+
+            test("enchanted creature's power is reduced by the controller's graveyard size") {
+                val builder = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardAttachedTo(1, "Fear of Death", "Grizzly Bears")
+                repeat(3) { builder.withCardInGraveyard(1, "Swamp") }
+                val game = builder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("with three cards in the graveyard, Grizzly Bears (2/2 base) becomes -1/2") {
+                    game.state.projectedState.getPower(bears) shouldBe -1
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlameBlessedBoltScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlameBlessedBoltScenarioTest.kt
@@ -1,0 +1,69 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Flame-Blessed Bolt (VOW #158) — {R} Instant.
+ *
+ * "Flame-Blessed Bolt deals 2 damage to target creature or planeswalker. If that creature or
+ *  planeswalker would die this turn, exile it instead."
+ *
+ * The spell deals 2 damage then marks the target with a death-replacement that sends it to exile
+ * instead of the graveyard if it dies this turn.
+ */
+class FlameBlessedBoltScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Flame-Blessed Bolt") {
+
+            test("kills a 1-toughness creature and exiles it instead of putting it in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Flame-Blessed Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Savannah Lions") // 1/1
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lions = game.findPermanent("Savannah Lions")!!
+                game.castSpell(1, "Flame-Blessed Bolt", lions).error shouldBe null
+                game.resolveStack()
+
+                withClue("the 1/1 should be exiled, not in the graveyard") {
+                    game.state.getZone(ZoneKey(game.player2Id, Zone.EXILE)) shouldContain lions
+                    game.state.getZone(ZoneKey(game.player2Id, Zone.GRAVEYARD)) shouldNotContain lions
+                }
+            }
+
+            test("a creature that survives the 2 damage stays on the battlefield with damage marked") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Flame-Blessed Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Hill Giant") // 3/3, survives 2 damage
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                game.castSpell(1, "Flame-Blessed Bolt", giant).error shouldBe null
+                game.resolveStack()
+
+                withClue("Hill Giant survives 2 damage and stays in play") {
+                    game.findPermanent("Hill Giant") shouldBe giant
+                    game.state.getEntity(giant)?.get<DamageComponent>()?.amount shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlourishingHunterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FlourishingHunterScenarioTest.kt
@@ -1,0 +1,65 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Flourishing Hunter (VOW #199) — {4}{G}{G} Creature — Wolf Spirit, 6/6.
+ *
+ *   When this creature enters, you gain life equal to the greatest toughness among other
+ *   creatures you control.
+ *
+ * Exercises the MAX-toughness aggregate with excludeSelf=true: with a 2/2 and a 3/3 other creature
+ * you control, life gained is 3 (the greatest OTHER toughness), not Flourishing Hunter's own 6.
+ */
+class FlourishingHunterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Flourishing Hunter ETB") {
+
+            test("gains life equal to the greatest toughness among other creatures you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Flourishing Hunter")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false) // 3/3
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Flourishing Hunter").error shouldBe null
+                game.resolveStack()
+
+                withClue("Flourishing Hunter entered the battlefield") {
+                    game.isOnBattlefield("Flourishing Hunter") shouldBe true
+                }
+                withClue("gained 3 life (Hill Giant's toughness, the greatest among other creatures)") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+            }
+
+            test("with no other creatures, gains no life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Flourishing Hunter")
+                    .withLandsOnBattlefield(1, "Forest", 6)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Flourishing Hunter").error shouldBe null
+                game.resolveStack()
+
+                withClue("no other creatures you control -> no life gained") {
+                    game.getLifeTotal(1) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrenziedDevilsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/FrenziedDevilsScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Frenzied Devils (VOW #159) — {4}{R} Creature — Devil, 3/3.
+ *
+ *   Haste
+ *   Whenever you cast a noncreature spell, this creature gets +2/+2 until end of turn.
+ *
+ * Exercises the "you cast a noncreature spell" trigger: casting an instant pumps Frenzied Devils
+ * +2/+2 until end of turn. Also confirms the printed Haste keyword is present.
+ */
+class FrenziedDevilsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Frenzied Devils — casting a noncreature spell pumps it") {
+
+            test("has Haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Frenzied Devils", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val devils = game.findPermanent("Frenzied Devils")!!
+                withClue("Frenzied Devils has Haste") {
+                    game.state.projectedState.hasKeyword(devils, Keyword.HASTE) shouldBe true
+                }
+            }
+
+            test("casting a noncreature spell gives Frenzied Devils +2/+2 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Frenzied Devils", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val devils = game.findPermanent("Frenzied Devils")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Frenzied Devils starts at its base 3/3") {
+                    game.state.projectedState.getPower(devils) shouldBe 3
+                    game.state.projectedState.getToughness(devils) shouldBe 3
+                }
+
+                game.castSpell(1, "Lightning Bolt", bears).error shouldBe null
+                game.resolveStack() // trigger + Lightning Bolt both resolve
+
+                withClue("Frenzied Devils gets +2/+2 (becomes 5/5)") {
+                    game.state.projectedState.getPower(devils) shouldBe 5
+                    game.state.projectedState.getToughness(devils) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeistlightSnareScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GeistlightSnareScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Geistlight Snare (VOW #60) — {2}{U} Instant.
+ *
+ *   This spell costs {1} less to cast if you control a Spirit. It also costs {1} less to cast if
+ *   you control an enchantment.
+ *   Counter target spell unless its controller pays {3}.
+ *
+ * Exercises the simplest meaningful branch of the "counter unless pays" effect: the targeted
+ * spell's controller has spent all their mana casting it, so when Geistlight Snare resolves they
+ * cannot pay {3} and the spell is auto-countered (no payment decision needed).
+ */
+class GeistlightSnareScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Geistlight Snare — counter target spell unless its controller pays {3}") {
+
+            test("auto-counters when the spell's controller has no mana left to pay {3}") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Geistlight Snare")
+                    .withLandsOnBattlefield(1, "Island", 3) // {2}{U}
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2) // exactly {1}{G}, none left over
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val castResult = game.castSpell(2, "Grizzly Bears")
+                withClue("Casting Grizzly Bears should succeed: ${castResult.error}") {
+                    castResult.error shouldBe null
+                }
+
+                game.passPriority() // let player 1 respond
+
+                val snareResult = game.castSpellTargetingStackSpell(1, "Geistlight Snare", "Grizzly Bears")
+                withClue("Casting Geistlight Snare should succeed: ${snareResult.error}") {
+                    snareResult.error shouldBe null
+                }
+
+                game.resolveStack()
+
+                withClue("Grizzly Bears should be countered (in player 2's graveyard, not on battlefield)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiftOfFangsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GiftOfFangsScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Gift of Fangs (VOW #113) — {B} Enchantment — Aura.
+ *
+ *   Enchant creature
+ *   Enchanted creature gets +2/+2 as long as it's a Vampire. Otherwise, it gets -2/-2.
+ *
+ * Exercises both conditional static branches: attached to a Vampire it's a +2/+2 buff, attached
+ * to a non-Vampire it's a -2/-2 debuff.
+ */
+class GiftOfFangsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Gift of Fangs") {
+
+            test("enchanting a Vampire grants +2/+2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Belligerent Guest", summoningSickness = false) // 3/2 Vampire
+                    .withCardAttachedTo(1, "Gift of Fangs", "Belligerent Guest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val guest = game.findPermanent("Belligerent Guest")!!
+
+                withClue("3/2 base Vampire + 2/2 = 5/4") {
+                    game.state.projectedState.getPower(guest) shouldBe 5
+                    game.state.projectedState.getToughness(guest) shouldBe 4
+                }
+            }
+
+            test("enchanting a non-Vampire grants -2/-2") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false) // 3/3 Giant
+                    .withCardAttachedTo(1, "Gift of Fangs", "Hill Giant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                withClue("3/3 base Giant - 2/2 = 1/1 (alive, not lethal)") {
+                    game.state.projectedState.getPower(giant) shouldBe 1
+                    game.state.projectedState.getToughness(giant) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GluttonousGuestScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GluttonousGuestScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Gluttonous Guest (VOW #114) — {2}{B} Creature — Vampire, 1/4.
+ *
+ *   When this creature enters, create a Blood token.
+ *   Whenever you sacrifice a Blood token, you gain 1 life.
+ *
+ * Exercises the ETB Blood-token creation, and the "whenever you sacrifice a Blood token" trigger
+ * by activating the Blood token's own "{1}, {T}, Discard a card, Sacrifice this artifact: Draw a
+ * card" ability, which sacrifices it as part of paying its cost.
+ */
+class GluttonousGuestScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Gluttonous Guest") {
+
+            test("entering the battlefield creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Gluttonous Guest")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Gluttonous Guest").error shouldBe null
+                game.resolveStack()
+
+                withClue("a Blood token is created on entering the battlefield") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+
+            test("sacrificing a Blood token (via its own ability) gains 1 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Gluttonous Guest", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withCardInHand(1, "Grizzly Bears") // fodder to discard for Blood's cost
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val blood = game.findPermanent("Blood")!!
+                val toDiscard = game.findCardsInHand(1, "Grizzly Bears").first()
+                val bloodAbilityId = cardRegistry.getCard("Blood")!!.activatedAbilities.first().id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = blood,
+                        abilityId = bloodAbilityId,
+                        costPayment = AdditionalCostPayment(discardedCards = listOf(toDiscard))
+                    )
+                )
+                withClue("Activating the Blood token's ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the Blood token was sacrificed to pay its own cost") {
+                    game.findPermanents("Blood").size shouldBe 0
+                }
+                withClue("Gluttonous Guest's trigger gains 1 life (20 -> 21)") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrislyRitualScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GrislyRitualScenarioTest.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Grisly Ritual (VOW #116) — {5}{B} Sorcery.
+ *
+ *   Destroy target creature or planeswalker. Create two Blood tokens.
+ *
+ * Exercises the destroy + Blood-token composite against a creature target. Note: the target
+ * filter also allows planeswalkers, but no planeswalker test card is registered in the shared
+ * test pool, so that branch of `Targets.CreatureOrPlaneswalker` is not exercised here.
+ */
+class GrislyRitualScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Grisly Ritual") {
+
+            test("destroys the target creature and creates two Blood tokens") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Grisly Ritual")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Swamp", 6)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.castSpell(1, "Grisly Ritual", targetId = giant).error shouldBe null
+                game.resolveStack()
+
+                withClue("Hill Giant is destroyed") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+                withClue("two Blood tokens are created") {
+                    game.findPermanents("Blood").size shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HalanaAndAlenaPartnersScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HalanaAndAlenaPartnersScenarioTest.kt
@@ -1,0 +1,85 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Halana and Alena, Partners (VOW #239) — {2}{R}{G} Legendary Creature —
+ * Human Ranger, 2/3.
+ *
+ *   First strike
+ *   Reach
+ *   At the beginning of combat on your turn, put X +1/+1 counters on another target creature you
+ *   control, where X is Halana and Alena's power. That creature gains haste until end of turn.
+ *
+ * Exercises the beginning-of-combat trigger: at 2 power, it puts two +1/+1 counters on another
+ * target creature you control and grants that creature haste.
+ */
+class HalanaAndAlenaPartnersScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Halana and Alena, Partners — begin combat trigger") {
+
+            test("has First Strike and Reach") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Halana and Alena, Partners", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val halanaAndAlena = game.findPermanent("Halana and Alena, Partners")!!
+                withClue("has First Strike") {
+                    game.state.projectedState.hasKeyword(halanaAndAlena, Keyword.FIRST_STRIKE) shouldBe true
+                }
+                withClue("has Reach") {
+                    game.state.projectedState.hasKeyword(halanaAndAlena, Keyword.REACH) shouldBe true
+                }
+            }
+
+            test("puts X +1/+1 counters (X = its power) on another target creature and grants haste") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Halana and Alena, Partners", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = true) // 2/2, has sickness
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val halanaAndAlena = game.findPermanent("Halana and Alena, Partners")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Halana and Alena start at base power 2") {
+                    game.state.projectedState.getPower(halanaAndAlena) shouldBe 2
+                }
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack() // trigger goes on the stack and asks for a target
+
+                val result = game.selectTargets(listOf(bears))
+                withClue("Targeting another creature you control is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets 2 +1/+1 counters (X = Halana and Alena's power)") {
+                    game.state.getEntity(bears)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 2
+                }
+                withClue("Grizzly Bears becomes a 4/4 with the counters applied") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 4
+                }
+                withClue("Grizzly Bears gains haste until end of turn") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.HASTE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HeadlessRiderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HeadlessRiderScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Headless Rider (VOW #372) — {2}{B} Creature — Zombie, 3/1.
+ *
+ *   Whenever this creature or another nontoken Zombie you control dies, create a 2/2 black
+ *   Zombie creature token.
+ *
+ * Exercises the shared dies-trigger filter: killing Headless Rider itself creates a 2/2 black
+ * Zombie token, and killing another nontoken Zombie you control also creates one.
+ */
+class HeadlessRiderScenarioTest : ScenarioTestBase() {
+
+    private fun zombieTokenCount(game: TestGame, playerId: com.wingedsheep.sdk.model.EntityId): Int =
+        game.state.getBattlefield(playerId).count { id ->
+            game.state.getEntity(id)?.get<CardComponent>()?.name == "Zombie Token"
+        }
+
+    init {
+        context("Headless Rider — shared dies trigger") {
+
+            test("Headless Rider dying to itself creates a 2/2 black Zombie token") {
+                // Headless Rider is black, so removal must not be color-restricted; Lightning Bolt's
+                // 3 damage is lethal to its 1 toughness.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Headless Rider", summoningSickness = false)
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val rider = game.findPermanent("Headless Rider")!!
+                val tokensBefore = zombieTokenCount(game, game.player1Id)
+
+                game.castSpell(2, "Lightning Bolt", rider).error shouldBe null
+                game.resolveStack() // Lightning Bolt resolves, Headless Rider dies (SBA)
+                game.resolveStack() // dies trigger resolves, token created
+
+                withClue("Headless Rider died") {
+                    game.isOnBattlefield("Headless Rider") shouldBe false
+                    game.isInGraveyard(1, "Headless Rider") shouldBe true
+                }
+                withClue("a 2/2 black Zombie token is created") {
+                    zombieTokenCount(game, game.player1Id) shouldBe tokensBefore + 1
+                }
+            }
+
+            test("another nontoken Zombie you control dying also creates a 2/2 black Zombie token") {
+                // Diregraf Scavenger (a Zombie) is black — use unrestricted removal. It's a 2/3, so
+                // Lightning Bolt's 3 damage is lethal.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Headless Rider", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Diregraf Scavenger", summoningSickness = false)
+                    .withCardInHand(2, "Lightning Bolt")
+                    .withLandsOnBattlefield(2, "Mountain", 1)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val scavenger = game.findPermanent("Diregraf Scavenger")!!
+                val tokensBefore = zombieTokenCount(game, game.player1Id)
+
+                game.castSpell(2, "Lightning Bolt", scavenger).error shouldBe null
+                game.resolveStack()
+                game.resolveStack()
+
+                withClue("Diregraf Scavenger died") {
+                    game.isOnBattlefield("Diregraf Scavenger") shouldBe false
+                }
+                withClue("Headless Rider is still alive to see another Zombie die") {
+                    game.isOnBattlefield("Headless Rider") shouldBe true
+                }
+                withClue("a 2/2 black Zombie token is created from another Zombie dying") {
+                    zombieTokenCount(game, game.player1Id) shouldBe tokensBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HeronBlessedGeistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HeronBlessedGeistScenarioTest.kt
@@ -1,0 +1,89 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Heron-Blessed Geist (VOW #19) — {4}{W} Creature — Spirit, 3/3.
+ *
+ *   Flying
+ *   {3}{W}, Exile this card from your graveyard: Create two 1/1 white Spirit creature tokens
+ *   with flying. Activate only if you control an enchantment and only as a sorcery.
+ *
+ * Exercises the graveyard-activated ability: it requires controlling an enchantment, and paying
+ * {3}{W} + exiling the card from the graveyard creates two 1/1 flying Spirit tokens.
+ */
+class HeronBlessedGeistScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Heron-Blessed Geist — graveyard activation gated on controlling an enchantment") {
+
+            test("with an enchantment you control, paying {3}{W} and exiling creates two 1/1 flying Spirits") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Heron-Blessed Geist")
+                    .withCardOnBattlefield(1, "Test Enchantment")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val geist = game.findCardsInGraveyard(1, "Heron-Blessed Geist").single()
+                val abilityId = cardRegistry.getCard("Heron-Blessed Geist")!!.activatedAbilities.first().id
+
+                val spiritsBefore = game.findPermanents("Spirit Token").size
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = geist,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("activation should succeed while controlling an enchantment: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the card is exiled from the graveyard") {
+                    game.isInGraveyard(1, "Heron-Blessed Geist") shouldBe false
+                    game.isInExile(1, "Heron-Blessed Geist") shouldBe true
+                }
+                withClue("two 1/1 white Spirit tokens with flying are created") {
+                    game.findPermanents("Spirit Token").size shouldBe spiritsBefore + 2
+                }
+            }
+
+            test("without controlling an enchantment, the ability cannot be activated") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Heron-Blessed Geist")
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val geist = game.findCardsInGraveyard(1, "Heron-Blessed Geist").single()
+                val abilityId = cardRegistry.getCard("Heron-Blessed Geist")!!.activatedAbilities.first().id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = geist,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("activation must fail without controlling an enchantment") {
+                    (activation.error != null) shouldBe true
+                }
+                withClue("Heron-Blessed Geist stays in the graveyard") {
+                    game.isInGraveyard(1, "Heron-Blessed Geist") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HonoredHeirloomScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HonoredHeirloomScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Honored Heirloom (VOW #257) — {3} Artifact.
+ *
+ *   {T}: Add one mana of any color.
+ *   {2}, {T}: Exile target card from a graveyard.
+ *
+ * Exercises both activated abilities: tapping for a chosen color of mana, and (on a fresh copy,
+ * since the first ability taps the permanent) paying {2} and tapping to exile a target card from
+ * a graveyard.
+ */
+class HonoredHeirloomScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Honored Heirloom") {
+
+            test("{T}: Add one mana of any color") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Honored Heirloom", tapped = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val heirloom = game.findPermanent("Honored Heirloom")!!
+                val manaAbilityId = cardRegistry.getCard("Honored Heirloom")!!.activatedAbilities[0].id
+
+                game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = heirloom,
+                        abilityId = manaAbilityId,
+                        manaColorChoice = Color.BLACK
+                    )
+                ).error shouldBe null
+
+                withClue("taps for one black mana") {
+                    game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()?.black shouldBe 1
+                }
+            }
+
+            test("{2}, {T}: Exile target card from a graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Honored Heirloom", tapped = false)
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val heirloom = game.findPermanent("Honored Heirloom")!!
+                val bears = game.findCardsInGraveyard(2, "Grizzly Bears").first()
+                val exileAbilityId = cardRegistry.getCard("Honored Heirloom")!!.activatedAbilities[1].id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = heirloom,
+                        abilityId = exileAbilityId,
+                        targets = listOf(ChosenTarget.Card(bears, game.player2Id, Zone.GRAVEYARD))
+                    )
+                )
+                withClue("Activating the exile ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears is exiled from the graveyard") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HullbreakerHorrorScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HullbreakerHorrorScenarioTest.kt
@@ -1,0 +1,81 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hullbreaker Horror (VOW #63) — {5}{U}{U} Creature — Kraken Horror, 7/8.
+ *
+ *   Flash
+ *   This spell can't be countered.
+ *   Whenever you cast a spell, choose up to one —
+ *   • Return target spell you don't control to its owner's hand.
+ *   • Return target nonland permanent to its owner's hand.
+ *
+ * Exercises the printed Flash + can't-be-countered flags on the card definition, and the modal
+ * "choose up to one" cast trigger: casting a further spell offers the two modes plus a decline
+ * option, and choosing "return target nonland permanent" bounces a permanent to its owner's hand.
+ */
+class HullbreakerHorrorScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hullbreaker Horror") {
+
+            test("has Flash and can't be countered") {
+                val card = cardRegistry.getCard("Hullbreaker Horror")!!
+                withClue("Flash is a printed keyword") {
+                    card.keywords.contains(Keyword.FLASH) shouldBe true
+                }
+                withClue("the spell can't be countered") {
+                    card.script.cantBeCountered shouldBe true
+                }
+            }
+
+            test("casting a further spell offers the modal choice; bouncing a nonland permanent returns it to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hullbreaker Horror", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withCardOnBattlefield(2, "Grizzly Bears") // target for the bounce mode
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+
+                // The cast trigger resolves before the Bolt itself, offering the modal choice.
+                game.resolveStack()
+                val modeDecision = game.getPendingDecision() as? ChooseOptionDecision
+                    ?: error("Expected a ChooseOptionDecision; got ${game.getPendingDecision()}")
+                withClue("both bounce modes plus a decline option are offered") {
+                    modeDecision.options.size shouldBe 3
+                }
+                val bounceModeIndex = modeDecision.options.indexOfFirst { it.contains("nonland permanent") }
+                withClue("the 'return target nonland permanent' mode is offered") {
+                    (bounceModeIndex >= 0) shouldBe true
+                }
+                game.submitDecision(OptionChosenResponse(modeDecision.id, bounceModeIndex))
+
+                withClue("the mode asks for a target nonland permanent") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears was returned to its owner's hand") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInHand(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HungryRidgewolfScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/HungryRidgewolfScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Hungry Ridgewolf (VOW #161) — {1}{R} Creature — Wolf, 2/2.
+ *
+ *   As long as you control another Wolf or Werewolf, this creature gets +1/+0 and has trample.
+ *
+ * Exercises the split "as long as" condition (stats + keyword, same condition): with no other
+ * Wolf/Werewolf, Hungry Ridgewolf is a vanilla 2/2 without trample; controlling another Wolf turns
+ * on both the +1/+0 (3/2) and trample.
+ */
+class HungryRidgewolfScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Hungry Ridgewolf — conditional pump + trample") {
+
+            test("without another Wolf or Werewolf, it stays a vanilla 2/2 without trample") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hungry Ridgewolf", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Hungry Ridgewolf")!!
+
+                withClue("no other Wolf/Werewolf: base 2/2, no trample") {
+                    game.state.projectedState.getPower(wolf) shouldBe 2
+                    game.state.projectedState.getToughness(wolf) shouldBe 2
+                    game.state.projectedState.hasKeyword(wolf, Keyword.TRAMPLE) shouldBe false
+                }
+            }
+
+            test("with another Wolf you control, it gets +1/+0 and gains trample") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Hungry Ridgewolf", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Lightning Wolf", summoningSickness = false) // another Wolf
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val ridgewolf = game.findPermanent("Hungry Ridgewolf")!!
+
+                withClue("controlling another Wolf turns on the pump") {
+                    game.state.projectedState.getPower(ridgewolf) shouldBe 3
+                    game.state.projectedState.getToughness(ridgewolf) shouldBe 2
+                }
+                withClue("controlling another Wolf grants trample") {
+                    game.state.projectedState.hasKeyword(ridgewolf, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KessigFlamebreatherScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KessigFlamebreatherScenarioTest.kt
@@ -1,0 +1,62 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Kessig Flamebreather (VOW #164) — {1}{R} Creature — Human Shaman, 1/3.
+ *
+ *   Whenever you cast a noncreature spell, this creature deals 1 damage to each opponent.
+ *
+ * Exercises the noncreature-cast trigger: casting an instant (Lightning Bolt) triggers Kessig
+ * Flamebreather's 1 damage to each opponent, on top of the Bolt's own 3 damage. Also verifies the
+ * trigger does NOT fire off a creature spell.
+ */
+class KessigFlamebreatherScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Kessig Flamebreather — noncreature-cast damage trigger") {
+
+            test("casting a noncreature spell deals 1 damage to each opponent") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kessig Flamebreather", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("Kessig Flamebreather's 1 + Lightning Bolt's 3 = 4 damage (20 -> 16)") {
+                    game.getLifeTotal(2) shouldBe 16
+                }
+            }
+
+            test("casting a creature spell does not trigger the damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kessig Flamebreather", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("a creature spell does not trigger Kessig Flamebreather") {
+                    game.getLifeTotal(2) shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KessigWolfriderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KessigWolfriderScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Kessig Wolfrider (VOW #165) — {R} Creature — Human Knight, 1/2.
+ *
+ *   Menace
+ *   {2}{R}, {T}, Exile three cards from your graveyard: Create a 3/2 red Wolf creature token.
+ *
+ * Exercises the printed Menace keyword and the tap + mana + exile-three-from-graveyard activated
+ * ability that creates a 3/2 red Wolf token.
+ */
+class KessigWolfriderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Kessig Wolfrider") {
+
+            test("has Menace") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kessig Wolfrider", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolfrider = game.findPermanent("Kessig Wolfrider")!!
+                withClue("Kessig Wolfrider has Menace") {
+                    game.state.projectedState.hasKeyword(wolfrider, Keyword.MENACE) shouldBe true
+                }
+            }
+
+            test("{2}{R}, {T}, exile three cards from graveyard creates a 3/2 red Wolf token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Kessig Wolfrider", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(1, "Centaur Courser")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolfrider = game.findPermanent("Kessig Wolfrider")!!
+                val abilityId = cardRegistry.getCard("Kessig Wolfrider")!!.activatedAbilities.first().id
+                val wolvesBefore = game.findPermanents("Wolf Token").size
+                val graveyardBefore = game.graveyardSize(1)
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = wolfrider,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("activation should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("three cards were exiled from the graveyard") {
+                    game.graveyardSize(1) shouldBe graveyardBefore - 3
+                }
+                withClue("a 3/2 red Wolf token is created") {
+                    game.findPermanents("Wolf Token").size shouldBe wolvesBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LanternOfTheLostScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LanternOfTheLostScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Lantern of the Lost (VOW #259) — {1} Artifact.
+ *
+ *   When this artifact enters, exile target card from a graveyard.
+ *   {1}, {T}, Exile this artifact: Exile all cards from all graveyards, then draw a card.
+ *
+ * Exercises the ETB exile-target-from-graveyard trigger and the activated ability that clears
+ * every graveyard and draws a card.
+ */
+class LanternOfTheLostScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lantern of the Lost") {
+
+            test("ETB exiles a targeted card from a graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Lantern of the Lost")
+                    .withLandsOnBattlefield(1, "Plains", 1) // Lantern costs {1}
+                    .withCardInGraveyard(2, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInGraveyard(2, "Grizzly Bears").single()
+
+                game.castSpell(1, "Lantern of the Lost").error shouldBe null
+                game.resolveStack() // Lantern enters -> ETB trigger asks for a target
+
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears is exiled from the graveyard") {
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe false
+                    game.isInExile(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("Lantern of the Lost resolved onto the battlefield") {
+                    game.isOnBattlefield("Lantern of the Lost") shouldBe true
+                }
+            }
+
+            test("{1}, {T}, exile this: exiles all cards from all graveyards, then draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lantern of the Lost", tapped = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(2, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val lantern = game.findPermanent("Lantern of the Lost")!!
+                val abilityId = cardRegistry.getCard("Lantern of the Lost")!!.activatedAbilities.first().id
+                val handSizeBefore = game.handSize(1)
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = lantern,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("activation should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("both graveyards are emptied") {
+                    game.graveyardSize(1) shouldBe 0
+                    game.graveyardSize(2) shouldBe 0
+                }
+                withClue("Lantern of the Lost was exiled as a cost") {
+                    game.isOnBattlefield("Lantern of the Lost") shouldBe false
+                    game.isInExile(1, "Lantern of the Lost") shouldBe true
+                }
+                withClue("a card was drawn") {
+                    game.handSize(1) shouldBe handSizeBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightningWolfScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LightningWolfScenarioTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Lightning Wolf (VOW #168) — {3}{R} Creature — Wolf, 4/3.
+ *
+ *   {1}{R}: This creature gains first strike until end of turn. Activate only as a sorcery.
+ *
+ * Exercises the mana-cost activated ability that grants first strike to itself.
+ */
+class LightningWolfScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Lightning Wolf — {1}{R}: gain first strike") {
+
+            test("activating the ability grants first strike until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Lightning Wolf", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Lightning Wolf")!!
+                val abilityId = cardRegistry.getCard("Lightning Wolf")!!.activatedAbilities.first().id
+
+                withClue("Lightning Wolf does not start with first strike") {
+                    game.state.projectedState.hasKeyword(wolf, Keyword.FIRST_STRIKE) shouldBe false
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = wolf,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("Activating the ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Lightning Wolf gains first strike until end of turn") {
+                    game.state.projectedState.hasKeyword(wolf, Keyword.FIRST_STRIKE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarkovPurifierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarkovPurifierScenarioTest.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.CardScript
+import com.wingedsheep.sdk.scripting.effects.GainLifeEffect
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Markov Purifier (VOW #312) — {1}{W}{B} Creature — Vampire Cleric, 2/3.
+ *
+ *   Lifelink
+ *   At the beginning of your end step, if you gained life this turn, you may pay {2}. If you do,
+ *   draw a card.
+ *
+ * Exercises the printed Lifelink keyword and the intervening-if end-step trigger: without life
+ * gained this turn the trigger doesn't even fire; after gaining life this turn, it offers the
+ * may-pay {2}, and paying draws a card.
+ */
+class MarkovPurifierScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A simple life-gain spell to turn the "if you gained life this turn" condition on.
+        cardRegistry.register(
+            CardDefinition.instant(
+                name = "Healing Salve Test",
+                manaCost = ManaCost.parse("{W}"),
+                oracleText = "You gain 3 life.",
+                script = CardScript.spell(effect = GainLifeEffect(3, EffectTarget.Controller)),
+            )
+        )
+
+        context("Markov Purifier") {
+
+            test("has Lifelink") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Markov Purifier", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val purifier = game.findPermanent("Markov Purifier")!!
+                withClue("Markov Purifier has Lifelink") {
+                    game.state.projectedState.hasKeyword(purifier, Keyword.LIFELINK) shouldBe true
+                }
+            }
+
+            test("without gaining life this turn, the end step trigger does not fire") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Markov Purifier", summoningSickness = false)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handSizeBefore = game.handSize(1)
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("no life gained this turn -> no may-pay offer, no card drawn") {
+                    game.handSize(1) shouldBe handSizeBefore
+                }
+            }
+
+            test("after gaining life this turn, paying {2} at the end step draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Markov Purifier", summoningSickness = false)
+                    .withCardInHand(1, "Healing Salve Test")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Healing Salve Test").error shouldBe null
+                game.resolveStack()
+
+                val handSizeBefore = game.handSize(1)
+
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack() // end-step trigger resolves to the may-pay gate
+
+                withClue("the may-pay {2} gate is offered") {
+                    (game.getPendingDecision() is YesNoDecision) shouldBe true
+                }
+                game.answerYesNo(true).error shouldBe null
+
+                withClue("paying then asks which mana sources to use") {
+                    (game.getPendingDecision() is SelectManaSourcesDecision) shouldBe true
+                }
+                game.submitManaSourcesAutoPay().error shouldBe null
+                game.resolveStack()
+
+                withClue("paying {2} draws a card") {
+                    game.handSize(1) shouldBe handSizeBefore + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarkovRetributionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarkovRetributionScenarioTest.kt
@@ -1,0 +1,145 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Markov Retribution (VOW #171) — {2}{R} Sorcery.
+ *
+ *   Choose one or both —
+ *   • Creatures you control get +1/+0 until end of turn.
+ *   • Target Vampire you control deals damage equal to its power to another target creature.
+ *
+ * Exercises all three modes: the team pump alone, the Vampire-damage bite alone (targeting a
+ * Vampire you control at index 0 and another creature at index 1), and choosing both.
+ */
+class MarkovRetributionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Markov Retribution — choose one or both") {
+
+            test("mode 0: creatures you control get +1/+0 until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Markov Retribution")
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                game.state.projectedState.getPower(bears) shouldBe 2
+                game.state.projectedState.getPower(giant) shouldBe 3
+
+                game.castSpellWithMode(1, "Markov Retribution", modeIndex = 0).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets +1/+0") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+                withClue("Hill Giant gets +1/+0") {
+                    game.state.projectedState.getPower(giant) shouldBe 4
+                    game.state.projectedState.getToughness(giant) shouldBe 3
+                }
+            }
+
+            test("mode 1: target Vampire you control deals damage equal to its power to another target creature") {
+                // Markov Purifier is a 2/3 (power 2), so it deals 2 damage — enough to kill a
+                // 2-toughness creature like Grizzly Bears.
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Markov Retribution")
+                    .withCardOnBattlefield(1, "Markov Purifier", summoningSickness = false) // 2/3 Vampire Cleric
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vampire = game.findPermanent("Markov Purifier")!!
+                val victim = game.findPermanent("Grizzly Bears")!!
+                game.state.projectedState.getPower(vampire) shouldBe 2
+
+                val cardId = game.state.getHand(game.player1Id).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Markov Retribution"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(vampire), ChosenTarget.Permanent(victim)),
+                        chosenModes = listOf(1),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(vampire), ChosenTarget.Permanent(victim))
+                        )
+                    )
+                )
+                withClue("casting mode 1 with the Vampire and victim targeted should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears takes 2 damage (equal to the Vampire's power) and dies (2 toughness)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("mode 2: choosing both applies the pump and the Vampire's damage") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Markov Retribution")
+                    .withCardOnBattlefield(1, "Markov Purifier", summoningSickness = false) // 2/3 Vampire Cleric
+                    .withCardOnBattlefield(2, "Grizzly Bears", summoningSickness = false) // 2/2
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val vampire = game.findPermanent("Markov Purifier")!!
+                val victim = game.findPermanent("Grizzly Bears")!!
+
+                val cardId = game.state.getHand(game.player1Id).first { entityId ->
+                    game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Markov Retribution"
+                }
+
+                val cast = game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        cardId,
+                        listOf(ChosenTarget.Permanent(vampire), ChosenTarget.Permanent(victim)),
+                        chosenModes = listOf(2),
+                        modeTargetsOrdered = listOf(
+                            listOf(ChosenTarget.Permanent(vampire), ChosenTarget.Permanent(victim))
+                        )
+                    )
+                )
+                withClue("casting mode 2 (both) should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Markov Purifier gets +1/+0 from the pump, becoming a 3/3") {
+                    game.state.projectedState.getPower(vampire) shouldBe 3
+                    game.state.projectedState.getToughness(vampire) shouldBe 3
+                }
+                withClue("Grizzly Bears (2 toughness) dies to 2 damage from the Vampire's power") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarkovWaltzerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MarkovWaltzerScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Markov Waltzer (VOW #242) — {2}{R}{W} Creature — Vampire, 1/3.
+ *
+ *   Flying, haste
+ *   At the beginning of combat on your turn, up to two target creatures you control each get
+ *   +1/+0 until end of turn.
+ *
+ * Exercises the begin-combat "up to two target creatures you control" trigger: choosing two
+ * targets pumps both, choosing only one pumps only that one, and Markov Waltzer itself (a
+ * creature you control) is a legal target.
+ */
+class MarkovWaltzerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Markov Waltzer — begin combat, up to two target creatures you control get +1/+0") {
+
+            test("choosing two targets pumps both by +1/+0") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Markov Waltzer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val waltzer = game.findPermanent("Markov Waltzer")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                withClue("the begin-combat trigger asks for its targets") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                game.selectTargets(listOf(waltzer, bears))
+                game.resolveStack()
+
+                withClue("Markov Waltzer gets +1/+0 (1 -> 2 power)") {
+                    game.state.projectedState.getPower(waltzer) shouldBe 2
+                }
+                withClue("Grizzly Bears gets +1/+0 (2 -> 3 power)") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                }
+            }
+
+            test("choosing only one target pumps only that creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Markov Waltzer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val waltzer = game.findPermanent("Markov Waltzer")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Grizzly Bears (the only chosen target) gets +1/+0") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                }
+                withClue("Markov Waltzer (not chosen) stays at its base power") {
+                    game.state.projectedState.getPower(waltzer) shouldBe 1
+                }
+            }
+
+            test("choosing zero targets ('up to two') leaves everyone at base power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Markov Waltzer", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val waltzer = game.findPermanent("Markov Waltzer")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.skipTargets()
+                game.resolveStack()
+
+                withClue("declining all targets leaves Markov Waltzer at base power") {
+                    game.state.projectedState.getPower(waltzer) shouldBe 1
+                }
+                withClue("declining all targets leaves Grizzly Bears at base power") {
+                    game.state.projectedState.getPower(bears) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MassiveMightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MassiveMightScenarioTest.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Massive Might (VOW #208) — {G} Instant.
+ *
+ *   Target creature gets +2/+2 and gains trample until end of turn.
+ *
+ * Exercises the combined pump + keyword grant on a single target.
+ */
+class MassiveMightScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Massive Might pump + trample") {
+
+            test("target creature gets +2/+2 and gains trample until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Massive Might")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 target
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Grizzly Bears does not start with trample") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe false
+                }
+
+                game.castSpell(1, "Massive Might", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets +2/+2 (becomes 4/4)") {
+                    game.state.projectedState.getPower(bears) shouldBe 4
+                    game.state.projectedState.getToughness(bears) shouldBe 4
+                }
+                withClue("Grizzly Bears gains trample") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.TRAMPLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MilitiaRallierScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MilitiaRallierScenarioTest.kt
@@ -1,0 +1,76 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario test for Militia Rallier (VOW #24) — {2}{W} Creature — Human Soldier, 3/3.
+ *
+ *   This creature can't attack alone.
+ *   Whenever this creature attacks, untap target creature.
+ *
+ * Exercises the "can't attack alone" restriction (illegal solo, legal with a co-attacker) and the
+ * attack trigger that untaps a target creature.
+ */
+class MilitiaRallierScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Militia Rallier") {
+
+            test("can't attack alone, but can attack alongside another creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Militia Rallier", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                withClue("Militia Rallier can't be the only attacker") {
+                    game.declareAttackers(mapOf("Militia Rallier" to 2)).error shouldNotBe null
+                }
+                withClue("...but can attack alongside another attacker") {
+                    game.declareAttackers(mapOf("Militia Rallier" to 2, "Grizzly Bears" to 2)).error shouldBe null
+                }
+            }
+
+            test("whenever Militia Rallier attacks, untap target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Militia Rallier", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    // A separate, non-attacking tapped creature to serve as the untap target
+                    // (an attacking creature must be untapped to be declared, barring vigilance).
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false, tapped = true)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val rallier = game.findPermanent("Militia Rallier")!!
+                val giant = game.findPermanent("Hill Giant")!!
+
+                withClue("Hill Giant starts tapped") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe true
+                }
+
+                game.declareAttackers(mapOf("Militia Rallier" to 2, "Grizzly Bears" to 2)).error shouldBe null
+                game.resolveStack() // attack trigger goes on the stack and asks for a target
+
+                game.selectTargets(listOf(giant))
+                game.resolveStack()
+
+                withClue("the target creature is untapped by the attack trigger") {
+                    game.state.getEntity(giant)?.has<TappedComponent>() shouldBe false
+                }
+                withClue("Militia Rallier itself is still tapped from attacking") {
+                    game.state.getEntity(rallier)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoldgrafMillipedeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MoldgrafMillipedeScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Moldgraf Millipede (VOW #209) — {4}{G} Creature — Insect Horror, 2/2.
+ *
+ *   When this creature enters, mill three cards, then put a +1/+1 counter on this creature for
+ *   each creature card in your graveyard.
+ *
+ * Exercises the ETB mill-then-count: the library is seeded with exactly three cards so the mill
+ * consumes the whole seeded set deterministically (no ambiguity about "top of library" order),
+ * and the resulting +1/+1 counter total is checked against how many of those milled cards (plus
+ * any creature cards already in the graveyard) are creatures.
+ */
+class MoldgrafMillipedeScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Moldgraf Millipede — mill three, then a +1/+1 counter per creature card in graveyard") {
+
+            test("milling two creatures and a land nets two +1/+1 counters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Moldgraf Millipede")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Mountain")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("the library starts with exactly the three seeded cards") {
+                    game.librarySize(1) shouldBe 3
+                }
+
+                game.castSpell(1, "Moldgraf Millipede").error shouldBe null
+                game.resolveStack()
+
+                val millipede = game.findPermanent("Moldgraf Millipede")!!
+
+                withClue("all three seeded cards were milled to the graveyard") {
+                    game.librarySize(1) shouldBe 0
+                    game.graveyardSize(1) shouldBe 3
+                }
+                withClue("two of the three milled cards are creatures -> two +1/+1 counters") {
+                    plusOneCounters(game, millipede) shouldBe 2
+                }
+            }
+
+            test("a creature already in the graveyard also counts toward the total") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Moldgraf Millipede")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Mountain")
+                    .withCardInLibrary(1, "Mountain")
+                    .withLandsOnBattlefield(1, "Forest", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Moldgraf Millipede").error shouldBe null
+                game.resolveStack()
+
+                val millipede = game.findPermanent("Moldgraf Millipede")!!
+
+                withClue("no new creature cards were milled, but the pre-existing one still counts") {
+                    plusOneCounters(game, millipede) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NebelgastBeguilerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NebelgastBeguilerScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Nebelgast Beguiler (VOW #25) — {4}{W} Creature — Spirit, 2/5.
+ *
+ *   {W}, {T}: Tap target creature.
+ *
+ * Exercises the mana + tap-cost activated ability: it taps a target creature (an opponent's
+ * attacker, in the common use case) and taps Nebelgast Beguiler itself as part of its own cost.
+ */
+class NebelgastBeguilerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Nebelgast Beguiler — {W}, {T}: Tap target creature") {
+
+            test("activating the ability taps the target creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Nebelgast Beguiler", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val beguiler = game.findPermanent("Nebelgast Beguiler")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.getCard("Nebelgast Beguiler")!!
+                    .activatedAbilities.first().id
+
+                withClue("Grizzly Bears does not start tapped") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe false
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = beguiler,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating the ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears is now tapped") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+                withClue("Nebelgast Beguiler is tapped by its own {T} cost") {
+                    game.state.getEntity(beguiler)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NecrodualityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/NecrodualityScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.identity.ControllerComponent
+import com.wingedsheep.engine.state.components.identity.TokenComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Necroduality (VOW #70) — {3}{U} Enchantment.
+ *
+ *   Whenever a nontoken Zombie you control enters, create a token that's a copy of that creature.
+ *
+ * Exercises the ETB observer trigger for nontoken Zombies you control: casting a plain Zombie
+ * creature spawns a token copy alongside the original. Also verifies a nonZombie creature entering
+ * does not trigger it, and that the created token (itself a Zombie) does not recursively trigger
+ * another copy.
+ */
+class NecrodualityScenarioTest : ScenarioTestBase() {
+
+    init {
+        // A vanilla nontoken Zombie to cast — avoids the extra costs/triggers on the real VOW
+        // Zombies (Cobbled Lancer's exile-a-creature-card additional cost, Undead Butler's own
+        // ETB mill trigger) that would complicate isolating Necroduality's behavior.
+        cardRegistry.register(
+            CardDefinition.creature(
+                name = "Plain Zombie",
+                manaCost = ManaCost.parse("{2}{B}"),
+                subtypes = setOf(Subtype("Zombie")),
+                power = 2,
+                toughness = 2
+            )
+        )
+
+        context("Necroduality") {
+
+            test("a nontoken Zombie you control entering creates a token copy of it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Necroduality")
+                    .withCardInHand(1, "Plain Zombie")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Plain Zombie").error shouldBe null
+                game.resolveStack()
+
+                val zombies = game.findPermanents("Plain Zombie")
+                withClue("the original Zombie plus one token copy are on the battlefield") {
+                    zombies.size shouldBe 2
+                }
+
+                val tokens = zombies.filter { game.state.getEntity(it)?.has<TokenComponent>() == true }
+                withClue("exactly one of the two is a token") {
+                    tokens.size shouldBe 1
+                }
+                val token = tokens.single()
+                withClue("the token is controlled by the same player") {
+                    game.state.getEntity(token)?.get<ControllerComponent>()?.playerId shouldBe game.player1Id
+                }
+                withClue("the token copy has the same power/toughness as the original") {
+                    game.state.projectedState.getPower(token) shouldBe 2
+                    game.state.projectedState.getToughness(token) shouldBe 2
+                }
+            }
+
+            test("a non-Zombie creature entering does not trigger a token copy") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Necroduality")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("only the original Grizzly Bears is on the battlefield, no copy") {
+                    game.findPermanents("Grizzly Bears").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OllenbockEscortScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OllenbockEscortScenarioTest.kt
@@ -1,0 +1,79 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Ollenbock Escort (VOW #27) — {W} Creature — Human Cleric, 1/1.
+ *
+ *   Vigilance
+ *   Sacrifice this creature: Target creature you control with a +1/+1 counter on it gains
+ *   lifelink and indestructible until end of turn.
+ *
+ * Exercises the sacrifice-cost activated ability: sacrificing Ollenbock Escort to target a
+ * counter-bearing creature you control grants it lifelink and indestructible.
+ */
+class OllenbockEscortScenarioTest : ScenarioTestBase() {
+
+    private fun seedCounters(game: TestGame, id: EntityId, amount: Int) {
+        game.state = game.state.updateEntity(id) { c ->
+            c.with(CountersComponent().withAdded(CounterType.PLUS_ONE_PLUS_ONE, amount))
+        }
+    }
+
+    init {
+        context("Ollenbock Escort — sacrifice to grant lifelink and indestructible") {
+
+            test("sacrificing Ollenbock Escort grants lifelink and indestructible to a +1/+1-countered creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Ollenbock Escort", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val escort = game.findPermanent("Ollenbock Escort")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                seedCounters(game, bears, 1)
+
+                val abilityId = cardRegistry.getCard("Ollenbock Escort")!!.activatedAbilities.first().id
+
+                withClue("Grizzly Bears does not start with lifelink or indestructible") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.LIFELINK) shouldBe false
+                    game.state.projectedState.hasKeyword(bears, Keyword.INDESTRUCTIBLE) shouldBe false
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = escort,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating the ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                withClue("Ollenbock Escort is sacrificed as a cost") {
+                    game.isOnBattlefield("Ollenbock Escort") shouldBe false
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears gains lifelink and indestructible until end of turn") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.LIFELINK) shouldBe true
+                    game.state.projectedState.hasKeyword(bears, Keyword.INDESTRUCTIBLE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PacksongPupScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PacksongPupScenarioTest.kt
@@ -1,0 +1,96 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Packsong Pup (VOW #213) — {1}{G} Creature — Wolf, 1/1.
+ *
+ *   At the beginning of combat on your turn, if you control another Wolf or Werewolf, put a
+ *   +1/+1 counter on this creature.
+ *   When this creature dies, you gain life equal to its power.
+ *
+ * Exercises both halves: the conditional begin-combat counter (only fires while controlling
+ * another Wolf/Werewolf) and the dies trigger paying out life equal to Packsong Pup's power at
+ * the time it died (including any +1/+1 counters already on it).
+ */
+class PacksongPupScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Packsong Pup — conditional begin-combat counter") {
+
+            test("without another Wolf or Werewolf, no counter is added at begin of combat") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Packsong Pup", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pup = game.findPermanent("Packsong Pup")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("no other Wolf/Werewolf: no +1/+1 counter is added") {
+                    val counters = game.state.getEntity(pup)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 0
+                }
+            }
+
+            test("with another Wolf you control, a +1/+1 counter is added at begin of combat") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Packsong Pup", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Lightning Wolf", summoningSickness = false) // another Wolf
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pup = game.findPermanent("Packsong Pup")!!
+
+                game.passUntilPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                game.resolveStack()
+
+                withClue("controlling another Wolf adds a +1/+1 counter") {
+                    val counters = game.state.getEntity(pup)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+                    counters shouldBe 1
+                }
+            }
+        }
+
+        context("Packsong Pup — dies trigger gains life equal to its power") {
+
+            test("dying gains its controller life equal to its power") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Packsong Pup", summoningSickness = false)
+                    .withCardInHand(2, "Doom Blade")
+                    .withLandsOnBattlefield(2, "Swamp", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val pup = game.findPermanent("Packsong Pup")!!
+
+                game.castSpell(2, "Doom Blade", pup).error shouldBe null
+                game.resolveStack()
+
+                withClue("Packsong Pup died to Doom Blade") {
+                    game.isOnBattlefield("Packsong Pup") shouldBe false
+                }
+                withClue("its controller gains 1 life (its power) from the dies trigger") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PersistentSpecimenScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PersistentSpecimenScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Persistent Specimen (VOW #125) — {B} Creature — Skeleton, 1/1.
+ *
+ *   {2}{B}: Return this card from your graveyard to the battlefield tapped.
+ *
+ * Exercises the graveyard-activated recursion (same shape as Teacher's Pest): the ability is
+ * activated from the graveyard and the card re-enters the battlefield tapped.
+ */
+class PersistentSpecimenScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Persistent Specimen graveyard recursion") {
+
+            test("the {2}{B} ability returns the card from the graveyard to the battlefield tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInGraveyard(1, "Persistent Specimen")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                withClue("Starts in the graveyard, not on the battlefield") {
+                    game.isInGraveyard(1, "Persistent Specimen") shouldBe true
+                    game.isOnBattlefield("Persistent Specimen") shouldBe false
+                }
+
+                val graveyardCard = game.state.getGraveyard(game.player1Id).first {
+                    game.state.getEntity(it)?.get<CardComponent>()?.name == "Persistent Specimen"
+                }
+                val abilityId = cardRegistry.getCard("Persistent Specimen")!!
+                    .activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = graveyardCard,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("Activating the {2}{B} graveyard ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                val returned = game.findPermanent("Persistent Specimen")
+                withClue("Persistent Specimen is back on the battlefield") {
+                    (returned != null) shouldBe true
+                }
+                withClue("It returns tapped") {
+                    game.state.getEntity(returned!!)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PiercingLightScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PiercingLightScenarioTest.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Piercing Light (VOW #30) — {W} Instant.
+ *
+ *   Piercing Light deals 2 damage to target attacking or blocking creature. Scry 1.
+ *
+ * The target restriction (`AttackingOrBlockingCreature`) means the creature has to be in combat, so
+ * the test declares an attacker first, then casts the instant during the declare-attackers step. It
+ * exercises the composite: 2 damage lands on the attacker, then a Scry 1 selection pauses.
+ */
+class PiercingLightScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Piercing Light — damage an attacking creature + scry") {
+
+            test("deals 2 damage to a target attacking creature, then scrys 1") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Piercing Light")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    // A 3/3 attacker so it survives 2 damage and we can read the marked damage.
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    .withCardInLibrary(1, "Plains") // scry 1 fodder
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                // Move to combat and declare Hill Giant as an attacker so it is a legal target.
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hill Giant" to 2)).error shouldBe null
+
+                val giant = game.findPermanent("Hill Giant")!!
+                game.castSpell(1, "Piercing Light", targetId = giant).error shouldBe null
+                game.resolveStack()
+
+                // The composite deals damage, then pauses for the Scry 1 selection.
+                withClue("Scry 1 presents a selection over the single top card") {
+                    val decision = game.getPendingDecision()
+                    (decision is SelectCardsDecision) shouldBe true
+                    (decision as SelectCardsDecision).options.size shouldBe 1
+                }
+                game.skipSelection() // keep the card on top
+
+                withClue("Hill Giant (3/3) survives with 2 marked damage") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                    val damage = game.state.getEntity(giant)?.get<DamageComponent>()?.amount ?: 0
+                    damage shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PointedDiscussionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/PointedDiscussionScenarioTest.kt
@@ -1,0 +1,54 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Pointed Discussion (VOW #126) — {2}{B} Sorcery.
+ *
+ *   You draw two cards, lose 2 life, then create a Blood token.
+ *
+ * Exercises the composite draw/lose-life/create-token effect: resolving the sorcery draws two
+ * cards, costs 2 life, and leaves exactly one Blood token on the battlefield.
+ */
+class PointedDiscussionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Pointed Discussion — draw two, lose 2 life, create a Blood token") {
+
+            test("resolves by drawing two cards, losing 2 life, and creating a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Pointed Discussion")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Mountain")
+                    .withLandsOnBattlefield(1, "Swamp", 3)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Pointed Discussion").error shouldBe null
+                game.resolveStack()
+
+                withClue("hand grows by two cards drawn minus the spell cast (net +1)") {
+                    game.handSize(1) shouldBe handBefore + 1
+                }
+                withClue("the library is depleted by the two cards drawn") {
+                    game.librarySize(1) shouldBe 0
+                }
+                withClue("the caster loses 2 life (20 -> 18)") {
+                    game.getLifeTotal(1) shouldBe 18
+                }
+                withClue("exactly one Blood token is created") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RecklessImpulseScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RecklessImpulseScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Reckless Impulse (VOW #174) — {1}{R} Sorcery.
+ *
+ *   Exile the top two cards of your library. Until the end of your next turn, you may play those
+ *   cards.
+ *
+ * Exercises the impulse-exile: casting the spell exiles the top two library cards and grants
+ * permission to play them until the end of the caster's next turn.
+ */
+class RecklessImpulseScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Reckless Impulse") {
+
+            test("exiles the top two cards of the library and grants permission to play them") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Reckless Impulse")
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val player1 = game.player1Id
+                val exileBefore = game.state.getExile(player1).size
+                val libraryBefore = game.librarySize(1)
+
+                game.castSpell(1, "Reckless Impulse").error shouldBe null
+                game.resolveStack()
+
+                withClue("two cards moved from library to exile") {
+                    game.librarySize(1) shouldBe libraryBefore - 2
+                    game.state.getExile(player1).size shouldBe exileBefore + 2
+                }
+
+                val exiledCards = game.state.getExile(player1)
+                withClue("both exiled cards have a may-play permission granted") {
+                    game.state.mayPlayPermissions.any { permission ->
+                        exiledCards.all { it in permission.cardIds }
+                    } shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReclusiveTaxidermistScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ReclusiveTaxidermistScenarioTest.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.player.ManaPoolComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Reclusive Taxidermist (VOW #214) — {1}{G} Creature — Human Druid, 1/2.
+ *
+ *   This creature gets +3/+2 as long as there are four or more creature cards in your graveyard.
+ *   {T}: Add one mana of any color.
+ *
+ * Exercises the conditional +3/+2 static ability gated on the graveyard creature-card count, and
+ * the {T}: add one mana of any color activated ability.
+ */
+class ReclusiveTaxidermistScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Reclusive Taxidermist") {
+
+            test("base stats 1/2 with fewer than four creature cards in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Reclusive Taxidermist", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(1, "Centaur Courser")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val taxidermist = game.findPermanent("Reclusive Taxidermist")!!
+                withClue("3 creature cards in graveyard < 4 -> base 1/2") {
+                    game.state.projectedState.getPower(taxidermist) shouldBe 1
+                    game.state.projectedState.getToughness(taxidermist) shouldBe 2
+                }
+            }
+
+            test("gets +3/+2 (becomes 4/4) with four or more creature cards in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Reclusive Taxidermist", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(1, "Centaur Courser")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val taxidermist = game.findPermanent("Reclusive Taxidermist")!!
+                withClue("4 creature cards in graveyard >= 4 -> boosted to 4/4") {
+                    game.state.projectedState.getPower(taxidermist) shouldBe 4
+                    game.state.projectedState.getToughness(taxidermist) shouldBe 4
+                }
+            }
+
+            test("{T}: add one mana of any color") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Reclusive Taxidermist", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val taxidermist = game.findPermanent("Reclusive Taxidermist")!!
+                val ability = cardRegistry.getCard("Reclusive Taxidermist")!!.script.activatedAbilities[0]
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = taxidermist,
+                        abilityId = ability.id,
+                        manaColorChoice = Color.GREEN
+                    )
+                )
+                withClue("Activating the mana ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+
+                val pool = game.state.getEntity(game.player1Id)?.get<ManaPoolComponent>()
+                withClue("one green mana was added to the pool") {
+                    (pool?.green ?: 0) shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RendingFlameScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RendingFlameScenarioTest.kt
@@ -1,0 +1,74 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Rending Flame (VOW #175) — {2}{R} Instant.
+ *
+ *   Rending Flame deals 5 damage to target creature or planeswalker. If that permanent is a
+ *   Spirit, Rending Flame also deals 2 damage to that permanent's controller.
+ *
+ * Exercises the base 5 damage to a non-Spirit creature (no rider damage) and the Spirit rider:
+ * targeting a Spirit deals the same 5 damage plus 2 damage to that Spirit's controller.
+ */
+class RendingFlameScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Rending Flame") {
+
+            test("deals 5 damage to a non-Spirit creature with no rider damage to its controller") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rending Flame")
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false) // 3/3, not a Spirit
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val lifeBefore = game.getLifeTotal(2)
+
+                game.castSpell(1, "Rending Flame", giant).error shouldBe null
+                game.resolveStack()
+
+                withClue("Hill Giant takes 5 damage and dies (3 toughness)") {
+                    game.isOnBattlefield("Hill Giant") shouldBe false
+                    game.isInGraveyard(2, "Hill Giant") shouldBe true
+                }
+                withClue("no rider damage since Hill Giant is not a Spirit") {
+                    game.getLifeTotal(2) shouldBe lifeBefore
+                }
+            }
+
+            test("targeting a Spirit also deals 2 damage to that Spirit's controller") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Rending Flame")
+                    .withCardOnBattlefield(2, "Dawnhart Geist", summoningSickness = false) // 1/3 Spirit Warlock
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val geist = game.findPermanent("Dawnhart Geist")!!
+                val lifeBefore = game.getLifeTotal(2)
+
+                game.castSpell(1, "Rending Flame", geist).error shouldBe null
+                game.resolveStack()
+
+                withClue("Dawnhart Geist takes 5 damage and dies (3 toughness)") {
+                    game.isOnBattlefield("Dawnhart Geist") shouldBe false
+                    game.isInGraveyard(2, "Dawnhart Geist") shouldBe true
+                }
+                withClue("its controller also takes 2 rider damage since it's a Spirit") {
+                    game.getLifeTotal(2) shouldBe lifeBefore - 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ResistanceSquadScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ResistanceSquadScenarioTest.kt
@@ -1,0 +1,73 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Resistance Squad (VOW #32) — {2}{W} Creature — Human Soldier, 3/2.
+ *
+ *   When this creature enters, if you control another Human, draw a card.
+ *
+ * Exercises the ETB intervening-if gated on `Conditions.YouControl(Human, excludeSelf = true)`:
+ * the draw fires only when another Human is already on the battlefield.
+ */
+class ResistanceSquadScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Resistance Squad ETB draw") {
+
+            test("draws a card when you already control another Human") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Resistance Squad")
+                    .withCardOnBattlefield(1, "Traveling Minister") // Human Cleric
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Resistance Squad").error shouldBe null
+                game.resolveStack()
+
+                withClue("Resistance Squad enters the battlefield") {
+                    game.isOnBattlefield("Resistance Squad") shouldBe true
+                }
+                // Hand: -1 (Resistance Squad leaves hand) + 1 (drawn card) = net 0.
+                withClue("Controlling another Human triggers the draw") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+
+            test("does not draw a card when you control no other Human") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Resistance Squad")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // not a Human
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+
+                game.castSpell(1, "Resistance Squad").error shouldBe null
+                game.resolveStack()
+
+                withClue("Resistance Squad enters the battlefield") {
+                    game.isOnBattlefield("Resistance Squad") shouldBe true
+                }
+                // Hand: -1 (Resistance Squad leaves hand), no draw.
+                withClue("No other Human means no draw") {
+                    game.handSize(1) shouldBe handBefore - 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RetrieveScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RetrieveScenarioTest.kt
@@ -1,0 +1,91 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CastSpell
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Retrieve (VOW #215) — {2}{G} Sorcery.
+ *
+ *   Return up to one target creature card and up to one target noncreature permanent card from
+ *   your graveyard to your hand. Exile Retrieve.
+ *
+ * Exercises the two independent "up to one target" graveyard slots (creature card at index 0,
+ * noncreature permanent card at index 1): targeting both returns both to hand and Retrieve itself
+ * ends up exiled (not in the graveyard) as it finishes resolving.
+ */
+class RetrieveScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Retrieve") {
+
+            test("returns a targeted creature card and a targeted noncreature permanent card to hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Retrieve")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Test Enchantment")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+                val enchantment = game.findCardsInGraveyard(1, "Test Enchantment").single()
+
+                val card = game.findCardsInHand(1, "Retrieve").first()
+                game.execute(
+                    CastSpell(
+                        game.player1Id,
+                        card,
+                        listOf(
+                            ChosenTarget.Card(bears, game.player1Id, Zone.GRAVEYARD),
+                            ChosenTarget.Card(enchantment, game.player1Id, Zone.GRAVEYARD),
+                        ),
+                    )
+                ).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears returned to hand") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Test Enchantment returned to hand") {
+                    game.isInGraveyard(1, "Test Enchantment") shouldBe false
+                    game.isInHand(1, "Test Enchantment") shouldBe true
+                }
+                withClue("Retrieve is exiled rather than going to the graveyard") {
+                    game.isInGraveyard(1, "Retrieve") shouldBe false
+                    game.isInExile(1, "Retrieve") shouldBe true
+                }
+            }
+
+            test("skipping both optional targets still exiles Retrieve with nothing returned") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Retrieve")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val card = game.findCardsInHand(1, "Retrieve").first()
+                game.execute(CastSpell(game.player1Id, card, emptyList())).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears stays in the graveyard when not targeted") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("Retrieve still ends up in exile") {
+                    game.isInExile(1, "Retrieve") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuneboundWolfScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/RuneboundWolfScenarioTest.kt
@@ -1,0 +1,66 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Runebound Wolf (VOW #176) — {1}{R} Creature — Wolf, 2/2.
+ *
+ *   {3}{R}, {T}: This creature deals damage equal to the number of Wolves and Werewolves you
+ *   control to target opponent.
+ *
+ * Exercises the DynamicAmount.Count(Wolves + Werewolves) damage ability: with two Wolves
+ * (itself + one more) on the battlefield, the ability should deal 2 damage to the opponent.
+ */
+class RuneboundWolfScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Runebound Wolf damage ability") {
+
+            test("deals damage equal to the number of Wolves and Werewolves you control") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Runebound Wolf", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Sporeback Wolf", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Mountain", 4) // pays {3}{R}
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Runebound Wolf")!!
+                val abilityId = cardRegistry.getCard("Runebound Wolf")!!.activatedAbilities.first().id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = wolf,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Player(game.player2Id))
+                    )
+                )
+                withClue("Activating the {3}{R}, {T} ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("Two Wolves you control (Runebound Wolf + Sporeback Wolf) deal 2 damage") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("Runebound Wolf is tapped by its own cost") {
+                    game.state.getEntity(wolf)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SanctifyScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SanctifyScenarioTest.kt
@@ -1,0 +1,49 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sanctify (VOW #33) — {1}{W} Sorcery.
+ *
+ *   Destroy target artifact or enchantment. You gain 3 life.
+ *
+ * Exercises the destroy + gain-life composite against an enchantment target.
+ */
+class SanctifyScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sanctify destroy + gain life") {
+
+            test("destroys a target enchantment and gains 3 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sanctify")
+                    .withCardOnBattlefield(2, "Test Enchantment") // opponent's enchantment
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val enchantment = game.findPermanent("Test Enchantment")!!
+
+                game.castSpell(1, "Sanctify", targetId = enchantment).error shouldBe null
+                game.resolveStack()
+
+                withClue("The enchantment is destroyed (no longer on the battlefield)") {
+                    game.findPermanent("Test Enchantment") shouldBe null
+                }
+                withClue("The enchantment is in its owner's graveyard") {
+                    game.findCardsInGraveyard(2, "Test Enchantment").size shouldBe 1
+                }
+                withClue("Player 1 gains 3 life (20 -> 23)") {
+                    game.getLifeTotal(1) shouldBe 23
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SawbladeSlingerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SawbladeSlingerScenarioTest.kt
@@ -1,0 +1,84 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sawblade Slinger (VOW #217) — {3}{G} Creature — Human Archer, 4/3.
+ *
+ *   When this creature enters, choose up to one —
+ *   • Destroy target artifact an opponent controls.
+ *   • This creature fights target Zombie an opponent controls.
+ *
+ * Exercises the ETB "choose up to one" modal: mode 1 destroys an opponent's artifact; declining
+ * both modes leaves the board untouched.
+ */
+class SawbladeSlingerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sawblade Slinger ETB modal") {
+
+            test("choosing mode 1 destroys the targeted opponent artifact") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sawblade Slinger")
+                    .withCardOnBattlefield(2, "Artifact Creature") // 2/2 Golem, an artifact
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val artifact = game.findPermanent("Artifact Creature")!!
+
+                game.castSpell(1, "Sawblade Slinger").error shouldBe null
+                game.resolveStack()
+
+                val modeDecision = game.getPendingDecision() as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision for the ETB modal; got ${game.getPendingDecision()}")
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = 0))
+
+                if (game.hasPendingDecision()) game.selectTargets(listOf(artifact))
+                game.resolveStack()
+
+                withClue("the targeted artifact was destroyed") {
+                    game.isOnBattlefield("Artifact Creature") shouldBe false
+                }
+                withClue("Sawblade Slinger itself is on the battlefield") {
+                    game.isOnBattlefield("Sawblade Slinger") shouldBe true
+                }
+            }
+
+            test("declining both modes leaves the board untouched") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sawblade Slinger")
+                    .withCardOnBattlefield(2, "Artifact Creature")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Sawblade Slinger").error shouldBe null
+                game.resolveStack()
+
+                val modeDecision = game.getPendingDecision() as? ChooseOptionDecision
+                    ?: error("expected a ChooseOptionDecision for the ETB modal; got ${game.getPendingDecision()}")
+                val declineIndex = modeDecision.options.indexOfFirst { it.contains("Don't choose", ignoreCase = true) }
+                withClue("a decline option should be offered (minChooseCount = 0)") {
+                    (declineIndex >= 0) shouldBe true
+                }
+                game.submitDecision(OptionChosenResponse(modeDecision.id, optionIndex = declineIndex))
+                game.resolveStack()
+
+                withClue("the opponent's artifact survives when no mode is chosen") {
+                    game.isOnBattlefield("Artifact Creature") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScatteredThoughtsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ScatteredThoughtsScenarioTest.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Scattered Thoughts (VOW #74) — {3}{U} Instant.
+ *
+ *   Look at the top four cards of your library. Put two of those cards into your hand and the
+ *   rest into your graveyard.
+ *
+ * Exercises the Patterns.Library.lookAtTopAndKeep(count = 4, keepCount = 2) pipeline: the player
+ * is presented with the four top cards, keeps two (-> hand), and the other two go to the
+ * graveyard.
+ */
+class ScatteredThoughtsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Scattered Thoughts dig") {
+
+            test("look at top four, keep two to hand, rest to graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Scattered Thoughts")
+                    .withLandsOnBattlefield(1, "Island", 4)
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handBefore = game.handSize(1)
+                val graveyardBefore = game.graveyardSize(1)
+
+                game.castSpell(1, "Scattered Thoughts").error shouldBe null
+                game.resolveStack()
+
+                withClue("Scattered Thoughts pauses for a keep-2 selection") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision().shouldBeInstanceOf<SelectCardsDecision>()
+                withClue("Looks at the top four cards") {
+                    decision.options.size shouldBe 4
+                }
+                decision.minSelections shouldBe 2
+                decision.maxSelections shouldBe 2
+
+                game.selectCards(decision.options.take(2)).error shouldBe null
+
+                // Hand: -1 (the spell, now in graveyard) + 2 (kept cards).
+                withClue("Two cards kept go to hand (net +1 after the spell leaves hand)") {
+                    game.handSize(1) shouldBe handBefore - 1 + 2
+                }
+                // Graveyard: +2 (the rest) + 1 (the spell itself).
+                withClue("Remaining two cards plus the spell go to the graveyard") {
+                    game.graveyardSize(1) shouldBe graveyardBefore + 2 + 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelhoffEntomberScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SelhoffEntomberScenarioTest.kt
@@ -1,0 +1,64 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Selhoff Entomber (VOW #76) — {1}{U} Creature — Zombie, 1/3.
+ *
+ *   {T}, Discard a creature card: Draw a card.
+ *
+ * Exercises the tap + discard-a-creature-card cost paying off with a card draw.
+ */
+class SelhoffEntomberScenarioTest : ScenarioTestBase() {
+
+    private val abilityId = cardRegistry.getCard("Selhoff Entomber")!!.activatedAbilities.first().id
+
+    init {
+        context("Selhoff Entomber") {
+
+            test("tapping and discarding a creature card draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Selhoff Entomber", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val entomber = game.findPermanent("Selhoff Entomber")!!
+                val bears = game.findCardsInHand(1, "Grizzly Bears").single()
+                val handBefore = game.handSize(1)
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = entomber,
+                        abilityId = abilityId,
+                        costPayment = AdditionalCostPayment(discardedCards = listOf(bears)),
+                    )
+                )
+                withClue("Activating Selhoff Entomber should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears was discarded to the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+                withClue("hand size is unchanged (discarded one, drew one)") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("a new card (Plains) was drawn from the library") {
+                    game.isInHand(1, "Plains") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShatteredSanctumScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShatteredSanctumScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Shattered Sanctum (VOW #264) — Land.
+ *
+ *   This land enters tapped unless you control two or more other lands.
+ *   {T}: Add {W} or {B}.
+ *
+ * One of the "slow lands" — exercises the EntersTapped replacement effect gated on controlling
+ * three or more lands total (the entering land plus two others).
+ */
+class ShatteredSanctumScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Shattered Sanctum enters-tapped condition") {
+
+            test("enters tapped with fewer than two other lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Shattered Sanctum")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    PlayLand(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Shattered Sanctum").single()
+                    )
+                ).error shouldBe null
+
+                val sanctum = game.findPermanent("Shattered Sanctum")!!
+                withClue("Enters tapped with only one other land") {
+                    game.state.getEntity(sanctum)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("enters untapped with two or more other lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Shattered Sanctum")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withLandsOnBattlefield(1, "Swamp", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    PlayLand(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Shattered Sanctum").single()
+                    )
+                ).error shouldBe null
+
+                val sanctum = game.findPermanent("Shattered Sanctum")!!
+                withClue("Enters untapped with two other lands already in play") {
+                    game.state.getEntity(sanctum)?.has<TappedComponent>() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShelteringBoughsScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ShelteringBoughsScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sheltering Boughs (VOW #218) — {2}{G} Enchantment — Aura.
+ *
+ *   Enchant creature
+ *   When this Aura enters, draw a card.
+ *   Enchanted creature gets +1/+3.
+ *
+ * Exercises the ETB card draw and the static +1/+3 buff on the enchanted creature.
+ */
+class ShelteringBoughsScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sheltering Boughs") {
+
+            test("entering the battlefield draws a card and grants +1/+3 to the enchanted creature") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sheltering Boughs")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 target
+                    .withCardInLibrary(1, "Forest")
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val handBefore = game.handSize(1)
+
+                val cast = game.castSpell(1, "Sheltering Boughs", targetId = bears)
+                withClue("Casting Sheltering Boughs should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Sheltering Boughs is attached and on the battlefield") {
+                    game.isOnBattlefield("Sheltering Boughs") shouldBe true
+                }
+                withClue("the ETB trigger drew a card (net hand size after casting the aura)") {
+                    game.handSize(1) shouldBe handBefore
+                }
+                withClue("Grizzly Bears (2/2) gets +1/+3, becoming 3/5") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 5
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SigardasImprisonmentScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SigardasImprisonmentScenarioTest.kt
@@ -1,0 +1,100 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sigarda's Imprisonment (VOW #35) — {2}{W} Enchantment — Aura.
+ *
+ *   Enchant creature
+ *   Enchanted creature can't attack or block.
+ *   {4}{W}: Exile enchanted creature. Create a Blood token.
+ *
+ * Exercises the Pacifism-style "can't attack or block" static abilities and the activated
+ * ability that exiles the enchanted creature and creates a Blood token.
+ */
+class SigardasImprisonmentScenarioTest : ScenarioTestBase() {
+
+    private val exileAbilityId =
+        cardRegistry.getCard("Sigarda's Imprisonment")!!.activatedAbilities.first().id
+
+    init {
+        context("Sigarda's Imprisonment") {
+
+            test("enchanted creature can't attack or block") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sigarda's Imprisonment")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val cast = game.castSpell(1, "Sigarda's Imprisonment", targetId = bears)
+                withClue("Casting Sigarda's Imprisonment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Sigarda's Imprisonment is on the battlefield") {
+                    game.isOnBattlefield("Sigarda's Imprisonment") shouldBe true
+                }
+                withClue("the enchanted creature can't attack") {
+                    game.state.projectedState.cantAttack(bears) shouldBe true
+                }
+                withClue("the enchanted creature can't block") {
+                    game.state.projectedState.cantBlock(bears) shouldBe true
+                }
+            }
+
+            test("{4}{W}: exiles the enchanted creature and creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sigarda's Imprisonment")
+                    .withCardOnBattlefield(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Plains", 8)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+                game.castSpell(1, "Sigarda's Imprisonment", targetId = bears)
+                game.resolveStack()
+
+                val aura = game.findPermanent("Sigarda's Imprisonment")
+                withClue("Aura should be on the battlefield before activation") {
+                    aura.shouldNotBeNull()
+                }
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = aura!!,
+                        abilityId = exileAbilityId,
+                    )
+                )
+                withClue("Activating the exile ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("the enchanted creature is exiled") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.state.getExile(game.player2Id).contains(bears) shouldBe true
+                }
+                withClue("a Blood token is created") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkywarpSkaabScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SkywarpSkaabScenarioTest.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Skywarp Skaab (VOW #78) — {3}{U}{U} Creature — Zombie Drake, 2/5, Flying.
+ *
+ *   When this creature enters, you may exile two creature cards from your graveyard. If you do,
+ *   draw a card.
+ *
+ * Exercises the "exile exactly two" pipeline: accepting with two creature cards available exiles
+ * both and draws a card; declining leaves the graveyard untouched and draws nothing.
+ */
+class SkywarpSkaabScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Skywarp Skaab ETB") {
+
+            test("Skywarp Skaab is a 2/5 flyer") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Skywarp Skaab", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val skaab = game.findPermanent("Skywarp Skaab")!!
+                withClue("Skywarp Skaab is a 2/5") {
+                    game.state.projectedState.getPower(skaab) shouldBe 2
+                    game.state.projectedState.getToughness(skaab) shouldBe 5
+                }
+                withClue("Skywarp Skaab has flying") {
+                    game.state.projectedState.hasKeyword(skaab, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("accepting the may exiles two creature cards and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Skywarp Skaab")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Skywarp Skaab").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("the ETB offers a yes/no to exile two creature cards") {
+                    decision.shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+
+                if (game.hasPendingDecision()) {
+                    val graveyard = game.state.getGraveyard(game.player1Id)
+                    game.selectCards(graveyard.take(2))
+                }
+                game.resolveStack()
+
+                withClue("both creature cards were exiled from the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                    game.isInGraveyard(1, "Hill Giant") shouldBe false
+                    game.isInExile(1, "Grizzly Bears") shouldBe true
+                    game.isInExile(1, "Hill Giant") shouldBe true
+                }
+                withClue("a card was drawn") {
+                    game.isInHand(1, "Plains") shouldBe true
+                }
+            }
+
+            test("declining the may leaves the graveyard untouched and draws no card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Skywarp Skaab")
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Island", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Skywarp Skaab").error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("both creature cards remain in the graveyard") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                }
+                withClue("no card was drawn") {
+                    game.isInHand(1, "Plains") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SporeCrawlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SporeCrawlerScenarioTest.kt
@@ -1,0 +1,52 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Spore Crawler (VOW #222) — {2}{G} Creature — Fungus, 3/2.
+ *
+ *   When this creature dies, draw a card.
+ *
+ * Exercises the Triggers.Dies + DrawCardsEffect(1) composition: killing the creature with
+ * lethal damage fires the trigger and draws a card.
+ */
+class SporeCrawlerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Spore Crawler dies trigger") {
+
+            test("draws a card when it dies") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Spore Crawler", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val crawler = game.findPermanent("Spore Crawler")!!
+                val handBefore = game.handSize(1)
+
+                // Lightning Bolt deals 3 damage, lethal to the 3/2 Spore Crawler.
+                game.castSpell(1, "Lightning Bolt", crawler).error shouldBe null
+                game.resolveStack() // resolve the bolt (and the resulting SBA death)
+                game.resolveStack() // resolve the dies trigger
+
+                withClue("Spore Crawler died") {
+                    game.isOnBattlefield("Spore Crawler") shouldBe false
+                    game.isInGraveyard(1, "Spore Crawler") shouldBe true
+                }
+                // Hand: -1 (Lightning Bolt leaves hand) + 1 (drawn card) = net 0.
+                withClue("Dying draws a card") {
+                    game.handSize(1) shouldBe handBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SporebackWolfScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SporebackWolfScenarioTest.kt
@@ -1,0 +1,56 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sporeback Wolf (VOW #223) — {1}{G} Creature — Wolf, 2/2.
+ *
+ *   During your turn, this creature gets +0/+2.
+ *
+ * Exercises the ConditionalStaticAbility(ModifyStats(0, 2, Self), Conditions.IsYourTurn):
+ * present (4 toughness) during the controller's turn, absent (2 toughness) during the
+ * opponent's turn.
+ */
+class SporebackWolfScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sporeback Wolf conditional toughness boost") {
+
+            test("is 2/4 during its controller's turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sporeback Wolf")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Sporeback Wolf")!!
+
+                withClue("Gets +0/+2 during its controller's turn (becomes 2/4)") {
+                    game.state.projectedState.getPower(wolf) shouldBe 2
+                    game.state.projectedState.getToughness(wolf) shouldBe 4
+                }
+            }
+
+            test("is 2/2 during the opponent's turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Sporeback Wolf")
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val wolf = game.findPermanent("Sporeback Wolf")!!
+
+                withClue("No boost outside its controller's turn (stays 2/2)") {
+                    game.state.projectedState.getPower(wolf) shouldBe 2
+                    game.state.projectedState.getToughness(wolf) shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SteelcladSpiritScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SteelcladSpiritScenarioTest.kt
@@ -1,0 +1,77 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.combat.AttackingComponent
+import com.wingedsheep.engine.state.components.combat.CanAttackDespiteDefenderThisTurnComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Steelclad Spirit (VOW #80) — {1}{U} Creature — Spirit, 3/3, Defender.
+ *
+ *   Defender
+ *   Whenever an enchantment you control enters, this creature can attack this turn as though it
+ *   didn't have defender.
+ *
+ * Exercises the enchantment-enters trigger granting the temporary can-attack-despite-defender
+ * marker: with Defender it cannot attack before any enchantment enters, but once an enchantment
+ * you control enters it gains the marker and can attack this turn.
+ */
+class SteelcladSpiritScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Steelclad Spirit — enchantment-enters grants attack despite Defender") {
+
+            test("cannot attack with Defender before any enchantment enters") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Steelclad Spirit", tapped = false, summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                    .build()
+
+                val result = game.declareAttackers(mapOf("Steelclad Spirit" to 2))
+                withClue("Defender blocks the attack before any enchantment enters") {
+                    (result.error != null) shouldBe true
+                }
+            }
+
+            test("an enchantment you control entering lets it attack this turn despite Defender") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Steelclad Spirit", tapped = false, summoningSickness = false)
+                    .withCardInHand(1, "Test Enchantment") // {1}{W}
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spirit = game.findPermanent("Steelclad Spirit")!!
+
+                val cast = game.castSpell(1, "Test Enchantment")
+                withClue("Casting Test Enchantment should succeed: ${cast.error}") {
+                    cast.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the trigger fired — Steelclad Spirit gains the can-attack-despite-defender marker") {
+                    game.state.getEntity(spirit)
+                        ?.get<CanAttackDespiteDefenderThisTurnComponent>().shouldNotBeNull()
+                }
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+
+                val result = game.declareAttackers(mapOf("Steelclad Spirit" to 2))
+                withClue("after the trigger fired it can attack despite Defender: ${result.error}") {
+                    result.error shouldBe null
+                }
+                withClue("Steelclad Spirit is now an attacker") {
+                    game.state.getEntity(spirit)?.get<AttackingComponent>().shouldNotBeNull()
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormcarvedCoastScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StormcarvedCoastScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Stormcarved Coast (VOW #265) — Land.
+ *
+ *   This land enters tapped unless you control two or more other lands.
+ *   {T}: Add {U} or {R}.
+ *
+ * One of the "slow lands" — exercises the EntersTapped replacement effect gated on controlling
+ * three or more lands total (the entering land plus two others).
+ */
+class StormcarvedCoastScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Stormcarved Coast enters-tapped condition") {
+
+            test("enters tapped with fewer than two other lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stormcarved Coast")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    PlayLand(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Stormcarved Coast").single()
+                    )
+                ).error shouldBe null
+
+                val coast = game.findPermanent("Stormcarved Coast")!!
+                withClue("Enters tapped with only one other land") {
+                    game.state.getEntity(coast)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("enters untapped with two or more other lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Stormcarved Coast")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    PlayLand(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Stormcarved Coast").single()
+                    )
+                ).error shouldBe null
+
+                val coast = game.findPermanent("Stormcarved Coast")!!
+                withClue("Enters untapped with two other lands already in play") {
+                    game.state.getEntity(coast)?.has<TappedComponent>() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SundownPassScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SundownPassScenarioTest.kt
@@ -1,0 +1,71 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.PlayLand
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Sundown Pass (VOW #266) — Land.
+ *
+ *   This land enters tapped unless you control two or more other lands.
+ *   {T}: Add {R} or {W}.
+ *
+ * One of the "slow lands" — exercises the EntersTapped replacement effect gated on controlling
+ * three or more lands total (the entering land plus two others).
+ */
+class SundownPassScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Sundown Pass enters-tapped condition") {
+
+            test("enters tapped with fewer than two other lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sundown Pass")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    PlayLand(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Sundown Pass").single()
+                    )
+                ).error shouldBe null
+
+                val pass = game.findPermanent("Sundown Pass")!!
+                withClue("Enters tapped with only one other land") {
+                    game.state.getEntity(pass)?.has<TappedComponent>() shouldBe true
+                }
+            }
+
+            test("enters untapped with two or more other lands") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Sundown Pass")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.execute(
+                    PlayLand(
+                        game.player1Id,
+                        game.findCardsInHand(1, "Sundown Pass").single()
+                    )
+                ).error shouldBe null
+
+                val pass = game.findPermanent("Sundown Pass")!!
+                withClue("Enters untapped with two other lands already in play") {
+                    game.state.getEntity(pass)?.has<TappedComponent>() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SyphonEssenceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SyphonEssenceScenarioTest.kt
@@ -1,0 +1,51 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Syphon Essence (VOW #84) — {2}{U} Instant.
+ *
+ *   Counter target creature or planeswalker spell. Create a Blood token.
+ *
+ * Exercises Effects.CounterSpell() then Effects.CreateBlood(1): the targeted creature spell is
+ * countered (goes to its owner's graveyard) and the caster gets a Blood token.
+ */
+class SyphonEssenceScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Syphon Essence — counter a creature spell and make a Blood token") {
+
+            test("counters the targeted creature spell and creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Syphon Essence")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    // Player 2 (active player) casts a creature spell to be countered.
+                    .withCardInHand(2, "Grizzly Bears")
+                    .withLandsOnBattlefield(2, "Forest", 2)
+                    .withActivePlayer(2)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(2, "Grizzly Bears").error shouldBe null
+                game.passPriority()
+
+                game.castSpellTargetingStackSpell(1, "Syphon Essence", "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears is countered (in player 2's graveyard, not on the battlefield)") {
+                    game.isOnBattlefield("Grizzly Bears") shouldBe false
+                    game.isInGraveyard(2, "Grizzly Bears") shouldBe true
+                }
+                withClue("A Blood token is created for the caster") {
+                    game.findPermanent("Blood").shouldNotBeNull()
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThirstForDiscoveryScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ThirstForDiscoveryScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Thirst for Discovery (VOW #85) — {2}{U} Instant.
+ *
+ *   Draw three cards. Then discard two cards unless you discard a basic land card.
+ *
+ * Exercises Effects.DrawCards(3).then(Effects.DiscardUnlessMatching(2, GameObjectFilter.BasicLand)):
+ * discarding a single basic land satisfies the discard instruction; otherwise two cards must be
+ * discarded.
+ */
+class ThirstForDiscoveryScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Thirst for Discovery — draw three, conditional discard") {
+
+            test("discarding one basic land satisfies the discard instruction") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Thirst for Discovery")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Forest")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Thirst for Discovery").error shouldBe null
+                game.resolveStack()
+
+                withClue("Draws three cards, then pauses for the conditional discard") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision() as SelectCardsDecision
+                val forestId = game.findCardsInHand(1, "Forest").single()
+
+                withClue("A single basic land card satisfies the discard requirement") {
+                    decision.minSelections shouldBe 1
+                    decision.conditionalMinimums.single().matchingOptions shouldContain forestId
+                }
+
+                game.selectCards(listOf(forestId)).error shouldBe null
+
+                withClue("The basic land is discarded and nothing else") {
+                    game.isInGraveyard(1, "Forest") shouldBe true
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("discarding two nonland cards satisfies the normal discard count") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Thirst for Discovery")
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withCardInHand(1, "Hill Giant")
+                    .withLandsOnBattlefield(1, "Island", 3)
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Thirst for Discovery").error shouldBe null
+                game.resolveStack()
+
+                val bearsId = game.findCardsInHand(1, "Grizzly Bears").single()
+                val giantId = game.findCardsInHand(1, "Hill Giant").single()
+
+                game.selectCards(listOf(bearsId, giantId)).error shouldBe null
+
+                withClue("Both nonland cards discarded") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                    game.isInGraveyard(1, "Hill Giant") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ToxicScorpionScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ToxicScorpionScenarioTest.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Toxic Scorpion (VOW #224) — {1}{G} Creature — Scorpion, 1/1, deathtouch.
+ *
+ *   When this creature enters, another target creature you control gains deathtouch until end of turn.
+ *
+ * Exercises the ETB grant: the trigger targets another creature you control and grants it deathtouch.
+ */
+class ToxicScorpionScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Toxic Scorpion ETB grants deathtouch") {
+
+            test("entering grants another creature you control deathtouch until end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Toxic Scorpion")
+                    .withCardOnBattlefield(1, "Grizzly Bears") // another creature you control
+                    .withLandsOnBattlefield(1, "Forest", 3)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Grizzly Bears does not start with deathtouch") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.DEATHTOUCH) shouldBe false
+                }
+
+                game.castSpell(1, "Toxic Scorpion").error shouldBe null
+                game.resolveStack() // creature enters → ETB trigger asks for a target
+
+                val result = game.selectTargets(listOf(bears))
+                withClue("Targeting another creature you control is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears gains deathtouch") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.DEATHTOUCH) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TravelingMinisterScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TravelingMinisterScenarioTest.kt
@@ -1,0 +1,67 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Traveling Minister (VOW #39) — {W} Creature — Human Cleric, 1/1.
+ *
+ *   {T}: Target creature gets +1/+0 until end of turn. You gain 1 life. Activate only as a sorcery.
+ *
+ * Exercises the tap-cost, sorcery-speed activated ability: it pumps a target creature +1/+0 and
+ * gains its controller 1 life. The Minister itself is left with no summoning sickness so its {T}
+ * cost is payable (CR 302.6).
+ */
+class TravelingMinisterScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Traveling Minister tap ability") {
+
+            test("the {T} ability gives a target creature +1/+0 and gains 1 life") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Traveling Minister", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears") // 2/2 target
+                    .withLifeTotal(1, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val minister = game.findPermanent("Traveling Minister")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+                val abilityId = cardRegistry.getCard("Traveling Minister")!!
+                    .activatedAbilities.first().id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = minister,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears))
+                    )
+                )
+                withClue("Activating the {T} ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets +1/+0 (becomes 3/2)") {
+                    game.state.projectedState.getPower(bears) shouldBe 3
+                    game.state.projectedState.getToughness(bears) shouldBe 2
+                }
+                withClue("Player 1 gains 1 life (20 -> 21)") {
+                    game.getLifeTotal(1) shouldBe 21
+                }
+                withClue("Traveling Minister is tapped by its own cost") {
+                    game.state.getEntity(minister)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndeadButlerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UndeadButlerScenarioTest.kt
@@ -1,0 +1,115 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Undead Butler (VOW #133) — {1}{B} Creature — Zombie, 1/2.
+ *
+ *   When this creature enters, mill three cards.
+ *   When this creature dies, you may exile it. When you do, return target creature card from
+ *   your graveyard to your hand.
+ *
+ * Exercises the ETB mill-three and the dies-trigger optional exile-then-return: exiling Undead
+ * Butler from the graveyard and returning a targeted creature card to hand; declining the exile
+ * leaves everything untouched.
+ */
+class UndeadButlerScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Undead Butler") {
+
+            test("entering the battlefield mills three cards") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Undead Butler")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Undead Butler").error shouldBe null
+                game.resolveStack()
+
+                withClue("Undead Butler resolved onto the battlefield") {
+                    game.isOnBattlefield("Undead Butler") shouldBe true
+                }
+                withClue("three cards were milled to the graveyard") {
+                    game.librarySize(1) shouldBe 0
+                    game.graveyardSize(1) shouldBe 3
+                }
+            }
+
+            test("dies, exiling it returns a targeted creature card from the graveyard") {
+                // Undead Butler is a black 1/2 — Doom Blade can't target black creatures, so use
+                // Lightning Bolt (3 damage is lethal).
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Undead Butler", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val butler = game.findPermanent("Undead Butler")!!
+                val bears = game.findCardsInGraveyard(1, "Grizzly Bears").single()
+
+                game.castSpell(1, "Lightning Bolt", targetId = butler).error shouldBe null
+                game.resolveStack()
+
+                withClue("Undead Butler died to the graveyard") {
+                    game.isInGraveyard(1, "Undead Butler") shouldBe true
+                }
+
+                // "You may exile it." — accept.
+                if (game.hasPendingDecision()) game.answerYesNo(true)
+                // The reflexive "When you do" trigger now wants a target creature card in the graveyard.
+                if (game.hasPendingDecision()) game.selectTargets(listOf(bears))
+                game.resolveStack()
+
+                withClue("Undead Butler was exiled instead of staying in the graveyard") {
+                    game.isInGraveyard(1, "Undead Butler") shouldBe false
+                    game.isInExile(1, "Undead Butler") shouldBe true
+                }
+                withClue("Grizzly Bears was returned to hand") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe false
+                    game.isInHand(1, "Grizzly Bears") shouldBe true
+                }
+            }
+
+            test("declining the exile leaves Undead Butler in the graveyard") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Undead Butler", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val butler = game.findPermanent("Undead Butler")!!
+                game.castSpell(1, "Lightning Bolt", targetId = butler).error shouldBe null
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("Undead Butler stays in the graveyard when declining the exile") {
+                    game.isInGraveyard(1, "Undead Butler") shouldBe true
+                }
+                withClue("Grizzly Bears stays in the graveyard too") {
+                    game.isInGraveyard(1, "Grizzly Bears") shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnhallowedPhalanxScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnhallowedPhalanxScenarioTest.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Unhallowed Phalanx (VOW #135) — {4}{B} Creature — Zombie Soldier, 1/13.
+ *
+ *   This creature enters tapped.
+ *
+ * Exercises the [com.wingedsheep.sdk.scripting.EntersTapped] replacement effect: casting the
+ * creature from hand puts it onto the battlefield already tapped.
+ */
+class UnhallowedPhalanxScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Unhallowed Phalanx enters tapped") {
+
+            test("casting it from hand puts it onto the battlefield tapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Unhallowed Phalanx")
+                    .withLandsOnBattlefield(1, "Swamp", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Unhallowed Phalanx").error shouldBe null
+                game.resolveStack()
+
+                val phalanx = game.findPermanent("Unhallowed Phalanx")
+                withClue("Unhallowed Phalanx is on the battlefield") {
+                    (phalanx != null) shouldBe true
+                }
+                withClue("It enters tapped") {
+                    game.state.getEntity(phalanx!!)?.has<TappedComponent>() shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnholyOfficiantScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/UnholyOfficiantScenarioTest.kt
@@ -1,0 +1,80 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectManaSourcesDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Unholy Officiant (VOW #41) — {W} Creature — Vampire Cleric, 1/2.
+ *
+ *   Vigilance
+ *   {4}{W}: Put a +1/+1 counter on this creature.
+ *
+ * Exercises the printed Vigilance keyword and the mana-only activated ability that adds a
+ * +1/+1 counter to itself.
+ */
+class UnholyOfficiantScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Unholy Officiant") {
+
+            test("has vigilance") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Unholy Officiant")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val officiant = game.findPermanent("Unholy Officiant")!!
+                withClue("Unholy Officiant has vigilance") {
+                    game.state.projectedState.hasKeyword(officiant, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+
+            test("{4}{W}: puts a +1/+1 counter on itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Unholy Officiant", summoningSickness = false)
+                    .withLandsOnBattlefield(1, "Plains", 5)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val officiant = game.findPermanent("Unholy Officiant")!!
+                val abilityId = cardRegistry.getCard("Unholy Officiant")!!.activatedAbilities.first().id
+
+                val activation = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = officiant,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("Activating the {4}{W} ability should succeed: ${activation.error}") {
+                    activation.error shouldBe null
+                }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                withClue("A +1/+1 counter is placed on Unholy Officiant") {
+                    game.state.getEntity(officiant)?.get<CountersComponent>()
+                        ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) shouldBe 1
+                }
+                withClue("Power/toughness reflect the counter (becomes 2/3)") {
+                    game.state.projectedState.getPower(officiant) shouldBe 2
+                    game.state.projectedState.getToughness(officiant) shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VampiresKissScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VampiresKissScenarioTest.kt
@@ -1,0 +1,48 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Vampire's Kiss (VOW #136) — {1}{B} Sorcery.
+ *
+ *   Target player loses 2 life and you gain 2 life. Create two Blood tokens.
+ *
+ * Exercises the composite: the target player loses 2 life, the caster gains 2 life, and two
+ * Blood tokens are created under the caster's control.
+ */
+class VampiresKissScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Vampire's Kiss — drain 2 + two Blood tokens") {
+
+            test("target player loses 2 life, caster gains 2 life, two Blood tokens are created") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Vampire's Kiss")
+                    .withLandsOnBattlefield(1, "Swamp", 2)
+                    .withLifeTotal(1, 20)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Vampire's Kiss", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("Target player (2) loses 2 life (20 -> 18)") {
+                    game.getLifeTotal(2) shouldBe 18
+                }
+                withClue("Caster (1) gains 2 life (20 -> 22)") {
+                    game.getLifeTotal(1) shouldBe 22
+                }
+                withClue("Two Blood tokens are created") {
+                    game.findPermanents("Blood").size shouldBe 2
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VampiresVengeanceScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VampiresVengeanceScenarioTest.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.DamageComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Vampires' Vengeance (VOW #339) — {2}{R} Instant.
+ *
+ *   Vampires' Vengeance deals 2 damage to each non-Vampire creature. Create a Blood token.
+ *
+ * Exercises the mass damage sweep filtered by subtype: a non-Vampire creature (Hill Giant, 3/3)
+ * takes 2 marked damage and survives, while a Vampire creature (Voldaren Epicure, 1/1) is
+ * unaffected. A Blood token is created for the caster.
+ */
+class VampiresVengeanceScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Vampires' Vengeance — 2 damage to each non-Vampire creature + Blood token") {
+
+            test("non-Vampire creatures take 2 damage; Vampires are unaffected; a Blood token is created") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Vampires' Vengeance")
+                    .withLandsOnBattlefield(1, "Mountain", 3)
+                    // Non-Vampire creature — must take 2 damage.
+                    .withCardOnBattlefield(1, "Hill Giant", summoningSickness = false)
+                    // Vampire creature — must be unaffected.
+                    .withCardOnBattlefield(2, "Voldaren Epicure", summoningSickness = false)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val giant = game.findPermanent("Hill Giant")!!
+                val vampire = game.findPermanent("Voldaren Epicure")!!
+
+                game.castSpell(1, "Vampires' Vengeance").error shouldBe null
+                game.resolveStack()
+
+                withClue("Hill Giant (non-Vampire, 3/3) takes 2 marked damage and survives") {
+                    game.isOnBattlefield("Hill Giant") shouldBe true
+                    val damage = game.state.getEntity(giant)?.get<DamageComponent>()?.amount ?: 0
+                    damage shouldBe 2
+                }
+                withClue("Voldaren Epicure (Vampire) is unaffected — no marked damage") {
+                    game.isOnBattlefield("Voldaren Epicure") shouldBe true
+                    val damage = game.state.getEntity(vampire)?.get<DamageComponent>()?.amount ?: 0
+                    damage shouldBe 0
+                }
+                withClue("A Blood token is created") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VilespawnSpiderScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VilespawnSpiderScenarioTest.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Vilespawn Spider (VOW #250) — {G}{U} Creature — Spider, 2/3, reach.
+ *
+ *   At the beginning of your upkeep, mill a card.
+ *   {2}{G}{U}, {T}, Sacrifice this creature: Create a 1/1 green Insect creature token for each
+ *   creature card in your graveyard. Activate only as a sorcery.
+ *
+ * Exercises both abilities: the upkeep mill trigger, and the sacrifice ability creating one
+ * Insect token per creature card already in the graveyard.
+ */
+class VilespawnSpiderScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Vilespawn Spider") {
+
+            test("has reach and enters as a 2/3") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Vilespawn Spider")
+                    .withActivePlayer(1)
+                    .build()
+
+                val spider = game.findPermanent("Vilespawn Spider")!!
+                withClue("2/3 with reach") {
+                    game.state.projectedState.getPower(spider) shouldBe 2
+                    game.state.projectedState.getToughness(spider) shouldBe 3
+                    game.state.projectedState.hasKeyword(spider, Keyword.REACH) shouldBe true
+                }
+            }
+
+            test("upkeep trigger mills exactly one card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Vilespawn Spider")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.BEGINNING, Step.UNTAP)
+                    .build()
+
+                val librarySizeBefore = game.librarySize(1)
+                val graveyardSizeBefore = game.graveyardSize(1)
+
+                game.passUntilPhase(Phase.BEGINNING, Step.UPKEEP)
+                game.resolveStack()
+
+                withClue("upkeep mills exactly one card") {
+                    game.librarySize(1) shouldBe librarySizeBefore - 1
+                    game.graveyardSize(1) shouldBe graveyardSizeBefore + 1
+                }
+            }
+
+            test("sacrifice ability creates a 1/1 Insect token for each creature card in the graveyard, counting itself") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Vilespawn Spider", summoningSickness = false)
+                    .withCardInGraveyard(1, "Grizzly Bears")
+                    .withCardInGraveyard(1, "Hill Giant")
+                    .withCardInGraveyard(1, "Lightning Bolt") // not a creature card — excluded
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withLandsOnBattlefield(1, "Island", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val spider = game.findPermanent("Vilespawn Spider")!!
+                val abilityId = cardRegistry.getCard("Vilespawn Spider")!!.activatedAbilities.first().id
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = spider,
+                        abilityId = abilityId
+                    )
+                )
+                withClue("Activating the sacrifice ability should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                if (game.hasPendingDecision()) game.submitManaSourcesAutoPay()
+                game.resolveStack()
+
+                withClue("Vilespawn Spider was sacrificed") {
+                    game.isOnBattlefield("Vilespawn Spider") shouldBe false
+                    game.isInGraveyard(1, "Vilespawn Spider") shouldBe true
+                }
+                withClue(
+                    "Sacrifice is paid on activation, so the Spider is already in the graveyard when " +
+                        "the effect counts creature cards: Grizzly Bears + Hill Giant + Vilespawn Spider " +
+                        "= 3 Insect tokens (Lightning Bolt is not a creature card)"
+                ) {
+                    game.findPermanents("Insect Token").size shouldBe 3
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoiceOfTheBlessedScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoiceOfTheBlessedScenarioTest.kt
@@ -1,0 +1,117 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Voice of the Blessed (VOW #44) — {W}{W} Creature — Spirit Cleric, 2/2.
+ *
+ *   Whenever you gain life, put a +1/+1 counter on this creature.
+ *   As long as this creature has four or more +1/+1 counters on it, it has flying and vigilance.
+ *   As long as this creature has ten or more +1/+1 counters on it, it has indestructible.
+ *
+ * Exercises the lifegain trigger and both counter-count-gated static abilities.
+ */
+class VoiceOfTheBlessedScenarioTest : ScenarioTestBase() {
+
+    // A minimal sorcery that gains the caster 1 life, used to drive the lifegain trigger
+    // repeatedly without relying on a specific pre-registered lifegain card.
+    private val gainOneLife = card("Test Gain One") {
+        manaCost = "{W}"
+        typeLine = "Sorcery"
+        spell { effect = Effects.GainLife(1) }
+    }
+
+    private fun plusOneCounters(game: TestGame): Int {
+        val voice = game.findPermanent("Voice of the Blessed")!!
+        return game.state.getEntity(voice)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+    }
+
+    init {
+        cardRegistry.register(gainOneLife)
+
+        context("Voice of the Blessed") {
+
+            test("gaining life puts a +1/+1 counter on it") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Voice of the Blessed", summoningSickness = false)
+                    .withCardInHand(1, "Test Gain One")
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Test Gain One").error shouldBe null
+                game.resolveStack()
+
+                withClue("gaining 1 life adds a +1/+1 counter") {
+                    plusOneCounters(game) shouldBe 1
+                }
+
+                val voice = game.findPermanent("Voice of the Blessed")!!
+                withClue("still under 4 counters -> no flying/vigilance yet") {
+                    game.state.projectedState.hasKeyword(voice, Keyword.FLYING) shouldBe false
+                    game.state.projectedState.hasKeyword(voice, Keyword.VIGILANCE) shouldBe false
+                }
+            }
+
+            test("with 4 or more +1/+1 counters it has flying and vigilance") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Voice of the Blessed", summoningSickness = false)
+                    .withCardsInHand(1, "Test Gain One", 4)
+                    .withLandsOnBattlefield(1, "Plains", 4)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                repeat(4) {
+                    game.castSpell(1, "Test Gain One").error shouldBe null
+                    game.resolveStack()
+                }
+
+                withClue("4 lifegain triggers -> 4 counters") {
+                    plusOneCounters(game) shouldBe 4
+                }
+
+                val voice = game.findPermanent("Voice of the Blessed")!!
+                withClue("4+ counters grants flying and vigilance") {
+                    game.state.projectedState.hasKeyword(voice, Keyword.FLYING) shouldBe true
+                    game.state.projectedState.hasKeyword(voice, Keyword.VIGILANCE) shouldBe true
+                }
+                withClue("still under 10 counters -> no indestructible yet") {
+                    game.state.projectedState.hasKeyword(voice, Keyword.INDESTRUCTIBLE) shouldBe false
+                }
+            }
+
+            test("with 10 or more +1/+1 counters it also has indestructible") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Voice of the Blessed", summoningSickness = false)
+                    .build()
+
+                val voice = game.findPermanent("Voice of the Blessed")!!
+                game.state = game.state.updateEntity(voice) { container ->
+                    val counters = container.get<CountersComponent>() ?: CountersComponent()
+                    container.with(counters.withAdded(CounterType.PLUS_ONE_PLUS_ONE, 10))
+                }
+
+                withClue("10+ counters grants indestructible (as well as flying/vigilance)") {
+                    game.state.projectedState.hasKeyword(voice, Keyword.INDESTRUCTIBLE) shouldBe true
+                    game.state.projectedState.hasKeyword(voice, Keyword.FLYING) shouldBe true
+                    game.state.projectedState.hasKeyword(voice, Keyword.VIGILANCE) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoldarenEpicureScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/VoldarenEpicureScenarioTest.kt
@@ -1,0 +1,50 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Voldaren Epicure (VOW #182) — {R} Creature — Vampire, 1/1.
+ *
+ *   When this creature enters, it deals 1 damage to each opponent. Create a Blood token.
+ *
+ * Exercises the ETB composite: each opponent takes 1 damage and a Blood token is created for
+ * the caster.
+ */
+class VoldarenEpicureScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Voldaren Epicure ETB") {
+
+            test("entering deals 1 damage to each opponent and creates a Blood token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Voldaren Epicure")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withLifeTotal(2, 20)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Voldaren Epicure").error shouldBe null
+                game.resolveStack()
+
+                withClue("Voldaren Epicure is on the battlefield as a 1/1") {
+                    val epicure = game.findPermanent("Voldaren Epicure")
+                    (epicure != null) shouldBe true
+                    game.state.projectedState.getPower(epicure!!) shouldBe 1
+                    game.state.projectedState.getToughness(epicure) shouldBe 1
+                }
+                withClue("Opponent takes 1 damage (20 -> 19)") {
+                    game.getLifeTotal(2) shouldBe 19
+                }
+                withClue("A Blood token is created") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WanderingMindScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WanderingMindScenarioTest.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Wandering Mind (VOW #251) — {1}{U}{R} Creature — Horror, 2/1, flying.
+ *
+ *   When this creature enters, look at the top six cards of your library. You may reveal a
+ *   noncreature, nonland card from among them and put it into your hand. Put the rest on the
+ *   bottom of your library in a random order.
+ *
+ * Exercises the ETB look-and-maybe-reveal pipeline: only the noncreature, nonland card among the
+ * top six is a legal reveal target, and taking it moves it to hand while the rest go to the
+ * bottom.
+ */
+class WanderingMindScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Wandering Mind ETB — look at 6, may reveal a noncreature nonland card") {
+
+            test("the noncreature, nonland card can be revealed and put into hand") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Wandering Mind")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    // Top six of the library: one noncreature/nonland (Lightning Bolt) plus five
+                    // creatures that don't qualify.
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Wandering Mind").error shouldBe null
+                game.resolveStack()
+
+                val decision = game.getPendingDecision()
+                withClue("presents a selection over the top six cards") {
+                    (decision is SelectCardsDecision) shouldBe true
+                    (decision as SelectCardsDecision).options.size shouldBe 1
+                }
+                val bolt = (decision as SelectCardsDecision).options.first()
+
+                game.selectCards(listOf(bolt)).error shouldBe null
+                game.resolveStack()
+
+                withClue("Lightning Bolt (the noncreature, nonland card) is now in hand") {
+                    game.isInHand(1, "Lightning Bolt") shouldBe true
+                }
+                withClue("Wandering Mind is on the battlefield as a 2/1 flyer") {
+                    val mind = game.findPermanent("Wandering Mind")!!
+                    game.state.projectedState.getPower(mind) shouldBe 2
+                    game.state.projectedState.getToughness(mind) shouldBe 1
+                    game.state.projectedState.hasKeyword(mind, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("declining the reveal puts all six looked-at cards on the bottom") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Wandering Mind")
+                    .withLandsOnBattlefield(1, "Island", 1)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withCardInLibrary(1, "Lightning Bolt")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withCardInLibrary(1, "Hill Giant")
+                    .withCardInLibrary(1, "Centaur Courser")
+                    .withCardInLibrary(1, "Savannah Lions")
+                    .withCardInLibrary(1, "Glory Seeker")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val librarySizeBefore = game.librarySize(1)
+
+                game.castSpell(1, "Wandering Mind").error shouldBe null
+                game.resolveStack()
+                game.skipSelection() // decline the optional reveal
+                game.resolveStack()
+
+                withClue("Lightning Bolt is NOT in hand") {
+                    game.isInHand(1, "Lightning Bolt") shouldBe false
+                }
+                withClue("all six looked-at cards return to the library") {
+                    game.librarySize(1) shouldBe librarySizeBefore
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WanderlightSpiritScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WanderlightSpiritScenarioTest.kt
@@ -1,0 +1,75 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Scenario test for Wanderlight Spirit (VOW #86) — {2}{U} Creature — Spirit, 2/3, flying.
+ *
+ *   This creature can block only creatures with flying.
+ *
+ * Exercises the [com.wingedsheep.sdk.scripting.CanOnlyBlockCreaturesWith] restriction: it may
+ * legally block a flying attacker (Birds of Paradise), but not a non-flying attacker (Hill Giant).
+ */
+class WanderlightSpiritScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Wanderlight Spirit can only block creatures with flying") {
+
+            test("is a 2/3 flyer") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wanderlight Spirit")
+                    .build()
+
+                val spirit = game.findPermanent("Wanderlight Spirit")!!
+                game.state.projectedState.getPower(spirit) shouldBe 2
+                game.state.projectedState.getToughness(spirit) shouldBe 3
+                game.state.projectedState.hasKeyword(spirit, Keyword.FLYING) shouldBe true
+            }
+
+            test("can legally block a flying attacker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wanderlight Spirit", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Birds of Paradise", summoningSickness = false) // flying
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Birds of Paradise" to 1)).error shouldBe null
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                val result = game.declareBlockers(mapOf("Wanderlight Spirit" to listOf("Birds of Paradise")))
+                withClue("blocking a flying attacker is legal: ${result.error}") {
+                    result.error shouldBe null
+                }
+            }
+
+            test("cannot legally block a non-flying attacker") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wanderlight Spirit", summoningSickness = false)
+                    .withCardOnBattlefield(2, "Hill Giant", summoningSickness = false) // no flying
+                    .withActivePlayer(2)
+                    .inPhase(Phase.COMBAT, Step.BEGIN_COMBAT)
+                    .build()
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Hill Giant" to 1)).error shouldBe null
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                val result = game.declareBlockers(mapOf("Wanderlight Spirit" to listOf("Hill Giant")))
+                withClue("blocking a non-flying attacker is illegal: ${result.error}") {
+                    result.error shouldNotBe null
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeddingInvitationScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeddingInvitationScenarioTest.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.AbilityFlag
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Wedding Invitation (VOW #260) — {2} Artifact.
+ *
+ *   When this artifact enters, draw a card.
+ *   {T}, Sacrifice this artifact: Target creature can't be blocked this turn. If it's a Vampire,
+ *   it also gains lifelink until end of turn.
+ *
+ * Exercises the ETB draw, the tap+sacrifice activated ability granting can't-be-blocked, and the
+ * conditional bonus lifelink when the target is a Vampire.
+ */
+class WeddingInvitationScenarioTest : ScenarioTestBase() {
+
+    private val abilityId = cardRegistry.getCard("Wedding Invitation")!!.activatedAbilities.first().id
+
+    init {
+        context("Wedding Invitation") {
+
+            test("entering the battlefield draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Wedding Invitation")
+                    .withCardInLibrary(1, "Plains")
+                    .withLandsOnBattlefield(1, "Plains", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Wedding Invitation").error shouldBe null
+                game.resolveStack()
+
+                withClue("Wedding Invitation resolved onto the battlefield") {
+                    game.isOnBattlefield("Wedding Invitation") shouldBe true
+                }
+                withClue("a card was drawn from the library") {
+                    game.isInHand(1, "Plains") shouldBe true
+                }
+            }
+
+            test("tap, sacrifice: a non-Vampire creature can't be blocked, no lifelink") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wedding Invitation", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val invitation = game.findPermanent("Wedding Invitation")!!
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = invitation,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(bears)),
+                    )
+                )
+                withClue("Activating Wedding Invitation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("Wedding Invitation is sacrificed") {
+                    game.isOnBattlefield("Wedding Invitation") shouldBe false
+                }
+                withClue("Grizzly Bears can't be blocked this turn") {
+                    game.state.projectedState.hasKeyword(bears, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+                }
+                withClue("Grizzly Bears is not a Vampire, so it does not gain lifelink") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.LIFELINK) shouldBe false
+                }
+            }
+
+            test("tap, sacrifice: a Vampire creature can't be blocked and also gains lifelink") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wedding Invitation", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Bloodcrazed Socialite") // {3}{B} Vampire, 3/3
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val invitation = game.findPermanent("Wedding Invitation")!!
+                val vampire = game.findPermanent("Bloodcrazed Socialite")!!
+
+                val result = game.execute(
+                    ActivateAbility(
+                        playerId = game.player1Id,
+                        sourceId = invitation,
+                        abilityId = abilityId,
+                        targets = listOf(ChosenTarget.Permanent(vampire)),
+                    )
+                )
+                withClue("Activating Wedding Invitation should succeed: ${result.error}") {
+                    result.error shouldBe null
+                }
+                game.resolveStack()
+
+                withClue("the Vampire can't be blocked this turn") {
+                    game.state.projectedState.hasKeyword(vampire, AbilityFlag.CANT_BE_BLOCKED) shouldBe true
+                }
+                withClue("the Vampire also gains lifelink until end of turn") {
+                    game.state.projectedState.hasKeyword(vampire, Keyword.LIFELINK) shouldBe true
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeddingSecurityScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WeddingSecurityScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario test for Wedding Security (VOW #299) — {3}{B}{B} Creature — Vampire Soldier, 4/4.
+ *
+ *   Whenever this creature attacks, you may sacrifice a Blood token. If you do, put a +1/+1
+ *   counter on this creature and draw a card.
+ *
+ * Exercises the attack-trigger gated Blood sacrifice: paying by sacrificing the Blood token adds
+ * a +1/+1 counter and draws a card; declining leaves the attacker unbuffed.
+ */
+class WeddingSecurityScenarioTest : ScenarioTestBase() {
+
+    private fun plusOneCounters(game: TestGame, id: com.wingedsheep.sdk.model.EntityId): Int =
+        game.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    init {
+        context("Wedding Security") {
+
+            test("attacking and sacrificing a Blood token adds a +1/+1 counter and draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wedding Security", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val security = game.findPermanent("Wedding Security")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Wedding Security" to 2)).error shouldBe null
+                game.resolveStack()
+
+                withClue("the attack trigger offers a yes/no to sacrifice the Blood token") {
+                    game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                }
+                game.answerYesNo(true)
+                game.resolveStack()
+
+                withClue("the Blood token was sacrificed") {
+                    game.findPermanents("Blood").size shouldBe 0
+                }
+                withClue("Wedding Security has a +1/+1 counter") {
+                    plusOneCounters(game, security) shouldBe 1
+                }
+                withClue("a card was drawn") {
+                    game.isInHand(1, "Plains") shouldBe true
+                }
+            }
+
+            test("declining the sacrifice leaves Wedding Security unbuffed") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wedding Security", summoningSickness = false)
+                    .withCardOnBattlefield(1, "Blood", isToken = true)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val security = game.findPermanent("Wedding Security")!!
+
+                game.advanceToPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                game.declareAttackers(mapOf("Wedding Security" to 2)).error shouldBe null
+                game.resolveStack()
+
+                game.getPendingDecision().shouldBeInstanceOf<YesNoDecision>()
+                game.answerYesNo(false)
+                game.resolveStack()
+
+                withClue("the Blood token is not sacrificed") {
+                    game.findPermanents("Blood").size shouldBe 1
+                }
+                withClue("Wedding Security has no counter") {
+                    plusOneCounters(game, security) shouldBe 0
+                }
+                withClue("no card was drawn") {
+                    game.isInHand(1, "Plains") shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WelcomingVampireScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WelcomingVampireScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Welcoming Vampire (VOW #46) — {2}{W} Creature — Vampire, 2/3, flying.
+ *
+ *   Whenever one or more other creatures you control with power 2 or less enter, draw a card.
+ *   This ability triggers only once each turn.
+ *
+ * Exercises the ETB draw trigger gated on power <= 2, and the once-per-turn cap when multiple
+ * small creatures enter in the same turn.
+ */
+class WelcomingVampireScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Welcoming Vampire — draw when a small creature you control enters") {
+
+            test("another creature you control with power 2 or less entering draws a card") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Welcoming Vampire", summoningSickness = false)
+                    .withCardInHand(1, "Savannah Lions") // 1/1, power <= 2
+                    .withLandsOnBattlefield(1, "Plains", 1)
+                    .withCardInLibrary(1, "Forest")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val handSizeBefore = game.handSize(1)
+
+                game.castSpell(1, "Savannah Lions").error shouldBe null
+                game.resolveStack()
+
+                withClue("drew a card from the small creature entering (net: -1 for casting, +1 from draw)") {
+                    game.handSize(1) shouldBe handSizeBefore
+                }
+                withClue("Welcoming Vampire is a 2/3 flyer") {
+                    val vamp = game.findPermanent("Welcoming Vampire")!!
+                    game.state.projectedState.getPower(vamp) shouldBe 2
+                    game.state.projectedState.getToughness(vamp) shouldBe 3
+                    game.state.projectedState.hasKeyword(vamp, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("a creature with power greater than 2 entering does not trigger the draw") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Welcoming Vampire", summoningSickness = false)
+                    .withCardInHand(1, "Hill Giant") // 3/3, power > 2
+                    .withLandsOnBattlefield(1, "Mountain", 4)
+                    .build()
+
+                val handSizeBefore = game.handSize(1)
+
+                game.castSpell(1, "Hill Giant").error shouldBe null
+                game.resolveStack()
+
+                withClue("casting Hill Giant costs a card and no draw replaces it") {
+                    game.handSize(1) shouldBe handSizeBefore - 1
+                }
+            }
+
+            test("only triggers once per turn even if two small creatures enter") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Welcoming Vampire", summoningSickness = false)
+                    .withCardInHand(1, "Savannah Lions")
+                    .withCardInHand(1, "Glory Seeker") // 2/2, power <= 2
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInLibrary(1, "Island")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Savannah Lions").error shouldBe null
+                game.resolveStack()
+                val handSizeAfterFirst = game.handSize(1)
+
+                game.castSpell(1, "Glory Seeker").error shouldBe null
+                game.resolveStack()
+
+                withClue("second small creature this turn does not draw again (once per turn)") {
+                    game.handSize(1) shouldBe handSizeAfterFirst - 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WhisperingWizardScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WhisperingWizardScenarioTest.kt
@@ -1,0 +1,88 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Whispering Wizard (VOW #88) — {3}{U} Creature — Human Wizard, 3/2.
+ *
+ *   Whenever you cast a noncreature spell, create a 1/1 white Spirit creature token with
+ *   flying. This ability triggers only once each turn.
+ *
+ * Exercises the cast-trigger token creation, the noncreature filter (a creature spell must not
+ * trigger it), and the once-per-turn cap.
+ */
+class WhisperingWizardScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Whispering Wizard — Spirit token on noncreature cast") {
+
+            test("casting a noncreature spell creates a 1/1 flying Spirit token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Whispering Wizard", summoningSickness = false)
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                val tokens = game.findPermanents("Spirit Token")
+                withClue("exactly one Spirit token created") {
+                    tokens.size shouldBe 1
+                }
+                val token = tokens.single()
+                withClue("the token is a 1/1 flyer") {
+                    game.state.projectedState.getPower(token) shouldBe 1
+                    game.state.projectedState.getToughness(token) shouldBe 1
+                    game.state.projectedState.hasKeyword(token, Keyword.FLYING) shouldBe true
+                }
+            }
+
+            test("casting a creature spell does not create a token") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Whispering Wizard", summoningSickness = false)
+                    .withCardInHand(1, "Grizzly Bears")
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpell(1, "Grizzly Bears").error shouldBe null
+                game.resolveStack()
+
+                withClue("a creature spell must not create a Spirit token") {
+                    game.findPermanents("Spirit Token").size shouldBe 0
+                }
+            }
+
+            test("only creates one token per turn even after two noncreature spells") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Whispering Wizard", summoningSickness = false)
+                    .withCardsInHand(1, "Lightning Bolt", 2)
+                    .withLandsOnBattlefield(1, "Mountain", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+                game.castSpellTargetingPlayer(1, "Lightning Bolt", 2).error shouldBe null
+                game.resolveStack()
+
+                withClue("once-per-turn cap holds even for two noncreature spells") {
+                    game.findPermanents("Spirit Token").size shouldBe 1
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitchsWebScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WitchsWebScenarioTest.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Witch's Web (VOW #227) — {1}{G} Instant.
+ *
+ *   Target creature gets +3/+3 and gains reach until end of turn. Untap it.
+ *
+ * Exercises the combined pump + keyword grant + untap on a single target.
+ */
+class WitchsWebScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Witch's Web — pump + reach + untap") {
+
+            test("target creature gets +3/+3, gains reach, and is untapped") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Witch's Web")
+                    .withCardOnBattlefield(1, "Grizzly Bears", tapped = true) // 2/2 tapped target
+                    .withLandsOnBattlefield(1, "Forest", 2)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val bears = game.findPermanent("Grizzly Bears")!!
+
+                withClue("Grizzly Bears does not start with reach") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.REACH) shouldBe false
+                }
+                withClue("Grizzly Bears starts tapped") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe true
+                }
+
+                game.castSpell(1, "Witch's Web", targetId = bears).error shouldBe null
+                game.resolveStack()
+
+                withClue("Grizzly Bears gets +3/+3 (becomes 5/5)") {
+                    game.state.projectedState.getPower(bears) shouldBe 5
+                    game.state.projectedState.getToughness(bears) shouldBe 5
+                }
+                withClue("Grizzly Bears gains reach") {
+                    game.state.projectedState.hasKeyword(bears, Keyword.REACH) shouldBe true
+                }
+                withClue("Grizzly Bears is untapped") {
+                    game.state.getEntity(bears)?.has<TappedComponent>() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WretchedThrongScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WretchedThrongScenarioTest.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Scenario test for Wretched Throng (VOW #91) — {1}{U} Creature — Zombie Horror, 2/1.
@@ -46,14 +47,19 @@ class WretchedThrongScenarioTest : ScenarioTestBase() {
                 withClue("the dies trigger offers a search decision") {
                     game.hasPendingDecision() shouldBe true
                 }
-                val decision = game.getPendingDecision()
-                val libraryCopy = (decision as? com.wingedsheep.engine.core.SelectCardsDecision)
-                    ?.options?.firstOrNull()
-                if (libraryCopy != null) {
-                    game.selectCards(listOf(libraryCopy)).error shouldBe null
-                } else {
-                    game.answerYesNo(true)
+
+                // The optional trigger surfaces two sequential decisions: first the "you may
+                // search" yes/no gate, then the library-search card selection. Accept the gate,
+                // then pick the copy of Wretched Throng out of the library.
+                if (game.getPendingDecision() is com.wingedsheep.engine.core.YesNoDecision) {
+                    game.answerYesNo(true).error shouldBe null
                 }
+                val selection = game.getPendingDecision() as? com.wingedsheep.engine.core.SelectCardsDecision
+                withClue("the search offers the library copy of Wretched Throng") {
+                    selection shouldNotBe null
+                }
+                val libraryCopy = selection!!.options.first()
+                game.selectCards(listOf(libraryCopy)).error shouldBe null
                 game.resolveStack()
 
                 withClue("the found copy of Wretched Throng is now in hand") {

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WretchedThrongScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WretchedThrongScenarioTest.kt
@@ -1,0 +1,95 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario test for Wretched Throng (VOW #91) — {1}{U} Creature — Zombie Horror, 2/1.
+ *
+ *   When this creature dies, you may search your library for a card named Wretched Throng,
+ *   reveal it, put it into your hand, then shuffle.
+ *
+ * Exercises the dies trigger: killing the creature offers an optional library search for another
+ * copy of itself; accepting puts it into hand, declining leaves the library untouched.
+ */
+class WretchedThrongScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Wretched Throng dies trigger") {
+
+            test("dying offers an optional search for another Wretched Throng, which can be accepted") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wretched Throng", summoningSickness = false)
+                    .withCardInLibrary(1, "Wretched Throng")
+                    .withCardInLibrary(1, "Forest")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val throng = game.findPermanent("Wretched Throng")!!
+
+                // Kill it with 3 damage (it's a 2/1) so its dies trigger fires.
+                game.castSpell(1, "Lightning Bolt", targetId = throng).error shouldBe null
+                game.resolveStack()
+
+                withClue("Wretched Throng died") {
+                    game.isOnBattlefield("Wretched Throng") shouldBe false
+                    game.isInGraveyard(1, "Wretched Throng") shouldBe true
+                }
+
+                withClue("the dies trigger offers a search decision") {
+                    game.hasPendingDecision() shouldBe true
+                }
+                val decision = game.getPendingDecision()
+                val libraryCopy = (decision as? com.wingedsheep.engine.core.SelectCardsDecision)
+                    ?.options?.firstOrNull()
+                if (libraryCopy != null) {
+                    game.selectCards(listOf(libraryCopy)).error shouldBe null
+                } else {
+                    game.answerYesNo(true)
+                }
+                game.resolveStack()
+
+                withClue("the found copy of Wretched Throng is now in hand") {
+                    game.isInHand(1, "Wretched Throng") shouldBe true
+                }
+            }
+
+            test("declining the search leaves the library copy in place") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardOnBattlefield(1, "Wretched Throng", summoningSickness = false)
+                    .withCardInLibrary(1, "Wretched Throng")
+                    .withCardInHand(1, "Lightning Bolt")
+                    .withLandsOnBattlefield(1, "Mountain", 1)
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val throng = game.findPermanent("Wretched Throng")!!
+                game.castSpell(1, "Lightning Bolt", targetId = throng).error shouldBe null
+                game.resolveStack()
+
+                if (game.hasPendingDecision()) {
+                    val decision = game.getPendingDecision()
+                    if (decision is com.wingedsheep.engine.core.SelectCardsDecision) {
+                        game.selectCards(emptyList())
+                    } else {
+                        game.answerYesNo(false)
+                    }
+                }
+                game.resolveStack()
+
+                withClue("declining leaves the copy out of hand") {
+                    game.isInHand(1, "Wretched Throng") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Bring Innistrad: Crimson Vow (VOW) to 109/272 implemented cards. Adds the new card definitions, registers them in InnistradCrimsonVowSet.kt, and pairs every non-reprint / non-basic-land card with a Kotest scenario test — the set now has verified 1:1 card-to-scenario-test coverage.

- New VOW card definitions (creatures, spells, artifacts, duals) plus the Hero's Downfall / Sure Strike / Valorous Stance reprints and basic lands.
- ~97 *ScenarioTest.kt classes in rules-engine covering ETB/dies triggers, modal spells, activated abilities, and combat interactions.
- Fix Arm the Cathars: its two "up to one other target creature" slots shared one binding name, so the name-keyed target map (EffectContext.buildNamedTargets) collapsed them last-write-wins and the middle creature got no bonus. Rename the slots to distinct names so each optional target resolves independently.
- Re-bless the VOW card-definition snapshot golden after the fix.
- Refresh the VOW backlog checklist + mechanics notes to match implemented state.