### PR TITLE
Add 5 LCI Craft DFCs (batch 2)

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -139,7 +139,7 @@
 - [ ] Jade Seedstones
 - [x] Jadelight Spelunker
 - [x] Join the Dead
-- [ ] Kaslem's Stonetree
+- [x] Kaslem's Stonetree
 - [ ] Kellan, Daring Traveler
 - [x] Kinjalli's Dawnrunner
 - [ ] Kitesail Larcenist

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -128,7 +128,7 @@
 - [x] Hulking Raptor
 - [x] Hunter's Blowgun
 - [x] Hurl into History
-- [ ] Idol of the Deep King
+- [x] Idol of the Deep King
 - [x] In the Presence of Ages
 - [x] Inti, Seneschal of the Sun
 - [ ] Intrepid Paleontologist

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -175,7 +175,7 @@
 - [x] Oltec Archaeologists
 - [x] Oltec Cloud Guard
 - [x] Orazca Puzzle-Door
-- [ ] Oteclan Landmark
+- [x] Oteclan Landmark
 - [x] Out of Air
 - [x] Over the Edge
 - [x] Palani's Hatcher

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 217 / 286
+**Implemented:** 222 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -231,7 +231,7 @@
 - [ ] Souls of the Lost
 - [ ] Sovereign Okinec Ahau
 - [x] Spelunking
-- [ ] Spring-Loaded Sawblades
+- [x] Spring-Loaded Sawblades
 - [x] Spyglass Siren
 - [x] Squirming Emergence
 - [x] Staggering Size

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -132,7 +132,7 @@
 - [x] In the Presence of Ages
 - [x] Inti, Seneschal of the Sun
 - [ ] Intrepid Paleontologist
-- [ ] Inverted Iceberg
+- [x] Inverted Iceberg
 - [x] Ironpaw Aspirant
 - [x] Itzquinth, Firstborn of Gishath
 - [x] Ixalli's Lorekeeper

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -156,7 +156,7 @@
 - [ ] Malicious Eclipse
 - [x] Marauding Brinefang
 - [ ] Market Gnome
-- [ ] Master's Guide-Mural
+- [x] Master's Guide-Mural
 - [ ] Matzalantli, the Great Door
 - [x] Mephitic Draught
 - [ ] Merfolk Cave-Diver

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -53,7 +53,7 @@
 - [x] Child of the Volcano
 - [x] Chimil, the Inner Sun
 - [x] Chupacabra Echo
-- [ ] Clay-Fired Bricks
+- [x] Clay-Fired Bricks
 - [x] Coati Scavenger
 - [x] Cogwork Wrestler
 - [x] Colossadactyl

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 222 / 286
+**Implemented:** 227 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -145,7 +145,7 @@
 - [ ] Kitesail Larcenist
 - [ ] Kutzil's Flanker
 - [ ] Kutzil, Malamet Exemplar
-- [ ] Lodestone Needle
+- [x] Lodestone Needle
 - [x] Magmatic Galleon
 - [ ] Malamet Battle Glyph
 - [x] Malamet Brawler

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -266,7 +266,7 @@
 - [ ] Throne of the Grim Captain
 - [x] Tinker's Tote
 - [ ] Tishana's Tidebinder
-- [ ] Tithing Blade
+- [x] Tithing Blade
 - [ ] Treasure Map
 - [x] Triumphant Chomp
 - [x] Trumpeting Carnosaur

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -283,7 +283,7 @@
 - [x] Wail of the Forgotten
 - [x] Walk with the Ancestors
 - [x] Warden of the Inner Sky
-- [ ] Waterlogged Hulk
+- [x] Waterlogged Hulk
 - [x] Waterwind Scout
 - [x] Waylaying Pirates
 - [x] Zoetic Glyph

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -237,9 +237,12 @@ excluded.
   additional cost (Feed the Cycle), and the graveyard-cast permission (Osteomancer Adept, where the
   card being cast is excluded from the exile pool). For a "you may forage" *effect* (not a cost) use
   `Patterns.Mechanic.forage(afterEffect?)` instead.
-- `Costs.Craft(filter, minCount = 1)` — Craft material cost (CR 702.167a): exile this permanent
-  **and** exile at least `minCount` cards matching `filter` selected from the combined pool of
-  permanents you control and cards in your graveyard. Atomic because CR 702.167a pairs the
+- `Costs.Craft(filter, minCount = 1, maxCount = null)` — Craft material cost (CR 702.167a): exile
+  this permanent **and** exile at least `minCount` (and, when `maxCount` is set, at most `maxCount`)
+  cards matching `filter` selected from the combined pool of
+  permanents you control and cards in your graveyard. Exact-count crafts ("Craft with artifact" =
+  exactly one, "Craft with two creatures" = exactly two) set `maxCount == minCount`; "... or more"
+  wordings leave `maxCount = null`. Atomic because CR 702.167a pairs the
   self-exile with the materials-exile in one clause. Records the chosen materials on the source's
   `CraftedFromExiledComponent` so the back face's CDA can read them after the source returns
   transformed. Always combined with `Mana(...)` and used with the
@@ -4656,11 +4659,14 @@ composite abilities).
   original stays in exile; each cast copy is a phantom that ceases to exist (CR 707.10a / 112.3b), so there is no
   exponential growth. The `Lesson` spell subtype (`Subtype.LESSON`) is a plain, non-functional subtype (no Learn
   mechanic in the set), but the type line must parse it.
