### PR TITLE
Add 5 LCI Craft DFCs (batch 1) + exact-count Craft costs

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -139,7 +139,7 @@
 - [ ] Jade Seedstones
 - [x] Jadelight Spelunker
 - [x] Join the Dead
-- [ ] Kaslem's Stonetree
+- [x] Kaslem's Stonetree
 - [ ] Kellan, Daring Traveler
 - [x] Kinjalli's Dawnrunner
 - [ ] Kitesail Larcenist

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -175,7 +175,7 @@
 - [x] Oltec Archaeologists
 - [x] Oltec Cloud Guard
 - [x] Orazca Puzzle-Door
-- [ ] Oteclan Landmark
+- [x] Oteclan Landmark
 - [x] Out of Air
 - [x] Over the Edge
 - [x] Palani's Hatcher

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 217 / 286
+**Implemented:** 222 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -132,7 +132,7 @@
 - [x] In the Presence of Ages
 - [x] Inti, Seneschal of the Sun
 - [ ] Intrepid Paleontologist
-- [ ] Inverted Iceberg
+- [x] Inverted Iceberg
 - [x] Ironpaw Aspirant
 - [x] Itzquinth, Firstborn of Gishath
 - [x] Ixalli's Lorekeeper

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -53,7 +53,7 @@
 - [x] Child of the Volcano
 - [x] Chimil, the Inner Sun
 - [x] Chupacabra Echo
-- [ ] Clay-Fired Bricks
+- [x] Clay-Fired Bricks
 - [x] Coati Scavenger
 - [x] Cogwork Wrestler
 - [x] Colossadactyl

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -266,7 +266,7 @@
 - [ ] Throne of the Grim Captain
 - [x] Tinker's Tote
 - [ ] Tishana's Tidebinder
-- [ ] Tithing Blade
+- [x] Tithing Blade
 - [ ] Treasure Map
 - [x] Triumphant Chomp
 - [x] Trumpeting Carnosaur

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -237,9 +237,12 @@ excluded.
   additional cost (Feed the Cycle), and the graveyard-cast permission (Osteomancer Adept, where the
   card being cast is excluded from the exile pool). For a "you may forage" *effect* (not a cost) use
   `Patterns.Mechanic.forage(afterEffect?)` instead.
-- `Costs.Craft(filter, minCount = 1)` — Craft material cost (CR 702.167a): exile this permanent
-  **and** exile at least `minCount` cards matching `filter` selected from the combined pool of
-  permanents you control and cards in your graveyard. Atomic because CR 702.167a pairs the
+- `Costs.Craft(filter, minCount = 1, maxCount = null)` — Craft material cost (CR 702.167a): exile
+  this permanent **and** exile at least `minCount` (and, when `maxCount` is set, at most `maxCount`)
+  cards matching `filter` selected from the combined pool of
+  permanents you control and cards in your graveyard. Exact-count crafts ("Craft with artifact" =
+  exactly one, "Craft with two creatures" = exactly two) set `maxCount == minCount`; "... or more"
+  wordings leave `maxCount = null`. Atomic because CR 702.167a pairs the
   self-exile with the materials-exile in one clause. Records the chosen materials on the source's
   `CraftedFromExiledComponent` so the back face's CDA can read them after the source returns
   transformed. Always combined with `Mana(...)` and used with the
@@ -4656,11 +4659,14 @@ composite abilities).
   original stays in exile; each cast copy is a phantom that ceases to exist (CR 707.10a / 112.3b), so there is no
   exponential growth. The `Lesson` spell subtype (`Subtype.LESSON`) is a plain, non-functional subtype (no Learn
   mechanic in the set), but the type line must parse it.
