### PR TITLE
Fix warp end-step exile hitting a blinked (new-object) permanent

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -6605,7 +6605,10 @@ Card authors rarely reference these directly; they are created/updated by the ma
   when only one (or neither) is payable; the unpayable side appears grayed out (CR 118.9a, the caster
   chooses which cost to use). The warp action is enumerated by `CastFromZoneEnumerator`, which also
   emits the grayed-out normal-cast placeholder when the normal cost is unaffordable (mirroring
-  `MorphCastEnumerator`).
+  `MorphCastEnumerator`). The end-step exile is a delayed trigger whose `WarpExileEffect` snapshots
+  the permanent's battlefield-entry timestamp (`enteredBattlefieldTimestamp`); at resolution it only
+  exiles the *same object* — a warped permanent that left the battlefield and returned before the
+  end step (blink, e.g. Daydream) is a new object (CR 603.7c / 400.7) and stays permanently.
 - **Evoke** — `evoke = "{U}"`; pay alt cost, sacrifice on ETB.
 - **Sneak** — `sneak("{1}{U}")`; declare-blockers-step alt cost (pay mana + return an unblocked attacker you control to hand); a resolving permanent enters tapped and attacking the same defender. `Conditions.SneakCostWasPaid` reads the rider flag.
 - **Ninjutsu** — `ninjutsu("{1}{U}{B}")`; the canonical CR 702.49 keyword that **Sneak** reflavors. Same declare-blockers alt cost and tapped-and-attacking entry, shared via `KeywordAbility.ninjutsuStyleCost`. *Kaito, Bane of Nightmares* (DSK).