-- `Craft(filter, cost)` — `card { craft(filter, cost) }` builder helper (CR 702.167, The Lost Caverns of
+- `Craft(filter, cost)` — `card { craft(filter, cost, materialDescription?, minCount = 1, maxCount = null) }`
+  builder helper (CR 702.167, The Lost Caverns of
   Ixalan). On the front face of a transforming DFC: "Craft with [filter] [cost] ([cost], Exile this permanent,
   Exile [filter] you control and/or [filter] cards from your graveyard: Return this card to the battlefield
-  transformed under its owner's control. Activate only as a sorcery.)" Composes entirely from existing primitives
-  — `AbilityCost.Composite(Mana(cost), AbilityCost.Craft(filter))` (the atomic `Craft` sub-cost handles both the
+  transformed under its owner's control. Activate only as a sorcery.)" `minCount`/`maxCount` bound the material
+  count: exact-count wordings ("Craft with artifact" = exactly one, "Craft with two creatures" = exactly two)
+  pass `maxCount = minCount`; "one or more [filter]s" leaves `maxCount = null`. Composes entirely from existing primitives
+  — `AbilityCost.Composite(Mana(cost), AbilityCost.Craft(filter, minCount, maxCount))` (the atomic `Craft` sub-cost handles both the
   self-exile and the materials-exile because CR 702.167a defines them as one paired clause), plus
   `Effects.ReturnSelfFromExileTransformed` as the resolution effect, and `timing = TimingRule.SorcerySpeed`.
   Records the exiled materials on the source's `CraftedFromExiledComponent` so the back face's CDA
@@ -4668,7 +4674,7 @@ composite abilities).
   can read them via `DynamicAmount.CraftedMaterialsTotalPower`. Declares `Keyword.CRAFT` for display.
 
   Material selection: the engine surfaces the combined BF + GY candidate pool on each Craft activation as
-  `AdditionalCostData.validCraftMaterials` / `craftMinCount`. The web client renders both zones side-by-side
+  `AdditionalCostData.validCraftMaterials` / `craftMinCount` / `craftMaxCount`. The web client renders both zones side-by-side
   via the dedicated `CraftMaterialOverlay` (routed by the `Craft` cost-type branch in `pipelinePhases`) and
   submits the picked IDs back as `ActivateAbility.costPayment.exiledCards`. Headless / game-server callers can
   supply the chosen IDs directly. The cost handler validates that every chosen entity is either a permanent

--- a/manual-scenarios/sets/lci/craft-01.json
+++ b/manual-scenarios/sets/lci/craft-01.json
@@ -1,0 +1,53 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Oteclan Landmark",
+      "Inverted Iceberg",
+      "Tithing Blade",
+      "Kaslem's Stonetree",
+      "Clay-Fired Bricks"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"},
+      {"name": "Captivating Cave"},
+      {"name": "Saheeli's Lattice"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [
+      "Grizzly Bears",
+      "Saheeli's Lattice",
+      "Swamp"
+    ],
+    "library": ["Plains", "Forest", "Grizzly Bears", "Island", "Grizzly Bears", "Swamp", "Grizzly Bears"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Island"],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Island", "Grizzly Bears", "Swamp", "Grizzly Bears", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/manual-scenarios/sets/lci/craft-02.json
+++ b/manual-scenarios/sets/lci/craft-02.json
@@ -1,0 +1,56 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Idol of the Deep King",
+      "Lodestone Needle",
+      "Waterlogged Hulk",
+      "Spring-Loaded Sawblades",
+      "Master's Guide-Mural"
+    ],
+    "battlefield": [
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Island"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Saheeli's Lattice"},
+      {"name": "Saheeli's Lattice"},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [
+      "Island",
+      "Saheeli's Lattice",
+      "Grizzly Bears"
+    ],
+    "library": ["Island", "Plains", "Grizzly Bears", "Island", "Grizzly Bears", "Mountain"]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": ["Grizzly Bears", "Island"],
+    "battlefield": [
+      {"name": "Grizzly Bears", "tapped": true},
+      {"name": "Grizzly Bears"}
+    ],
+    "graveyard": [],
+    "library": ["Grizzly Bears", "Island", "Grizzly Bears", "Swamp", "Grizzly Bears", "Mountain"]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": [],
+  "mode": "SELF"
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -309,8 +309,8 @@ object Costs {
      * Costs.Composite(Costs.Mana("{4}{R}"), Costs.Craft(Filters.Dinosaur))
      * ```
      */
-    fun Craft(filter: GameObjectFilter, minCount: Int = 1): AbilityCost =
-        AbilityCost.Craft(filter, minCount)
+    fun Craft(filter: GameObjectFilter, minCount: Int = 1, maxCount: Int? = null): AbilityCost =
+        AbilityCost.Craft(filter, minCount, maxCount)
 
     // =========================================================================
     // Additional Costs (paid while casting a spell) — wraps AdditionalCost

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/CraftDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/CraftDsl.kt
@@ -25,24 +25,33 @@ import com.wingedsheep.sdk.scripting.costs.CostAtom
  * Marks the front face with the [Keyword.CRAFT] tag for client display.
  *
  * ```kotlin
- * craft(filter = Filters.Dinosaur, cost = "{4}{R}")
+ * craft(filter = Filters.Dinosaur, cost = "{4}{R}")                             // one or more
+ * craft(filter = Filters.Artifact, cost = "{2}{W}", minCount = 1, maxCount = 1) // exactly one
  * ```
  *
  * @param filter The material filter (the [filter] in "Craft with [filter]").
  * @param cost The mana portion of the craft cost.
  * @param materialDescription Optional override for the filter's name in the rendered cost
  *   description — e.g. "one or more Dinosaurs". Defaults to the filter's own description.
+ * @param minCount Minimum number of materials (CR 702.167a).
+ * @param maxCount Maximum number of materials, or `null` for "... or more" wordings. Exact-count
+ *   crafts ("Craft with artifact", "Craft with two creatures") set `maxCount == minCount`.
  */
 fun CardBuilder.craft(
     filter: GameObjectFilter,
     cost: String,
-    materialDescription: String? = null
+    materialDescription: String? = null,
+    minCount: Int = 1,
+    maxCount: Int? = null
 ) {
     val materials = materialDescription ?: "one or more ${filter.description}s"
     activatedAbilities.add(
         ActivatedAbility(
             cost = AbilityCost.Composite(
-                listOf(AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost))), AbilityCost.Craft(filter))
+                listOf(
+                    AbilityCost.Atom(CostAtom.Mana(ManaCost.parse(cost))),
+                    AbilityCost.Craft(filter, minCount = minCount, maxCount = maxCount)
+                )
             ),
             effect = com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect,
             targetRequirements = emptyList(),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -491,18 +491,21 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
         val maxCount: Int? = null,
     ) : AbilityCost {
         override val description: String = buildString {
+            val exactlyOne = maxCount == 1
+            val article = if (filter.description.firstOrNull()?.lowercaseChar() in listOf('a', 'e', 'i', 'o', 'u')) "an" else "a"
             append("Exile this permanent, Exile ")
             when {
                 maxCount == null && minCount == 1 -> append("one or more ")
                 maxCount == null -> append("$minCount or more ")
-                maxCount == 1 -> append("a ")
+                exactlyOne -> append("$article ")
                 else -> append("$minCount ")
             }
             append(filter.description)
-            if (maxCount != 1) append("s")
+            if (!exactlyOne) append("s")
             append(" you control and/or ")
+            if (exactlyOne) append("$article ")
             append(filter.description)
-            append(" cards from your graveyard")
+            append(if (exactlyOne) " card from your graveyard" else " cards from your graveyard")
         }
 
         override fun applyTextReplacement(replacer: TextReplacer): AbilityCost {

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -478,18 +478,29 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
      * @property filter Material filter (typically the same one used in the Craft display text,
      *   e.g. `Filters.Dinosaur` for Saheeli's Lattice).
      * @property minCount Minimum number of materials to exile (1 for "one or more").
+     * @property maxCount Maximum number of materials, or `null` for unbounded ("... or more").
+     *   Most Craft costs name an exact count — "Craft with artifact" exiles exactly one
+     *   artifact, "Craft with two creatures" exactly two — so those set `maxCount == minCount`;
+     *   only "one or more" / "N or more" wordings leave it `null` (CR 702.167a).
      */
     @SerialName("CostCraft")
     @Serializable
     data class Craft(
         val filter: GameObjectFilter,
         val minCount: Int = 1,
+        val maxCount: Int? = null,
     ) : AbilityCost {
         override val description: String = buildString {
             append("Exile this permanent, Exile ")
-            if (minCount == 1) append("one or more ") else append("$minCount or more ")
+            when {
+                maxCount == null && minCount == 1 -> append("one or more ")
+                maxCount == null -> append("$minCount or more ")
+                maxCount == 1 -> append("a ")
+                else -> append("$minCount ")
+            }
             append(filter.description)
-            append("s you control and/or ")
+            if (maxCount != 1) append("s")
+            append(" you control and/or ")
             append(filter.description)
             append(" cards from your graveyard")
         }

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ClayFiredBricks.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/ClayFiredBricks.kt
@@ -1,0 +1,132 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.effects.SearchDestination
+import com.wingedsheep.sdk.scripting.filters.unified.GroupFilter
+
+/**
+ * Clay-Fired Bricks // Cosmium Kiln (CR 702.167, The Lost Caverns of Ixalan)
+ * {1}{W}
+ * Artifact // Artifact
+ *
+ * Front face — Clay-Fired Bricks ({1}{W}, Artifact)
+ *   When this artifact enters, search your library for a basic Plains card, reveal it,
+ *   put it into your hand, then shuffle. You gain 2 life.
+ *   Craft with artifact {5}{W}{W} ({5}{W}{W}, Exile this artifact, Exile another artifact
+ *   you control or an artifact card from your graveyard: Return this card transformed
+ *   under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Cosmium Kiln (Artifact)
+ *   When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens.
+ *   Creatures you control get +1/+1.
+ *
+ * Implementation: the front face's ETB is [Effects.Composite] sequencing the atomic
+ * [Patterns.Library.searchLibrary] pipeline (basic Plains → reveal → hand → shuffle) before
+ * [Effects.GainLife]. The `craft(...)` helper wires the activated ability with an
+ * [com.wingedsheep.sdk.scripting.AbilityCost.Craft] material cost (exactly one artifact:
+ * minCount = maxCount = 1) paired with the printed mana cost; resolution returns the card
+ * from exile as the back face via
+ * [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect]. The back
+ * face's ETB fires off the normal battlefield-entry event when the craft return puts it
+ * onto the battlefield transformed, creating the Gnomes with
+ * [com.wingedsheep.sdk.scripting.effects.CreateTokenEffect]; its anthem is a [ModifyStats]
+ * static over [GameObjectFilter.Creature.youControl] (Glorious Anthem pattern).
+ */
+
+private val ClayFiredBricksFront = card("Clay-Fired Bricks") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, search your library for a basic Plains card, " +
+        "reveal it, put it into your hand, then shuffle. You gain 2 life.\n" +
+        "Craft with artifact {5}{W}{W} ({5}{W}{W}, Exile this artifact, Exile another artifact " +
+        "you control or an artifact card from your graveyard: Return this card transformed " +
+        "under its owner's control. Craft only as a sorcery.)"
+
+    // ETB: search your library for a basic Plains card, reveal it, put it into your hand,
+    // then shuffle. You gain 2 life.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.searchLibrary(
+                filter = GameObjectFilter.BasicLand.withSubtype(Subtype.PLAINS),
+                count = 1,
+                destination = SearchDestination.HAND,
+                reveal = true,
+                shuffleAfter = true
+            ),
+            Effects.GainLife(2)
+        )
+        description = "When this artifact enters, search your library for a basic Plains card, " +
+            "reveal it, put it into your hand, then shuffle. You gain 2 life."
+    }
+
+    // Craft with artifact {5}{W}{W} — exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{5}{W}{W}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Steve Ellis"
+        imageUri = "https://cards.scryfall.io/normal/front/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1782694608"
+    }
+}
+
+private val CosmiumKiln = card("Cosmium Kiln") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens.\n" +
+        "Creatures you control get +1/+1."
+
+    // ETB: create two 1/1 colorless Gnome artifact creature tokens.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.CreateToken(
+            power = 1,
+            toughness = 1,
+            creatureTypes = setOf("Gnome"),
+            count = 2,
+            artifactToken = true,
+            imageUri = "https://cards.scryfall.io/normal/front/6/d/6def709a-53b3-4520-9544-74ab6472d256.jpg?1782731572"
+        )
+        description = "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens."
+    }
+
+    // Creatures you control get +1/+1.
+    staticAbility {
+        ability = ModifyStats(
+            powerBonus = 1,
+            toughnessBonus = 1,
+            filter = GroupFilter(GameObjectFilter.Creature.youControl())
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "6"
+        artist = "Steve Ellis"
+        flavorText = "\"I love the smell of freshly baked gnomes!\"\n—Yelha, Oltec artisan"
+        imageUri = "https://cards.scryfall.io/normal/back/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1782694608"
+    }
+}
+
+val ClayFiredBricks: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = ClayFiredBricksFront,
+    backFace = CosmiumKiln
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/IdolOfTheDeepKing.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/IdolOfTheDeepKing.kt
@@ -1,0 +1,112 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Idol of the Deep King // Sovereign's Macuahuitl (CR 702.167, The Lost Caverns of Ixalan)
+ * {2}{R}
+ * Artifact // Artifact — Equipment
+ *
+ * Front face — Idol of the Deep King ({2}{R}, Artifact)
+ *   Flash
+ *   When this artifact enters, it deals 2 damage to any target.
+ *   Craft with artifact {2}{R} ({2}{R}, Exile this artifact, Exile another artifact you
+ *   control or an artifact card from your graveyard: Return this card transformed under
+ *   its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Sovereign's Macuahuitl (Artifact — Equipment)
+ *   When this Equipment enters, attach it to target creature you control.
+ *   Equipped creature gets +2/+0.
+ *   Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)
+ *
+ * Implementation: the front face's ETB strike is [Triggers.EntersBattlefield] +
+ * [Effects.DealDamage] at [Targets.Any] (damage source defaults to the trigger's source,
+ * matching the "it deals" wording). The craft line uses the `craft(...)` helper with
+ * [GameObjectFilter.Artifact] and `minCount = maxCount = 1` — "Craft with artifact" exiles
+ * exactly one artifact material (CR 702.167a-b); resolution returns this card transformed
+ * (back face) under its owner's control. The back face composes the standard Equipment
+ * primitives: an ETB [Effects.AttachEquipment] trigger targeting a creature you control
+ * (the Coral Sword / Malamet Scythe idiom), a no-filter [ModifyStats] static that defaults
+ * to the equipped creature, and the canonical `equipAbility("{2}")` (sorcery-speed attach,
+ * CR 702.6).
+ */
+
+private val IdolOfTheDeepKingFront = card("Idol of the Deep King") {
+    manaCost = "{2}{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact"
+    oracleText = "Flash\n" +
+        "When this artifact enters, it deals 2 damage to any target.\n" +
+        "Craft with artifact {2}{R} ({2}{R}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    keywords(Keyword.FLASH)
+
+    // ETB: it deals 2 damage to any target.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val anyTarget = target("any target", Targets.Any)
+        effect = Effects.DealDamage(2, anyTarget)
+    }
+
+    // Craft with artifact {2}{R} — exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{2}{R}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Matteo Bassini"
+        imageUri = "https://cards.scryfall.io/normal/front/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg?1782694484"
+    }
+}
+
+private val SovereignsMacuahuitl = card("Sovereign's Macuahuitl") {
+    manaCost = ""
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "When this Equipment enters, attach it to target creature you control.\n" +
+        "Equipped creature gets +2/+0.\n" +
+        "Equip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    // ETB: attach it to target creature you control.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target("target creature you control", TargetCreature(filter = TargetFilter.Creature.youControl()))
+        effect = Effects.AttachEquipment(creature)
+    }
+
+    // Equipped creature gets +2/+0.
+    staticAbility {
+        ability = ModifyStats(2, 0)
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "155"
+        artist = "Matteo Bassini"
+        imageUri = "https://cards.scryfall.io/normal/back/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg?1782694484"
+    }
+}
+
+val IdolOfTheDeepKing: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = IdolOfTheDeepKingFront,
+    backFace = SovereignsMacuahuitl
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/InvertedIceberg.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/InvertedIceberg.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.EffectChoice
+import com.wingedsheep.sdk.scripting.effects.MayEffect
+
+/**
+ * Inverted Iceberg // Iceberg Titan (CR 702.167, The Lost Caverns of Ixalan #60)
+ * {1}{U}
+ * Artifact // Artifact Creature — Golem
+ *
+ * Front face — Inverted Iceberg ({1}{U}, Artifact)
+ *   When this artifact enters, mill a card, then draw a card.
+ *   Craft with artifact {4}{U}{U} ({4}{U}{U}, Exile this artifact, Exile another
+ *   artifact you control or an artifact card from your graveyard: Return this card
+ *   transformed under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Iceberg Titan (Artifact Creature — Golem, 6/6)
+ *   Whenever this creature attacks, you may tap or untap target artifact or creature.
+ *
+ * Implementation:
+ *  - Front ETB: [Effects.Composite] sequencing `Patterns.Library.mill(1)` then
+ *    `Effects.DrawCards(1)` — mill fully resolves before the draw, matching the
+ *    "mill a card, then draw a card" ordering.
+ *  - Craft: the `craft(...)` helper wires [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ *    (exactly one artifact material: `minCount = 1, maxCount = 1`) plus the {4}{U}{U} mana
+ *    cost at sorcery speed; resolution returns the source from exile transformed via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect].
+ *  - Back attack trigger: declared target ([Targets.CreatureOrArtifact], chosen when the
+ *    trigger goes on the stack) with a [MayEffect]-wrapped two-mode [ModalEffect]
+ *    (tap / untap via [TapUntapEffect]) decided at resolution — the same idiom as
+ *    Sewer-veillance Cam / Gandalf the Grey's "you may tap or untap target ..." clause.
+ */
+
+private val InvertedIcebergFront = card("Inverted Iceberg") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, mill a card, then draw a card. (To mill a card, put the top card of your library into your graveyard.)\n" +
+        "Craft with artifact {4}{U}{U} ({4}{U}{U}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // When this artifact enters, mill a card, then draw a card.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            Patterns.Library.mill(1),
+            Effects.DrawCards(1)
+        )
+    }
+
+    // Craft with artifact {4}{U}{U} — exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{4}{U}{U}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Campbell White"
+        imageUri = "https://cards.scryfall.io/normal/front/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1782694562"
+    }
+}
+
+private val IcebergTitan = card("Iceberg Titan") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Artifact Creature — Golem"
+    power = 6
+    toughness = 6
+    oracleText = "Whenever this creature attacks, you may tap or untap target artifact or creature."
+
+    // Whenever this creature attacks, you may tap or untap target artifact or creature.
+    // MayEffect + Effects.ChooseAction is the proven tap-or-untap idiom (Gandalf the Grey);
+    // the engine asks the may-question and locks the target when the trigger goes on the
+    // stack, then the tap/untap choice is made at resolution.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val permanent = target("target artifact or creature", Targets.CreatureOrArtifact)
+        effect = MayEffect(
+            Effects.ChooseAction(
+                listOf(
+                    EffectChoice("Tap it", Effects.Tap(permanent)),
+                    EffectChoice("Untap it", Effects.Untap(permanent))
+                )
+            ),
+            descriptionOverride = "You may tap or untap target artifact or creature"
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "60"
+        artist = "Campbell White"
+        flavorText = "The force of a blizzard. The rage of a monstrosaur."
+        imageUri = "https://cards.scryfall.io/normal/back/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1782694562"
+    }
+}
+
+val InvertedIceberg: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = InvertedIcebergFront,
+    backFace = IcebergTitan
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/KaslemsStonetree.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/KaslemsStonetree.kt
@@ -1,0 +1,121 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardOrder
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.effects.ZonePlacement
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Kaslem's Stonetree // Kaslem's Strider (CR 702.167, The Lost Caverns of Ixalan)
+ * {2}{G}
+ * Artifact // Artifact Creature — Golem
+ *
+ * Front face — Kaslem's Stonetree ({2}{G}, Artifact)
+ *   When this artifact enters, look at the top six cards of your library. You may put
+ *   a land card from among them onto the battlefield tapped. Put the rest on the
+ *   bottom in a random order.
+ *   Craft with Cave {5}{G}
+ *
+ * Back face — Kaslem's Strider (Artifact Creature — Golem, 5/5)
+ *   Vanilla.
+ *
+ * Implementation:
+ *  - The ETB trigger is the Gather → Select → Move library pipeline (Freestrider
+ *    Lookout's shape): [GatherCardsEffect] over the top six, an optional filtered
+ *    [SelectFromCollectionEffect] ([SelectionMode.ChooseUpTo] 1 land), the pick moved
+ *    to the battlefield [ZonePlacement.Tapped], the rest to the bottom of the library
+ *    in [CardOrder.Random] order.
+ *  - The `craft(...)` helper wires the activated ability: [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ *    with an exactly-one Cave material filter (`minCount = maxCount = 1`; a Cave you
+ *    control or a Cave card in your graveyard, CR 702.167a-b) plus the {5}{G} mana
+ *    cost, resolving via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect]
+ *    (return transformed as the back face). Sorcery-only timing is enforced by the
+ *    helper.
+ */
+
+private val CaveFilter: GameObjectFilter = GameObjectFilter.Any.withSubtype("Cave")
+
+private val KaslemsStonetreeFront = card("Kaslem's Stonetree") {
+    manaCost = "{2}{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, look at the top six cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom in a random order.\n" +
+        "Craft with Cave {5}{G} ({5}{G}, Exile this artifact, Exile a Cave you control or a Cave card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // ETB: look at the top six, optionally put a land onto the battlefield tapped,
+    // rest to the bottom of the library in a random order.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Composite(
+            listOf(
+                GatherCardsEffect(
+                    source = CardSource.TopOfLibrary(DynamicAmount.Fixed(6)),
+                    storeAs = "looked"
+                ),
+                SelectFromCollectionEffect(
+                    from = "looked",
+                    selection = SelectionMode.ChooseUpTo(DynamicAmount.Fixed(1)),
+                    filter = GameObjectFilter.Land,
+                    storeSelected = "kept",
+                    storeRemainder = "rest",
+                    prompt = "You may put a land card onto the battlefield tapped",
+                    showAllCards = true
+                ),
+                MoveCollectionEffect(
+                    from = "kept",
+                    destination = CardDestination.ToZone(Zone.BATTLEFIELD, placement = ZonePlacement.Tapped)
+                ),
+                MoveCollectionEffect(
+                    from = "rest",
+                    destination = CardDestination.ToZone(Zone.LIBRARY, placement = ZonePlacement.Bottom),
+                    order = CardOrder.Random
+                )
+            )
+        )
+    }
+
+    craft(filter = CaveFilter, cost = "{5}{G}", materialDescription = "Cave", minCount = 1, maxCount = 1)
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Victor Adame Minguez"
+        imageUri = "https://cards.scryfall.io/normal/front/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1782694451"
+    }
+}
+
+private val KaslemsStrider = card("Kaslem's Strider") {
+    manaCost = ""
+    colorIdentity = "G"
+    typeLine = "Artifact Creature — Golem"
+    power = 5
+    toughness = 5
+    oracleText = ""
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "197"
+        artist = "Victor Adame Minguez"
+        flavorText = "The Oltec long ago abandoned the caverns to the mycoids, but the Deep Gods still keep watch over the spore-strewn darkness."
+        imageUri = "https://cards.scryfall.io/normal/back/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1782694451"
+    }
+}
+
+val KaslemsStonetree: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = KaslemsStonetreeFront,
+    backFace = KaslemsStrider
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/LodestoneNeedle.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/LodestoneNeedle.kt
@@ -1,0 +1,126 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.TimingRule
+import com.wingedsheep.sdk.scripting.effects.AddCountersEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Lodestone Needle // Guidestone Compass (CR 702.167, The Lost Caverns of Ixalan #62)
+ * {1}{U}
+ * Artifact // Artifact
+ *
+ * Front face — Lodestone Needle ({1}{U}, Artifact)
+ *   Flash
+ *   When this artifact enters, tap up to one target artifact or creature and put
+ *   two stun counters on it.
+ *   Craft with artifact {2}{U} ({2}{U}, Exile this artifact, Exile another artifact
+ *   you control or an artifact card from your graveyard: Return this card transformed
+ *   under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Guidestone Compass (Artifact)
+ *   {1}, {T}: Target creature you control explores. Activate only as a sorcery.
+ *
+ * Implementation:
+ *  - Front ETB: "up to one target artifact or creature" is a [TargetPermanent] with
+ *    `optional = true` (Queen's Bay Paladin idiom); the effect is a [Effects.Composite]
+ *    of [Effects.Tap] plus [AddCountersEffect] with two [Counters.STUN] counters — the
+ *    tap + stun-counter pairing proven by Waylaying Pirates. If the target is declined,
+ *    both steps are no-ops.
+ *  - Craft: the `craft(...)` helper wires [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ *    with exactly one artifact material (`minCount = 1, maxCount = 1`) plus the {2}{U}
+ *    mana cost at sorcery speed; resolution returns the source from exile transformed via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect].
+ *  - Back activated ability: the predefined Map token's idiom minus the sacrifice —
+ *    declared target [Targets.CreatureYouControl], cost `{1}, {T}`
+ *    ([Costs.Composite] of [Costs.Mana] + [Costs.Tap]), [Effects.Explore] on the target,
+ *    restricted by [TimingRule.SorcerySpeed].
+ */
+
+private val LodestoneNeedleFront = card("Lodestone Needle") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "Flash\n" +
+        "When this artifact enters, tap up to one target artifact or creature and put two stun counters on it.\n" +
+        "Craft with artifact {2}{U} ({2}{U}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    keywords(Keyword.FLASH)
+
+    // When this artifact enters, tap up to one target artifact or creature
+    // and put two stun counters on it.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val permanent = target(
+            "up to one target artifact or creature",
+            TargetPermanent(
+                optional = true,
+                filter = TargetFilter(GameObjectFilter.CreatureOrArtifact)
+            )
+        )
+        effect = Effects.Composite(
+            Effects.Tap(permanent),
+            AddCountersEffect(counterType = Counters.STUN, count = 2, target = permanent)
+        )
+    }
+
+    // Craft with artifact {2}{U} — exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{2}{U}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "José Parodi"
+        imageUri = "https://cards.scryfall.io/normal/front/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg?1782694560"
+    }
+}
+
+private val GuidestoneCompass = card("Guidestone Compass") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{1}, {T}: Target creature you control explores. Activate only as a sorcery. " +
+        "(Reveal the top card of your library. Put that card into your hand if it's a land. " +
+        "Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)"
+
+    // {1}, {T}: Target creature you control explores. Activate only as a sorcery.
+    // Same shape as the predefined Map token's ability, without the sacrifice.
+    activatedAbility {
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        cost = Costs.Composite(
+            Costs.Mana("{1}"),
+            Costs.Tap
+        )
+        effect = Effects.Explore(creature)
+        timing = TimingRule.SorcerySpeed
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "62"
+        artist = "José Parodi"
+        imageUri = "https://cards.scryfall.io/normal/back/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg?1782694560"
+    }
+}
+
+val LodestoneNeedle: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = LodestoneNeedleFront,
+    backFace = GuidestoneCompass
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MastersGuideMural.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/MastersGuideMural.kt
@@ -1,0 +1,111 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ActivationRestriction
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Master's Guide-Mural // Master's Manufactory (CR 702.167, The Lost Caverns of Ixalan)
+ * {3}{W}{U}
+ * Artifact // Artifact
+ *
+ * Front face — Master's Guide-Mural ({3}{W}{U}, Artifact)
+ *   When this artifact enters, create a 4/4 white and blue Golem artifact creature token.
+ *   Craft with artifact {4}{W}{W}{U} ({4}{W}{W}{U}, Exile this artifact, Exile another
+ *   artifact you control or an artifact card from your graveyard: Return this card
+ *   transformed under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Master's Manufactory (Artifact)
+ *   {T}: Create a 4/4 white and blue Golem artifact creature token. Activate only if this
+ *   artifact or another artifact entered the battlefield under your control this turn.
+ *
+ * Implementation:
+ *  - Front ETB: [Triggers.EntersBattlefield] + [Effects.CreateToken] (4/4 WU Golem,
+ *    `artifactToken = true`, official LCI token art).
+ *  - Craft: the `craft(...)` DSL helper — "Craft with artifact" is an exact-count craft
+ *    (`minCount = 1, maxCount = 1`) over [GameObjectFilter.Artifact]; the material may come
+ *    from the battlefield or the graveyard (CR 702.167a-b), and the helper's
+ *    [com.wingedsheep.sdk.scripting.TimingRule.SorcerySpeed] enforces "Craft only as a sorcery".
+ *  - Back {T} ability: same token effect, gated by [ActivationRestriction.OnlyIfCondition]
+ *    on [Conditions.ArtifactEnteredBattlefieldThisTurn] — a pure per-turn ETB event tracker
+ *    ("this artifact or another artifact" = any artifact under your control this turn,
+ *    including the Manufactory itself entering via the craft return). As a noncreature
+ *    artifact it has no summoning-sickness restriction on {T} abilities (CR 302.6 applies
+ *    to creatures only), so it can be activated the turn it is crafted.
+ */
+
+/** The official LCI 4/4 white and blue Golem artifact creature token (TLCI #13). */
+private val GolemToken = Effects.CreateToken(
+    power = 4,
+    toughness = 4,
+    colors = setOf(Color.WHITE, Color.BLUE),
+    creatureTypes = setOf("Golem"),
+    artifactToken = true,
+    imageUri = "https://cards.scryfall.io/normal/front/3/3/33a88096-dcfd-4acb-a092-b51507edd13e.jpg?1782731574"
+)
+
+private val MastersGuideMuralFront = card("Master's Guide-Mural") {
+    manaCost = "{3}{W}{U}"
+    colorIdentity = "WU"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, create a 4/4 white and blue Golem artifact creature token.\n" +
+        "Craft with artifact {4}{W}{W}{U} ({4}{W}{W}{U}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // ETB: create a 4/4 white and blue Golem artifact creature token.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = GolemToken
+    }
+
+    // "Craft with artifact" = exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{4}{W}{W}{U}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Racrufi"
+        imageUri = "https://cards.scryfall.io/normal/front/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg?1782694425"
+    }
+}
+
+private val MastersManufactory = card("Master's Manufactory") {
+    manaCost = ""
+    colorIdentity = "WU"
+    typeLine = "Artifact"
+    oracleText = "{T}: Create a 4/4 white and blue Golem artifact creature token. Activate only if this artifact or another artifact entered the battlefield under your control this turn."
+
+    activatedAbility {
+        cost = Costs.Tap
+        effect = GolemToken
+        restrictions = listOf(
+            ActivationRestriction.OnlyIfCondition(Conditions.ArtifactEnteredBattlefieldThisTurn)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "233"
+        artist = "Racrufi"
+        flavorText = "\"The Fomori are a foul and distant memory, but their war machines taught us much about large-scale armorcraft.\"\n—Anim Pakal, Thousandth Moon"
+        imageUri = "https://cards.scryfall.io/normal/back/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg?1782694425"
+    }
+}
+
+val MastersGuideMural: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = MastersGuideMuralFront,
+    backFace = MastersManufactory
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OteclanLandmark.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/OteclanLandmark.kt
@@ -1,0 +1,107 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Oteclan Landmark // Oteclan Levitator (CR 702.167, The Lost Caverns of Ixalan)
+ * {W}
+ * Artifact // Artifact Creature — Golem
+ *
+ * Front face — Oteclan Landmark ({W}, Artifact)
+ *   When this artifact enters, scry 2.
+ *   Craft with artifact {2}{W} ({2}{W}, Exile this artifact, Exile another artifact you
+ *   control or an artifact card from your graveyard: Return this card transformed under
+ *   its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Oteclan Levitator (Artifact Creature — Golem, 1/4)
+ *   Flying
+ *   Whenever this creature attacks, target attacking creature without flying gains
+ *   flying until end of turn.
+ *
+ * Implementation:
+ *  - Front ETB: [Triggers.EntersBattlefield] → [Patterns.Library.scry] (2).
+ *  - Craft: the `craft(...)` helper wires [com.wingedsheep.sdk.scripting.AbilityCost.Craft]
+ *    (material filter [GameObjectFilter.Artifact], exactly one material — minCount = maxCount = 1
+ *    per "Craft with artifact") paired with the {2}{W} mana cost, resolving via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect] at
+ *    sorcery speed.
+ *  - Back attack trigger: [Triggers.Attacks] targeting
+ *    [TargetFilter.AttackingCreature].withoutKeyword(FLYING) →
+ *    [Effects.GrantKeyword] (FLYING, until end of turn).
+ */
+
+private val OteclanLandmarkFront = card("Oteclan Landmark") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, scry 2.\n" +
+        "Craft with artifact {2}{W} ({2}{W}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // When this artifact enters, scry 2.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Patterns.Library.scry(2)
+    }
+
+    // "Craft with artifact" = exactly one artifact material.
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{2}{W}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Warren Mahy"
+        imageUri = "https://cards.scryfall.io/normal/front/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1782694588"
+    }
+}
+
+private val OteclanLevitator = card("Oteclan Levitator") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Artifact Creature — Golem"
+    power = 1
+    toughness = 4
+    oracleText = "Flying\n" +
+        "Whenever this creature attacks, target attacking creature without flying gains flying until end of turn."
+
+    keywords(Keyword.FLYING)
+
+    // Whenever this creature attacks, target attacking creature without flying
+    // gains flying until end of turn.
+    triggeredAbility {
+        trigger = Triggers.Attacks
+        val creature = target(
+            "attacking creature without flying",
+            TargetCreature(filter = TargetFilter.AttackingCreature.withoutKeyword(Keyword.FLYING))
+        )
+        effect = Effects.GrantKeyword(Keyword.FLYING, creature)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "29"
+        artist = "Warren Mahy"
+        flavorText = "Dusk Legion invaders sought lone Oltec travelers to prey upon. The Core's guidestones did not approve."
+        imageUri = "https://cards.scryfall.io/normal/back/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1782694588"
+    }
+}
+
+val OteclanLandmark: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = OteclanLandmarkFront,
+    backFace = OteclanLevitator
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SpringLoadedSawblades.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SpringLoadedSawblades.kt
@@ -1,0 +1,114 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Spring-Loaded Sawblades // Bladewheel Chariot (CR 702.167, The Lost Caverns of Ixalan)
+ * {1}{W}
+ * Artifact // Artifact — Vehicle
+ *
+ * Front face — Spring-Loaded Sawblades ({1}{W}, Artifact)
+ *   Flash
+ *   When this artifact enters, it deals 5 damage to target tapped creature an opponent controls.
+ *   Craft with artifact {3}{W} ({3}{W}, Exile this artifact, Exile another artifact you control
+ *   or an artifact card from your graveyard: Return this card transformed under its owner's
+ *   control. Craft only as a sorcery.)
+ *
+ * Back face — Bladewheel Chariot (Artifact — Vehicle, 5/5)
+ *   Tap two other untapped artifacts you control: This Vehicle becomes an artifact creature
+ *   until end of turn.
+ *   Crew 1
+ *
+ * Implementation: the front face's ETB is a targeted [Triggers.EntersBattlefield] trigger with a
+ * tapped + opponent-controlled creature target ([TargetFilter.TappedCreature.opponentControls])
+ * and [Effects.DealDamage] — the damage source defaults to the trigger's source, matching "it
+ * deals 5 damage". The `craft(...)` helper wires the exactly-one-artifact material cost
+ * (`minCount = 1, maxCount = 1`) with the {3}{W} mana portion (CR 702.167a-b). The back face's
+ * self-animate is an activated ability whose cost is [Costs.TapPermanents] with
+ * `excludeSelf = true` ("two OTHER untapped artifacts you control" — the Chariot can't tap
+ * itself) and whose effect is the same [Effects.BecomeCreature] shape the engine's crew handler
+ * uses: CREATURE is added, existing types/subtypes are kept (empty `creatureTypes` sets nothing,
+ * so it stays a Vehicle), and base P/T is set to its printed 5/5 until end of turn. Crew 1 is
+ * the standard [KeywordAbility.crew] keyword.
+ */
+
+private val SpringLoadedSawbladesFront = card("Spring-Loaded Sawblades") {
+    manaCost = "{1}{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact"
+    oracleText = "Flash\n" +
+        "When this artifact enters, it deals 5 damage to target tapped creature an opponent controls.\n" +
+        "Craft with artifact {3}{W} ({3}{W}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    keywords(Keyword.FLASH)
+
+    // ETB: it deals 5 damage to target tapped creature an opponent controls.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        val creature = target(
+            "target tapped creature an opponent controls",
+            TargetCreature(filter = TargetFilter.TappedCreature.opponentControls())
+        )
+        effect = Effects.DealDamage(5, creature)
+    }
+
+    // "Craft with artifact" = exactly one artifact material (CR 702.167a-b).
+    craft(
+        filter = GameObjectFilter.Artifact,
+        cost = "{3}{W}",
+        materialDescription = "artifact",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/front/2/4/24417388-f2bb-4783-bdce-264774531838.jpg?1782694581"
+    }
+}
+
+private val BladewheelChariot = card("Bladewheel Chariot") {
+    manaCost = ""
+    colorIdentity = "W"
+    typeLine = "Artifact — Vehicle"
+    power = 5
+    toughness = 5
+    oracleText = "Tap two other untapped artifacts you control: This Vehicle becomes an artifact creature until end of turn.\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)"
+
+    // Tap two other untapped artifacts you control: becomes an artifact creature until EOT.
+    // Same animate the crew handler applies: adds CREATURE (it's already an artifact), keeps
+    // the Vehicle subtype (empty creatureTypes = no subtype set), base P/T = printed 5/5.
+    activatedAbility {
+        cost = Costs.TapPermanents(count = 2, filter = GameObjectFilter.Artifact, excludeSelf = true)
+        effect = Effects.BecomeCreature(power = 5, toughness = 5)
+        description = "Tap two other untapped artifacts you control: This Vehicle becomes an artifact creature until end of turn."
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "36"
+        artist = "Wayne Reynolds"
+        imageUri = "https://cards.scryfall.io/normal/back/2/4/24417388-f2bb-4783-bdce-264774531838.jpg?1782694581"
+    }
+}
+
+val SpringLoadedSawblades: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = SpringLoadedSawbladesFront,
+    backFace = BladewheelChariot
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TithingBlade.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/TithingBlade.kt
@@ -1,0 +1,101 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Tithing Blade // Consuming Sepulcher (CR 702.167, The Lost Caverns of Ixalan)
+ * {1}{B}
+ * Artifact // Artifact
+ *
+ * Front face — Tithing Blade ({1}{B}, Artifact)
+ *   When this artifact enters, each opponent sacrifices a creature of their choice.
+ *   Craft with creature {4}{B} ({4}{B}, Exile this artifact, Exile a creature you
+ *   control or a creature card from your graveyard: Return this card transformed
+ *   under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Consuming Sepulcher (Artifact)
+ *   At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life.
+ *
+ * Implementation:
+ *  - ETB edict: [Triggers.EntersBattlefield] + `Effects.Sacrifice` aimed at
+ *    [Player.EachOpponent] — each opponent chooses their own creature to sacrifice
+ *    (same shape as Susurian Dirgecraft / Cabal Executioner).
+ *  - Craft: the `craft(...)` DSL helper wires the activated ability with an
+ *    [com.wingedsheep.sdk.scripting.AbilityCost.Craft] material cost (exactly one
+ *    creature: `minCount = maxCount = 1`, drawn from battlefield-controlled creatures
+ *    and/or creature cards in your graveyard per CR 702.167b) plus the {4}{B} mana
+ *    portion; resolution returns the card transformed via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect].
+ *  - Back-face drain: [Triggers.YourUpkeep] + composite of `Effects.LoseLife(1)` on
+ *    [Player.EachOpponent] and `Effects.GainLife(1)` for the controller.
+ */
+
+private val TithingBladeFront = card("Tithing Blade") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "When this artifact enters, each opponent sacrifices a creature of their choice.\n" +
+        "Craft with creature {4}{B} ({4}{B}, Exile this artifact, Exile a creature you control or a creature card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // ETB: each opponent sacrifices a creature of their choice.
+    triggeredAbility {
+        trigger = Triggers.EntersBattlefield
+        effect = Effects.Sacrifice(
+            GameObjectFilter.Creature,
+            target = EffectTarget.PlayerRef(Player.EachOpponent)
+        )
+    }
+
+    // Craft with creature {4}{B} — exactly one creature material.
+    craft(
+        filter = GameObjectFilter.Creature,
+        cost = "{4}{B}",
+        materialDescription = "creature",
+        minCount = 1,
+        maxCount = 1
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Michael Walsh"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1782694508"
+    }
+}
+
+private val ConsumingSepulcher = card("Consuming Sepulcher") {
+    manaCost = ""
+    colorIdentity = "B"
+    typeLine = "Artifact"
+    oracleText = "At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life."
+
+    // At the beginning of your upkeep: drain each opponent for 1.
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.Composite(
+            Effects.LoseLife(1, EffectTarget.PlayerRef(Player.EachOpponent)),
+            Effects.GainLife(1)
+        )
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "128"
+        artist = "Michael Walsh"
+        flavorText = "\"Slake my thirst so that we both may be free.\"\n—Faded inscription"
+        imageUri = "https://cards.scryfall.io/normal/back/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1782694508"
+    }
+}
+
+val TithingBlade: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = TithingBladeFront,
+    backFace = ConsumingSepulcher
+)

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/WaterloggedHulk.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/WaterloggedHulk.kt
@@ -1,0 +1,110 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Patterns
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlocked
+import com.wingedsheep.sdk.scripting.ConditionalStaticAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+
+/**
+ * Waterlogged Hulk // Watertight Gondola (CR 702.167, The Lost Caverns of Ixalan)
+ * {U}
+ * Artifact // Artifact — Vehicle
+ *
+ * Front face — Waterlogged Hulk ({U}, Artifact)
+ *   {T}: Mill a card.
+ *   Craft with Island {3}{U} ({3}{U}, Exile this artifact, Exile an Island you
+ *   control or an Island card from your graveyard: Return this card transformed
+ *   under its owner's control. Craft only as a sorcery.)
+ *
+ * Back face — Watertight Gondola (Artifact — Vehicle, 4/4)
+ *   Vigilance
+ *   Descend 8 — This Vehicle can't be blocked as long as there are eight or more
+ *   permanent cards in your graveyard.
+ *   Crew 1
+ *
+ * Implementation:
+ *  - The front face's tap ability is [Patterns.Library.mill] (Gather → Move mill
+ *    pipeline) with [Costs.Tap].
+ *  - The `craft(...)` helper wires the activated ability: a
+ *    [com.wingedsheep.sdk.scripting.AbilityCost.Craft] with an exactly-one Island
+ *    material filter (`minCount = maxCount = 1`; an Island you control or an Island
+ *    card in your graveyard, CR 702.167a-b) plus the {3}{U} mana cost, resolving via
+ *    [com.wingedsheep.sdk.scripting.effects.ReturnSelfFromExileTransformedEffect]
+ *    (return transformed as the back face). Sorcery-only timing is enforced by the
+ *    helper.
+ *  - Descend 8 is an ability word: a [ConditionalStaticAbility] wrapping
+ *    [CantBeBlocked] on the source, gated on
+ *    [Conditions.CardsInGraveyardMatchingAtLeast] (8, [GameObjectFilter.Permanent])
+ *    — the Nightwhorl Hermit / The Ancient One idiom.
+ *  - Vigilance is a plain keyword; Crew 1 is [KeywordAbility.crew].
+ */
+
+private val IslandFilter: GameObjectFilter = GameObjectFilter.Any.withSubtype(Subtype.ISLAND)
+
+private val WaterloggedHulkFront = card("Waterlogged Hulk") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Artifact"
+    oracleText = "{T}: Mill a card. (Put the top card of your library into your graveyard.)\n" +
+        "Craft with Island {3}{U} ({3}{U}, Exile this artifact, Exile an Island you control or an Island card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)"
+
+    // {T}: Mill a card.
+    activatedAbility {
+        cost = Costs.Tap
+        effect = Patterns.Library.mill(1)
+    }
+
+    craft(filter = IslandFilter, cost = "{3}{U}", materialDescription = "Island", minCount = 1, maxCount = 1)
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Artur Treffner"
+        imageUri = "https://cards.scryfall.io/normal/front/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg?1782694543"
+    }
+}
+
+private val WatertightGondola = card("Watertight Gondola") {
+    manaCost = ""
+    colorIdentity = "U"
+    typeLine = "Artifact — Vehicle"
+    power = 4
+    toughness = 4
+    oracleText = "Vigilance\n" +
+        "Descend 8 — This Vehicle can't be blocked as long as there are eight or more permanent cards in your graveyard.\n" +
+        "Crew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)"
+
+    keywords(Keyword.VIGILANCE)
+
+    // Descend 8 — can't be blocked as long as there are eight or more permanent
+    // cards in your graveyard.
+    staticAbility {
+        ability = ConditionalStaticAbility(
+            ability = CantBeBlocked(),
+            condition = Conditions.CardsInGraveyardMatchingAtLeast(8, GameObjectFilter.Permanent)
+        )
+    }
+
+    keywordAbility(KeywordAbility.crew(1))
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "83"
+        artist = "Artur Treffner"
+        imageUri = "https://cards.scryfall.io/normal/back/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg?1782694543"
+    }
+}
+
+val WaterloggedHulk: CardDefinition = CardDefinition.doubleFacedPermanent(
+    frontFace = WaterloggedHulkFront,
+    backFace = WatertightGondola
+)

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -7021,6 +7021,130 @@
     ]
 }
 
+// Kaslem's Stonetree
+{
+    "name": "Kaslem's Stonetree",
+    "manaCost": "{2}{G}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, look at the top six cards of your library. You may put a land card from among them onto the battlefield tapped. Put the rest on the bottom in a random order.\nCraft with Cave {5}{G} ({5}{G}, Exile this artifact, Exile a Cave you control or a Cave card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 6
+                                }
+                            },
+                            "storeAs": "looked"
+                        },
+                        {
+                            "type": "SelectFromCollection",
+                            "from": "looked",
+                            "selection": {
+                                "type": "ChooseUpTo",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            },
+                            "filter": "land",
+                            "storeSelected": "kept",
+                            "storeRemainder": "rest",
+                            "prompt": "You may put a land card onto the battlefield tapped",
+                            "showAllCards": true
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "kept",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Battlefield",
+                                "placement": "Tapped"
+                            }
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "rest",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Library",
+                                "placement": "Bottom"
+                            },
+                            "order": "Random"
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{G}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "Cave",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with Cave — {5}{G}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Kaslem's Strider",
+        "manaCost": "",
+        "typeLine": "Artifact Creature — Golem",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 5
+        },
+        "metadata": {
+            "collectorNumber": "197",
+            "artist": "Victor Adame Minguez",
+            "flavorText": "The Oltec long ago abandoned the caverns to the mycoids, but the Deep Gods still keep watch over the spore-strewn darkness.",
+            "imageUri": "https://cards.scryfall.io/normal/back/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1782694451"
+        },
+        "colorIdentityOverride": [
+            "GREEN"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "197",
+        "artist": "Victor Adame Minguez",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/8/78b1b412-228a-4e05-a4b3-8159ebf54dc6.jpg?1782694451"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Kinjalli's Dawnrunner
 {
     "name": "Kinjalli's Dawnrunner",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6341,6 +6341,154 @@
     ]
 }
 
+// Idol of the Deep King
+{
+    "name": "Idol of the Deep King",
+    "manaCost": "{2}{R}",
+    "typeLine": "Artifact",
+    "oracleText": "Flash\nWhen this artifact enters, it deals 2 damage to any target.\nCraft with artifact {2}{R} ({2}{R}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "FLASH",
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 2
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "any target"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "AnyTarget",
+                    "id": "any target"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{R}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {2}{R}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Sovereign's Macuahuitl",
+        "manaCost": "",
+        "typeLine": "Artifact — Equipment",
+        "oracleText": "When this Equipment enters, attach it to target creature you control.\nEquipped creature gets +2/+0.\nEquip {2} ({2}: Attach to target creature you control. Equip only as a sorcery.)",
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Battlefield"
+                    },
+                    "effect": {
+                        "type": "AttachEquipment",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                }
+            ],
+            "activatedAbilities": [
+                {
+                    "id": "ability_4",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomMana",
+                            "cost": "{2}"
+                        }
+                    },
+                    "effect": {
+                        "type": "AttachEquipment",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "creature you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "creature you control"
+                        }
+                    ],
+                    "timing": "SorcerySpeed",
+                    "isEquipAbility": true
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 0
+                }
+            ]
+        },
+        "equipCost": "{2}",
+        "metadata": {
+            "collectorNumber": "155",
+            "artist": "Matteo Bassini",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg?1782694484"
+        },
+        "colorIdentityOverride": [
+            "RED"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "155",
+        "artist": "Matteo Bassini",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/1/d1d8d8ef-c8b2-4e7c-89e4-b381dff20584.jpg?1782694484"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
+}
+
 // In the Presence of Ages
 {
     "name": "In the Presence of Ages",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -11934,6 +11934,138 @@
     ]
 }
 
+// Spring-Loaded Sawblades
+{
+    "name": "Spring-Loaded Sawblades",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "Flash\nWhen this artifact enters, it deals 5 damage to target tapped creature an opponent controls.\nCraft with artifact {3}{W} ({3}{W}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "FLASH",
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 5
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target tapped creature an opponent controls"
+                    }
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "filter": {
+                        "baseFilter": "creature tapped ctrl:opponent"
+                    },
+                    "id": "target tapped creature an opponent controls"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{W}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {3}{W}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Bladewheel Chariot",
+        "manaCost": "",
+        "typeLine": "Artifact — Vehicle",
+        "oracleText": "Tap two other untapped artifacts you control: This Vehicle becomes an artifact creature until end of turn.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+        "creatureStats": {
+            "power": 5,
+            "toughness": 5
+        },
+        "keywords": [
+            "CREW"
+        ],
+        "keywordAbilities": [
+            {
+                "type": "Numeric",
+                "keyword": "CREW",
+                "n": 1
+            }
+        ],
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostAtomWrapper",
+                        "atom": {
+                            "type": "AtomTapPermanents",
+                            "count": 2,
+                            "filter": "artifact",
+                            "excludeSelf": true
+                        }
+                    },
+                    "effect": {
+                        "type": "BecomeCreature",
+                        "power": {
+                            "type": "Fixed",
+                            "amount": 5
+                        },
+                        "toughness": {
+                            "type": "Fixed",
+                            "amount": 5
+                        }
+                    },
+                    "descriptionOverride": "Tap two other untapped artifacts you control: This Vehicle becomes an artifact creature until end of turn."
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "36",
+            "rarity": "UNCOMMON",
+            "artist": "Wayne Reynolds",
+            "imageUri": "https://cards.scryfall.io/normal/back/2/4/24417388-f2bb-4783-bdce-264774531838.jpg?1782694581"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "36",
+        "rarity": "UNCOMMON",
+        "artist": "Wayne Reynolds",
+        "imageUri": "https://cards.scryfall.io/normal/front/2/4/24417388-f2bb-4783-bdce-264774531838.jpg?1782694581"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Spyglass Siren
 {
     "name": "Spyglass Siren",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -8113,6 +8113,121 @@
     ]
 }
 
+// Oteclan Landmark
+{
+    "name": "Oteclan Landmark",
+    "manaCost": "{W}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, scry 2.\nCraft with artifact {2}{W} ({2}{W}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Scry",
+                    "count": 2
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{W}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {2}{W}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Oteclan Levitator",
+        "manaCost": "",
+        "typeLine": "Artifact Creature — Golem",
+        "oracleText": "Flying\nWhenever this creature attacks, target attacking creature without flying gains flying until end of turn.",
+        "creatureStats": {
+            "power": 1,
+            "toughness": 4
+        },
+        "keywords": [
+            "FLYING"
+        ],
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "GrantKeyword",
+                        "keyword": "FLYING",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "attacking creature without flying"
+                        }
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": {
+                                "cardPredicates": [
+                                    "IsCreature",
+                                    {
+                                        "type": "NotKeyword",
+                                        "keyword": "FLYING"
+                                    }
+                                ],
+                                "statePredicates": [
+                                    "IsAttacking"
+                                ]
+                            }
+                        },
+                        "id": "attacking creature without flying"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "29",
+            "artist": "Warren Mahy",
+            "flavorText": "Dusk Legion invaders sought lone Oltec travelers to prey upon. The Core's guidestones did not approve.",
+            "imageUri": "https://cards.scryfall.io/normal/back/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1782694588"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "29",
+        "artist": "Warren Mahy",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/9/099a1d1c-72ba-468e-9385-8f93e1fce001.jpg?1782694588"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Out of Air
 {
     "name": "Out of Air",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -6576,6 +6576,163 @@
     ]
 }
 
+// Inverted Iceberg
+{
+    "name": "Inverted Iceberg",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, mill a card, then draw a card. (To mill a card, put the top card of your library into your graveyard.)\nCraft with artifact {4}{U}{U} ({4}{U}{U}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "TopOfLibrary",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        },
+                                        "isMill": true
+                                    },
+                                    "storeAs": "milled"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "milled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Graveyard"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "DrawCards",
+                            "count": {
+                                "type": "Fixed",
+                                "amount": 1
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{U}{U}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {4}{U}{U}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Iceberg Titan",
+        "manaCost": "",
+        "typeLine": "Artifact Creature — Golem",
+        "oracleText": "Whenever this creature attacks, you may tap or untap target artifact or creature.",
+        "creatureStats": {
+            "power": 6,
+            "toughness": 6
+        },
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "Gated",
+                        "gate": "Gate.MayDecide",
+                        "then": {
+                            "type": "ChooseAction",
+                            "choices": [
+                                {
+                                    "label": "Tap it",
+                                    "effect": {
+                                        "type": "TapUntap",
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target artifact or creature"
+                                        }
+                                    }
+                                },
+                                {
+                                    "label": "Untap it",
+                                    "effect": {
+                                        "type": "TapUntap",
+                                        "target": {
+                                            "type": "BoundVariable",
+                                            "name": "target artifact or creature"
+                                        },
+                                        "tap": false
+                                    }
+                                }
+                            ]
+                        },
+                        "descriptionOverride": "You may tap or untap target artifact or creature"
+                    },
+                    "targetRequirement": {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature|artifact"
+                        },
+                        "id": "target artifact or creature"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "60",
+            "artist": "Campbell White",
+            "flavorText": "The force of a blizzard. The rage of a monstrosaur.",
+            "imageUri": "https://cards.scryfall.io/normal/back/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1782694562"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "60",
+        "artist": "Campbell White",
+        "imageUri": "https://cards.scryfall.io/normal/front/a/c/ac5e9a53-cc4f-4ced-8088-5a73d619eae3.jpg?1782694562"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ironpaw Aspirant
 {
     "name": "Ironpaw Aspirant",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -14931,6 +14931,134 @@
     ]
 }
 
+// Waterlogged Hulk
+{
+    "name": "Waterlogged Hulk",
+    "manaCost": "{U}",
+    "typeLine": "Artifact",
+    "oracleText": "{T}: Mill a card. (Put the top card of your library into your graveyard.)\nCraft with Island {3}{U} ({3}{U}, Exile this artifact, Exile an Island you control or an Island card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": "CostTap",
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "GatherCards",
+                            "source": {
+                                "type": "TopOfLibrary",
+                                "count": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "isMill": true
+                            },
+                            "storeAs": "milled"
+                        },
+                        {
+                            "type": "MoveCollection",
+                            "from": "milled",
+                            "destination": {
+                                "type": "ToZone",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{3}{U}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "Island",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with Island — {3}{U}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Watertight Gondola",
+        "manaCost": "",
+        "typeLine": "Artifact — Vehicle",
+        "oracleText": "Vigilance\nDescend 8 — This Vehicle can't be blocked as long as there are eight or more permanent cards in your graveyard.\nCrew 1 (Tap any number of creatures you control with total power 1 or more: This Vehicle becomes an artifact creature until end of turn.)",
+        "creatureStats": {
+            "power": 4,
+            "toughness": 4
+        },
+        "keywords": [
+            "VIGILANCE",
+            "CREW"
+        ],
+        "keywordAbilities": [
+            {
+                "type": "Numeric",
+                "keyword": "CREW",
+                "n": 1
+            }
+        ],
+        "script": {
+            "staticAbilities": [
+                {
+                    "type": "ConditionalStaticAbility",
+                    "ability": "CantBeBlocked",
+                    "condition": {
+                        "type": "Compare",
+                        "left": {
+                            "type": "Count",
+                            "player": "You",
+                            "zone": "Graveyard",
+                            "filter": "permanent"
+                        },
+                        "operator": "GTE",
+                        "right": {
+                            "type": "Fixed",
+                            "amount": 8
+                        }
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "83",
+            "rarity": "UNCOMMON",
+            "artist": "Artur Treffner",
+            "imageUri": "https://cards.scryfall.io/normal/back/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg?1782694543"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "83",
+        "rarity": "UNCOMMON",
+        "artist": "Artur Treffner",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/e/7ea89d3c-8d47-4bbb-9271-8cdfd9296e2f.jpg?1782694543"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Waterwind Scout
 {
     "name": "Waterwind Scout",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -7184,6 +7184,144 @@
     ]
 }
 
+// Lodestone Needle
+{
+    "name": "Lodestone Needle",
+    "manaCost": "{1}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "Flash\nWhen this artifact enters, tap up to one target artifact or creature and put two stun counters on it.\nCraft with artifact {2}{U} ({2}{U}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "FLASH",
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "TapUntap",
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target artifact or creature"
+                            }
+                        },
+                        {
+                            "type": "AddCounters",
+                            "counterType": "stun",
+                            "count": 2,
+                            "target": {
+                                "type": "BoundVariable",
+                                "name": "up to one target artifact or creature"
+                            }
+                        }
+                    ]
+                },
+                "targetRequirement": {
+                    "type": "TargetObject",
+                    "optional": true,
+                    "filter": {
+                        "baseFilter": "creature|artifact"
+                    },
+                    "id": "up to one target artifact or creature"
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{2}{U}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {2}{U}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Guidestone Compass",
+        "manaCost": "",
+        "typeLine": "Artifact",
+        "oracleText": "{1}, {T}: Target creature you control explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{1}"
+                                }
+                            },
+                            "CostTap"
+                        ]
+                    },
+                    "effect": {
+                        "type": "Explore",
+                        "target": {
+                            "type": "BoundVariable",
+                            "name": "target creature you control"
+                        }
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature ctrl:you"
+                            },
+                            "id": "target creature you control"
+                        }
+                    ],
+                    "timing": "SorcerySpeed"
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "62",
+            "rarity": "UNCOMMON",
+            "artist": "José Parodi",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg?1782694560"
+        },
+        "colorIdentityOverride": [
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "62",
+        "rarity": "UNCOMMON",
+        "artist": "José Parodi",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/e/dedd7a22-92e2-41fd-aa80-944c69653a5e.jpg?1782694560"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Magmatic Galleon
 {
     "name": "Magmatic Galleon",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -13397,6 +13397,119 @@
     ]
 }
 
+// Tithing Blade
+{
+    "name": "Tithing Blade",
+    "manaCost": "{1}{B}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, each opponent sacrifices a creature of their choice.\nCraft with creature {4}{B} ({4}{B}, Exile this artifact, Exile a creature you control or a creature card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ForceSacrifice",
+                    "filter": "creature",
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "EachOpponent"
+                    }
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{B}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "creature",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with creature — {4}{B}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Consuming Sepulcher",
+        "manaCost": "",
+        "typeLine": "Artifact",
+        "oracleText": "At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life.",
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "StepEvent",
+                        "step": "UPKEEP"
+                    },
+                    "binding": "ANY",
+                    "effect": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "LoseLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                },
+                                "target": {
+                                    "type": "PlayerRef",
+                                    "player": "EachOpponent"
+                                }
+                            },
+                            {
+                                "type": "GainLife",
+                                "amount": {
+                                    "type": "Fixed",
+                                    "amount": 1
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "128",
+            "artist": "Michael Walsh",
+            "flavorText": "\"Slake my thirst so that we both may be free.\"\n—Faded inscription",
+            "imageUri": "https://cards.scryfall.io/normal/back/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1782694508"
+        },
+        "colorIdentityOverride": [
+            "BLACK"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "128",
+        "artist": "Michael Walsh",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbaa9a2d-e9fd-4746-a26c-f99ae731f024.jpg?1782694508"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Triumphant Chomp
 {
     "name": "Triumphant Chomp",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -2508,6 +2508,165 @@
     ]
 }
 
+// Clay-Fired Bricks
+{
+    "name": "Clay-Fired Bricks",
+    "manaCost": "{1}{W}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, search your library for a basic Plains card, reveal it, put it into your hand, then shuffle. You gain 2 life.\nCraft with artifact {5}{W}{W} ({5}{W}{W}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "Composite",
+                    "effects": [
+                        {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Library",
+                                        "filter": "basicland Plains"
+                                    },
+                                    "storeAs": "searchable"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "searchable",
+                                    "selection": {
+                                        "type": "ChooseUpTo",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "found"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "found",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Hand"
+                                    },
+                                    "revealed": true
+                                },
+                                "ShuffleLibrary",
+                                "EmitLibrarySearchedEvent"
+                            ]
+                        },
+                        {
+                            "type": "GainLife",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            }
+                        }
+                    ]
+                },
+                "descriptionOverride": "When this artifact enters, search your library for a basic Plains card, reveal it, put it into your hand, then shuffle. You gain 2 life."
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{5}{W}{W}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {5}{W}{W}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Cosmium Kiln",
+        "manaCost": "",
+        "typeLine": "Artifact",
+        "oracleText": "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens.\nCreatures you control get +1/+1.",
+        "script": {
+            "triggeredAbilities": [
+                {
+                    "id": "ability_3",
+                    "trigger": {
+                        "type": "ZoneChangeEvent",
+                        "to": "Battlefield"
+                    },
+                    "effect": {
+                        "type": "CreateToken",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 2
+                        },
+                        "power": 1,
+                        "toughness": 1,
+                        "colors": [],
+                        "creatureTypes": [
+                            "Gnome"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/6/d/6def709a-53b3-4520-9544-74ab6472d256.jpg?1782731572",
+                        "artifactToken": true
+                    },
+                    "descriptionOverride": "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens."
+                }
+            ],
+            "staticAbilities": [
+                {
+                    "type": "ModifyStats",
+                    "powerBonus": 1,
+                    "toughnessBonus": 1,
+                    "filter": {
+                        "baseFilter": "creature ctrl:you"
+                    }
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "6",
+            "rarity": "UNCOMMON",
+            "artist": "Steve Ellis",
+            "flavorText": "\"I love the smell of freshly baked gnomes!\"\n—Yelha, Oltec artisan",
+            "imageUri": "https://cards.scryfall.io/normal/back/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1782694608"
+        },
+        "colorIdentityOverride": [
+            "WHITE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "6",
+        "rarity": "UNCOMMON",
+        "artist": "Steve Ellis",
+        "imageUri": "https://cards.scryfall.io/normal/front/8/a/8aece300-656b-4e0d-a45f-aa7feaff0a4e.jpg?1782694608"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Coati Scavenger
 {
     "name": "Coati Scavenger",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -7978,6 +7978,125 @@
     ]
 }
 
+// Master's Guide-Mural
+{
+    "name": "Master's Guide-Mural",
+    "manaCost": "{3}{W}{U}",
+    "typeLine": "Artifact",
+    "oracleText": "When this artifact enters, create a 4/4 white and blue Golem artifact creature token.\nCraft with artifact {4}{W}{W}{U} ({4}{W}{W}{U}, Exile this artifact, Exile another artifact you control or an artifact card from your graveyard: Return this card transformed under its owner's control. Craft only as a sorcery.)",
+    "keywords": [
+        "CRAFT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 4,
+                    "toughness": 4,
+                    "colors": [
+                        "WHITE",
+                        "BLUE"
+                    ],
+                    "creatureTypes": [
+                        "Golem"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/3/3/33a88096-dcfd-4acb-a092-b51507edd13e.jpg?1782731574",
+                    "artifactToken": true
+                }
+            }
+        ],
+        "activatedAbilities": [
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostComposite",
+                    "costs": [
+                        {
+                            "type": "CostAtomWrapper",
+                            "atom": {
+                                "type": "AtomMana",
+                                "cost": "{4}{W}{W}{U}"
+                            }
+                        },
+                        {
+                            "type": "CostCraft",
+                            "filter": "artifact",
+                            "maxCount": 1
+                        }
+                    ]
+                },
+                "effect": "ReturnSelfFromExileTransformed",
+                "timing": "SorcerySpeed",
+                "descriptionOverride": "Craft with artifact — {4}{W}{W}{U}"
+            }
+        ]
+    },
+    "backFace": {
+        "name": "Master's Manufactory",
+        "manaCost": "",
+        "typeLine": "Artifact",
+        "oracleText": "{T}: Create a 4/4 white and blue Golem artifact creature token. Activate only if this artifact or another artifact entered the battlefield under your control this turn.",
+        "script": {
+            "activatedAbilities": [
+                {
+                    "id": "ability_3",
+                    "cost": "CostTap",
+                    "effect": {
+                        "type": "CreateToken",
+                        "power": 4,
+                        "toughness": 4,
+                        "colors": [
+                            "WHITE",
+                            "BLUE"
+                        ],
+                        "creatureTypes": [
+                            "Golem"
+                        ],
+                        "imageUri": "https://cards.scryfall.io/normal/front/3/3/33a88096-dcfd-4acb-a092-b51507edd13e.jpg?1782731574",
+                        "artifactToken": true
+                    },
+                    "restrictions": [
+                        {
+                            "type": "ActivationOnlyIfCondition",
+                            "condition": {
+                                "type": "PermanentTypeEnteredBattlefieldThisTurn",
+                                "cardType": "ARTIFACT"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "metadata": {
+            "collectorNumber": "233",
+            "rarity": "UNCOMMON",
+            "artist": "Racrufi",
+            "flavorText": "\"The Fomori are a foul and distant memory, but their war machines taught us much about large-scale armorcraft.\"\n—Anim Pakal, Thousandth Moon",
+            "imageUri": "https://cards.scryfall.io/normal/back/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg?1782694425"
+        },
+        "colorIdentityOverride": [
+            "WHITE",
+            "BLUE"
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "233",
+        "rarity": "UNCOMMON",
+        "artist": "Racrufi",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/7/f7a41343-7cdb-49aa-a9d1-7460195355d8.jpg?1782694425"
+    },
+    "colorIdentityOverride": [
+        "WHITE",
+        "BLUE"
+    ]
+}
+
 // Mephitic Draught
 {
     "name": "Mephitic Draught",

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -1197,6 +1197,14 @@ class CostHandler(
                 "Craft requires at least ${cost.minCount} ${cost.filter.description}(s) to exile"
             )
         }
+        val maxCount = cost.maxCount
+        if (maxCount != null && chosen.size > maxCount) {
+            // Exact-count crafts ("Craft with artifact") exile exactly maxCount materials —
+            // costs are paid exactly as written (CR 118.8), no over-payment.
+            return CostPaymentResult.failure(
+                "Craft accepts at most $maxCount ${cost.filter.description}(s) to exile"
+            )
+        }
         if (chosen.any { it !in candidates }) {
             return CostPaymentResult.failure("Craft material is not a legal candidate")
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/LegalAction.kt
@@ -325,7 +325,9 @@ data class AdditionalCostData(
      * `ActivateAbility.costPayment.exiledCards`.
      */
     val validCraftMaterials: List<EntityId> = emptyList(),
-    val craftMinCount: Int = 1
+    val craftMinCount: Int = 1,
+    /** Cap on material count for exact-count crafts ("Craft with artifact"); null = unbounded. */
+    val craftMaxCount: Int? = null
 )
 
 /**

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/legalactions/enumerators/ActivatedAbilityEnumerator.kt
@@ -1030,6 +1030,7 @@ class ActivatedAbilityEnumerator : ActionEnumerator {
                 costType = "Craft",
                 validCraftMaterials = craftMaterials,
                 craftMinCount = craftCost.minCount,
+                craftMaxCount = craftCost.maxCount,
                 counterRemovalCreatures = counterRemovalCreatures
             )
         }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionEnricher.kt
@@ -164,7 +164,8 @@ class LegalActionEnricher(
         payXLifeMaxX = payXLifeMaxX,
         distributedCounterRemovalTotal = distributedCounterRemovalTotal,
         validCraftMaterials = validCraftMaterials,
-        craftMinCount = craftMinCount
+        craftMinCount = craftMinCount,
+        craftMaxCount = craftMaxCount
     )
 
     private fun ConvokeCreatureData.toDto() = ConvokeCreatureInfo(

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/LegalActionPresentation.kt
@@ -220,7 +220,9 @@ data class AdditionalCostInfo(
      * `ActivateAbility.costPayment.exiledCards`.
      */
     val validCraftMaterials: List<EntityId> = emptyList(),
-    val craftMinCount: Int = 1
+    val craftMinCount: Int = 1,
+    /** Cap on material count for exact-count crafts ("Craft with artifact"); null = unbounded. */
+    val craftMaxCount: Int? = null
 )
 
 @Serializable

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClayFiredBricksScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ClayFiredBricksScenarioTest.kt
@@ -1,0 +1,202 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.ClayFiredBricks
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Clay-Fired Bricks // Cosmium Kiln (LCI #6, CR 702.167).
+ *
+ * Front face — Clay-Fired Bricks ({1}{W} Artifact):
+ *   "When this artifact enters, search your library for a basic Plains card, reveal it,
+ *    put it into your hand, then shuffle. You gain 2 life.
+ *    Craft with artifact {5}{W}{W}"
+ *
+ * Back face — Cosmium Kiln (Artifact):
+ *   "When this artifact enters, create two 1/1 colorless Gnome artifact creature tokens.
+ *    Creatures you control get +1/+1."
+ *
+ * Covers:
+ *  - Front ETB: basic-Plains-only library search (non-Plains basics excluded) to hand,
+ *    then the sequenced 2-life gain.
+ *  - Craft end-to-end: mana + exactly-one-artifact material paid, source returns
+ *    transformed as Cosmium Kiln, and the back face's ETB (a fresh battlefield entry,
+ *    not a transform — CR 701.27a) creates the two Gnome tokens.
+ *  - Back-face anthem: creatures you control (including the Gnome tokens) get +1/+1 in
+ *    projection; opponent's creatures are unaffected.
+ *  - Validation: a non-artifact creature is rejected as craft material.
+ */
+class ClayFiredBricksScenarioTest : FunSpec({
+
+    // Plain artifact to use as legal craft material.
+    val testRelic = CardDefinition.artifact(
+        name = "Test Relic",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(testRelic))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        return driver
+    }
+
+    // The front face's only activated ability is the Craft.
+    fun craftAbilityId() = ClayFiredBricks.activatedAbilities.single().id
+
+    /** Craft Clay-Fired Bricks (already on the battlefield) using [material], resolving the ability. */
+    fun GameTestDriver.craftBricks(
+        player: com.wingedsheep.sdk.model.EntityId,
+        bricks: com.wingedsheep.sdk.model.EntityId,
+        material: com.wingedsheep.sdk.model.EntityId
+    ) {
+        giveMana(player, Color.WHITE, 7)
+        submitSuccess(
+            ActivateAbility(
+                playerId = player,
+                sourceId = bricks,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material))
+            )
+        )
+        bothPass() // resolve the craft ability -> back face enters, its ETB trigger goes on the stack
+    }
+
+    test("front ETB searches for a basic Plains (only), puts it into hand, and gains 2 life") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        // Library is all Mountains (basic, but not Plains) plus this one Plains.
+        val plains = driver.putCardOnTopOfLibrary(p1, "Plains")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val bricks = driver.putCardInHand(p1, "Clay-Fired Bricks")
+        driver.giveMana(p1, Color.WHITE, 2)
+        val lifeBefore = driver.getLifeTotal(p1)
+
+        driver.castSpell(p1, bricks).isSuccess shouldBe true
+        driver.bothPass() // resolve the artifact spell -> ETB trigger on the stack
+        driver.bothPass() // resolve the trigger -> pauses on the library search selection
+
+        val decision = driver.pendingDecision
+        decision.shouldBeInstanceOf<SelectCardsDecision>()
+        // Only the basic Plains is searchable — the basic Mountains don't match the filter.
+        decision.options shouldBe listOf(plains)
+
+        driver.submitCardSelection(p1, listOf(plains))
+
+        driver.getHand(p1) shouldContain plains
+        driver.getLifeTotal(p1) shouldBe lifeBefore + 2
+    }
+
+    test("craft with an artifact exiles the material and returns transformed as Cosmium Kiln, whose ETB creates two Gnome tokens") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val bricks = driver.putPermanentOnBattlefield(p1, "Clay-Fired Bricks")
+        val relic = driver.putPermanentOnBattlefield(p1, "Test Relic")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.craftBricks(p1, bricks, relic)
+
+        // Material exiled.
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain relic
+
+        // Source returned to the battlefield as the back face.
+        val container = driver.state.getEntity(bricks)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Cosmium Kiln"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // The craft return is a battlefield entry, so the back face's ETB trigger fired
+        // and is on the stack; resolving it creates the two Gnome tokens.
+        driver.bothPass()
+        val gnomes = driver.getPermanents(p1).filter { driver.getCardName(it) == "Gnome Token" }
+        gnomes.size shouldBe 2
+    }
+
+    test("Cosmium Kiln's anthem gives your creatures +1/+1 (Gnome tokens are 2/2) but not the opponent's") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        val bricks = driver.putPermanentOnBattlefield(p1, "Clay-Fired Bricks")
+        val relic = driver.putPermanentOnBattlefield(p1, "Test Relic")
+        val myLions = driver.putCreatureOnBattlefield(p1, "Savannah Lions")       // 1/1
+        val oppCourser = driver.putCreatureOnBattlefield(p2, "Centaur Courser")   // 3/3
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        driver.craftBricks(p1, bricks, relic)
+        driver.bothPass() // resolve the back-face ETB trigger -> two Gnome tokens
+
+        val projected = projector.project(driver.state)
+
+        // My 1/1 Savannah Lions is projected 2/2 under the anthem.
+        projected.getPower(myLions) shouldBe 2
+        projected.getToughness(myLions) shouldBe 2
+
+        // The 1/1 Gnome tokens are projected 2/2.
+        val gnomes = driver.getPermanents(p1).filter { driver.getCardName(it) == "Gnome Token" }
+        gnomes.size shouldBe 2
+        gnomes.forEach { gnome ->
+            projected.getPower(gnome) shouldBe 2
+            projected.getToughness(gnome) shouldBe 2
+        }
+
+        // Opponent's 3/3 Centaur Courser is unaffected.
+        projected.getPower(oppCourser) shouldBe 3
+        projected.getToughness(oppCourser) shouldBe 3
+    }
+
+    test("rejects a non-artifact creature as craft material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val bricks = driver.putPermanentOnBattlefield(p1, "Clay-Fired Bricks")
+        val lions = driver.putCreatureOnBattlefield(p1, "Savannah Lions") // not an artifact
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.WHITE, 7)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = bricks,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(lions))
+            )
+        )
+        result.isSuccess shouldBe false
+
+        // Nothing moved: still the front face on the battlefield, no exile.
+        driver.state.getEntity(bricks)!!.get<CardComponent>()!!.name shouldBe "Clay-Fired Bricks"
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldNotContain lions
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CraftExactCountScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CraftExactCountScenarioTest.kt
@@ -1,0 +1,120 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.craft
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Exact-count Craft costs (CR 702.167a): "Craft with artifact" exiles exactly one material —
+ * costs are paid exactly as written, so supplying more materials than [maxCount] must be
+ * rejected, exactly like supplying fewer than [minCount].
+ *
+ * Uses a test-local DFC with `craft(filter = artifact, maxCount = 1)` so the check is
+ * independent of any particular set's card.
+ */
+class CraftExactCountScenarioTest : FunSpec({
+
+    val artifactFilter = GameObjectFilter.Artifact
+
+    val frontFace = card("Test Exact Crafter") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = "Craft with artifact {2}"
+        craft(filter = artifactFilter, cost = "{2}", materialDescription = "artifact", minCount = 1, maxCount = 1)
+    }
+    val backFace = card("Test Crafted Golem") {
+        manaCost = ""
+        typeLine = "Artifact Creature — Golem"
+        power = 3
+        toughness = 3
+        oracleText = ""
+    }
+    val exactCrafter: CardDefinition = CardDefinition.doubleFacedPermanent(
+        frontFace = frontFace,
+        backFace = backFace
+    )
+
+    val trinket = card("Test Trinket") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(exactCrafter, trinket))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        return driver
+    }
+
+    fun craftAbilityId() = exactCrafter.activatedAbilities.single().id
+
+    test("accepts exactly one material and returns transformed") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val crafter = driver.putPermanentOnBattlefield(p1, "Test Exact Crafter")
+        val material = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 2)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = crafter,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material))
+            )
+        )
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)).contains(material) shouldBe true
+        val card = driver.state.getEntity(crafter)?.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Test Crafted Golem"
+    }
+
+    test("rejects supplying two materials when the craft cost is exactly one (CR 118.8)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val crafter = driver.putPermanentOnBattlefield(p1, "Test Exact Crafter")
+        val material1 = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val material2 = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 2)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = crafter,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material1, material2))
+            )
+        )
+        result.isSuccess shouldBe false
+        result.error.shouldNotBeNull() shouldContain "at most"
+
+        // Nothing moved: both materials and the crafter are still on the battlefield.
+        val battlefield = driver.state.getZone(ZoneKey(p1, Zone.BATTLEFIELD))
+        battlefield.contains(crafter) shouldBe true
+        battlefield.contains(material1) shouldBe true
+        battlefield.contains(material2) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IdolOfTheDeepKingScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/IdolOfTheDeepKingScenarioTest.kt
@@ -1,0 +1,228 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.IdolOfTheDeepKing
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Idol of the Deep King // Sovereign's Macuahuitl (LCI #155) — {2}{R} Artifact // Artifact — Equipment.
+ *
+ * Front: Flash; "When this artifact enters, it deals 2 damage to any target.";
+ *        Craft with artifact {2}{R} (exactly one artifact material, CR 702.167).
+ * Back:  "When this Equipment enters, attach it to target creature you control.";
+ *        Equipped creature gets +2/+0; Equip {2}.
+ *
+ * Covers:
+ *  - Front ETB: cast from hand, targeted trigger deals 2 damage (kills a 2/1).
+ *  - Flash: the front face can be cast at instant speed (upkeep, not a main phase).
+ *  - Craft end-to-end: pays {2}{R}, exiles self + exactly one artifact material, returns
+ *    transformed as Sovereign's Macuahuitl; the back-face ETB attaches it to a target
+ *    creature you control, which gets +2/+0 via projection.
+ *  - Equip {2}: moves the Equipment to another creature at sorcery speed; buff follows.
+ *  - Negative: craft rejected when the supplied material is a creature, not an artifact.
+ */
+class IdolOfTheDeepKingScenarioTest : FunSpec({
+
+    // Plain artifact — a legal craft material.
+    val trinket = card("Test Idol Trinket") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(trinket))
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), skipMulligans = true)
+        return driver
+    }
+
+    // Front face's only activated ability is the Craft.
+    fun craftAbilityId() = IdolOfTheDeepKing.activatedAbilities.single().id
+
+    // Back face's only activated ability is Equip {2}.
+    fun equipAbilityId() = IdolOfTheDeepKing.backFace!!.activatedAbilities.single().id
+
+    fun GameTestDriver.drainStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard++ < 20) bothPass()
+    }
+
+    fun GameTestDriver.resolveUntilDecision() {
+        var guard = 0
+        while (pendingDecision == null && guard++ < 20) bothPass()
+        pendingDecision.shouldNotBeNull()
+    }
+
+    /**
+     * Shared craft setup: Idol + a trinket material + a Centaur Courser (3/3) on p1's
+     * battlefield; crafts in the precombat main and answers the back-face ETB attach
+     * trigger by attaching to the Courser. Returns (idol, courser).
+     */
+    fun GameTestDriver.craftOntoCourser(p1: EntityId): Pair<EntityId, EntityId> {
+        val idol = putPermanentOnBattlefield(p1, "Idol of the Deep King")
+        val material = putPermanentOnBattlefield(p1, "Test Idol Trinket")
+        val courser = putCreatureOnBattlefield(p1, "Centaur Courser") // 3/3
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        giveMana(p1, Color.RED, 3)
+
+        submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = idol,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material))
+            )
+        ).isSuccess shouldBe true
+
+        // Resolve the craft ability; the back face enters and its ETB attach trigger
+        // asks for a target creature you control.
+        resolveUntilDecision()
+        submitTargetSelection(p1, listOf(courser)).error shouldBe null
+        drainStack()
+
+        // Material exiled; source back on the battlefield.
+        state.getZone(ZoneKey(p1, Zone.EXILE)).shouldContain(material)
+        return idol to courser
+    }
+
+    test("front ETB: cast from hand, trigger deals 2 damage to target opponent creature") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val guide = driver.putCreatureOnBattlefield(opponent, "Goblin Guide") // 2/1
+        val idol = driver.putCardInHand(p1, "Idol of the Deep King")
+        driver.giveMana(p1, Color.RED, 3)
+        driver.castSpell(p1, idol, emptyList())
+
+        // Resolve the artifact; its ETB trigger asks for "any target".
+        driver.resolveUntilDecision()
+        driver.submitTargetSelection(p1, listOf(guide)).error shouldBe null
+        driver.drainStack()
+
+        // 2 damage kills the 2/1; the Idol is on the battlefield as its front face.
+        driver.findPermanent(opponent, "Goblin Guide") shouldBe null
+        val idolCard = driver.state.getEntity(idol)!!.get<CardComponent>()!!
+        idolCard.name shouldBe "Idol of the Deep King"
+    }
+
+    test("flash: can be cast at instant speed during upkeep") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+
+        val guide = driver.putCreatureOnBattlefield(opponent, "Goblin Guide") // 2/1
+        val idol = driver.putCardInHand(p1, "Idol of the Deep King")
+        driver.passPriorityUntil(Step.UPKEEP) // not a main phase — instant speed only
+        driver.giveMana(p1, Color.RED, 3)
+
+        driver.castSpell(p1, idol, emptyList()).error shouldBe null
+
+        driver.resolveUntilDecision()
+        driver.submitTargetSelection(p1, listOf(guide)).error shouldBe null
+        driver.drainStack()
+
+        driver.findPermanent(opponent, "Goblin Guide") shouldBe null
+        driver.findPermanent(p1, "Idol of the Deep King") shouldNotBe null
+    }
+
+    test("craft with artifact: exiles self + one artifact, returns as Sovereign's Macuahuitl and ETB-attaches for +2/+0") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val (idol, courser) = driver.craftOntoCourser(p1)
+
+        // Back face on the battlefield: an Artifact — Equipment named Sovereign's Macuahuitl.
+        val container = driver.state.getEntity(idol)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Sovereign's Macuahuitl"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+        card.typeLine.subtypes.shouldContain(Subtype.EQUIPMENT)
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // ETB trigger attached it to the chosen creature: +2/+0.
+        container.get<AttachedToComponent>()?.targetId shouldBe courser
+        projector.getProjectedPower(driver.state, courser) shouldBe 5
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+    }
+
+    test("equip {2} moves the Equipment to another creature at sorcery speed") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val (idol, courser) = driver.craftOntoCourser(p1)
+        val guide = driver.putCreatureOnBattlefield(p1, "Goblin Guide") // 2/1
+
+        driver.giveColorlessMana(p1, 2)
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = idol,
+                abilityId = equipAbilityId(),
+                targets = listOf(ChosenTarget.Permanent(guide))
+            )
+        ).isSuccess shouldBe true
+        driver.bothPass()
+
+        // Re-attached to the new creature; the buff moves with it.
+        driver.state.getEntity(idol)?.get<AttachedToComponent>()?.targetId shouldBe guide
+        projector.getProjectedPower(driver.state, guide) shouldBe 4
+        projector.getProjectedToughness(driver.state, guide) shouldBe 1
+        projector.getProjectedPower(driver.state, courser) shouldBe 3
+        projector.getProjectedToughness(driver.state, courser) shouldBe 3
+    }
+
+    test("negative: craft rejected when the supplied material is a creature, not an artifact") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val idol = driver.putPermanentOnBattlefield(p1, "Idol of the Deep King")
+        val courser = driver.putCreatureOnBattlefield(p1, "Centaur Courser") // not an artifact
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.RED, 3)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = idol,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(courser))
+            )
+        )
+        result.isSuccess shouldBe false
+
+        // Nothing moved: Idol still the front face on the battlefield, Courser untouched.
+        driver.state.getEntity(idol)!!.get<CardComponent>()!!.name shouldBe "Idol of the Deep King"
+        driver.findPermanent(p1, "Centaur Courser") shouldNotBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InvertedIcebergScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/InvertedIcebergScenarioTest.kt
@@ -1,0 +1,247 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.InvertedIceberg
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Inverted Iceberg // Iceberg Titan (LCI #60).
+ *
+ * Front — Inverted Iceberg ({1}{U}, Artifact):
+ *   When this artifact enters, mill a card, then draw a card.
+ *   Craft with artifact {4}{U}{U} (exactly one artifact material; CR 702.167).
+ * Back — Iceberg Titan (Artifact Creature — Golem, 6/6):
+ *   Whenever this creature attacks, you may tap or untap target artifact or creature.
+ *
+ * Covers:
+ *  - Casting the front face fires the ETB trigger: top card milled to the graveyard,
+ *    then the next card drawn (mill happens before the draw).
+ *  - Craft end-to-end with a battlefield artifact material: mana paid, material exiled,
+ *    source returns transformed as a 6/6 Iceberg Titan (back face).
+ *  - Craft with an artifact card from the graveyard as material (CR 702.167b).
+ *  - Back-face attack trigger: target chosen at declare-attackers, may-clause accepted,
+ *    "Tap it" mode taps the targeted opponent creature.
+ *  - Negative: a non-artifact (creature) material is rejected.
+ *  - Negative: two materials are rejected ("Craft with artifact" = exactly one).
+ */
+class InvertedIcebergScenarioTest : FunSpec({
+
+    // Simple artifact to use as craft material.
+    val testTrinket = CardDefinition.artifact(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        // InvertedIceberg is a catalog card, already included in TestCards.all.
+        driver.registerCards(TestCards.all + listOf(testTrinket))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        return driver
+    }
+
+    // The craft ability is the front face's only activated ability.
+    fun craftAbilityId() = InvertedIceberg.activatedAbilities.single().id
+
+    test("casting Inverted Iceberg mills the top card, then draws the next one") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Seed the library: second call ends up on top, so `milled` is the top card
+        // (goes to the graveyard) and `drawn` sits beneath it (drawn afterwards).
+        val drawn = driver.putCardOnTopOfLibrary(p1, "Island")
+        val milled = driver.putCardOnTopOfLibrary(p1, "Island")
+
+        val iceberg = driver.putCardInHand(p1, "Inverted Iceberg")
+        val handBefore = driver.getHandSize(p1)
+        val graveyardBefore = driver.getGraveyard(p1).size
+
+        driver.giveMana(p1, Color.BLUE, 2)
+        driver.castSpell(p1, iceberg).isSuccess shouldBe true
+        driver.bothPass() // resolve the artifact spell; ETB trigger goes on the stack
+        driver.bothPass() // resolve the ETB trigger: mill a card, then draw a card
+
+        driver.assertPermanentExists(p1, "Inverted Iceberg")
+        driver.getGraveyard(p1).size shouldBe graveyardBefore + 1
+        driver.getGraveyard(p1) shouldContain milled
+        driver.getHand(p1) shouldContain drawn
+        // Net: -1 (cast) +1 (draw).
+        driver.getHandSize(p1) shouldBe handBefore
+    }
+
+    test("craft with a battlefield artifact exiles it and returns Inverted Iceberg as a 6/6 Iceberg Titan") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val trinket = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        driver.bothPass() // resolve the craft ability
+
+        // Material exiled.
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain trinket
+
+        // Source returned to the battlefield as the back face.
+        val container = driver.state.getEntity(iceberg)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Iceberg Titan"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        val projected = projector.project(driver.state)
+        projected.getPower(iceberg) shouldBe 6
+        projected.getToughness(iceberg) shouldBe 6
+    }
+
+    test("craft accepts an artifact card from the graveyard as material (CR 702.167b)") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val trinket = driver.putCardInGraveyard(p1, "Test Trinket")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain trinket
+        driver.state.getEntity(iceberg)!!.get<CardComponent>()!!.name shouldBe "Iceberg Titan"
+    }
+
+    test("Iceberg Titan attack trigger may tap target artifact or creature") {
+        val driver = setup()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val trinket = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val victim = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        driver.bothPass() // resolve the craft; Iceberg Titan is on the battlefield
+
+        // The crafted Titan entered this turn — clear summoning sickness so it can attack.
+        driver.removeSummoningSickness(iceberg)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val attackResult = driver.declareAttackers(p1, listOf(iceberg), p2)
+        attackResult.error shouldBe null
+
+        // Optional targeted trigger: the engine asks the may-question at put-on-stack time
+        // (before targeting — see TriggerProcessor.processMayThenTargetTrigger), then the
+        // target, then the trigger waits on the stack for priority.
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(p1, true)
+
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(p1, listOf(victim))
+
+        driver.bothPass() // resolve the trigger — pauses on the tap-or-untap choice
+
+        val modeDecision = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        val tapIndex = modeDecision.options.indexOfFirst { it.startsWith("Tap") }
+        (tapIndex >= 0) shouldBe true
+        driver.submitDecision(p1, OptionChosenResponse(modeDecision.id, tapIndex))
+
+        driver.isTapped(victim) shouldBe true
+    }
+
+    test("rejects a non-artifact creature as craft material") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bears))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+
+    test("rejects two materials — 'Craft with artifact' takes exactly one") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val iceberg = driver.putPermanentOnBattlefield(p1, "Inverted Iceberg")
+        val trinketA = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val trinketB = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        driver.giveMana(p1, Color.BLUE, 6)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = iceberg,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinketA, trinketB))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaslemsStonetreeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/KaslemsStonetreeScenarioTest.kt
@@ -1,0 +1,213 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CardsSelectedResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.KaslemsStonetree
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Kaslem's Stonetree // Kaslem's Strider (LCI #197) — Craft transform DFC.
+ *
+ * Front ({2}{G} Artifact):
+ *   "When this artifact enters, look at the top six cards of your library. You may put a land
+ *    card from among them onto the battlefield tapped. Put the rest on the bottom in a random
+ *    order."
+ *   "Craft with Cave {5}{G}" — exactly one Cave you control or Cave card from your graveyard
+ *   (CR 702.167a-b).
+ *
+ * Back (Artifact Creature — Golem, 5/5): vanilla.
+ */
+class KaslemsStonetreeScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Mountain" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    // The craft is the front face's only activated ability.
+    fun craftAbilityId() = KaslemsStonetree.activatedAbilities.single().id
+
+    fun GameTestDriver.library(playerId: EntityId): List<EntityId> =
+        state.getZone(ZoneKey(playerId, Zone.LIBRARY))
+
+    fun GameTestDriver.battlefieldNames(playerId: EntityId): List<String> =
+        state.getZone(ZoneKey(playerId, Zone.BATTLEFIELD)).mapNotNull {
+            state.getEntity(it)?.get<CardComponent>()?.name
+        }
+
+    test("cast from hand: ETB looks at top six, puts a chosen land onto the battlefield tapped, rest on the bottom") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Seed a known top six: one Forest buried under five non-land cards.
+        // putCardOnTopOfLibrary prepends, so the LAST push ends up on top —
+        // top six = [bolt5..bolt1, Forest].
+        val forest = driver.putCardOnTopOfLibrary(p1, "Forest")
+        val bolts = (1..5).map { driver.putCardOnTopOfLibrary(p1, "Lightning Bolt") }
+
+        val stonetree = driver.putCardInHand(p1, "Kaslem's Stonetree")
+        driver.giveMana(p1, Color.GREEN, 3)
+        driver.castSpell(p1, stonetree)
+
+        driver.bothPass() // resolve the artifact spell -> enters -> ETB trigger on stack
+        driver.bothPass() // resolve the trigger -> pauses for the land selection
+
+        driver.isPaused shouldBe true
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        val select = driver.pendingDecision as SelectCardsDecision
+        select.options shouldContain forest
+
+        driver.submitDecision(p1, CardsSelectedResponse(decisionId = select.id, selectedCards = listOf(forest)))
+
+        // "Put the rest on the bottom in a random order" needs no player input.
+        driver.isPaused shouldBe false
+
+        // The Forest entered the battlefield tapped; the source is on the battlefield as its front face.
+        driver.battlefieldNames(p1) shouldContain "Forest"
+        driver.isTapped(forest) shouldBe true
+        driver.state.getEntity(stonetree)!!.get<CardComponent>()!!.name shouldBe "Kaslem's Stonetree"
+
+        // The five non-land cards went to the bottom of the library (top = index 0).
+        driver.library(p1).takeLast(5).shouldContainExactlyInAnyOrder(bolts)
+    }
+
+    test("craft with a Cave you control: Cave exiled, returns transformed as Kaslem's Strider 5/5") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val stonetree = driver.putPermanentOnBattlefield(p1, "Kaslem's Stonetree")
+        val cave = driver.putLandOnBattlefield(p1, "Captivating Cave")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.GREEN, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = stonetree,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(cave))
+            )
+        )
+        driver.bothPass() // resolve the craft ability
+
+        // The Cave material is exiled.
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain cave
+
+        // The source is back on the battlefield as its back face.
+        val container = driver.state.getEntity(stonetree)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Kaslem's Strider"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+        card.typeLine.subtypes shouldContain Subtype("Golem")
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // Vanilla 5/5.
+        val projected = projector.project(driver.state)
+        projected.getPower(stonetree) shouldBe 5
+        projected.getToughness(stonetree) shouldBe 5
+    }
+
+    test("craft with a Cave card from the graveyard (CR 702.167b)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val stonetree = driver.putPermanentOnBattlefield(p1, "Kaslem's Stonetree")
+        val cave = driver.putCardInGraveyard(p1, "Captivating Cave")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.GREEN, 6)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = stonetree,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(cave))
+            )
+        )
+        driver.bothPass()
+
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain cave
+        driver.state.getEntity(stonetree)!!.get<CardComponent>()!!.name shouldBe "Kaslem's Strider"
+        driver.state.getEntity(stonetree)!!.get<DoubleFacedComponent>()!!.currentFace shouldBe
+            DoubleFacedComponent.Face.BACK
+    }
+
+    test("rejects a non-Cave land as craft material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val stonetree = driver.putPermanentOnBattlefield(p1, "Kaslem's Stonetree")
+        val forest = driver.putLandOnBattlefield(p1, "Forest")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.GREEN, 6)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = stonetree,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(forest))
+            )
+        )
+        result.isSuccess shouldBe false
+
+        // Nothing moved: the Stonetree is still on the battlefield as its front face,
+        // the Forest is not exiled.
+        driver.state.getEntity(stonetree)!!.get<CardComponent>()!!.name shouldBe "Kaslem's Stonetree"
+        driver.battlefieldNames(p1) shouldContain "Forest"
+    }
+
+    test("rejects more than one Cave (craft with Cave is exactly one material)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val stonetree = driver.putPermanentOnBattlefield(p1, "Kaslem's Stonetree")
+        val cave1 = driver.putLandOnBattlefield(p1, "Captivating Cave")
+        val cave2 = driver.putLandOnBattlefield(p1, "Captivating Cave")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.GREEN, 6)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = stonetree,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(cave1, cave2))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LodestoneNeedleScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/LodestoneNeedleScenarioTest.kt
@@ -1,0 +1,234 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.handlers.continuations.entityIdToChosenTarget
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.LodestoneNeedle
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Lodestone Needle // Guidestone Compass (LCI #62).
+ *
+ * Front — Lodestone Needle ({1}{U}, Artifact):
+ *   Flash
+ *   When this artifact enters, tap up to one target artifact or creature and put
+ *   two stun counters on it.
+ *   Craft with artifact {2}{U} (exactly one artifact material; CR 702.167).
+ * Back — Guidestone Compass (Artifact):
+ *   {1}, {T}: Target creature you control explores. Activate only as a sorcery.
+ *
+ * Covers:
+ *  - Casting the front face fires the ETB trigger: the targeted opponent creature is
+ *    tapped and gets two stun counters.
+ *  - "Up to one target": declining the target resolves the trigger without effect.
+ *  - Craft end-to-end: mana paid, artifact material exiled, source returns transformed
+ *    as Guidestone Compass (back face); then the back-face ability makes a creature
+ *    you control explore — a revealed land goes to hand (CR 701.44a).
+ *  - Timing: the back-face explore ability is sorcery-only — rejected at upkeep.
+ *  - Negative: a non-artifact creature is rejected as craft material.
+ */
+class LodestoneNeedleScenarioTest : FunSpec({
+
+    // Simple artifact to use as craft material.
+    val testTrinket = CardDefinition.artifact(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        // LodestoneNeedle is a catalog card, already included in TestCards.all.
+        driver.registerCards(TestCards.all + listOf(testTrinket))
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true)
+        return driver
+    }
+
+    // The craft ability is the front face's only activated ability.
+    fun craftAbilityId() = LodestoneNeedle.activatedAbilities.single().id
+
+    // The explore ability is the back face's only activated ability.
+    fun exploreAbilityId() = LodestoneNeedle.backFace!!.activatedAbilities.single().id
+
+    fun stunCounters(driver: GameTestDriver, id: com.wingedsheep.sdk.model.EntityId): Int =
+        driver.state.getEntity(id)?.get<CountersComponent>()?.getCount(CounterType.STUN) ?: 0
+
+    test("casting Lodestone Needle taps the targeted creature and puts two stun counters on it") {
+        val driver = setup()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val victim = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        val needle = driver.putCardInHand(p1, "Lodestone Needle")
+        driver.giveMana(p1, Color.BLUE, 2)
+
+        driver.castSpell(p1, needle).isSuccess shouldBe true
+        driver.bothPass() // resolve the artifact spell; the ETB trigger asks for its target
+
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(p1, listOf(victim)).error shouldBe null
+        driver.bothPass() // resolve the ETB trigger
+
+        driver.assertPermanentExists(p1, "Lodestone Needle")
+        driver.isTapped(victim) shouldBe true
+        stunCounters(driver, victim) shouldBe 2
+    }
+
+    test("up to one target: declining the target resolves the trigger without effect") {
+        val driver = setup()
+        val p1 = driver.player1
+        val p2 = driver.player2
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val bystander = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        val needle = driver.putCardInHand(p1, "Lodestone Needle")
+        driver.giveMana(p1, Color.BLUE, 2)
+
+        driver.castSpell(p1, needle).isSuccess shouldBe true
+        driver.bothPass() // resolve the artifact spell; the ETB trigger asks for its target
+
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        // Choose no target ("up to one").
+        driver.submitTargetSelection(p1, emptyList()).error shouldBe null
+        driver.bothPass() // resolve the (targetless) trigger
+
+        driver.assertPermanentExists(p1, "Lodestone Needle")
+        driver.isTapped(bystander) shouldBe false
+        stunCounters(driver, bystander) shouldBe 0
+    }
+
+    test("craft exiles the artifact material, returns as Guidestone Compass, and its ability makes a creature explore") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val needle = driver.putPermanentOnBattlefield(p1, "Lodestone Needle")
+        val trinket = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val island = driver.putCardOnTopOfLibrary(p1, "Island")
+        driver.giveMana(p1, Color.BLUE, 4) // {2}{U} craft + {1} explore
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = needle,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        driver.bothPass() // resolve the craft ability
+
+        // Material exiled.
+        driver.state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain trinket
+
+        // Source returned to the battlefield as the back face.
+        val container = driver.state.getEntity(needle)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Guidestone Compass"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // {1}, {T}: Target creature you control explores — still in the precombat
+        // main phase with an empty stack, so sorcery timing is satisfied.
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = needle,
+                abilityId = exploreAbilityId(),
+                targets = listOf(entityIdToChosenTarget(driver.state, bears))
+            )
+        )
+        driver.isTapped(needle) shouldBe true // {T} was part of the cost
+        driver.bothPass() // resolve the explore
+
+        // The revealed land goes to the hand; no +1/+1 counter (CR 701.44a).
+        driver.getHand(p1) shouldContain island
+        (driver.state.getEntity(bears)?.get<CountersComponent>()
+            ?.getCount(CounterType.PLUS_ONE_PLUS_ONE) ?: 0) shouldBe 0
+    }
+
+    test("Guidestone Compass explore ability is rejected outside sorcery speed (upkeep)") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val needle = driver.putPermanentOnBattlefield(p1, "Lodestone Needle")
+        val trinket = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.giveMana(p1, Color.BLUE, 3)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = needle,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        driver.bothPass() // resolve the craft — Guidestone Compass on the battlefield
+        driver.state.getEntity(needle)!!.get<CardComponent>()!!.name shouldBe "Guidestone Compass"
+
+        // Advance to p1's own upkeep (turn 3): active player has priority, but it
+        // is not a main phase — instant speed only.
+        driver.passPriorityUntil(Step.UPKEEP)          // turn 2 upkeep (p2 active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)  // turn 2 main
+        driver.passPriorityUntil(Step.UPKEEP)          // turn 3 upkeep (p1 active)
+        driver.giveMana(p1, Color.BLUE, 1)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = needle,
+                abilityId = exploreAbilityId(),
+                targets = listOf(entityIdToChosenTarget(driver.state, bears))
+            )
+        )
+        result.isSuccess shouldBe false
+        result.error.shouldNotBeNull() shouldContain "sorcery"
+    }
+
+    test("rejects a non-artifact creature as craft material") {
+        val driver = setup()
+        val p1 = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val needle = driver.putPermanentOnBattlefield(p1, "Lodestone Needle")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.giveMana(p1, Color.BLUE, 3)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = needle,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bears))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MastersGuideMuralScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/MastersGuideMuralScenarioTest.kt
@@ -1,0 +1,233 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.TappedComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.MastersGuideMural
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Scenario tests for Master's Guide-Mural // Master's Manufactory (LCI #233).
+ *
+ * Covers:
+ *  - Front-face ETB (cast from hand): creates a 4/4 white and blue Golem artifact creature token.
+ *  - Craft with artifact {4}{W}{W}{U} (CR 702.167): exiles self + exactly one artifact material,
+ *    returns transformed as Master's Manufactory.
+ *  - Back-face {T} ability the SAME turn it was crafted: the craft return itself is an artifact
+ *    that entered the battlefield under your control this turn ("this artifact or another
+ *    artifact"), and a noncreature artifact's {T} ability is not restricted by summoning
+ *    sickness (CR 302.6 applies to creatures only).
+ *  - Activation restriction: on a later turn with no artifact having entered, activation is
+ *    rejected; after casting an artifact that turn, activation succeeds.
+ *  - Negative: a non-artifact (creature) craft material is rejected.
+ */
+class MastersGuideMuralScenarioTest : FunSpec({
+
+    // A cheap plain artifact — craft material / entered-this-turn enabler.
+    val testTrinket = card("Test Trinket") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+
+    // A non-artifact creature — illegal craft material.
+    val testBear = CardDefinition.creature(
+        name = "Test Bear",
+        manaCost = ManaCost.parse("{1}{G}"),
+        subtypes = setOf(Subtype("Bear")),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(testTrinket, testBear))
+        driver.initMirrorMatch(
+            deck = Deck.of("Plains" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    // The front face's only activated ability is the Craft.
+    fun craftAbilityId() = MastersGuideMural.activatedAbilities.single().id
+
+    // The back face's only activated ability is the {T} token maker.
+    fun manufactoryAbilityId() = MastersGuideMural.backFace!!.activatedAbilities.single().id
+
+    fun GameTestDriver.golemsOf(playerId: EntityId): List<EntityId> =
+        state.getBattlefield().filter { id ->
+            // CreateTokenExecutor names tokens "<creature types> Token" by default.
+            state.getEntity(id)?.get<CardComponent>()?.name == "Golem Token" && getController(id) == playerId
+        }
+
+    /** Craft the Mural with a Test Trinket material during p1's precombat main; returns the entity id. */
+    fun GameTestDriver.craftMural(p1: EntityId): EntityId {
+        val mural = putPermanentOnBattlefield(p1, "Master's Guide-Mural")
+        val trinket = putPermanentOnBattlefield(p1, "Test Trinket")
+        passPriorityUntil(Step.PRECOMBAT_MAIN)
+        giveMana(p1, Color.WHITE, 2)
+        giveMana(p1, Color.BLUE, 1)
+        giveColorlessMana(p1, 4)
+        val result = submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = mural,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trinket))
+            )
+        )
+        withClue("Craft activation should succeed") { result.error shouldBe null }
+        bothPass() // resolve the craft ability
+        // Material exiled + returned transformed.
+        state.getZone(ZoneKey(p1, Zone.EXILE)) shouldContain trinket
+        state.getEntity(mural)!!.get<CardComponent>()!!.name shouldBe "Master's Manufactory"
+        return mural
+    }
+
+    test("cast from hand: ETB trigger creates one 4/4 white and blue Golem artifact creature token") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val mural = driver.putCardInHand(p1, "Master's Guide-Mural")
+        driver.giveMana(p1, Color.WHITE, 1)
+        driver.giveMana(p1, Color.BLUE, 1)
+        driver.giveColorlessMana(p1, 3)
+
+        val cast = driver.castSpell(p1, mural)
+        withClue("Casting Master's Guide-Mural should succeed") { cast.error shouldBe null }
+        driver.bothPass() // resolve the artifact spell
+        driver.bothPass() // resolve the ETB trigger
+
+        val golems = driver.golemsOf(p1)
+        golems.size shouldBe 1
+        val golem = golems.single()
+
+        val golemCard = driver.state.getEntity(golem)?.get<CardComponent>()
+        golemCard.shouldNotBeNull()
+        golemCard.colors shouldBe setOf(Color.WHITE, Color.BLUE)
+        golemCard.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+        golemCard.typeLine.subtypes shouldContain Subtype("Golem")
+
+        val projected = projector.project(driver.state)
+        projected.getPower(golem) shouldBe 4
+        projected.getToughness(golem) shouldBe 4
+    }
+
+    test("craft with artifact: exiles the material, returns transformed, and the {T} ability works the same turn") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val mural = driver.craftMural(p1)
+
+        // Back face on the battlefield: Master's Manufactory, a noncreature Artifact.
+        val container = driver.state.getEntity(mural)
+        container.shouldNotBeNull()
+        container.get<CardComponent>()!!.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // The Manufactory itself entered the battlefield under p1's control this turn (via the
+        // craft return), satisfying "this artifact or another artifact entered ...". As a
+        // noncreature artifact it has no summoning-sickness restriction on {T} (CR 302.6), so
+        // the ability is activatable immediately.
+        val activate = driver.submit(
+            ActivateAbility(playerId = p1, sourceId = mural, abilityId = manufactoryAbilityId())
+        )
+        withClue("Same-turn activation should succeed") { activate.error shouldBe null }
+        driver.bothPass() // resolve the token ability
+
+        driver.state.getEntity(mural)?.has<TappedComponent>() shouldBe true
+        val golems = driver.golemsOf(p1)
+        golems.size shouldBe 1
+        val projected = projector.project(driver.state)
+        projected.getPower(golems.single()) shouldBe 4
+        projected.getToughness(golems.single()) shouldBe 4
+    }
+
+    test("activation restriction: rejected on a later turn with no artifact entered; allowed after one enters") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val mural = driver.craftMural(p1)
+
+        // Advance whole turns until it is p1's turn again — the entered-this-turn tracker is
+        // cleared at each cleanup, and no artifact enters in between.
+        do {
+            driver.passPriorityUntil(Step.END)
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        } while (driver.activePlayer != p1)
+
+        val rejected = driver.submit(
+            ActivateAbility(playerId = p1, sourceId = mural, abilityId = manufactoryAbilityId())
+        )
+        withClue("No artifact entered this turn — activation must be rejected") {
+            rejected.isSuccess shouldBe false
+        }
+        driver.golemsOf(p1).size shouldBe 0
+
+        // Cast an artifact this turn (casting routes through the real entry pipeline, which
+        // records the per-turn "artifact entered under your control" tracker).
+        val trinket = driver.putCardInHand(p1, "Test Trinket")
+        driver.giveColorlessMana(p1, 1)
+        val cast = driver.castSpell(p1, trinket)
+        withClue("Casting Test Trinket should succeed") { cast.error shouldBe null }
+        driver.bothPass() // resolve the trinket
+
+        val allowed = driver.submit(
+            ActivateAbility(playerId = p1, sourceId = mural, abilityId = manufactoryAbilityId())
+        )
+        withClue("An artifact entered this turn — activation should now succeed") {
+            allowed.error shouldBe null
+        }
+        driver.bothPass() // resolve the token ability
+        driver.golemsOf(p1).size shouldBe 1
+    }
+
+    test("craft rejects a non-artifact (creature) material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val mural = driver.putPermanentOnBattlefield(p1, "Master's Guide-Mural")
+        val bear = driver.putCreatureOnBattlefield(p1, "Test Bear")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.WHITE, 2)
+        driver.giveMana(p1, Color.BLUE, 1)
+        driver.giveColorlessMana(p1, 4)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = mural,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bear))
+            )
+        )
+        result.isSuccess shouldBe false
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OteclanLandmarkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/OteclanLandmarkScenarioTest.kt
@@ -1,0 +1,239 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.OteclanLandmark
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain as stringShouldContain
+
+/**
+ * Scenario tests for Oteclan Landmark // Oteclan Levitator (LCI #29).
+ *
+ * Front face — Oteclan Landmark ({W}, Artifact):
+ *   "When this artifact enters, scry 2."
+ *   "Craft with artifact {2}{W}" — exactly one artifact material (CR 702.167).
+ *
+ * Back face — Oteclan Levitator (Artifact Creature — Golem, 1/4):
+ *   Flying. "Whenever this creature attacks, target attacking creature without flying
+ *   gains flying until end of turn."
+ */
+class OteclanLandmarkScenarioTest : FunSpec({
+
+    // Test-local cards: a vanilla artifact as craft material, and a ground creature
+    // both as an illegal (non-artifact) craft material and as the attack-trigger target.
+    val testRelic = CardDefinition.artifact(
+        name = "Test Relic",
+        manaCost = ManaCost.parse("{1}"),
+        oracleText = ""
+    )
+    val groundTrooper = CardDefinition.creature(
+        name = "Test Ground Trooper",
+        manaCost = ManaCost.parse("{1}{W}"),
+        subtypes = setOf(Subtype("Soldier")),
+        power = 2,
+        toughness = 2,
+        oracleText = ""
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(OteclanLandmark, testRelic, groundTrooper))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        return driver
+    }
+
+    // The craft is the front face's only activated ability.
+    fun craftAbilityId() = OteclanLandmark.activatedAbilities.single().id
+
+    fun cardName(driver: GameTestDriver, id: EntityId): String? =
+        driver.state.getEntity(id)?.get<CardComponent>()?.name
+
+    // Craft Oteclan Landmark with a Test Relic material; returns (landmarkId, relicId).
+    // Leaves the game in the crafting player's precombat main with an empty stack.
+    fun craftLandmark(driver: GameTestDriver, player: EntityId): Pair<EntityId, EntityId> {
+        val landmark = driver.putPermanentOnBattlefield(player, "Oteclan Landmark")
+        val relic = driver.putPermanentOnBattlefield(player, "Test Relic")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(player, Color.WHITE, 3)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = player,
+                sourceId = landmark,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(relic))
+            )
+        )
+        driver.bothPass() // resolve the craft ability
+        return landmark to relic
+    }
+
+    test("front face: casting Oteclan Landmark fires the ETB trigger and scries 2") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Known cards on top of the library (prepended: Forest on top, Mountain second).
+        driver.putCardOnTopOfLibrary(p1, "Mountain")
+        driver.putCardOnTopOfLibrary(p1, "Forest")
+
+        val landmark = driver.putCardInHand(p1, "Oteclan Landmark")
+        driver.giveMana(p1, Color.WHITE, 1)
+        driver.castSpell(p1, landmark).isSuccess shouldBe true
+
+        driver.bothPass() // resolve the spell — the Landmark enters, ETB trigger queued
+        driver.bothPass() // resolve the ETB trigger — pauses for the scry decision
+
+        // Scry 2 presents a card selection over the top two library cards.
+        val decision = driver.pendingDecision as SelectCardsDecision
+        decision.playerId shouldBe p1
+        decision.options.size shouldBe 2
+
+        // Put both looked-at cards on the bottom.
+        driver.submitCardSelection(p1, decision.options)
+        while (driver.pendingDecision != null) driver.autoResolveDecision()
+
+        // A Plains surfaces on top; Forest and Mountain are now the bottom two cards.
+        val library = driver.state.getLibrary(p1)
+        cardName(driver, library.first()) shouldBe "Plains"
+        library.takeLast(2).map { cardName(driver, it) }.toSet() shouldBe setOf("Forest", "Mountain")
+
+        // The Landmark itself resolved onto the battlefield as its front face.
+        val entity = driver.state.getEntity(landmark)
+        entity.shouldNotBeNull()
+        entity.get<CardComponent>()!!.name shouldBe "Oteclan Landmark"
+        entity.get<DoubleFacedComponent>()!!.currentFace shouldBe DoubleFacedComponent.Face.FRONT
+    }
+
+    test("craft with artifact exiles the material and returns transformed as Oteclan Levitator (1/4 flier)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val (landmark, relic) = craftLandmark(driver, p1)
+
+        // Material is in exile.
+        driver.getExile(p1) shouldContain relic
+
+        // Source returned to the battlefield as the back face.
+        val entity = driver.state.getEntity(landmark)
+        entity.shouldNotBeNull()
+        val card = entity.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Oteclan Levitator"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT, CardType.CREATURE)
+        card.typeLine.subtypes shouldContain Subtype("Golem")
+        entity.get<DoubleFacedComponent>()!!.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // Back-face characteristics: 1/4 with flying.
+        val projected = projector.project(driver.state)
+        projected.getPower(landmark) shouldBe 1
+        projected.getToughness(landmark) shouldBe 4
+        projected.hasKeyword(landmark, Keyword.FLYING) shouldBe true
+    }
+
+    test("back face: attack trigger grants flying to a target attacking creature without flying") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        // Two ground attackers so the trigger has more than one legal target (a single legal
+        // choice could be auto-selected without surfacing the decision).
+        val trooper = driver.putCreatureOnBattlefield(p1, "Test Ground Trooper")
+        val trooper2 = driver.putCreatureOnBattlefield(p1, "Test Ground Trooper")
+        val (landmark, _) = craftLandmark(driver, p1)
+
+        // All entered this turn — clear summoning sickness so they can attack.
+        driver.removeSummoningSickness(landmark)
+        driver.removeSummoningSickness(trooper)
+        driver.removeSummoningSickness(trooper2)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val attackResult = driver.declareAttackers(p1, listOf(landmark, trooper, trooper2), p2)
+        attackResult.error shouldBe null
+
+        // The Levitator's attack trigger asks for a target: only the non-flying attackers are
+        // legal — the Levitator itself has flying and can't be chosen.
+        val decision = driver.pendingDecision as ChooseTargetsDecision
+        decision.legalTargets[0]!! shouldContain trooper
+        decision.legalTargets[0]!! shouldContain trooper2
+        decision.legalTargets[0]!! shouldNotContain landmark
+        driver.submitTargetSelection(p1, listOf(trooper))
+
+        driver.bothPass() // resolve the attack trigger
+
+        val projected = projector.project(driver.state)
+        projected.hasKeyword(trooper, Keyword.FLYING) shouldBe true
+        projected.hasKeyword(trooper2, Keyword.FLYING) shouldBe false
+    }
+
+    test("craft rejects two materials — exactly one artifact (maxCount = 1)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val landmark = driver.putPermanentOnBattlefield(p1, "Oteclan Landmark")
+        val relic1 = driver.putPermanentOnBattlefield(p1, "Test Relic")
+        val relic2 = driver.putPermanentOnBattlefield(p1, "Test Relic")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.WHITE, 3)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = landmark,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(relic1, relic2))
+            )
+        )
+        result.isSuccess shouldBe false
+        result.error.shouldNotBeNull() stringShouldContain "at most"
+
+        // Nothing was exiled; the Landmark is still its front face on the battlefield.
+        driver.getExile(p1).size shouldBe 0
+        driver.state.getEntity(landmark)!!.get<CardComponent>()!!.name shouldBe "Oteclan Landmark"
+    }
+
+    test("craft rejects a non-artifact creature as material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val landmark = driver.putPermanentOnBattlefield(p1, "Oteclan Landmark")
+        val trooper = driver.putCreatureOnBattlefield(p1, "Test Ground Trooper")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.WHITE, 3)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = landmark,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(trooper))
+            )
+        )
+        result.isSuccess shouldBe false
+
+        // The creature stays on the battlefield; nothing transformed.
+        driver.findPermanent(p1, "Test Ground Trooper").shouldNotBeNull()
+        driver.state.getEntity(landmark)!!.get<CardComponent>()!!.name shouldBe "Oteclan Landmark"
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpringLoadedSawbladesScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SpringLoadedSawbladesScenarioTest.kt
@@ -1,0 +1,268 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SpringLoadedSawblades
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Spring-Loaded Sawblades // Bladewheel Chariot (LCI #36) — Craft transform DFC (CR 702.167).
+ *
+ * Front — {1}{W} Artifact:
+ *  - Flash; ETB "it deals 5 damage to target tapped creature an opponent controls".
+ *  - Craft with artifact {3}{W} (exactly one artifact material).
+ * Back — Bladewheel Chariot, Artifact — Vehicle 5/5:
+ *  - "Tap two other untapped artifacts you control: This Vehicle becomes an artifact creature
+ *     until end of turn." (excludeSelf tap cost)
+ *  - Crew 1.
+ *
+ * Covers: (1) instant-speed cast (flash) + targeted ETB damage killing a tapped opposing
+ * creature, with the negative that an untapped creature is not a legal target; (2) craft
+ * end-to-end — material exiled, source returns transformed as a non-creature Vehicle;
+ * (3) the tap-two-artifacts self-animate — both artifacts tapped, Chariot becomes a 5/5
+ * artifact creature (projected), and the Chariot itself can't be counted among the two
+ * (excludeSelf); (4) Crew 1 also animates it; (5) craft refuses a creature (non-artifact)
+ * material.
+ */
+class SpringLoadedSawbladesScenarioTest : FunSpec({
+
+    // Opponent's 3/3 victim — 5 ETB damage is lethal.
+    val testOx = CardDefinition.creature(
+        name = "Sawblades Test Ox",
+        manaCost = ManaCost.parse("{2}"),
+        subtypes = setOf(Subtype("Ox")),
+        power = 3,
+        toughness = 3,
+    )
+
+    // Plain artifact: craft material / tap-cost fodder.
+    val testRelic = card("Sawblades Test Relic") {
+        manaCost = "{1}"
+        typeLine = "Artifact"
+        oracleText = ""
+    }
+
+    val projector = StateProjector()
+
+    // Front face's only activated ability is the Craft; the ETB strike is a triggered ability.
+    val craftAbilityId = SpringLoadedSawblades.activatedAbilities.single().id
+
+    // Back face's only activated ability is the tap-two-artifacts self-animate.
+    val chariotAnimateAbilityId = SpringLoadedSawblades.backFace!!.activatedAbilities.single().id
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(testOx, testRelic))
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 40), skipMulligans = true)
+        return driver
+    }
+
+    fun GameTestDriver.drainStack() {
+        var guard = 0
+        while (state.stack.isNotEmpty() && guard++ < 20) bothPass()
+    }
+
+    /**
+     * Craft the Sawblades on [player]'s battlefield into Bladewheel Chariot, exiling a test
+     * relic as the single artifact material. Assumes a main phase with an empty stack.
+     * Returns the entity id (now the Chariot).
+     */
+    fun craftChariot(driver: GameTestDriver, player: EntityId): EntityId {
+        val sawblades = driver.putPermanentOnBattlefield(player, "Spring-Loaded Sawblades")
+        val material = driver.putPermanentOnBattlefield(player, "Sawblades Test Relic")
+        driver.giveMana(player, Color.WHITE, 4) // {3}{W}
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = player,
+                sourceId = sawblades,
+                abilityId = craftAbilityId,
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material))
+            )
+        )
+        driver.bothPass() // resolve the craft ability
+        return sawblades
+    }
+
+    test("flash: cast at instant speed; ETB deals 5 damage to target tapped opposing creature; untapped creature is not a legal target") {
+        val driver = setup()
+        val active = driver.activePlayer!!
+        val opponent = driver.getOpponent(active)
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val tappedOx = driver.putCreatureOnBattlefield(opponent, "Sawblades Test Ox")
+        driver.tapPermanent(tappedOx)
+        val untappedOx = driver.putCreatureOnBattlefield(opponent, "Sawblades Test Ox")
+
+        val sawblades = driver.putCardInHand(active, "Spring-Loaded Sawblades")
+
+        // End step of the active player's own turn: not a main phase, so only an
+        // instant-speed cast is legal — flash is what makes this succeed. Mana is
+        // given after the step change (pools empty at step boundaries, CR 500.4).
+        driver.passPriorityUntil(Step.END)
+        driver.giveMana(active, Color.WHITE, 2) // {1}{W}
+        val castResult = driver.castSpell(active, sawblades, emptyList())
+        castResult.error shouldBe null
+
+        // Resolve the artifact; its ETB trigger asks for a target when it goes on the stack.
+        var guard = 0
+        while (driver.pendingDecision == null && guard++ < 20) driver.bothPass()
+        driver.pendingDecision.shouldNotBeNull()
+
+        // Negative: the UNTAPPED creature is not a legal target for the trigger.
+        driver.submitTargetSelection(active, listOf(untappedOx)).isSuccess shouldBe false
+
+        // The tapped creature is legal; 5 damage kills the 3/3.
+        driver.submitTargetSelection(active, listOf(tappedOx)).isSuccess shouldBe true
+        driver.drainStack()
+
+        // 5 damage kills the tapped 3/3.
+        (tappedOx in driver.state.getBattlefield()) shouldBe false
+        // The untapped bystander is untouched.
+        (untappedOx in driver.state.getBattlefield()) shouldBe true
+
+        // The Sawblades itself is on the battlefield as its front face.
+        val card = driver.state.getEntity(sawblades)!!.get<CardComponent>()!!
+        card.name shouldBe "Spring-Loaded Sawblades"
+    }
+
+    test("craft with artifact {3}{W}: exiles the material and returns transformed as Bladewheel Chariot, a non-creature Vehicle") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sawblades = driver.putPermanentOnBattlefield(p1, "Spring-Loaded Sawblades")
+        val material = driver.putPermanentOnBattlefield(p1, "Sawblades Test Relic")
+        driver.giveMana(p1, Color.WHITE, 4)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = sawblades,
+                abilityId = craftAbilityId,
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material))
+            )
+        )
+        driver.bothPass()
+
+        // Material exiled.
+        (material in driver.state.getZone(com.wingedsheep.engine.state.ZoneKey(p1, Zone.EXILE))) shouldBe true
+
+        // Source returned to the battlefield as the back face.
+        val container = driver.state.getEntity(sawblades)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Bladewheel Chariot"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+        (Subtype.VEHICLE in card.typeLine.subtypes) shouldBe true
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // A Vehicle is not a creature until crewed/animated.
+        val projected = projector.project(driver.state)
+        projected.isCreature(sawblades) shouldBe false
+    }
+
+    test("tap two other untapped artifacts: both tapped, Chariot becomes a 5/5 artifact creature; the Chariot can't count itself") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val chariot = craftChariot(driver, p1)
+        val relicA = driver.putPermanentOnBattlefield(p1, "Sawblades Test Relic")
+        val relicB = driver.putPermanentOnBattlefield(p1, "Sawblades Test Relic")
+
+        // excludeSelf: the Chariot (itself an untapped artifact) is not a legal tap choice.
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = chariot,
+                abilityId = chariotAnimateAbilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(chariot, relicA))
+            )
+        ).isSuccess shouldBe false
+
+        // Two OTHER untapped artifacts pay the cost.
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = chariot,
+                abilityId = chariotAnimateAbilityId,
+                costPayment = AdditionalCostPayment(tappedPermanents = listOf(relicA, relicB))
+            )
+        )
+        driver.isTapped(relicA) shouldBe true
+        driver.isTapped(relicB) shouldBe true
+
+        driver.bothPass() // resolve the animate
+
+        val projected = projector.project(driver.state)
+        projected.isCreature(chariot) shouldBe true
+        projected.hasType(chariot, "ARTIFACT") shouldBe true
+        projected.hasSubtype(chariot, "Vehicle") shouldBe true
+        projected.getPower(chariot) shouldBe 5
+        projected.getToughness(chariot) shouldBe 5
+    }
+
+    test("crew 1 animates Bladewheel Chariot") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val chariot = craftChariot(driver, p1)
+        val bear = driver.putCreatureOnBattlefield(p1, "Grizzly Bears") // power 2 >= crew 1
+
+        driver.submitSuccess(CrewVehicle(p1, chariot, listOf(bear)))
+        driver.isTapped(bear) shouldBe true
+        driver.bothPass() // resolve the crew animate
+
+        val projected = projector.project(driver.state)
+        projected.isCreature(chariot) shouldBe true
+        projected.getPower(chariot) shouldBe 5
+        projected.getToughness(chariot) shouldBe 5
+    }
+
+    test("craft rejects a creature (non-artifact) material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        val sawblades = driver.putPermanentOnBattlefield(p1, "Spring-Loaded Sawblades")
+        val bear = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.giveMana(p1, Color.WHITE, 4)
+
+        val result = driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = sawblades,
+                abilityId = craftAbilityId,
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bear))
+            )
+        )
+        result.isSuccess shouldBe false
+
+        // Still the front face on the battlefield; the bear is untouched.
+        driver.state.getEntity(sawblades)!!.get<CardComponent>()!!.name shouldBe "Spring-Loaded Sawblades"
+        (bear in driver.state.getBattlefield()) shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TithingBladeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TithingBladeScenarioTest.kt
@@ -1,0 +1,244 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.TithingBlade
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.ManaCost
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.CardDefinition
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Scenario tests for Tithing Blade // Consuming Sepulcher (LCI #128).
+ *
+ * Front face — Tithing Blade ({1}{B}, Artifact):
+ *   "When this artifact enters, each opponent sacrifices a creature of their choice.
+ *    Craft with creature {4}{B}"
+ * Back face — Consuming Sepulcher (Artifact):
+ *   "At the beginning of your upkeep, each opponent loses 1 life and you gain 1 life."
+ *
+ * Covers:
+ *  - ETB edict: the sacrifice is the OPPONENT's choice — the engine pauses with a
+ *    [SelectCardsDecision] for the opponent, whose options are only their own creatures.
+ *  - Craft (CR 702.167): exactly one creature material, from the battlefield or from the
+ *    graveyard, is exiled and the card returns transformed as Consuming Sepulcher — an
+ *    Artifact that is NOT a creature.
+ *  - Back-face drain: at the beginning of the controller's upkeep (and only theirs), each
+ *    opponent loses 1 life and the controller gains 1.
+ *  - Negative: a non-creature artifact is rejected as craft material; two materials exceed
+ *    the exact-one count.
+ */
+class TithingBladeScenarioTest : FunSpec({
+
+    // Local non-creature artifact — illegal craft material for "Craft with creature".
+    val trinket = CardDefinition.artifact(
+        name = "Test Trinket",
+        manaCost = ManaCost.parse("{1}")
+    )
+
+    val projector = StateProjector()
+
+    fun setup(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all + listOf(trinket))
+        driver.initMirrorMatch(
+            deck = Deck.of("Swamp" to 40),
+            skipMulligans = true
+        )
+        return driver
+    }
+
+    // The craft is the front face's only activated ability.
+    fun craftAbilityId() = TithingBlade.activatedAbilities.single().id
+
+    /** Pass priority until a pending decision appears (a resolving effect pauses there). */
+    fun GameTestDriver.passUntilDecision(maxPasses: Int = 10) {
+        repeat(maxPasses) { if (pendingDecision == null) bothPass() }
+    }
+
+    test("ETB: each opponent sacrifices a creature of their own choice") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        // Opponent has two creatures -> a real choice; controller's own creature must be spared.
+        val oppBears = driver.putCreatureOnBattlefield(p2, "Grizzly Bears")
+        val oppGiant = driver.putCreatureOnBattlefield(p2, "Hill Giant")
+        val myBears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val blade = driver.putCardInHand(p1, "Tithing Blade")
+        driver.giveMana(p1, Color.BLACK, 2)
+        driver.castSpell(p1, blade).isSuccess shouldBe true
+
+        // Resolve the spell, then its ETB trigger — which pauses on the opponent's choice.
+        driver.passUntilDecision()
+
+        val decision = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        decision.playerId shouldBe p2
+        decision.options.shouldContainExactlyInAnyOrder(listOf(oppBears, oppGiant))
+
+        // The opponent picks the Hill Giant.
+        driver.submitCardSelection(p2, listOf(oppGiant))
+
+        driver.getGraveyard(p2).shouldContain(oppGiant)
+        driver.findPermanent(p2, "Hill Giant") shouldBe null
+        driver.findPermanent(p2, "Grizzly Bears") shouldBe oppBears
+        driver.findPermanent(p1, "Grizzly Bears") shouldBe myBears
+        driver.findPermanent(p1, "Tithing Blade") shouldBe blade
+    }
+
+    test("craft with a battlefield creature: material exiled, returns as Consuming Sepulcher (not a creature)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(p1, "Tithing Blade")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.BLACK, 5)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bears))
+            )
+        )
+        driver.bothPass()
+
+        // Material exiled.
+        driver.getExile(p1).shouldContain(bears)
+
+        // Source returned to the battlefield as its back face.
+        val container = driver.state.getEntity(blade)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Consuming Sepulcher"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        // Consuming Sepulcher is an Artifact — NOT a creature — in the projection too.
+        projector.project(driver.state).isCreature(blade) shouldBe false
+    }
+
+    test("craft with a creature card from the graveyard works as material (CR 702.167b)") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(p1, "Tithing Blade")
+        val deadBears = driver.putCardInGraveyard(p1, "Grizzly Bears")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.BLACK, 5)
+
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(deadBears))
+            )
+        )
+        driver.bothPass()
+
+        driver.getExile(p1).shouldContain(deadBears)
+        driver.getGraveyard(p1).contains(deadBears) shouldBe false
+        driver.state.getEntity(blade)!!.get<CardComponent>()!!.name shouldBe "Consuming Sepulcher"
+    }
+
+    test("back face: at the beginning of your upkeep each opponent loses 1 life and you gain 1 — and only on YOUR upkeep") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val p2 = driver.getOpponent(p1)
+
+        val blade = driver.putPermanentOnBattlefield(p1, "Tithing Blade")
+        val bears = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.BLACK, 5)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bears))
+            )
+        )
+        driver.bothPass()
+        driver.state.getEntity(blade)!!.get<CardComponent>()!!.name shouldBe "Consuming Sepulcher"
+
+        driver.getLifeTotal(p1) shouldBe 20
+        driver.getLifeTotal(p2) shouldBe 20
+
+        // Opponent's upkeep — "your upkeep" means the controller's, so no trigger fires.
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldBe p2
+        driver.stackSize shouldBe 0
+        driver.getLifeTotal(p1) shouldBe 20
+        driver.getLifeTotal(p2) shouldBe 20
+
+        // Cross the opponent's turn to our next upkeep — the drain trigger is on the stack.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.passPriorityUntil(Step.UPKEEP)
+        driver.activePlayer shouldBe p1
+        driver.stackSize shouldBe 1
+        driver.bothPass()
+
+        driver.getLifeTotal(p1) shouldBe 21
+        driver.getLifeTotal(p2) shouldBe 19
+    }
+
+    test("craft rejects a non-creature artifact material and rejects more than one material") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+
+        val blade = driver.putPermanentOnBattlefield(p1, "Tithing Blade")
+        val badMaterial = driver.putPermanentOnBattlefield(p1, "Test Trinket")
+        val bearsA = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val bearsB = driver.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        driver.giveMana(p1, Color.BLACK, 5)
+
+        // Non-creature artifact is not a legal "Craft with creature" material.
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(badMaterial))
+            )
+        ).isSuccess shouldBe false
+
+        // "Craft with creature" is exactly one material — two creatures must be rejected.
+        driver.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = blade,
+                abilityId = craftAbilityId(),
+                costPayment = AdditionalCostPayment(exiledCards = listOf(bearsA, bearsB))
+            )
+        ).isSuccess shouldBe false
+
+        // Nothing moved: the blade is still the front face on the battlefield, nothing exiled.
+        driver.findPermanent(p1, "Tithing Blade") shouldBe blade
+        driver.findPermanent(p1, "Test Trinket") shouldBe badMaterial
+        driver.getExile(p1).isEmpty() shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WaterloggedHulkScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/WaterloggedHulkScenarioTest.kt
@@ -1,0 +1,253 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.CrewVehicle
+import com.wingedsheep.engine.mechanics.layers.StateProjector
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.state.components.identity.DoubleFacedComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.WaterloggedHulk
+import com.wingedsheep.sdk.core.CardType
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import com.wingedsheep.sdk.scripting.AbilityCost
+import com.wingedsheep.sdk.scripting.AdditionalCostPayment
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Waterlogged Hulk // Watertight Gondola — {U} Artifact // Artifact — Vehicle 4/4 (LCI #83).
+ *
+ * Front face:
+ *  - {T}: Mill a card.
+ *  - Craft with Island {3}{U} (exactly one Island you control or Island card in your
+ *    graveyard, CR 702.167a-b; sorcery-only).
+ *
+ * Back face — Watertight Gondola:
+ *  - Vigilance, Crew 1.
+ *  - Descend 8 — can't be blocked as long as there are eight or more permanent cards
+ *    in your graveyard (ConditionalStaticAbility gate on CantBeBlocked).
+ */
+class WaterloggedHulkScenarioTest : FunSpec({
+
+    val projector = StateProjector()
+
+    val millAbilityId = WaterloggedHulk.activatedAbilities.single { it.cost == AbilityCost.Tap }.id
+    val craftAbilityId = WaterloggedHulk.activatedAbilities.single { it.cost != AbilityCost.Tap }.id
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(deck = Deck.of("Island" to 40), skipMulligans = true, startingPlayer = 0)
+        return driver
+    }
+
+    /** Crafts the hulk using [material], resolving the ability; returns the (transformed) entity. */
+    fun craftGondola(driver: GameTestDriver, me: EntityId, hulk: EntityId, material: EntityId) {
+        driver.giveMana(me, Color.BLUE, 4)
+        driver.submitSuccess(
+            ActivateAbility(
+                playerId = me,
+                sourceId = hulk,
+                abilityId = craftAbilityId,
+                costPayment = AdditionalCostPayment(exiledCards = listOf(material))
+            )
+        )
+        driver.bothPass()
+    }
+
+    // -------------------------------------------------------------------------
+    // Front face — {T}: Mill a card
+    // -------------------------------------------------------------------------
+
+    test("front face: {T}: Mill a card puts the top card of your library into your graveyard") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val hulk = driver.putPermanentOnBattlefield(me, "Waterlogged Hulk")
+        // A recognizable top card so we know exactly what got milled.
+        driver.putCardOnTopOfLibrary(me, "Grizzly Bears")
+
+        driver.submitSuccess(ActivateAbility(playerId = me, sourceId = hulk, abilityId = millAbilityId))
+        driver.bothPass()
+
+        withClue("tap cost paid") {
+            driver.isTapped(hulk) shouldBe true
+        }
+        withClue("the top card was milled into the graveyard") {
+            driver.getGraveyardCardNames(me) shouldBe listOf("Grizzly Bears")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Craft with Island {3}{U}
+    // -------------------------------------------------------------------------
+
+    test("craft with an Island you control exiles it and returns the source transformed as Watertight Gondola (not a creature until crewed)") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val hulk = driver.putPermanentOnBattlefield(me, "Waterlogged Hulk")
+        val island = driver.putPermanentOnBattlefield(me, "Island")
+
+        craftGondola(driver, me, hulk, island)
+
+        withClue("the Island material was exiled") {
+            driver.state.getZone(ZoneKey(me, Zone.EXILE)) shouldContain island
+        }
+
+        val container = driver.state.getEntity(hulk)
+        container.shouldNotBeNull()
+        val card = container.get<CardComponent>()
+        card.shouldNotBeNull()
+        card.name shouldBe "Watertight Gondola"
+        card.typeLine.cardTypes shouldBe setOf(CardType.ARTIFACT)
+        (Subtype.VEHICLE in card.typeLine.subtypes) shouldBe true
+
+        val dfc = container.get<DoubleFacedComponent>()
+        dfc.shouldNotBeNull()
+        dfc.currentFace shouldBe DoubleFacedComponent.Face.BACK
+
+        withClue("an uncrewed Vehicle is not a creature") {
+            projector.project(driver.state).isCreature(hulk) shouldBe false
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Back face — Crew 1, vigilance, Descend 8 unblockable
+    // -------------------------------------------------------------------------
+
+    test("crew 1 makes it a 4/4 artifact creature with vigilance; with eight or more permanent cards in the graveyard it can't be blocked") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opponent = driver.getOpponent(me)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val hulk = driver.putPermanentOnBattlefield(me, "Waterlogged Hulk")
+        // Nine Island cards in the graveyard; crafting exiles one from there (a graveyard
+        // Island is a legal material, CR 702.167b), leaving exactly eight permanent cards
+        // — the Descend 8 threshold.
+        repeat(9) { driver.putCardInGraveyard(me, "Island") }
+        val graveyardIsland = driver.getGraveyard(me).first()
+
+        craftGondola(driver, me, hulk, graveyardIsland)
+        driver.getGraveyard(me).size shouldBe 8
+
+        driver.removeSummoningSickness(hulk)
+        val crewer = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        driver.submitSuccess(CrewVehicle(me, hulk, listOf(crewer)))
+        driver.bothPass() // the crew animate goes on the stack — resolve it
+
+        val projected = projector.project(driver.state)
+        withClue("crewed Vehicle is a 4/4 artifact creature with vigilance") {
+            projected.isCreature(hulk) shouldBe true
+            projected.getPower(hulk) shouldBe 4
+            projected.getToughness(hulk) shouldBe 4
+            projected.hasKeyword(hulk, Keyword.VIGILANCE) shouldBe true
+        }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(hulk), opponent).error shouldBe null
+        withClue("vigilance: attacking doesn't tap it") {
+            driver.isTapped(hulk) shouldBe false
+        }
+
+        driver.bothPass()
+        withClue("Descend 8 met (8 permanent cards) → can't be blocked") {
+            driver.declareBlockers(opponent, mapOf(blocker to listOf(hulk))).error shouldNotBe null
+        }
+    }
+
+    test("with fewer than eight permanent cards in the graveyard it can be blocked") {
+        val driver = createDriver()
+        val me = driver.player1
+        val opponent = driver.getOpponent(me)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val hulk = driver.putPermanentOnBattlefield(me, "Waterlogged Hulk")
+        val island = driver.putPermanentOnBattlefield(me, "Island")
+        // Seven permanent cards — one short of Descend 8. The material comes from the
+        // battlefield, so the graveyard count is untouched by the craft.
+        repeat(7) { driver.putCardInGraveyard(me, "Island") }
+
+        craftGondola(driver, me, hulk, island)
+        driver.getGraveyard(me).size shouldBe 7
+
+        driver.removeSummoningSickness(hulk)
+        val crewer = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val blocker = driver.putCreatureOnBattlefield(opponent, "Grizzly Bears")
+
+        driver.submitSuccess(CrewVehicle(me, hulk, listOf(crewer)))
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(hulk), opponent).error shouldBe null
+        driver.bothPass()
+        withClue("Descend 8 unmet (7 permanent cards) → can be blocked") {
+            driver.declareBlockers(opponent, mapOf(blocker to listOf(hulk))).error shouldBe null
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Negative — illegal craft materials
+    // -------------------------------------------------------------------------
+
+    test("craft rejects a non-Island land and rejects two Islands (exactly one material)") {
+        val driver = createDriver()
+        val me = driver.player1
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val hulk = driver.putPermanentOnBattlefield(me, "Waterlogged Hulk")
+        val plains = driver.putPermanentOnBattlefield(me, "Plains")
+        val island1 = driver.putPermanentOnBattlefield(me, "Island")
+        val island2 = driver.putPermanentOnBattlefield(me, "Island")
+        driver.giveMana(me, Color.BLUE, 4)
+
+        withClue("a Plains is not an Island — rejected as craft material") {
+            driver.submit(
+                ActivateAbility(
+                    playerId = me,
+                    sourceId = hulk,
+                    abilityId = craftAbilityId,
+                    costPayment = AdditionalCostPayment(exiledCards = listOf(plains))
+                )
+            ).isSuccess shouldBe false
+        }
+
+        withClue("Craft with Island takes exactly one material — two Islands rejected") {
+            driver.submit(
+                ActivateAbility(
+                    playerId = me,
+                    sourceId = hulk,
+                    abilityId = craftAbilityId,
+                    costPayment = AdditionalCostPayment(exiledCards = listOf(island1, island2))
+                )
+            ).isSuccess shouldBe false
+        }
+
+        withClue("sanity: a single Island is accepted") {
+            driver.submit(
+                ActivateAbility(
+                    playerId = me,
+                    sourceId = hulk,
+                    abilityId = craftAbilityId,
+                    costPayment = AdditionalCostPayment(exiledCards = listOf(island1))
+                )
+            ).isSuccess shouldBe true
+        }
+    }
+})

--- a/web-client/src/store/slices/ui/pipelinePhases.ts
+++ b/web-client/src/store/slices/ui/pipelinePhases.ts
@@ -800,7 +800,7 @@ export function enterPhase(
           // dedicated cross-zone overlay rather than the single-zone targeting flow.
           validTargets = [...(costInfo.validCraftMaterials ?? [])]
           minTargets = costInfo.craftMinCount ?? 1
-          maxTargets = validTargets.length
+          maxTargets = costInfo.craftMaxCount ?? validTargets.length
           flags.isCraftMaterialSelection = true
           flags.targetDescription = costInfo.description
           flags.sourceCardName = actionInfo.description

--- a/web-client/src/types/messages.ts
+++ b/web-client/src/types/messages.ts
@@ -1046,6 +1046,8 @@ export interface AdditionalCostInfo {
    */
   readonly validCraftMaterials?: readonly EntityId[]
   readonly craftMinCount?: number
+  /** Cap on material count for exact-count crafts ("Craft with artifact"); absent = unbounded. */
+  readonly craftMaxCount?: number
 }
 
 export interface CounterRemovalCreatureInfo {


### PR DESCRIPTION
Depends on: https://github.com/wingedsheep/argentum-engine/pull/1285

Second batch of LCI Craft transform-DFCs (5 cards, one per commit, scenario test each). Stacked on `lci-craft-01` — **review only the diff vs that branch**; the commits below `lci-craft-01`'s tip belong to that PR.

| Card | Front | Back |
|---|---|---|
| Spring-Loaded Sawblades // Bladewheel Chariot | Flash, ETB 5 dmg to tapped opp creature; Craft with artifact | Vehicle 5/5; tap-two-other-artifacts animate + Crew 1 |
| Lodestone Needle // Guidestone Compass | Flash, ETB tap + 2 stun counters (up to one target); Craft with artifact | {1},{T}: target creature you control explores (sorcery) |
| Waterlogged Hulk // Watertight Gondola | {T}: mill 1; Craft with Island | Vehicle 4/4 vigilance, Descend 8 unblockable, Crew 1 |
| Idol of the Deep King // Sovereign's Macuahuitl | Flash, ETB 2 dmg any target; Craft with artifact | Equipment: ETB auto-attach, +2/+0, Equip {2} |
| Master's Guide-Mural // Master's Manufactory | ETB 4/4 WU Golem token; Craft with artifact | {T}: Golem token, only if an artifact ETB'd your side this turn |

Notes:
- **No new SDK types** — every card composes existing primitives (`craft(...)` DSL, `Effects.DealDamage/Composite/Tap/AttachEquipment/CreateToken/Explore`, `Patterns.Library.mill`, `Costs.TapPermanents(excludeSelf = true)`, `ConditionalStaticAbility(CantBeBlocked, CardsInGraveyardMatchingAtLeast)`, `ActivationRestriction.OnlyIfCondition(ArtifactEnteredBattlefieldThisTurn)`, `ModifyStats`, `equipAbility`, `KeywordAbility.crew`).
- All five crafts are exact-one-material, using the `maxCount` support introduced in the `lci-craft-01` stack. Waterlogged Hulk crafts with an **Island** (subtype filter; materials from battlefield or graveyard).
- Master's Manufactory's activation gate ("this artifact or another artifact entered ... this turn") reads the permanent-entry tracker, which records the craft return itself — so the {T} ability works the same turn it's crafted, and the scenario test pins that.
- Known inherited gap (flagged, not new): printed color indicators aren't representable in the SDK, so the colorless-mana-cost back faces (e.g. Master's Manufactory's W/U indicator) are colorless in-engine — same as the existing Mastercraft Raptor precedent.
- `manual-scenarios/sets/lci/craft-02.json`: all five front faces in hand with enough untapped lands to cast them all in one turn, plus artifact/Island craft materials on the battlefield and in the graveyard, and a tapped opposing creature for Sawblades' ETB.
- Rebased onto the current `lci-craft-01` tip (picks up the Craft-cost grammar fix) with no conflicts; the branch's own diff is unchanged.

Verified: the 5 new scenario classes (24 tests) green this session; oracle text, mana/craft costs, and P/T cross-checked against Scryfall; `CardDefinitionSnapshotTest` golden (`LCI.json`) regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