-- `Craft(filter, cost)` — `card { craft(filter, cost) }` builder helper (CR 702.167, The Lost Caverns of
+- `Craft(filter, cost)` — `card { craft(filter, cost, materialDescription?, minCount = 1, maxCount = null) }`
+  builder helper (CR 702.167, The Lost Caverns of
   Ixalan). On the front face of a transforming DFC: "Craft with [filter] [cost] ([cost], Exile this permanent,
   Exile [filter] you control and/or [filter] cards from your graveyard: Return this card to the battlefield
-  transformed under its owner's control. Activate only as a sorcery.)" Composes entirely from existing primitives
-  — `AbilityCost.Composite(Mana(cost), AbilityCost.Craft(filter))` (the atomic `Craft` sub-cost handles both the
+  transformed under its owner's control. Activate only as a sorcery.)" `minCount`/`maxCount` bound the material
+  count: exact-count wordings ("Craft with artifact" = exactly one, "Craft with two creatures" = exactly two)
+  pass `maxCount = minCount`; "one or more [filter]s" leaves `maxCount = null`. Composes entirely from existing primitives
+  — `AbilityCost.Composite(Mana(cost), AbilityCost.Craft(filter, minCount, maxCount))` (the atomic `Craft` sub-cost handles both the
   self-exile and the materials-exile because CR 702.167a defines them as one paired clause), plus
   `Effects.ReturnSelfFromExileTransformed` as the resolution effect, and `timing = TimingRule.SorcerySpeed`.
   Records the exiled materials on the source's `CraftedFromExiledComponent` so the back face's CDA
@@ -4668,7 +4674,7 @@ composite abilities).
   can read them via `DynamicAmount.CraftedMaterialsTotalPower`. Declares `Keyword.CRAFT` for display.
 
   Material selection: the engine surfaces the combined BF + GY candidate pool on each Craft activation as
-  `AdditionalCostData.validCraftMaterials` / `craftMinCount`. The web client renders both zones side-by-side
+  `AdditionalCostData.validCraftMaterials` / `craftMinCount` / `craftMaxCount`. The web client renders both zones side-by-side
   via the dedicated `CraftMaterialOverlay` (routed by the `Craft` cost-type branch in `pipelinePhases`) and
   submits the picked IDs back as `ActivateAbility.costPayment.exiledCards`. Headless / game-server callers can
   supply the chosen IDs directly. The cost handler validates that every chosen entity is either a permanent

--- a/manual-scenarios/sets/lci/craft-01.json
+++ b/manual-scenarios/sets/lci/craft-01.json
@@ -1,0 +1,53 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Oteclan Landmark",
+      "Inverted Iceberg",
+      "Tithing Blade",
+      "Kaslem's Stonetree",
+      "Clay-Fired Bricks"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Captivating Cave"},
+      {"name": "Saheeli's Lattice"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [
+      "Grizzly Bears",
+      "Saheeli's Lattice",
+      "Swamp"
+    ],
+    "library": ["Plains", "Forest", "Grizzly Bears", "Island", "Grizzly Bears", "Swamp", "Grizzly Bears"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Island"],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Island", "Grizzly Bears", "Swamp", "Grizzly Bears", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -309,8 +309,8 @@ object Costs {
      * Costs.Composite(Costs.Mana("{4}{R}"), Costs.Craft(Filters.Dinosaur))
      * ```
      */
-    fun Craft(filter: GameObjectFilter, minCount: Int = 1): AbilityCost =
-        AbilityCost.Craft(filter, minCount)
+    fun Craft(filter: GameObjectFilter, minCount: Int = 1, maxCount: Int? = null): AbilityCost =
+        AbilityCost.Craft(filter, minCount, maxCount)
 
     // =========================================================================
     // Additional Costs (paid while casting a spell) — wraps AdditionalCost

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/CraftDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/CraftDsl.kt
@@ -25,24 +25,33 @@ import com.wingedsheep.sdk.scripting.costs.CostAtom
  * Marks the front face with the [Keyword.CRAFT] tag for client display.
  *
  * ```kotlin
- * craft(filter = Filters.Dinosaur, cost = "{4}{R}")
+ * craft(filter = Filters.Dinosaur, cost = "{4}{R}")                             // one or more
+ * craft(filter = Filters.Artifact, cost = "{2}{W}", minCount = 1, maxCount = 1) // exactly one
  * ```
  *
  * @param filter The material filter (the [filter] in "Craft with [filter]").
  * @param cost The mana portion of the craft cost.
  * @param materialDescription Optional override for the filter's name in the rendered cost
  *   description — e.g. "one or more Dinosaurs". Defaults to the filter's own description.
+ * @param minCount Minimum number of materials (CR 702.167a).
+ * @param maxCount Maximum number of materials, or `null` for "... or more" wordings. Exact-count
+ *   crafts ("Craft with artifact", "Craft with two creatures") set `maxCount == minCount`.
  */
 fun CardBuilder.craft(
     filter: GameObjectFilter,
     cost: String,
-    materialDescription: String? = null
+    materialDescription: String? = null,
+    minCount: Int = 1,
+    maxCount: Int? = null
 ) {
     val materials = materialDescription ?: "one or more ${filter.description}s"
     activatedAbilities.add(
         ActivatedAbility(
             cost = AbilityCost.Composite(
-                listOf(AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost))), AbilityCost.Craft(filter))
+                listOf(
+                    AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost))),
+                    AbilityCost.Craft(filter, minCount = minCount, maxCount = maxCount)
+                )
             ),
             effect = com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect,
             targetRequirements = emptyList(),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -491,18 +491,21 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
         val maxCount: Int? = null,
     ) : AbilityCost {
         override val description: String = buildString {
+            val exactlyOne = maxCount == 1
+            val article = if (filter.description.firstOrNull()?.lowercaseChar() in listOf('a', 'e', 'i', 'o', 'u')) "an" else "a"
             append("Exile this permanent, Exile ")
             when {
                 maxCount == null && minCount == 1 -> append("one or more ")
                 maxCount == null -> append("$minCount or more ")
-                maxCount == 1 -> append("a ")
+                exactlyOne -> append("$article ")
                 else -> append("$minCount ")
             }
             append(filter.description)
-            if (maxCount != 1) append("s")
+            if (!exactlyOne) append("s")
             append(" you control and/or ")
+            if (exactlyOne) append("$article ")
             append(filter.description)
-            append(" cards from your graveyard")
+            append(if (exactlyOne) " card from your graveyard" else " cards from your graveyard")
         }
 
         override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -478,18 +478,29 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
      * @property filter Material filter (typically the same one used in the Craft display text,
      *   e.g. `Filters.Dinosaur` for Saheeli's Lattice).
      * @property minCount Minimum number of materials to exile (1 for "one or more").
+     * @property maxCount Maximum number of materials, or `null` for unbounded ("... or more").
+     *   Most Craft costs name an exact count — "Craft with artifact" exiles exactly one
+     *   artifact, "Craft with two creatures" exactly two — so those set `maxCount == minCount`;
+     *   only "one or more" / "N or more" wordings leave it `null` (CR 702.167a).
      */
     @SerialName("CostCraft")
     @Serializable
     data class Craft(
         val filter: GameObjectFilter,
         val minCount: Int = 1,
+        val maxCount: Int? = null,
     ) : AbilityCost {
         override val description: String = buildString {
             append("Exile this permanent, Exile ")
-            if (minCount == 1) append("one or more ") else append("$minCount or more ")
+            when {
+                maxCount == null && minCount == 1 -> append("one or more ")
+                maxCount == null -> append("$minCount or more ")
+                maxCount == 1 -> append("a ")
+                else -> append("$minCount ")
+            }
             append(filter.description)
-            append("s you control and/or ")
+            if (maxCount != 1) append("s")
+            append(" you control and/or ")
             append(filter.description)
             append(" cards from your graveyard")
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ClayFiredBricks.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ClayFiredBricks.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Clay-Fired Bricks // Cosmium Kiln (CR 702.167, The Lost Caverns of Ixalan)
+ * {1}{W}
+ * Artifact // Artifact
+ *
+ * Front face — Clay-Fired Bricks ({1}{W}, Artifact)
+ *   When this artifact enters, search your library for a basic Plains card, reveal it,
+ *   put it into your hand, then shuffle. You gain 2 life.
+ *   Craft with artifact {5}{W}{W} ({5}{W}{W}, Exile this artifact, Exile another artifact
+ *   you control or an artifact card from your graveyard: Return this card transformed
+ *   under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Cosmium Kiln (Artifact)
+ *   When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens.
+ *   Creatures you control get +1/+1.
+ *
+ * Implementation: the front face's ETB is [Effects.Composite] sequencing the atomic
+ * [Patterns.Library.searchLibrary] pipeline (basic Plains → reveal → hand → shuffle) before
+ * [Effects.GainLife]. The `craft(...)` helper wires the activated ability with an
+ * [com.wingedsheep.sdk.scripting.AbilityCost.Craft] material cost (exactly one artifact:
+ * minCount = maxCount = 1) paired with the printed mana cost; resolution returns the card
+ * from exile as the back face via
+ * [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect]. The back
+ * face's ETB fires off the normal battlefield-entry event when the craft return puts it
+ * onto the battlefield transformed, creating the Gnomes with
+ * [com.wingedsheep.sdk.scripting.effects.CreateTokenEffect]; its anthem is a [ModifyStats]
+ * static over [GameObjectFilter.Creature.youControl] (Glorious Anthem pattern).
+ */
+
+private val ClayFiredBricksFront = card("Clay-Fired Bricks") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, search your library for a basic Plains card, " +
+        "reveal it, put it into your hand, then shuffle. You gain 2 life.\n" +
+        "Craft with artifact {5}{W}{W} ({5}{W}{W}, Exile this artifact, Exile another artifact " +
+        "you control or an artifact card from your graveyard: Return this card transformed " +
+        "under its owner's control. Craft only as a sorcery.)"
+
+    // ETB: search your library for a basic Plains card, reveal it, put it into your hand,
+    // then shuffle. You gain 2 life.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.BasicLand.withSubtype(Subtype.PLAINS),
+                count = 1,
+                destination = SearchDestination.HAND,
+                reveal = true,
+                shuffleAfter = true
+            ),
+            Effects.GainLife(2)
+        )
+        description = "When this artifact enters, search your library for a basic Plains card, " +
+            "reveal it, put it into your hand, then shuffle. You gain 2 life."
+    }
+
+    // Craft with artifact {5}{W}{W} — exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{5}{W}{W}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Steve Ellis"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1782694608"
+    }
+}
+
+private val CosmiumKiln = card("Cosmium Kiln") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens.\n" +
+        "Creatures you control get +1/+1."
+
+    // ETB: create two 1/1 colorless Gnome artifact creature tokens.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Gnome"),
+            count = 2,
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/6/d/6def709a-53b3-4520-9544-74ab6472d256.jpg?1782731572"
+        )
+        description = "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens."
+    }
+
+    // Creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Steve Ellis"
+        flavorText = "\"I love the smell of freshly baked gnomes!\"\n—Yelha, Oltec artisan"
+        imageUri = "https://cards.scryfall.io/normal/back/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1782694608"
+    }
+}
+
+val ClayFiredBricks: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = ClayFiredBricksFront,
+    backFace = CosmiumKiln
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/InvertedIceberg.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/InvertedIceberg.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Inverted Iceberg // Iceberg Titan (CR 702.167, The Lost Caverns of Ixalan #60)
+ * {1}{U}
+ * Artifact // Artifact Creature — Golem
+ *
+ * Front face — Inverted Iceberg ({1}{U}, Artifact)
+ *   When this artifact enters, mill a card, then draw a card.
+ *   Craft with artifact {4}{U}{U} ({4}{U}{U}, Exile this artifact, Exile another
+ *   artifact you control or an artifact card from your graveyard: Return this card
+ *   transformed under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Iceberg Titan (Artifact Creature — Golem, 6/6)
+ *   Whenever this creature attacks, you may tap or untap target artifact or creature.
+ *
+ * Implementation:
+ *  - Front ETB: [Effects.Composite] sequencing `Patterns.Library.mill(1)` then
+ *    `Effects.DrawCards(1)` — mill fully resolves before the draw, matching the
+ *    "mill a card, then draw a card" ordering.
+ *  - Craft: the `craft(...)` helper wires [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ *    (exactly one artifact material: `minCount = 1, maxCount = 1`) plus the {4}{U}{U} mana
+ *    cost at sorcery speed; resolution returns the source from exile transformed via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect].
+ *  - Back attack trigger: declared target ([Targets.CreatureOrArtifact], chosen when the
+ *    trigger goes on the stack) with a [MayEffect]-wrapped two-mode [ModalEffect]
+ *    (tap / untap via [TapUntapEffect]) decided at resolution — the same idiom as
+ *    Sewer-veillance Cam / Gandalf the Grey's "you may tap or untap target ..." clause.
+ */
+
+private val InvertedIcebergFront = card("Inverted Iceberg") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, mill a card, then draw a card. (To mill a card, put the top card of your library into your graveyard.)\n" +
+        "Craft with artifact {4}{U}{U} ({4}{U}{U}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // When this artifact enters, mill a card, then draw a card.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.mill(1),
+            Effects.DrawCards(1)
+        )
+    }
+
+    // Craft with artifact {4}{U}{U} — exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{4}{U}{U}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1782694562"
+    }
+}
+
+private val IcebergTitan = card("Iceberg Titan") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Golem"
+    power = 6
+    toughness = 6
+    oracleText = "Whenever this creature attacks, you may tap or untap target artifact or creature."
+
+    // Whenever this creature attacks, you may tap or untap target artifact or creature.
+    // MayEffect + Effects.ChooseAction is the proven tap-or-untap idiom (Gandalf the Grey);
+    // the engine asks the may-question and locks the target when the trigger goes on the
+    // stack, then the tap/untap choice is made at resolution.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val permanent = target("target artifact or creature", Targets.CreatureOrArtifact)
+        effect = MayEffect(
+            Effects.ChooseAction(
+                listOf(
+                    EffectChoice("Tap it", Effects.Tap(permanent)),
+                    EffectChoice("Untap it", Effects.Untap(permanent))
+                )
+            ),
+            descriptionOverride = "You may tap or untap target artifact or creature"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Campbell White"
+        flavorText = "The force of a blizzard. The rage of a monstrosaur."
+        imageUri = "https://cards.scryfall.io/normal/back/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1782694562"
+    }
+}
+
+val InvertedIceberg: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = InvertedIcebergFront,
+    backFace = IcebergTitan
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/KaslemsStonetree.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/KaslemsStonetree.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kaslem's Stonetree // Kaslem's Strider (CR 702.167, The Lost Caverns of Ixalan)
+ * {2}{G}
+ * Artifact // Artifact Creature — Golem
+ *
+ * Front face — Kaslem's Stonetree ({2}{G}, Artifact)
+ *   When this artifact enters, look at the top six cards of your library. You may put
+ *   a land card from among them onto the battlefield tapped. Put the rest on the
+ *   bottom in a random order.
+ *   Craft with Cave {5}{G}
+ *
+ * Back face — Kaslem's Strider (Artifact Creature — Golem, 5/5)
+ *   Vanilla.
+ *
+ * Implementation:
+ *  - The ETB trigger is the Gather → Select → Move library pipeline (Freestrider
+ *    Lookout's shape): [GatherCardsEffect] over the top six, an optional filtered
+ *    [SelectFromCollectionEffect] ([SelectionMode.ChooseUpTo] 1 land), the pick moved
+ *    to the battlefield [ZonePlacement.Tapped], the rest to the bottom of the library
+ *    in [CardOrder.Random] order.
+ *  - The `craft(...)` helper wires the activated ability: [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ *    with an exactly-one Cave material filter (`minCount = maxCount = 1`; a Cave you
+ *    control or a Cave card in your graveyard, CR 702.167a-b) plus the {5}{G} mana
+ *    cost, resolving via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect]
+ *    (return transformed as the back face). Sorcery-only timing is enforced by the
+ *    helper.
+ */
+
+private val CaveFilter: GameObjectFilter = GameObjectFilter.Any.withSubtype("Cave")
+
+private val KaslemsStonetreeFront = card("Kaslem's Stonetree") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, look at the top six cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom in a random order.\n" +
+        "Craft with Cave {5}{G} ({5}{G}, Exile this artifact, Exile a Cave you control or a Cave card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // ETB: look at the top six, optionally put a land onto the battlefield tapped,
+    // rest to the bottom of the library in a random order.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(6)),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Land,
+                    storeSelected = "kept",
+                    storeRemainder = "rest",
+                    prompt = "You may put a land card onto the battlefield tapped",
+                    showAllCards = true
+                ),
+                MoveCollectionEffect(
+                    from = "kept",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped)
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    craft(filter = CaveFilter, cost = "{5}{G}", materialDescription = "Cave", minCount = 1, maxCount = 1)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1782694451"
+    }
+}
+
+private val KaslemsStrider = card("Kaslem's Strider") {
+    manaCost = ""
+    colorIdentity = "G"
+    typeLine = "Artifact Creature — Golem"
+    power = 5
+    toughness = 5
+    oracleText = ""
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Victor Adame Minguez"
+        flavorText = "The Oltec long ago abandoned the caverns to the mycoids, but the Deep Gods still keep watch over the spore-strewn darkness."
+        imageUri = "https://cards.scryfall.io/normal/back/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1782694451"
+    }
+}
+
+val KaslemsStonetree: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = KaslemsStonetreeFront,
+    backFace = KaslemsStrider
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OteclanLandmark.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OteclanLandmark.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Oteclan Landmark // Oteclan Levitator (CR 702.167, The Lost Caverns of Ixalan)
+ * {W}
+ * Artifact // Artifact Creature — Golem
+ *
+ * Front face — Oteclan Landmark ({W}, Artifact)
+ *   When this artifact enters, scry 2.
+ *   Craft with artifact {2}{W} ({2}{W}, Exile this artifact, Exile another artifact you
+ *   control or an artifact card from your graveyard: Return this card transformed under
+ *   its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Oteclan Levitator (Artifact Creature — Golem, 1/4)
+ *   Flying
+ *   Whenever this creature attacks, target attacking creature without flying gains
+ *   flying until end of turn.
+ *
+ * Implementation:
+ *  - Front ETB: [Triggers.EntersBattlefield] → [Patterns.Library.scry] (2).
+ *  - Craft: the `craft(...)` helper wires [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ *    (material filter [GameObjectFilter.Artifact], exactly one material — minCount = maxCount = 1
+ *    per "Craft with artifact") paired with the {2}{W} mana cost, resolving via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect] at
+ *    sorcery speed.
+ *  - Back attack trigger: [Triggers.Attacks] targeting
+ *    [TargetFilter.AttackingCreature].withoutKeyword(FLYING) →
+ *    [Effects.GrantKeyword] (FLYING, until end of turn).
+ */
+
+private val OteclanLandmarkFront = card("Oteclan Landmark") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, scry 2.\n" +
+        "Craft with artifact {2}{W} ({2}{W}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // When this artifact enters, scry 2.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(2)
+    }
+
+    // "Craft with artifact" = exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{2}{W}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1782694588"
+    }
+}
+
+private val OteclanLevitator = card("Oteclan Levitator") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Golem"
+    power = 1
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, target attacking creature without flying gains flying until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever this creature attacks, target attacking creature without flying
+    // gains flying until end of turn.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target(
+            "attacking creature without flying",
+            TargetCreature(filter = TargetFilter.AttackingCreature.withoutKeyword(Keyword.FLYING))
+        )
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Warren Mahy"
+        flavorText = "Dusk Legion invaders sought lone Oltec travelers to prey upon. The Core's guidestones did not approve."
+        imageUri = "https://cards.scryfall.io/normal/back/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1782694588"
+    }
+}
+
+val OteclanLandmark: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = OteclanLandmarkFront,
+    backFace = OteclanLevitator
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TithingBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TithingBlade.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tithing Blade // Consuming Sepulcher (CR 702.167, The Lost Caverns of Ixalan)
+ * {1}{B}
+ * Artifact // Artifact
+ *
+ * Front face — Tithing Blade ({1}{B}, Artifact)
+ *   When this artifact enters, each opponent sacrifices a creature of their choice.
+ *   Craft with creature {4}{B} ({4}{B}, Exile this artifact, Exile a creature you
+ *   control or a creature card from your graveyard: Return this card transformed
+ *   under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Consuming Sepulcher (Artifact)
+ *   At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life.
+ *
+ * Implementation:
+ *  - ETB edict: [Triggers.EntersBattlefield] + `Effects.Sacrifice` aimed at
+ *    [Player.EachOpponent] — each opponent chooses their own creature to sacrifice
+ *    (same shape as Susurian Dirgecraft / Cabal Executioner).
+ *  - Craft: the `craft(...)` DSL helper wires the activated ability with an
+ *    [com.wingedsheep.sdk.scripting.AbilityCost.Craft] material cost (exactly one
+ *    creature: `minCount = maxCount = 1`, drawn from battlefield-controlled creatures
+ *    and/or creature cards in your graveyard per CR 702.167b) plus the {4}{B} mana
+ *    portion; resolution returns the card transformed via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect].
+ *  - Back-face drain: [Triggers.YourUpkeep] + composite of `Effects.LoseLife(1)` on
+ *    [Player.EachOpponent] and `Effects.GainLife(1)` for the controller.
+ */
+
+private val TithingBladeFront = card("Tithing Blade") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, each opponent sacrifices a creature of their choice.\n" +
+        "Craft with creature {4}{B} ({4}{B}, Exile this artifact, Exile a creature you control or a creature card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // ETB: each opponent sacrifices a creature of their choice.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Sacrifice(
+            GameObjectFilter.Creature,
+            target = EffectTarget.PlayerRef(Player.EachOpponent)
+        )
+    }
+
+    // Craft with creature {4}{B} — exactly one creature material.
+    craft(
+        filter = GameObjectFilter.Creature,
+        cost = "{4}{B}",
+        materialDescription = "creature",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Michael Walsh"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1782694508"
+    }
+}
+
+private val ConsumingSepulcher = card("Consuming Sepulcher") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life."
+
+    // At the beginning of your upkeep: drain each opponent for 1.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Michael Walsh"
+        flavorText = "\"Slake my thirst so that we both may be free.\"\n—Faded inscription"
+        imageUri = "https://cards.scryfall.io/normal/back/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1782694508"
+    }
+}
+
+val TithingBlade: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = TithingBladeFront,
+    backFace = ConsumingSepulcher
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -7021,6 +7021,130 @@
     ]
 }
 
+// Kaslem's Stonetree
+{
+    "name": "Kaslem's Stonetree",
+    "manaCost": "{2}{G}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, look at the top six cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom in a random order.\nCraft with Cave {5}{G} ({5}{G}, Exile this artifact, Exile a Cave you control or a Cave card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "land",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may put a land card onto the battlefield tapped",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{G}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "Cave",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with Cave — {5}{G}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Kaslem's Strider",
+        "manaCost": "",
+        "typeLine": "Artifact Creature — Golem",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 5
+        },
+        "metadata": {
+            "collectorNumber": "197",
+            "artist": "Victor Adame Minguez",
+            "flavorText": "The Oltec long ago abandoned the caverns to the mycoids, but the Deep Gods still keep watch over the spore-strewn darkness.",
+            "imageUri": "https://cards.scryfall.io/normal/back/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1782694451"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "artist": "Victor Adame Minguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1782694451"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Kinjalli's Dawnrunner
 {
     "name": "Kinjalli's Dawnrunner",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -8113,6 +8113,121 @@
     ]
 }
 
+// Oteclan Landmark
+{
+    "name": "Oteclan Landmark",
+    "manaCost": "{W}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, scry 2.\nCraft with artifact {2}{W} ({2}{W}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {2}{W}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Oteclan Levitator",
+        "manaCost": "",
+        "typeLine": "Artifact Creature — Golem",
+        "oracleText": "Flying\nWhenever this creature attacks, target attacking creature without flying gains flying until end of turn.",
+        "creatureStats": {
+            "power": 1,
+            "toughness": 4
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "FLYING",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "attacking creature without flying"
+                        }
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ],
+                                "statePredicates": [
+                                    "IsAttacking"
+                                ]
+                            }
+                        },
+                        "id": "attacking creature without flying"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "29",
+            "artist": "Warren Mahy",
+            "flavorText": "Dusk Legion invaders sought lone Oltec travelers to prey upon. The Core's guidestones did not approve.",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1782694588"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1782694588"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Out of Air
 {
     "name": "Out of Air",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6576,6 +6576,163 @@
     ]
 }
 
+// Inverted Iceberg
+{
+    "name": "Inverted Iceberg",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, mill a card, then draw a card. (To mill a card, put the top card of your library into your graveyard.)\nCraft with artifact {4}{U}{U} ({4}{U}{U}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{U}{U}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {4}{U}{U}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Iceberg Titan",
+        "manaCost": "",
+        "typeLine": "Artifact Creature — Golem",
+        "oracleText": "Whenever this creature attacks, you may tap or untap target artifact or creature.",
+        "creatureStats": {
+            "power": 6,
+            "toughness": 6
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "ChooseAction",
+                            "choices": [
+                                {
+                                    "label": "Tap it",
+                                    "effect": {
+                                        "type": "TapUntap",
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target artifact or creature"
+                                        }
+                                    }
+                                },
+                                {
+                                    "label": "Untap it",
+                                    "effect": {
+                                        "type": "TapUntap",
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target artifact or creature"
+                                        },
+                                        "tap": false
+                                    }
+                                }
+                            ]
+                        },
+                        "descriptionOverride": "You may tap or untap target artifact or creature"
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature|artifact"
+                        },
+                        "id": "target artifact or creature"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "60",
+            "artist": "Campbell White",
+            "flavorText": "The force of a blizzard. The rage of a monstrosaur.",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1782694562"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Campbell White",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1782694562"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ironpaw Aspirant
 {
     "name": "Ironpaw Aspirant",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -13397,6 +13397,119 @@
     ]
 }
 
+// Tithing Blade
+{
+    "name": "Tithing Blade",
+    "manaCost": "{1}{B}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, each opponent sacrifices a creature of their choice.\nCraft with creature {4}{B} ({4}{B}, Exile this artifact, Exile a creature you control or a creature card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "creature",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with creature — {4}{B}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Consuming Sepulcher",
+        "manaCost": "",
+        "typeLine": "Artifact",
+        "oracleText": "At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life.",
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "128",
+            "artist": "Michael Walsh",
+            "flavorText": "\"Slake my thirst so that we both may be free.\"\n—Faded inscription",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1782694508"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Michael Walsh",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1782694508"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Triumphant Chomp
 {
     "name": "Triumphant Chomp",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2508,6 +2508,165 @@
     ]
 }
 
+// Clay-Fired Bricks
+{
+    "name": "Clay-Fired Bricks",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, search your library for a basic Plains card, reveal it, put it into your hand, then shuffle. You gain 2 life.\nCraft with artifact {5}{W}{W} ({5}{W}{W}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": "basicland Plains"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    },
+                                    "revealed": true
+                                },
+                                "ShuffleLibrary",
+                                "EmitLibrarySearchedEvent"
+                            ]
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this artifact enters, search your library for a basic Plains card, reveal it, put it into your hand, then shuffle. You gain 2 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{W}{W}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {5}{W}{W}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Cosmium Kiln",
+        "manaCost": "",
+        "typeLine": "Artifact",
+        "oracleText": "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens.\nCreatures you control get +1/+1.",
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Battlefield"
+                    },
+                    "effect": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [],
+                        "creatureTypes": [
+                            "Gnome"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6def709a-53b3-4520-9544-74ab6472d256.jpg?1782731572",
+                        "artifactToken": true
+                    },
+                    "descriptionOverride": "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens."
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "6",
+            "rarity": "UNCOMMON",
+            "artist": "Steve Ellis",
+            "flavorText": "\"I love the smell of freshly baked gnomes!\"\n—Yelha, Oltec artisan",
+            "imageUri": "https://cards.scryfall.io/normal/back/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1782694608"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Ellis",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1782694608"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Coati Scavenger
 {
     "name": "Coati Scavenger",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1197,6 +1197,14 @@ class CostHandler(
                 "Craft requires at least ${cost.minCount} ${cost.filter.description}(s) to exile"
             )
         }
+        val maxCount = cost.maxCount
+        if (maxCount != null && chosen.size > maxCount) {
+            // Exact-count crafts ("Craft with artifact") exile exactly maxCount materials —
+            // costs are paid exactly as written (CR 118.8), no over-payment.
+            return CostPaymentResult.failure(
+                "Craft accepts at most $maxCount ${cost.filter.description}(s) to exile"
+            )
+        }
         if (chosen.any { it !in candidates }) {
             return CostPaymentResult.failure("Craft material is not a legal candidate")
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -325,7 +325,9 @@ data class AdditionalCostData(
      * `ActivateAbility.costPayment.exiledCards`.
      */
     val validCraftMaterials: List<EntityId> = emptyList(),
-    val craftMinCount: Int = 1
+    val craftMinCount: Int = 1,
+    /** Cap on material count for exact-count crafts ("Craft with artifact"); null = unbounded. */
+    val craftMaxCount: Int? = null
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -1030,6 +1030,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 costType = "Craft",
                 validCraftMaterials = craftMaterials,
                 craftMinCount = craftCost.minCount,
+                craftMaxCount = craftCost.maxCount,
                 counterRemovalCreatures = counterRemovalCreatures
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -164,7 +164,8 @@ class LegalActionEnricher(
         payXLifeMaxX = payXLifeMaxX,
         distributedCounterRemovalTotal = distributedCounterRemovalTotal,
         validCraftMaterials = validCraftMaterials,
-        craftMinCount = craftMinCount
+        craftMinCount = craftMinCount,
+        craftMaxCount = craftMaxCount
     )
 
     private fun ConvokeCreatureData.toDto() = ConvokeCreatureInfo(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -220,7 +220,9 @@ data class AdditionalCostInfo(
      * `ActivateAbility.costPayment.exiledCards`.
      */
     val validCraftMaterials: List<EntityId> = emptyList(),
-    val craftMinCount: Int = 1
+    val craftMinCount: Int = 1,
+    /** Cap on material count for exact-count crafts ("Craft with artifact"); null = unbounded. */
+    val craftMaxCount: Int? = null
 )
 
 @Serializable

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClayFiredBricksScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClayFiredBricksScenarioTest.kt
@@ -1,0 +1,202 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.ClayFiredBricks
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Clay-Fired Bricks // Cosmium Kiln (LCI #6, CR 702.167).
+ *
+ * Front face — Clay-Fired Bricks ({1}{W} Artifact):
+ *   "When this artifact enters, search your library for a basic Plains card, reveal it,
+ *    put it into your hand, then shuffle. You gain 2 life.
+ *    Craft with artifact {5}{W}{W}"
+ *
+ * Back face — Cosmium Kiln (Artifact):
+ *   "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens.
+ *    Creatures you control get +1/+1."
+ *
+ * Covers:
+ *  - Front ETB: basic-Plains-only library search (non-Plains basics excluded) to hand,
+ *    then the sequenced 2-life gain.
+ *  - Craft end-to-end: mana + exactly-one-artifact material paid, source returns
+ *    transformed as Cosmium Kiln, and the back face's ETB (a fresh battlefield entry,
+ *    not a transform — CR 701.27a) creates the two Gnome tokens.
+ *  - Back-face anthem: creatures you control (including the Gnome tokens) get +1/+1 in
+ *    projection; opponent's creatures are unaffected.
+ *  - Validation: a non-artifact creature is rejected as craft material.
+ */
+class ClayFiredBricksScenarioTest : FunSpec({
+
+    // Plain artifact to use as legal craft material.
+    val testRelic = CardDefinition.artifact(
+        name = "Test Relic",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(testRelic))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        return driver
+    }
+
+    // The front face's only activated ability is the Craft.
+    fun craftAbilityId() = ClayFiredBricks.activatedAbilities.single().id
+
+    /** Craft Clay-Fired Bricks (already on the battlefield) using [material], resolving the ability. */
+    fun GameTestDriver.craftBricks(
+        player: com.wingedsheep.sdk.model.EntityId,
+        bricks: com.wingedsheep.sdk.model.EntityId,
+        material: com.wingedsheep.sdk.model.EntityId
+    ) {
+        giveMana(player, Color.WHITE, 7)
+        submitSuccess(
+            ActivateAbility(
+                playerId = player,
+                sourceId = bricks,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material))
+            )
+        )
+        bothPass() // resolve the craft ability -> back face enters, its ETB trigger goes on the stack
+    }
+
+    test("front ETB searches for a basic Plains (only), puts it into hand, and gains 2 life") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        // Library is all Mountains (basic, but not Plains) plus this one Plains.
+        val plains = driver.putCardOnTopOfLibrary(p1, "Plains")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bricks = driver.putCardInHand(p1, "Clay-Fired Bricks")
+        driver.giveMana(p1, Color.WHITE, 2)
+        val lifeBefore = driver.getLifeTotal(p1)
+
+        driver.castSpell(p1, bricks).isSuccess shouldBe true
+        driver.bothPass() // resolve the artifact spell -> ETB trigger on the stack
+        driver.bothPass() // resolve the trigger -> pauses on the library search selection
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        // Only the basic Plains is searchable — the basic Mountains don't match the filter.
+        decision.options shouldBe listOf(plains)
+
+        driver.submitCardSelection(p1, listOf(plains))
+
+        driver.getHand(p1) shouldContain plains
+        driver.getLifeTotal(p1) shouldBe lifeBefore + 2
+    }
+
+    test("craft with an artifact exiles the material and returns transformed as Cosmium Kiln, whose ETB creates two Gnome tokens") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val bricks = driver.putPermanentOnBattlefield(p1, "Clay-Fired Bricks")
+        val relic = driver.putPermanentOnBattlefield(p1, "Test Relic")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.craftBricks(p1, bricks, relic)
+
+        // Material exiled.
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain relic
+
+        // Source returned to the battlefield as the back face.
+        val container = driver.state.getEntity(bricks)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Cosmium Kiln"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // The craft return is a battlefield entry, so the back face's ETB trigger fired
+        // and is on the stack; resolving it creates the two Gnome tokens.
+        driver.bothPass()
+        val gnomes = driver.getPermanents(p1).filter { driver.getCardName(it) == "Gnome Token" }
+        gnomes.size shouldBe 2
+    }
+
+    test("Cosmium Kiln's anthem gives your creatures +1/+1 (Gnome tokens are 2/2) but not the opponent's") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        val bricks = driver.putPermanentOnBattlefield(p1, "Clay-Fired Bricks")
+        val relic = driver.putPermanentOnBattlefield(p1, "Test Relic")
+        val myLions = driver.putCreatureOnBattlefield(p1, "Savannah Lions")       // 1/1
+        val oppCourser = driver.putCreatureOnBattlefield(p2, "Centaur Courser")   // 3/3
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.craftBricks(p1, bricks, relic)
+        driver.bothPass() // resolve the back-face ETB trigger -> two Gnome tokens
+
+        val projected = projector.project(driver.state)
+
+        // My 1/1 Savannah Lions is projected 2/2 under the anthem.
+        projected.getPower(myLions) shouldBe 2
+        projected.getToughness(myLions) shouldBe 2
+
+        // The 1/1 Gnome tokens are projected 2/2.
+        val gnomes = driver.getPermanents(p1).filter { driver.getCardName(it) == "Gnome Token" }
+        gnomes.size shouldBe 2
+        gnomes.forEach { gnome ->
+            projected.getPower(gnome) shouldBe 2
+            projected.getToughness(gnome) shouldBe 2
+        }
+
+        // Opponent's 3/3 Centaur Courser is unaffected.
+        projected.getPower(oppCourser) shouldBe 3
+        projected.getToughness(oppCourser) shouldBe 3
+    }
+
+    test("rejects a non-artifact creature as craft material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val bricks = driver.putPermanentOnBattlefield(p1, "Clay-Fired Bricks")
+        val lions = driver.putCreatureOnBattlefield(p1, "Savannah Lions") // not an artifact
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.WHITE, 7)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = bricks,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(lions))
+            )
+        )
+        result.isSuccess shouldBe false
+
+        // Nothing moved: still the front face on the battlefield, no exile.
+        driver.state.getEntity(bricks)!!.get<CardComponent>()!!.name shouldBe "Clay-Fired Bricks"
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldNotContain lions
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CraftExactCountScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CraftExactCountScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Exact-count Craft costs (CR 702.167a): "Craft with artifact" exiles exactly one material —
+ * costs are paid exactly as written, so supplying more materials than [maxCount] must be
+ * rejected, exactly like supplying fewer than [minCount].
+ *
+ * Uses a test-local DFC with `craft(filter = artifact, maxCount = 1)` so the check is
+ * independent of any particular set's card.
+ */
+class CraftExactCountScenarioTest : FunSpec({
+
+    val artifactFilter = GameObjectFilter.Artifact
+
+    val frontFace = card("Test Exact Crafter") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = "Craft with artifact {2}"
+        craft(filter = artifactFilter, cost = "{2}", materialDescription = "artifact", minCount = 1, maxCount = 1)
+    }
+    val backFace = card("Test Crafted Golem") {
+        manaCost = ""
+        typeLine = "Artifact Creature — Golem"
+        power = 3
+        toughness = 3
+        oracleText = ""
+    }
+    val exactCrafter: CardDefinition = CardDefinition.doubleFacedPermanent(
+        frontFace = frontFace,
+        backFace = backFace
+    )
+
+    val trinket = card("Test Trinket") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(exactCrafter, trinket))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        return driver
+    }
+
+    fun craftAbilityId() = exactCrafter.activatedAbilities.single().id
+
+    test("accepts exactly one material and returns transformed") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val crafter = driver.putPermanentOnBattlefield(p1, "Test Exact Crafter")
+        val material = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 2)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = crafter,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material))
+            )
+        )
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)).contains(material) shouldBe true
+        val card = driver.state.getEntity(crafter)?.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Test Crafted Golem"
+    }
+
+    test("rejects supplying two materials when the craft cost is exactly one (CR 118.8)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val crafter = driver.putPermanentOnBattlefield(p1, "Test Exact Crafter")
+        val material1 = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val material2 = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 2)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = crafter,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material1, material2))
+            )
+        )
+        result.isSuccess shouldBe false
+        result.error.shouldNotBeNull() shouldContain "at most"
+
+        // Nothing moved: both materials and the crafter are still on the battlefield.
+        val battlefield = driver.state.getZone(ZoneKey(p1, Zone.BATTLEFIELD))
+        battlefield.contains(crafter) shouldBe true
+        battlefield.contains(material1) shouldBe true
+        battlefield.contains(material2) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InvertedIcebergScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InvertedIcebergScenarioTest.kt
@@ -1,0 +1,247 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.InvertedIceberg
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Inverted Iceberg // Iceberg Titan (LCI #60).
+ *
+ * Front — Inverted Iceberg ({1}{U}, Artifact):
+ *   When this artifact enters, mill a card, then draw a card.
+ *   Craft with artifact {4}{U}{U} (exactly one artifact material; CR 702.167).
+ * Back — Iceberg Titan (Artifact Creature — Golem, 6/6):
+ *   Whenever this creature attacks, you may tap or untap target artifact or creature.
+ *
+ * Covers:
+ *  - Casting the front face fires the ETB trigger: top card milled to the graveyard,
+ *    then the next card drawn (mill happens before the draw).
+ *  - Craft end-to-end with a battlefield artifact material: mana paid, material exiled,
+ *    source returns transformed as a 6/6 Iceberg Titan (back face).
+ *  - Craft with an artifact card from the graveyard as material (CR 702.167b).
+ *  - Back-face attack trigger: target chosen at declare-attackers, may-clause accepted,
+ *    "Tap it" mode taps the targeted opponent creature.
+ *  - Negative: a non-artifact (creature) material is rejected.
+ *  - Negative: two materials are rejected ("Craft with artifact" = exactly one).
+ */
+class InvertedIcebergScenarioTest : FunSpec({
+
+    // Simple artifact to use as craft material.
+    val testTrinket = CardDefinition.artifact(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        // InvertedIceberg is a catalog card, already included in TestCards.all.
+        driver.registerCards(TestCards.all + listOf(testTrinket))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        return driver
+    }
+
+    // The craft ability is the front face's only activated ability.
+    fun craftAbilityId() = InvertedIceberg.activatedAbilities.single().id
+
+    test("casting Inverted Iceberg mills the top card, then draws the next one") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Seed the library: second call ends up on top, so `milled` is the top card
+        // (goes to the graveyard) and `drawn` sits beneath it (drawn afterwards).
+        val drawn = driver.putCardOnTopOfLibrary(p1, "Island")
+        val milled = driver.putCardOnTopOfLibrary(p1, "Island")
+
+        val iceberg = driver.putCardInHand(p1, "Inverted Iceberg")
+        val handBefore = driver.getHandSize(p1)
+        val graveyardBefore = driver.getGraveyard(p1).size
+
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.castSpell(p1, iceberg).isSuccess shouldBe true
+        driver.bothPass() // resolve the artifact spell; ETB trigger goes on the stack
+        driver.bothPass() // resolve the ETB trigger: mill a card, then draw a card
+
+        driver.assertPermanentExists(p1, "Inverted Iceberg")
+        driver.getGraveyard(p1).size shouldBe graveyardBefore + 1
+        driver.getGraveyard(p1) shouldContain milled
+        driver.getHand(p1) shouldContain drawn
+        // Net: -1 (cast) +1 (draw).
+        driver.getHandSize(p1) shouldBe handBefore
+    }
+
+    test("craft with a battlefield artifact exiles it and returns Inverted Iceberg as a 6/6 Iceberg Titan") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val trinket = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        driver.bothPass() // resolve the craft ability
+
+        // Material exiled.
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain trinket
+
+        // Source returned to the battlefield as the back face.
+        val container = driver.state.getEntity(iceberg)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Iceberg Titan"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        val projected = projector.project(driver.state)
+        projected.getPower(iceberg) shouldBe 6
+        projected.getToughness(iceberg) shouldBe 6
+    }
+
+    test("craft accepts an artifact card from the graveyard as material (CR 702.167b)") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val trinket = driver.putCardInGraveyard(p1, "Test Trinket")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain trinket
+        driver.state.getEntity(iceberg)!!.get<CardComponent>()!!.name shouldBe "Iceberg Titan"
+    }
+
+    test("Iceberg Titan attack trigger may tap target artifact or creature") {
+        val driver = setup()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val trinket = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val victim = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        driver.bothPass() // resolve the craft; Iceberg Titan is on the battlefield
+
+        // The crafted Titan entered this turn — clear summoning sickness so it can attack.
+        driver.removeSummoningSickness(iceberg)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val attackResult = driver.declareAttackers(p1, listOf(iceberg), p2)
+        attackResult.error shouldBe null
+
+        // Optional targeted trigger: the engine asks the may-question at put-on-stack time
+        // (before targeting — see TriggerProcessor.processMayThenTargetTrigger), then the
+        // target, then the trigger waits on the stack for priority.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(p1, true)
+
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(p1, listOf(victim))
+
+        driver.bothPass() // resolve the trigger — pauses on the tap-or-untap choice
+
+        val modeDecision = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val tapIndex = modeDecision.options.indexOfFirst { it.startsWith("Tap") }
+        (tapIndex >= 0) shouldBe true
+        driver.submitDecision(p1, OptionChosenResponse(modeDecision.id, tapIndex))
+
+        driver.isTapped(victim) shouldBe true
+    }
+
+    test("rejects a non-artifact creature as craft material") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bears))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("rejects two materials — 'Craft with artifact' takes exactly one") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val trinketA = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val trinketB = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinketA, trinketB))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaslemsStonetreeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaslemsStonetreeScenarioTest.kt
@@ -1,0 +1,213 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.KaslemsStonetree
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Kaslem's Stonetree // Kaslem's Strider (LCI #197) — Craft transform DFC.
+ *
+ * Front ({2}{G} Artifact):
+ *   "When this artifact enters, look at the top six cards of your library. You may put a land
+ *    card from among them onto the battlefield tapped. Put the rest on the bottom in a random
+ *    order."
+ *   "Craft with Cave {5}{G}" — exactly one Cave you control or Cave card from your graveyard
+ *   (CR 702.167a-b).
+ *
+ * Back (Artifact Creature — Golem, 5/5): vanilla.
+ */
+class KaslemsStonetreeScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    // The craft is the front face's only activated ability.
+    fun craftAbilityId() = KaslemsStonetree.activatedAbilities.single().id
+
+    fun GameTestDriver.library(playerId: EntityId): List<EntityId> =
+        state.getZone(ZoneKey(playerId, Zone.LIBRARY))
+
+    fun GameTestDriver.battlefieldNames(playerId: EntityId): List<String> =
+        state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).mapNotNull {
+            state.getEntity(it)?.get<CardComponent>()?.name
+        }
+
+    test("cast from hand: ETB looks at top six, puts a chosen land onto the battlefield tapped, rest on the bottom") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Seed a known top six: one Forest buried under five non-land cards.
+        // putCardOnTopOfLibrary prepends, so the LAST push ends up on top —
+        // top six = [bolt5..bolt1, Forest].
+        val forest = driver.putCardOnTopOfLibrary(p1, "Forest")
+        val bolts = (1..5).map { driver.putCardOnTopOfLibrary(p1, "Lightning Bolt") }
+
+        val stonetree = driver.putCardInHand(p1, "Kaslem's Stonetree")
+        driver.giveMana(p1, Color.GREEN, 3)
+        driver.castSpell(p1, stonetree)
+
+        driver.bothPass() // resolve the artifact spell -> enters -> ETB trigger on stack
+        driver.bothPass() // resolve the trigger -> pauses for the land selection
+
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val select = driver.pendingDecision as SelectCardsDecision
+        select.options shouldContain forest
+
+        driver.submitDecision(p1, CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(forest)))
+
+        // "Put the rest on the bottom in a random order" needs no player input.
+        driver.isPaused shouldBe false
+
+        // The Forest entered the battlefield tapped; the source is on the battlefield as its front face.
+        driver.battlefieldNames(p1) shouldContain "Forest"
+        driver.isTapped(forest) shouldBe true
+        driver.state.getEntity(stonetree)!!.get<CardComponent>()!!.name shouldBe "Kaslem's Stonetree"
+
+        // The five non-land cards went to the bottom of the library (top = index 0).
+        driver.library(p1).takeLast(5).shouldContainExactlyInAnyOrder(bolts)
+    }
+
+    test("craft with a Cave you control: Cave exiled, returns transformed as Kaslem's Strider 5/5") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val stonetree = driver.putPermanentOnBattlefield(p1, "Kaslem's Stonetree")
+        val cave = driver.putLandOnBattlefield(p1, "Captivating Cave")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.GREEN, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = stonetree,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(cave))
+            )
+        )
+        driver.bothPass() // resolve the craft ability
+
+        // The Cave material is exiled.
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain cave
+
+        // The source is back on the battlefield as its back face.
+        val container = driver.state.getEntity(stonetree)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Kaslem's Strider"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+        card.typeLine.subtypes shouldContain Subtype("Golem")
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // Vanilla 5/5.
+        val projected = projector.project(driver.state)
+        projected.getPower(stonetree) shouldBe 5
+        projected.getToughness(stonetree) shouldBe 5
+    }
+
+    test("craft with a Cave card from the graveyard (CR 702.167b)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val stonetree = driver.putPermanentOnBattlefield(p1, "Kaslem's Stonetree")
+        val cave = driver.putCardInGraveyard(p1, "Captivating Cave")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.GREEN, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = stonetree,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(cave))
+            )
+        )
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain cave
+        driver.state.getEntity(stonetree)!!.get<CardComponent>()!!.name shouldBe "Kaslem's Strider"
+        driver.state.getEntity(stonetree)!!.get<DoubleFacedComponent>()!!.currentFace shouldBe
+            DoubleFacedComponent.Face.BACK
+    }
+
+    test("rejects a non-Cave land as craft material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val stonetree = driver.putPermanentOnBattlefield(p1, "Kaslem's Stonetree")
+        val forest = driver.putLandOnBattlefield(p1, "Forest")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.GREEN, 6)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = stonetree,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(forest))
+            )
+        )
+        result.isSuccess shouldBe false
+
+        // Nothing moved: the Stonetree is still on the battlefield as its front face,
+        // the Forest is not exiled.
+        driver.state.getEntity(stonetree)!!.get<CardComponent>()!!.name shouldBe "Kaslem's Stonetree"
+        driver.battlefieldNames(p1) shouldContain "Forest"
+    }
+
+    test("rejects more than one Cave (craft with Cave is exactly one material)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val stonetree = driver.putPermanentOnBattlefield(p1, "Kaslem's Stonetree")
+        val cave1 = driver.putLandOnBattlefield(p1, "Captivating Cave")
+        val cave2 = driver.putLandOnBattlefield(p1, "Captivating Cave")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.GREEN, 6)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = stonetree,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(cave1, cave2))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OteclanLandmarkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OteclanLandmarkScenarioTest.kt
@@ -1,0 +1,239 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.OteclanLandmark
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain as stringShouldContain
+
+/**
+ * Scenario tests for Oteclan Landmark // Oteclan Levitator (LCI #29).
+ *
+ * Front face — Oteclan Landmark ({W}, Artifact):
+ *   "When this artifact enters, scry 2."
+ *   "Craft with artifact {2}{W}" — exactly one artifact material (CR 702.167).
+ *
+ * Back face — Oteclan Levitator (Artifact Creature — Golem, 1/4):
+ *   Flying. "Whenever this creature attacks, target attacking creature without flying
+ *   gains flying until end of turn."
+ */
+class OteclanLandmarkScenarioTest : FunSpec({
+
+    // Test-local cards: a vanilla artifact as craft material, and a ground creature
+    // both as an illegal (non-artifact) craft material and as the attack-trigger target.
+    val testRelic = CardDefinition.artifact(
+        name = "Test Relic",
+        manaCost = ManaCost.parse("{1}"),
+        oracleText = ""
+    )
+    val groundTrooper = CardDefinition.creature(
+        name = "Test Ground Trooper",
+        manaCost = ManaCost.parse("{1}{W}"),
+        subtypes = setOf(Subtype("Soldier")),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OteclanLandmark, testRelic, groundTrooper))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        return driver
+    }
+
+    // The craft is the front face's only activated ability.
+    fun craftAbilityId() = OteclanLandmark.activatedAbilities.single().id
+
+    fun cardName(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    // Craft Oteclan Landmark with a Test Relic material; returns (landmarkId, relicId).
+    // Leaves the game in the crafting player's precombat main with an empty stack.
+    fun craftLandmark(driver: GameTestDriver, player: EntityId): Pair<EntityId, EntityId> {
+        val landmark = driver.putPermanentOnBattlefield(player, "Oteclan Landmark")
+        val relic = driver.putPermanentOnBattlefield(player, "Test Relic")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(player, Color.WHITE, 3)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = player,
+                sourceId = landmark,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(relic))
+            )
+        )
+        driver.bothPass() // resolve the craft ability
+        return landmark to relic
+    }
+
+    test("front face: casting Oteclan Landmark fires the ETB trigger and scries 2") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Known cards on top of the library (prepended: Forest on top, Mountain second).
+        driver.putCardOnTopOfLibrary(p1, "Mountain")
+        driver.putCardOnTopOfLibrary(p1, "Forest")
+
+        val landmark = driver.putCardInHand(p1, "Oteclan Landmark")
+        driver.giveMana(p1, Color.WHITE, 1)
+        driver.castSpell(p1, landmark).isSuccess shouldBe true
+
+        driver.bothPass() // resolve the spell — the Landmark enters, ETB trigger queued
+        driver.bothPass() // resolve the ETB trigger — pauses for the scry decision
+
+        // Scry 2 presents a card selection over the top two library cards.
+        val decision = driver.pendingDecision as SelectCardsDecision
+        decision.playerId shouldBe p1
+        decision.options.size shouldBe 2
+
+        // Put both looked-at cards on the bottom.
+        driver.submitCardSelection(p1, decision.options)
+        while (driver.pendingDecision != null) driver.autoResolveDecision()
+
+        // A Plains surfaces on top; Forest and Mountain are now the bottom two cards.
+        val library = driver.state.getLibrary(p1)
+        cardName(driver, library.first()) shouldBe "Plains"
+        library.takeLast(2).map { cardName(driver, it) }.toSet() shouldBe setOf("Forest", "Mountain")
+
+        // The Landmark itself resolved onto the battlefield as its front face.
+        val entity = driver.state.getEntity(landmark)
+        entity.shouldNotBeNull()
+        entity.get<CardComponent>()!!.name shouldBe "Oteclan Landmark"
+        entity.get<DoubleFacedComponent>()!!.currentFace shouldBe DoubleFacedComponent.Face.FRONT
+    }
+
+    test("craft with artifact exiles the material and returns transformed as Oteclan Levitator (1/4 flier)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val (landmark, relic) = craftLandmark(driver, p1)
+
+        // Material is in exile.
+        driver.getExile(p1) shouldContain relic
+
+        // Source returned to the battlefield as the back face.
+        val entity = driver.state.getEntity(landmark)
+        entity.shouldNotBeNull()
+        val card = entity.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Oteclan Levitator"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+        card.typeLine.subtypes shouldContain Subtype("Golem")
+        entity.get<DoubleFacedComponent>()!!.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // Back-face characteristics: 1/4 with flying.
+        val projected = projector.project(driver.state)
+        projected.getPower(landmark) shouldBe 1
+        projected.getToughness(landmark) shouldBe 4
+        projected.hasKeyword(landmark, Keyword.FLYING) shouldBe true
+    }
+
+    test("back face: attack trigger grants flying to a target attacking creature without flying") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        // Two ground attackers so the trigger has more than one legal target (a single legal
+        // choice could be auto-selected without surfacing the decision).
+        val trooper = driver.putCreatureOnBattlefield(p1, "Test Ground Trooper")
+        val trooper2 = driver.putCreatureOnBattlefield(p1, "Test Ground Trooper")
+        val (landmark, _) = craftLandmark(driver, p1)
+
+        // All entered this turn — clear summoning sickness so they can attack.
+        driver.removeSummoningSickness(landmark)
+        driver.removeSummoningSickness(trooper)
+        driver.removeSummoningSickness(trooper2)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val attackResult = driver.declareAttackers(p1, listOf(landmark, trooper, trooper2), p2)
+        attackResult.error shouldBe null
+
+        // The Levitator's attack trigger asks for a target: only the non-flying attackers are
+        // legal — the Levitator itself has flying and can't be chosen.
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        decision.legalTargets[0]!! shouldContain trooper
+        decision.legalTargets[0]!! shouldContain trooper2
+        decision.legalTargets[0]!! shouldNotContain landmark
+        driver.submitTargetSelection(p1, listOf(trooper))
+
+        driver.bothPass() // resolve the attack trigger
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(trooper, Keyword.FLYING) shouldBe true
+        projected.hasKeyword(trooper2, Keyword.FLYING) shouldBe false
+    }
+
+    test("craft rejects two materials — exactly one artifact (maxCount = 1)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val landmark = driver.putPermanentOnBattlefield(p1, "Oteclan Landmark")
+        val relic1 = driver.putPermanentOnBattlefield(p1, "Test Relic")
+        val relic2 = driver.putPermanentOnBattlefield(p1, "Test Relic")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.WHITE, 3)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = landmark,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(relic1, relic2))
+            )
+        )
+        result.isSuccess shouldBe false
+        result.error.shouldNotBeNull() stringShouldContain "at most"
+
+        // Nothing was exiled; the Landmark is still its front face on the battlefield.
+        driver.getExile(p1).size shouldBe 0
+        driver.state.getEntity(landmark)!!.get<CardComponent>()!!.name shouldBe "Oteclan Landmark"
+    }
+
+    test("craft rejects a non-artifact creature as material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val landmark = driver.putPermanentOnBattlefield(p1, "Oteclan Landmark")
+        val trooper = driver.putCreatureOnBattlefield(p1, "Test Ground Trooper")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.WHITE, 3)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = landmark,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trooper))
+            )
+        )
+        result.isSuccess shouldBe false
+
+        // The creature stays on the battlefield; nothing transformed.
+        driver.findPermanent(p1, "Test Ground Trooper").shouldNotBeNull()
+        driver.state.getEntity(landmark)!!.get<CardComponent>()!!.name shouldBe "Oteclan Landmark"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TithingBladeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TithingBladeScenarioTest.kt
@@ -1,0 +1,244 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TithingBlade
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Tithing Blade // Consuming Sepulcher (LCI #128).
+ *
+ * Front face — Tithing Blade ({1}{B}, Artifact):
+ *   "When this artifact enters, each opponent sacrifices a creature of their choice.
+ *    Craft with creature {4}{B}"
+ * Back face — Consuming Sepulcher (Artifact):
+ *   "At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life."
+ *
+ * Covers:
+ *  - ETB edict: the sacrifice is the OPPONENT's choice — the engine pauses with a
+ *    [SelectCardsDecision] for the opponent, whose options are only their own creatures.
+ *  - Craft (CR 702.167): exactly one creature material, from the battlefield or from the
+ *    graveyard, is exiled and the card returns transformed as Consuming Sepulcher — an
+ *    Artifact that is NOT a creature.
+ *  - Back-face drain: at the beginning of the controller's upkeep (and only theirs), each
+ *    opponent loses 1 life and the controller gains 1.
+ *  - Negative: a non-creature artifact is rejected as craft material; two materials exceed
+ *    the exact-one count.
+ */
+class TithingBladeScenarioTest : FunSpec({
+
+    // Local non-creature artifact — illegal craft material for "Craft with creature".
+    val trinket = CardDefinition.artifact(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(trinket))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    // The craft is the front face's only activated ability.
+    fun craftAbilityId() = TithingBlade.activatedAbilities.single().id
+
+    /** Pass priority until a pending decision appears (a resolving effect pauses there). */
+    fun GameTestDriver.passUntilDecision(maxPasses: Int = 10) {
+        repeat(maxPasses) { if (pendingDecision == null) bothPass() }
+    }
+
+    test("ETB: each opponent sacrifices a creature of their own choice") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        // Opponent has two creatures -> a real choice; controller's own creature must be spared.
+        val oppBears = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        val oppGiant = driver.putCreatureOnBattlefield(p2, "Hill Giant")
+        val myBears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val blade = driver.putCardInHand(p1, "Tithing Blade")
+        driver.giveMana(p1, Color.BLACK, 2)
+        driver.castSpell(p1, blade).isSuccess shouldBe true
+
+        // Resolve the spell, then its ETB trigger — which pauses on the opponent's choice.
+        driver.passUntilDecision()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe p2
+        decision.options.shouldContainExactlyInAnyOrder(listOf(oppBears, oppGiant))
+
+        // The opponent picks the Hill Giant.
+        driver.submitCardSelection(p2, listOf(oppGiant))
+
+        driver.getGraveyard(p2).shouldContain(oppGiant)
+        driver.findPermanent(p2, "Hill Giant") shouldBe null
+        driver.findPermanent(p2, "Grizzly Bears") shouldBe oppBears
+        driver.findPermanent(p1, "Grizzly Bears") shouldBe myBears
+        driver.findPermanent(p1, "Tithing Blade") shouldBe blade
+    }
+
+    test("craft with a battlefield creature: material exiled, returns as Consuming Sepulcher (not a creature)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(p1, "Tithing Blade")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.BLACK, 5)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bears))
+            )
+        )
+        driver.bothPass()
+
+        // Material exiled.
+        driver.getExile(p1).shouldContain(bears)
+
+        // Source returned to the battlefield as its back face.
+        val container = driver.state.getEntity(blade)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Consuming Sepulcher"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // Consuming Sepulcher is an Artifact — NOT a creature — in the projection too.
+        projector.project(driver.state).isCreature(blade) shouldBe false
+    }
+
+    test("craft with a creature card from the graveyard works as material (CR 702.167b)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(p1, "Tithing Blade")
+        val deadBears = driver.putCardInGraveyard(p1, "Grizzly Bears")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.BLACK, 5)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(deadBears))
+            )
+        )
+        driver.bothPass()
+
+        driver.getExile(p1).shouldContain(deadBears)
+        driver.getGraveyard(p1).contains(deadBears) shouldBe false
+        driver.state.getEntity(blade)!!.get<CardComponent>()!!.name shouldBe "Consuming Sepulcher"
+    }
+
+    test("back face: at the beginning of your upkeep each opponent loses 1 life and you gain 1 — and only on YOUR upkeep") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        val blade = driver.putPermanentOnBattlefield(p1, "Tithing Blade")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.BLACK, 5)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bears))
+            )
+        )
+        driver.bothPass()
+        driver.state.getEntity(blade)!!.get<CardComponent>()!!.name shouldBe "Consuming Sepulcher"
+
+        driver.getLifeTotal(p1) shouldBe 20
+        driver.getLifeTotal(p2) shouldBe 20
+
+        // Opponent's upkeep — "your upkeep" means the controller's, so no trigger fires.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldBe p2
+        driver.stackSize shouldBe 0
+        driver.getLifeTotal(p1) shouldBe 20
+        driver.getLifeTotal(p2) shouldBe 20
+
+        // Cross the opponent's turn to our next upkeep — the drain trigger is on the stack.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldBe p1
+        driver.stackSize shouldBe 1
+        driver.bothPass()
+
+        driver.getLifeTotal(p1) shouldBe 21
+        driver.getLifeTotal(p2) shouldBe 19
+    }
+
+    test("craft rejects a non-creature artifact material and rejects more than one material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(p1, "Tithing Blade")
+        val badMaterial = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val bearsA = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val bearsB = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.BLACK, 5)
+
+        // Non-creature artifact is not a legal "Craft with creature" material.
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(badMaterial))
+            )
+        ).isSuccess shouldBe false
+
+        // "Craft with creature" is exactly one material — two creatures must be rejected.
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bearsA, bearsB))
+            )
+        ).isSuccess shouldBe false
+
+        // Nothing moved: the blade is still the front face on the battlefield, nothing exiled.
+        driver.findPermanent(p1, "Tithing Blade") shouldBe blade
+        driver.findPermanent(p1, "Test Trinket") shouldBe badMaterial
+        driver.getExile(p1).isEmpty() shouldBe true
+    }
+})

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -800,7 +800,7 @@ export function enterPhase(
           // dedicated cross-zone overlay rather than the single-zone targeting flow.
           validTargets = [...(costInfo.validCraftMaterials ?? [])]
           minTargets = costInfo.craftMinCount ?? 1
-          maxTargets = validTargets.length
+          maxTargets = costInfo.craftMaxCount ?? validTargets.length
           flags.isCraftMaterialSelection = true
           flags.targetDescription = costInfo.description
           flags.sourceCardName = actionInfo.description

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1046,6 +1046,8 @@ export interface AdditionalCostInfo {
    */
   readonly validCraftMaterials?: readonly EntityId[]
   readonly craftMinCount?: number
+  /** Cap on material count for exact-count crafts ("Craft with artifact"); absent = unbounded. */
+  readonly craftMaxCount?: number
 }
 
 export interface CounterRemovalCreatureInfo {


### PR DESCRIPTION
Adds the first 5 of the 18 remaining LCI Craft transform-DFCs (one card per commit), plus the SDK/engine groundwork they need:

## Exact-count Craft costs (first commit)

Most Craft costs name an exact material count — "Craft with **artifact**" exiles exactly one artifact, "Craft with **two creatures**" exactly two — but `AbilityCost.Craft` only enforced `minCount`, so an activator could over-exile materials (costs must be paid exactly as written). This PR adds `maxCount` (`null` = "... or more" wordings, the unchanged default, so Saheeli's Lattice is untouched):

- `CostHandler.payCraftCost` rejects over-supply ("at most N")
- `craft(...)` DSL helper + `Costs.Craft` facade gain `minCount`/`maxCount` params
- `craftMaxCount` threaded through `AdditionalCostData` → `AdditionalCostInfo` → client `messages.ts`, so `CraftMaterialOverlay` caps the selection (`maxTargets`)
- SDK reference updated; `CraftExactCountScenarioTest` covers accept-exact / reject-over-supply

## Cards (one commit each, scenario test each)

| Card | Front | Back |
|---|---|---|
| Clay-Fired Bricks // Cosmium Kiln | Plains tutor + gain 2 | 2 Gnome tokens ETB + anthem |
| Oteclan Landmark // Oteclan Levitator | ETB scry 2 | Flier granting flying to an attacker |
| Inverted Iceberg // Iceberg Titan | ETB mill 1, draw 1 | 6/6, attack: may tap/untap target |
| Tithing Blade // Consuming Sepulcher | ETB each-opponent edict | Upkeep drain 1 |
| Kaslem's Stonetree // Kaslem's Strider | ETB dig 6 for a tapped land | vanilla 5/5 |

Notes:
- Iceberg Titan's "you may tap or untap target artifact or creature" uses the proven `MayEffect` + `Effects.ChooseAction` idiom (Gandalf the Grey). The `MayEffect(ModalEffect(...))` idiom on Sewer-veillance Cam models the same wording — it works through the same may-then-target flow, but has no engine test; the new `InvertedIcebergScenarioTest` now covers the flow end-to-end (may → target at put-on-stack, tap/untap choice at resolution).
- All five crafts are exact-one-material ("Craft with artifact/creature/Cave"), exercising the new `maxCount` enforcement; each test includes a wrong-type-material and/or two-materials rejection case.
- `manual-scenarios/sets/lci/craft-01.json`: all five front faces in hand with exactly enough untapped lands to cast them all in one turn, plus craft materials on the battlefield (artifact, creature, Cave) and in the graveyard.

Verified: full `:mtg-sets:test` (snapshot + lint), `:game-server` compile, and the 7 craft-related scenario test classes (34 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