--- a/manual-scenarios/bugs/warp-blink-daydream-not-exiled.json
+++ b/manual-scenarios/bugs/warp-blink-daydream-not-exiled.json
@@ -1,0 +1,30 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": ["Starfield Shepherd", "Daydream"],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"}
+    ],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [],
+    "graveyard": [],
+    "library": ["Plains", "Plains"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RemovalEffects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/effects/RemovalEffects.kt
@@ -545,11 +545,18 @@ data class PutOnLibraryPositionOfChoiceEffect(
  * from exile for its warp cost on a later turn.
  *
  * @property target The permanent to exile (resolved to SpecificEntity by delayed trigger creation)
+ * @property enteredBattlefieldTimestamp The tracked permanent's battlefield-entry timestamp,
+ *   snapshotted when the delayed trigger is created. At resolution the executor exiles the
+ *   permanent only if its current entry timestamp still matches — if it left the battlefield
+ *   and returned in between (blink), it's a new object the delayed trigger no longer tracks
+ *   (CR 603.7c / 400.7) and the exile does nothing. Null skips the check (pre-existing
+ *   serialized states, or callers that resolve the target at fire time).
  */
 @SerialName("WarpExile")
 @Serializable
 data class WarpExileEffect(
-    val target: EffectTarget
+    val target: EffectTarget,
+    val enteredBattlefieldTimestamp: Long? = null
 ) : Effect {
     override val description: String = "Exile ${target.description} (warp)"
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/core/Serialization.kt
@@ -390,6 +390,7 @@ val engineSerializersModule = SerializersModule {
         subclass(HasDealtCombatDamageToPlayerComponent::class)
         subclass(com.wingedsheep.engine.state.components.battlefield.DealtCombatDamageToPlayersThisTurnComponent::class)
         subclass(TimestampComponent::class)
+        subclass(com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent::class)
         subclass(AbilityActivatedEverComponent::class)
         subclass(com.wingedsheep.engine.state.components.battlefield.ChosenModesEverComponent::class)
         subclass(AbilityActivatedThisTurnComponent::class)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.handlers.effects
 
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent
 import com.wingedsheep.engine.state.components.player.EnteredPermanentRecord
 import com.wingedsheep.engine.state.components.player.LandsEnteredUnderControlThisTurnComponent
 import com.wingedsheep.engine.state.components.player.PermanentTypesEnteredBattlefieldThisTurnComponent
@@ -43,10 +44,19 @@ object PermanentEntryTracker {
      * battlefield with its identity components in place).
      */
     fun record(state: GameState, controllerId: EntityId, entityId: EntityId): GameState {
-        val cardTypes = projectedCardTypes(state, entityId)
-        if (cardTypes.isEmpty()) return state
-        val subtypes = state.projectedState.getSubtypes(entityId)
-        return state.updateEntity(controllerId) { container ->
+        // Object-identity stamp (CR 400.7): every battlefield entry funnels through here, so
+        // this is where the entering permanent gets its entry timestamp. Delayed triggers that
+        // track a specific permanent (CR 603.7c) snapshot this value and compare it at
+        // resolution — a mismatch means the entity left and re-entered as a new object.
+        // Distinct entries always differ: the global timestamp ticks at the end of every
+        // resolution, and an entry and re-entry can never share one resolution.
+        val stamped = state.updateEntity(entityId) { container ->
+            container.with(BattlefieldEntryTimestampComponent(state.timestamp))
+        }
+        val cardTypes = projectedCardTypes(stamped, entityId)
+        if (cardTypes.isEmpty()) return stamped
+        val subtypes = stamped.projectedState.getSubtypes(entityId)
+        return stamped.updateEntity(controllerId) { container ->
             val typeMerged = run {
                 val existing = container.get<PermanentTypesEnteredBattlefieldThisTurnComponent>()
                     ?: PermanentTypesEnteredBattlefieldThisTurnComponent()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTracker.kt
@@ -48,11 +48,13 @@ object PermanentEntryTracker {
         // this is where the entering permanent gets its entry timestamp. Delayed triggers that
         // track a specific permanent (CR 603.7c) snapshot this value and compare it at
         // resolution — a mismatch means the entity left and re-entered as a new object.
-        // Distinct entries always differ: the global timestamp ticks at the end of every
-        // resolution, and an entry and re-entry can never share one resolution.
+        // Stamp, then tick: resolutions do NOT advance the global timestamp (only puts on the
+        // stack, land plays, and similar actions do), so two back-to-back resolutions can share
+        // a value — a blink resolving at the same timestamp as the original entry would collide
+        // with the snapshot. Ticking here makes every entry stamp unique unconditionally.
         val stamped = state.updateEntity(entityId) { container ->
             container.with(BattlefieldEntryTimestampComponent(state.timestamp))
-        }
+        }.tick()
         val cardTypes = projectedCardTypes(stamped, entityId)
         if (cardTypes.isEmpty()) return stamped
         val subtypes = stamped.projectedState.getSubtypes(entityId)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/ZoneMovementUtils.kt
@@ -370,6 +370,7 @@ object ZoneMovementUtils {
             .without<SagaComponent>()
             .without<ReplacementEffectSourceComponent>()
             .without<TimestampComponent>()
+            .without<com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent>()
             // Rule 400.7: zone changes create a new object with no memory of prior existence.
             // Strip linked exile tracking so the new instance starts with no exiled cards.
             .without<LinkedExileComponent>()

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/composite/CreateDelayedTriggerExecutor.kt
@@ -6,6 +6,7 @@ import com.wingedsheep.engine.handlers.DynamicAmountEvaluator
 import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.sdk.scripting.effects.AddColorlessManaEffect
 import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
@@ -217,7 +218,17 @@ class CreateDelayedTriggerExecutor : EffectExecutor<CreateDelayedTriggerEffect> 
             }
             is WarpExileEffect -> {
                 val resolvedId = context.resolveTarget(effect.target)
-                if (resolvedId != null) effect.copy(target = EffectTarget.SpecificEntity(resolvedId)) else effect
+                if (resolvedId != null) {
+                    // Snapshot the tracked object's entry stamp NOW (CR 603.7c), mirroring the
+                    // StackResolver warp path — a permanent that leaves and re-enters before
+                    // the trigger fires is a new object the exile must not hit.
+                    val entryTimestamp = state.getEntity(resolvedId)
+                        ?.get<BattlefieldEntryTimestampComponent>()?.timestamp
+                    effect.copy(
+                        target = EffectTarget.SpecificEntity(resolvedId),
+                        enteredBattlefieldTimestamp = entryTimestamp
+                    )
+                } else effect
             }
             is AddCountersEffect -> {
                 val resolvedId = context.resolveTarget(effect.target)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/WarpExileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/WarpExileExecutor.kt
@@ -46,6 +46,20 @@ class WarpExileExecutor : EffectExecutor<WarpExileEffect> {
         // Only exile if the permanent is still on the battlefield
         if (targetId !in state.getBattlefield()) return EffectResult.success(state)
 
+        // CR 603.7c: the delayed trigger tracks the specific object that was warped in. Entity
+        // ids survive zone round-trips in this engine, so a permanent that left the battlefield
+        // and returned (blink) is still findable by id — but it's a new object (CR 400.7) the
+        // trigger must not exile. Detect that via the battlefield-entry timestamp snapshotted
+        // when the trigger was created.
+        if (effect.enteredBattlefieldTimestamp != null) {
+            val currentEntry = container
+                .get<com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent>()
+                ?.timestamp
+            if (currentEntry != effect.enteredBattlefieldTimestamp) {
+                return EffectResult.success(state)
+            }
+        }
+
         // Use ZoneTransitionService for proper cleanup (strip battlefield components, etc.)
         val transitionResult = ZoneTransitionService.moveToZone(
             state = state,

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/WarpExileExecutor.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/effects/zones/WarpExileExecutor.kt
@@ -5,6 +5,7 @@ import com.wingedsheep.engine.handlers.EffectContext
 import com.wingedsheep.engine.handlers.effects.EffectExecutor
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent
 import com.wingedsheep.engine.state.components.identity.CardComponent
 import com.wingedsheep.engine.state.components.identity.WarpExiledComponent
 import com.wingedsheep.engine.state.permissions.MayPlayPermission
@@ -53,7 +54,7 @@ class WarpExileExecutor : EffectExecutor<WarpExileEffect> {
         // when the trigger was created.
         if (effect.enteredBattlefieldTimestamp != null) {
             val currentEntry = container
-                .get<com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent>()
+                .get<BattlefieldEntryTimestampComponent>()
                 ?.timestamp
             if (currentEntry != effect.enteredBattlefieldTimestamp) {
                 return EffectResult.success(state)

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/stack/StackResolver.kt
@@ -1506,11 +1506,20 @@ class StackResolver(
             }
         }
 
-        // Warp: create delayed trigger to exile at beginning of next end step
+        // Warp: create delayed trigger to exile at beginning of next end step. Snapshot the
+        // permanent's battlefield-entry timestamp so the exile only affects this battlefield
+        // object — if the permanent leaves and re-enters before the trigger resolves (blink),
+        // it's a new object the delayed trigger no longer tracks (CR 603.7c / 400.7).
         if (spellComponent.wasWarped) {
+            val entryTimestamp = newState.getEntity(spellId)
+                ?.get<com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent>()
+                ?.timestamp
             val delayedTrigger = DelayedTriggeredAbility(
                 id = java.util.UUID.randomUUID().toString(),
-                effect = WarpExileEffect(EffectTarget.SpecificEntity(spellId)),
+                effect = WarpExileEffect(
+                    target = EffectTarget.SpecificEntity(spellId),
+                    enteredBattlefieldTimestamp = entryTimestamp
+                ),
                 fireAtStep = Step.END,
                 sourceId = spellId,
                 sourceName = cardComponent?.name ?: "Unknown",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -440,6 +440,20 @@ data class TimestampComponent(
 ) : Component
 
 /**
+ * The value of [com.wingedsheep.engine.state.GameState.timestamp] when this permanent
+ * entered the battlefield. Identifies the battlefield *object* (CR 400.7): entity ids
+ * survive zone round-trips in this engine, so a delayed trigger that tracks a specific
+ * permanent (CR 603.7c — e.g. warp's "exile it at the beginning of the next end step")
+ * compares this stamp to detect that the entity left and returned as a new object.
+ * Stamped by [com.wingedsheep.engine.handlers.effects.PermanentEntryTracker.record] on
+ * every battlefield entry; stripped on leave.
+ */
+@Serializable
+data class BattlefieldEntryTimestampComponent(
+    val timestamp: Long
+) : Component
+
+/**
  * Tracks which activated abilities have been activated this turn.
  * Used for "Activate only once each turn" restrictions and planeswalker loyalty abilities (Rule 606.3).
  * Cleared at end of turn by TurnManager.

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/state/components/battlefield/BattlefieldComponents.kt
@@ -432,7 +432,15 @@ data class ReplacementEffectSourceComponent(
 ) : Component
 
 /**
- * Timestamp for ordering effects (Rule 613).
+ * Timestamp for ordering continuous effects in the layer system (Rule 613.7).
+ *
+ * Currently never stamped — [com.wingedsheep.engine.mechanics.layers.StateProjector]
+ * falls back to the current [com.wingedsheep.engine.state.GameState.timestamp] when it
+ * is absent. Conceptually this is the same moment as
+ * [BattlefieldEntryTimestampComponent] (both are "when the permanent entered the
+ * battlefield"), but the two stay separate: stamping this one on every entry would
+ * change layer ordering engine-wide, while the entry stamp is a pure identity marker
+ * with no projection impact.
  */
 @Serializable
 data class TimestampComponent(
@@ -446,7 +454,9 @@ data class TimestampComponent(
  * permanent (CR 603.7c — e.g. warp's "exile it at the beginning of the next end step")
  * compares this stamp to detect that the entity left and returned as a new object.
  * Stamped by [com.wingedsheep.engine.handlers.effects.PermanentEntryTracker.record] on
- * every battlefield entry; stripped on leave.
+ * every battlefield entry (which then ticks the global timestamp, so every entry stamp
+ * is unique); stripped on leave. Sibling of [TimestampComponent] — see its note on why
+ * the two aren't unified.
  */
 @Serializable
 data class BattlefieldEntryTimestampComponent(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTrackerStampTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/handlers/effects/PermanentEntryTrackerStampTest.kt
@@ -1,0 +1,57 @@
+package com.wingedsheep.engine.handlers.effects
+
+import com.wingedsheep.engine.state.ComponentContainer
+import com.wingedsheep.engine.state.GameState
+import com.wingedsheep.engine.state.components.battlefield.BattlefieldEntryTimestampComponent
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Pins the uniqueness invariant of the battlefield-entry object-identity stamp (CR 400.7 /
+ * 603.7c): [PermanentEntryTracker.record] stamps the entering permanent with the current
+ * global timestamp and then ticks it, so distinct entries always get distinct stamps —
+ * even when nothing else (a cast, a land play) advances the timestamp in between.
+ * Resolutions themselves don't tick, so without the tick-in-record two back-to-back
+ * resolutions could stamp an entry and a blink re-entry with the same value, and the
+ * delayed-trigger snapshot comparison in WarpExileExecutor would falsely match.
+ */
+class PermanentEntryTrackerStampTest : FunSpec({
+
+    fun entryStamp(state: GameState, id: EntityId): Long? =
+        state.getEntity(id)?.get<BattlefieldEntryTimestampComponent>()?.timestamp
+
+    test("two entries recorded with no tick in between get distinct stamps") {
+        val controller = EntityId.generate()
+        val first = EntityId.generate()
+        val second = EntityId.generate()
+        var state = GameState()
+            .withEntity(controller, ComponentContainer())
+            .withEntity(first, ComponentContainer())
+            .withEntity(second, ComponentContainer())
+
+        state = PermanentEntryTracker.record(state, controller, first)
+        state = PermanentEntryTracker.record(state, controller, second)
+
+        entryStamp(state, second) shouldNotBe entryStamp(state, first)
+    }
+
+    test("a re-entry of the same entity gets a fresh stamp") {
+        val controller = EntityId.generate()
+        val permanent = EntityId.generate()
+        var state = GameState()
+            .withEntity(controller, ComponentContainer())
+            .withEntity(permanent, ComponentContainer())
+
+        state = PermanentEntryTracker.record(state, controller, permanent)
+        val originalStamp = entryStamp(state, permanent)!!
+
+        // Leave the battlefield (the zone-change pipeline strips the stamp), then re-enter
+        // immediately — the same resolution, no tick from any cast or land play.
+        state = state.updateEntity(permanent) { it.without<BattlefieldEntryTimestampComponent>() }
+        state = PermanentEntryTracker.record(state, controller, permanent)
+
+        entryStamp(state, permanent)!! shouldBeGreaterThan originalStamp
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StarfieldShepherdDaydreamScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/StarfieldShepherdDaydreamScenarioTest.kt
@@ -1,0 +1,83 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.WarpedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Regression scenario for the warp + blink interaction (CR 603.7c / 400.7).
+ *
+ * Starfield Shepherd (EOE) is cast for its warp cost {1}{W}, then Daydream (SOS) exiles it
+ * and returns it to the battlefield. The returned permanent is a new object, so warp's
+ * "exile this creature at the beginning of the next end step" delayed trigger must not
+ * exile it — the Shepherd stays on the battlefield permanently.
+ */
+class StarfieldShepherdDaydreamScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("warp exile tracks the object, not the entity") {
+
+            test("Daydreamed Starfield Shepherd is not exiled by the warp trigger at end of turn") {
+                val game = scenario()
+                    .withPlayers("Player1", "Player2")
+                    .withCardInHand(1, "Starfield Shepherd")
+                    .withCardInHand(1, "Daydream")
+                    .withLandsOnBattlefield(1, "Plains", 3)
+                    .withCardInLibrary(1, "Plains")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                fun shepherdOnBattlefield() =
+                    game.state.getBattlefield(game.player1Id).find { entityId ->
+                        game.state.getEntity(entityId)?.get<CardComponent>()?.name == "Starfield Shepherd"
+                    }
+
+                // Cast the Shepherd for its warp cost {1}{W}.
+                val cast = game.castSpellWithAlternativeCost(1, "Starfield Shepherd")
+                withClue("Warp cast should succeed: ${cast.error}") { cast.error shouldBe null }
+                game.resolveStack()
+
+                // The ETB search trigger surfaces a library selection — fail to find.
+                val search = game.state.pendingDecision as? SelectCardsDecision
+                    ?: error("expected the ETB library-search decision; got ${game.state.pendingDecision}")
+                game.submitDecision(CardsSelectedResponse(search.id, emptyList()))
+                game.resolveStack()
+
+                val warped = shepherdOnBattlefield()
+                    ?: error("Starfield Shepherd should be on the battlefield after the warp cast")
+                game.state.getEntity(warped)?.has<WarpedComponent>() shouldBe true
+
+                // Daydream it: exile and return — the Shepherd comes back as a new object.
+                val daydream = game.castSpell(1, "Daydream", targetId = warped)
+                withClue("Daydream cast should succeed: ${daydream.error}") { daydream.error shouldBe null }
+                game.resolveStack()
+
+                val returned = shepherdOnBattlefield()
+                    ?: error("Starfield Shepherd should have returned to the battlefield")
+                game.state.getEntity(returned)?.has<WarpedComponent>() shouldBe false
+
+                // Advance to the end step and drain the warp delayed trigger — it must not
+                // exile the returned (new) object.
+                game.passUntilPhase(Phase.ENDING, Step.END)
+                game.resolveStack()
+
+                withClue("blinked Shepherd must survive the warp end-step trigger (CR 603.7c)") {
+                    shepherdOnBattlefield() shouldNotBe null
+                }
+                withClue("nothing should have been warp-exiled") {
+                    game.state.getZone(ZoneKey(game.player1Id, Zone.EXILE)) shouldBe emptyList()
+                }
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WarpMechanicTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WarpMechanicTest.kt
@@ -9,6 +9,7 @@ import com.wingedsheep.engine.state.components.identity.WarpExiledComponent
 import com.wingedsheep.engine.handlers.effects.ZoneTransitionService
 import com.wingedsheep.engine.legalactions.LegalActionEnumerator
 import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
 import com.wingedsheep.engine.support.GameTestDriver
 import com.wingedsheep.engine.support.TestCards
 import com.wingedsheep.sdk.core.Color
@@ -16,6 +17,8 @@ import com.wingedsheep.sdk.core.CounterType
 import com.wingedsheep.sdk.core.Keyword
 import com.wingedsheep.sdk.core.Step
 import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Deck
 import com.wingedsheep.sdk.model.EntityId
@@ -47,9 +50,21 @@ class WarpMechanicTest : FunSpec({
         replacementEffect(EntersWithDynamicCounters(count = DynamicAmount.XValue))
     }
 
+    // Minimal blink (cf. Daydream): exile the targeted creature, then return it to the
+    // battlefield — making it a new object (CR 400.7).
+    val blinkSorcery = card("Blink Test Sorcery") {
+        manaCost = "{R}"
+        typeLine = "Sorcery"
+        spell {
+            val creature = target("creature you control", Targets.CreatureYouControl)
+            effect = Effects.Move(creature, Zone.EXILE)
+                .then(Effects.Move(creature, Zone.BATTLEFIELD))
+        }
+    }
+
     fun createDriver(): GameTestDriver {
         val driver = GameTestDriver()
-        driver.registerCards(TestCards.all + listOf(warpCreature, warpXCreature))
+        driver.registerCards(TestCards.all + listOf(warpCreature, warpXCreature, blinkSorcery))
         return driver
     }
 
@@ -135,6 +150,55 @@ class WarpMechanicTest : FunSpec({
         driver.getExileCardNames(player) shouldBe listOf("Warp Test Creature")
         val exiledCardId = driver.getExile(player).first()
         driver.state.getEntity(exiledCardId)?.has<WarpExiledComponent>() shouldBe true
+    }
+
+    test("warped creature blinked before the end step is not exiled — new object, CR 603.7c") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40))
+        driver.gotoMainPhase()
+
+        val player = driver.activePlayer!!
+        val cardId = driver.putCardInHand(player, "Warp Test Creature")
+        driver.giveMana(player, Color.RED, 2)
+
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = cardId,
+                useAlternativeCost = true,
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        )
+        driver.bothPass()
+
+        val warped = driver.findPermanent(player, "Warp Test Creature")
+        warped shouldNotBe null
+        driver.state.getEntity(warped!!)?.has<WarpedComponent>() shouldBe true
+
+        // Blink it — exile and return. The returned permanent is a new object (CR 400.7)
+        // that warp's delayed exile trigger no longer tracks.
+        val blinkId = driver.putCardInHand(player, "Blink Test Sorcery")
+        driver.giveMana(player, Color.RED, 1)
+        driver.submit(
+            CastSpell(
+                playerId = player,
+                cardId = blinkId,
+                targets = listOf(ChosenTarget.Permanent(warped)),
+                paymentStrategy = PaymentStrategy.FromPool
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        val returned = driver.findPermanent(player, "Warp Test Creature")
+        returned shouldNotBe null
+        driver.state.getEntity(returned!!)?.has<WarpedComponent>() shouldBe false
+
+        // The delayed trigger still fires at the end step but must not exile the new object.
+        driver.passPriorityUntil(Step.END)
+        driver.bothPass()
+
+        driver.findPermanent(player, "Warp Test Creature") shouldNotBe null
+        driver.getExile(player) shouldBe emptyList()
     }
 
     test("warped creature can be re-cast from exile at its regular mana cost on a later turn") {


### PR DESCRIPTION
@wingedsheep please check if you think this is the right implementation for this problem.

## Problem

A permanent cast for its warp cost that left the battlefield and returned before the end step (blink — e.g. **Daydream** on **Starfield Shepherd**) was still exiled by warp's "exile it at the beginning of the next end step" delayed trigger. Per CR 603.7c / 400.7 the returned permanent is a new object the delayed trigger no longer tracks, so it must stay on the battlefield permanently. Entity ids survive zone round-trips in this engine, so the trigger could still find the blinked permanent by id.

## Fix

An object-identity stamp for battlefield entries:

- **`BattlefieldEntryTimestampComponent`** — stamped in `PermanentEntryTracker.record`, the chokepoint both entry pipelines (`BattlefieldEntry.place` and `ZoneTransitionService.moveToZone`) funnel through; stripped on leave alongside the other CR 400.7 "new object" components. `record` ticks the global timestamp after stamping: resolutions themselves don't advance the timestamp (only puts on the stack, land plays, and similar actions do), so two back-to-back resolutions could otherwise share a value — stamp-then-tick makes every entry stamp unique unconditionally.
- **`WarpExileEffect.enteredBattlefieldTimestamp`** (nullable, default `null` so previously serialized states keep working) — snapshotted when the delayed trigger is created, in both creation paths (`StackResolver`'s warp path and `CreateDelayedTriggerExecutor`'s generic path), and compared against the permanent's current stamp at resolution. A mismatch means the entity re-entered as a new object and the exile does nothing.
- `TimestampComponent` (Rule 613.7 layer ordering) and the new component describe the same notional moment; their KDocs now cross-reference each other and document why they stay separate (stamping the layer one on every entry would change layer ordering engine-wide).

## Tests

- `WarpMechanicTest` — new driver-level regression: a warped creature blinked before the end step survives the trigger. The blink card is composed inline from existing `Effects.Move` primitives; the test fails without the fix.
- `StarfieldShepherdDaydreamScenarioTest` — full scenario with the real EOE/SOS cards.
- `PermanentEntryTrackerStampTest` — pins the stamp-uniqueness invariant: distinct entries always get distinct stamps, even with no cast/land-play tick in between.
- Manual repro scenario: `manual-scenarios/bugs/warp-blink-daydream-not-exiled.json`.

Full `:rules-engine:test` suite green locally (includes the engine-wide stamp-then-tick change).

A self-review (per the repo's review-changes flow) is attached as a PR comment; its findings are addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
