### PR TITLE
Add Training keyword (CR 702.149, VOW) end-to-end

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -2755,6 +2755,14 @@ Adding a new attack-time mechanic is one new sealed-case + one matcher branch
   already scopes to one creature). The defender kind is fixed at declaration, so it's
   captured on `AttackersDeclaredEvent.attackersAgainstPlayer` rather than re-derived
   from post-declaration state. Prefer the `AttacksAnOpponent` sugar.
+- `AttackPredicate.AttackedAlongsideGreaterPower` — the trigger's own attacker was declared
+  **and** at least one *other* declared attacker has strictly greater **projected** power than
+  the trigger's attacker (CR 702.149a, the Training condition). Unlike the count/stamped-set
+  predicates, the matcher reads live `state.projectedState.getPower(...)` for every attacker, so
+  Rule 613 layer effects (anthems, auras, counters) on the *other* attacker count — a lord pumping
+  the partner can flip this from false to true. The comparison is strict (`>`); an equal-power
+  partner does not satisfy it. Per-attacker, so use it on a `SELF` binding. Prefer the `training()`
+  keyword helper (§11) over hand-wiring this predicate.
 
 Examples:
 
@@ -4665,6 +4673,21 @@ composite abilities).
   scan handles the exploiter-still-present case, and a battlefield-presence guard keeps the two from double-firing.
   `EmitExploitedEventEffect` is an internal `data object` (no player-facing text) and should not be used directly — it is
   wired into `exploit()`. See `EventPattern.ExploitedEvent` under Sacrifice triggers for the watcher form.
+- `Training` — "Training (Whenever this creature and at least one other creature with power greater than this creature's
+  power attack, put a +1/+1 counter on this creature.)" (CR 702.149, Innistrad: Midnight Hunt; also WHO, SLD). Display-only
+  keyword; wire the behavior with the `card { training() }` builder helper. It adds the keyword plus one attack-triggered
+  ability — `Triggers.attacks(requires = setOf(AttackPredicate.AttackedAlongsideGreaterPower))` (SELF) → `Effects.AddCounters(
+  Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self)`. The predicate reads **projected** power for every attacker (§8
+  `AttackPredicate`), so an anthem/aura on the *other* attacker can flip the trigger on; the comparison is strict. Multiple
+  instances trigger separately (CR 702.149b) — call `training()` twice, or add a second `trainingTriggeredAbility()`, for two
+  independent counters. The standalone `trainingTriggeredAbility()` factory (same file) exposes just the ability so an
+  **intrinsically-training token** can carry it: `Effects.CreateToken(…, keywords = setOf(Keyword.TRAINING))` sets the display
+  badge and `CreateTokenEffect(triggeredAbilities = listOf(trainingTriggeredAbility()))` supplies the behavior (Torens, Fist of
+  the Angels' "1/1 Human Soldier creature token with training" — the token trains when it later attacks alongside greater
+  power). **CR 702.149c "when this creature trains"** (a resolving training ability placing ≥1 +1/+1 counter) is *reserved but
+  not built*: when the first payoff card lands, add a custom `EventPattern.TrainedEvent` (template: `ScriedEvent` /
+  `SurveiledEvent`) emitted where the training `AddCounters` resolves — do not approximate it with a generic counter-placed
+  watcher, which would fire for non-training counters too.
 - `Job select` — "Job select (When this Equipment enters, create a 1/1 colorless Hero creature token, then attach
   this to it.)" (Final Fantasy). Equipment keyword; display-only. Wire it with the `card { jobSelect() }` builder
   helper, which adds the keyword plus an `EntersBattlefield` triggered ability composing two existing primitives

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/core/Keyword.kt
@@ -320,6 +320,21 @@ enum class Keyword(val displayName: String) {
      */
     EXPLOIT("Exploit"),
 
+    /**
+     * Training (CR 702.149, Innistrad: Midnight Hunt). A triggered attack ability:
+     * "Whenever this creature and at least one other creature with power greater than this
+     * creature's power attack, put a +1/+1 counter on this creature" (CR 702.149a). Multiple
+     * instances trigger separately (CR 702.149b).
+     *
+     * The keyword itself is display-only; the behavior is composed by the `training()` DSL helper
+     * on [com.wingedsheep.sdk.dsl.CardBuilder] — an attack-triggered ability
+     * ([com.wingedsheep.sdk.dsl.Triggers.attacks] gated by
+     * [com.wingedsheep.sdk.scripting.events.AttackPredicate.AttackedAlongsideGreaterPower], which
+     * compares *projected* power across the attacking band) whose effect puts one +1/+1 counter on
+     * the source ([com.wingedsheep.sdk.dsl.Effects.AddCounters]).
+     */
+    TRAINING("Training"),
+
     // ── Damage modification ──────────────────────────────
     WITHER("Wither"),
     TOXIC("Toxic"),

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/TrainingDsl.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/mechanics/TrainingDsl.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.sdk.dsl
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.events.AttackPredicate
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Reminder text for Training, rendered on every card and token that has the keyword. This is the
+ * *printed* oracle reminder (shorter than the CR 702.149a rules text — "attacks with another
+ * creature with greater power" rather than "and at least one other creature with power greater
+ * than this creature's power attack"); it matches what's on Gryff Rider, Cloaked Cadet, Torens,
+ * and the Human Soldier token, so descriptions line up with Scryfall.
+ */
+private const val TRAINING_REMINDER =
+    "Training (Whenever this creature attacks with another creature with greater power, " +
+        "put a +1/+1 counter on this creature.)"
+
+/**
+ * The single triggered ability that *is* Training (CR 702.149a): an attack trigger gated by
+ * [AttackPredicate.AttackedAlongsideGreaterPower] (a projected-power comparison across the
+ * attacking band) whose effect puts one +1/+1 counter on the source.
+ *
+ * Exposed as a standalone builder — not just inlined into [training] — so an intrinsically-training
+ * **token** can carry the identical ability via [com.wingedsheep.sdk.scripting.effects.CreateTokenEffect.triggeredAbilities]
+ * (e.g. Torens, Fist of the Angels' "1/1 Human Soldier creature token with training"). The token
+ * additionally sets `keywords = setOf(Keyword.TRAINING)` for the display badge; this ability supplies
+ * the behavior. Because each instance is a separate `TriggeredAbility`, two copies trigger separately
+ * (CR 702.149b).
+ */
+fun trainingTriggeredAbility(): TriggeredAbility {
+    val spec = Triggers.attacks(requires = setOf(AttackPredicate.AttackedAlongsideGreaterPower))
+    return TriggeredAbility.create(
+        trigger = spec.event,
+        binding = spec.binding, // SELF
+        effect = Effects.AddCounters(Counters.PLUS_ONE_PLUS_ONE, 1, EffectTarget.Self),
+        descriptionOverride = TRAINING_REMINDER
+    )
+}
+
+/**
+ * Add Training (CR 702.149, Innistrad: Midnight Hunt) — keyword + the triggered ability.
+ *
+ * "Whenever this creature and at least one other creature with power greater than this creature's
+ * power attack, put a +1/+1 counter on this creature" (CR 702.149a).
+ *
+ * The keyword is display-only (no separate Training handler exists); the behavior is composed here
+ * from existing primitives via [trainingTriggeredAbility]. Power is compared through **projected**
+ * state, so an anthem or aura on the *other* attacker can flip the trigger from off to on (the
+ * matcher branch for [AttackPredicate.AttackedAlongsideGreaterPower] reads
+ * `state.projectedState.getPower(...)` for every attacker).
+ *
+ * Multiple instances trigger separately (CR 702.149b): calling this twice, or adding a second
+ * [trainingTriggeredAbility], installs two independent triggers that each add a counter.
+ */
+fun CardBuilder.training() {
+    keywordSet.add(Keyword.TRAINING)
+    triggeredAbilities.add(trainingTriggeredAbility())
+}

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/events/EventFilters.kt
@@ -589,6 +589,28 @@ sealed interface AttackPredicate {
     data object DefenderIsPlayer : AttackPredicate {
         override val description = "a player"
     }
+
+    /**
+     * The attacker was declared as attacking **and** at least one *other* declared attacker has
+     * strictly greater **projected** power than the attacker's own projected power. This is the
+     * Training trigger condition (CR 702.149a: "Whenever this creature and at least one other
+     * creature with power greater than this creature's power attack, put a +1/+1 counter on this
+     * creature").
+     *
+     * Power is compared through **projected** state (Rule 613 layers), so anthems, auras, and
+     * counters on the attacking band are reflected — a lord that pumps the *other* attacker can
+     * flip this from false to true. Both powers are read at declaration time (when the trigger
+     * condition is checked); the comparison is strict (`>`), so an equal-power partner does not
+     * satisfy it.
+     *
+     * Per-attacker by design: it gates against the trigger's own source, so use it with a `SELF`
+     * binding — "Whenever this creature trains, …".
+     */
+    @SerialName("AttacksAlongsideGreaterPower")
+    @Serializable
+    data object AttackedAlongsideGreaterPower : AttackPredicate {
+        override val description = "with another creature with greater power"
+    }
 }
 
 // =============================================================================

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/AlchemistsRetrieval.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/AlchemistsRetrieval.kt
@@ -1,0 +1,58 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetPermanent
+
+/**
+ * Alchemist's Retrieval
+ * {U}
+ * Instant
+ * Cleave {1}{U} (You may cast this spell for its cleave cost. If you do, remove the words in
+ * square brackets.)
+ * Return target nonland permanent [you control] to its owner's hand.
+ *
+ * Cleave (CR 702.148) removes the bracketed words when its alternative cost is paid. The printed
+ * (cheaper) cast can only bounce a nonland permanent *you control* (a defensive save from removal);
+ * the cleaved cast bounces any nonland permanent (a tempo play against an opponent).
+ *
+ * Target-only difference: the base [target] carries the "you control" restriction and
+ * [cleaveTarget] drops it. Both modes return the chosen target to its owner's hand — the effect is
+ * identical, so only the target requirement is swapped when cast for the cleave cost.
+ */
+val AlchemistsRetrieval = card("Alchemist's Retrieval") {
+    manaCost = "{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Cleave {1}{U} (You may cast this spell for its cleave cost. If you do, remove " +
+        "the words in square brackets.)\nReturn target nonland permanent [you control] to its " +
+        "owner's hand."
+
+    keywordAbility(KeywordAbility.cleave("{1}{U}"))
+
+    spell {
+        // Printed (brackets present): return target nonland permanent you control.
+        val owned = target(
+            "nonland permanent you control",
+            TargetPermanent(filter = TargetFilter.NonlandPermanent.youControl()),
+        )
+        effect = Effects.ReturnToHand(owned)
+
+        // Cleaved (brackets removed): return target nonland permanent.
+        val any = cleaveTarget("nonland permanent", Targets.NonlandPermanent)
+        cleaveEffect = Effects.ReturnToHand(any)
+    }
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "47"
+        artist = "David Auden Nash"
+        flavorText = "To most, a terrifying apparition. To a necro-alchemist, a potent fuel source."
+        imageUri = "https://cards.scryfall.io/normal/front/e/d/edbf9d4f-6027-40b8-81c1-7f001a9119dd.jpg?1783924901"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CloakedCadet.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/CloakedCadet.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Counters
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.training
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+
+/**
+ * Cloaked Cadet
+ * {4}{G}
+ * Creature — Human Ranger
+ * 2/4
+ * Training (Whenever this creature attacks with another creature with greater power, put a
+ * +1/+1 counter on this creature.)
+ * Whenever one or more +1/+1 counters are put on one or more Humans you control, draw a card.
+ * This ability triggers only once each turn.
+ *
+ * Two independent pieces:
+ *  - [training] gives the keyword + the attack trigger. Cadet is itself a Human, so the very
+ *    +1/+1 counter Training places on it satisfies the draw watcher below.
+ *  - A hand-written [Triggers.countersPlacedOn] watcher over "+1/+1 counters on Humans you
+ *    control". `firstTimeEachTurn = false` because the CR wording caps the *ability* at once per
+ *    turn (`oncePerTurn = true`), not per-permanent — the once-per-turn gate belongs on the
+ *    ability, and per-permanent first-time tracking would wrongly re-arm for a second Human.
+ *    Per Scryfall rulings you draw only one card no matter how many counters land or on how many
+ *    Humans, which `oncePerTurn = true` delivers (the trigger fires once and won't re-trigger).
+ */
+val CloakedCadet = card("Cloaked Cadet") {
+    manaCost = "{4}{G}"
+    colorIdentity = "G"
+    typeLine = "Creature — Human Ranger"
+    power = 2
+    toughness = 4
+    oracleText = "Training (Whenever this creature attacks with another creature with greater " +
+        "power, put a +1/+1 counter on this creature.)\n" +
+        "Whenever one or more +1/+1 counters are put on one or more Humans you control, draw a " +
+        "card. This ability triggers only once each turn."
+
+    training()
+
+    triggeredAbility {
+        trigger = Triggers.countersPlacedOn(
+            filter = GameObjectFilter.Creature.withSubtype(Subtype.HUMAN).youControl(),
+            counterType = Counters.PLUS_ONE_PLUS_ONE,
+            firstTimeEachTurn = false,
+        )
+        oncePerTurn = true
+        effect = Effects.DrawCards(1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "192"
+        artist = "Igor Kieryluk"
+        imageUri = "https://cards.scryfall.io/normal/front/0/6/06d86c79-d2c7-4900-9474-4d4bc4c74d44.jpg?1783924816"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DreadFugue.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DreadFugue.kt
@@ -1,0 +1,113 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.effects.CardDestination
+import com.wingedsheep.sdk.scripting.effects.CardSource
+import com.wingedsheep.sdk.scripting.effects.Chooser
+import com.wingedsheep.sdk.scripting.effects.GatherCardsEffect
+import com.wingedsheep.sdk.scripting.effects.MoveCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.MoveType
+import com.wingedsheep.sdk.scripting.effects.RevealHandEffect
+import com.wingedsheep.sdk.scripting.effects.SelectFromCollectionEffect
+import com.wingedsheep.sdk.scripting.effects.SelectionMode
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.TargetPlayer
+import com.wingedsheep.sdk.scripting.values.DynamicAmount
+
+/**
+ * Dread Fugue
+ * {B}
+ * Sorcery
+ * Cleave {2}{B} (You may cast this spell for its cleave cost. If you do, remove the words in
+ * square brackets.)
+ * Target player reveals their hand. You choose a nonland card from it [with mana value 2 or less].
+ * That player discards that card.
+ *
+ * Cleave (CR 702.148) removes the bracketed words when its alternative cost is paid. The printed
+ * (cheaper) cast is a Duress-style targeted discard limited to cheap spells (nonland, mana value 2
+ * or less); paying the cleave cost drops the mana-value cap so you can take any nonland card.
+ *
+ * The bracket lives inside the *effect* (the card filter the caster chooses under), not the target
+ * line — the target ("target player") is identical in both modes. So `cleaveTarget` is left unset
+ * and only the effect differs. Both effects are the same Duress-shaped composite (reveal hand →
+ * caster chooses one card matching the filter → that player discards it); only the
+ * `SelectFromCollectionEffect` filter changes between the modes.
+ *
+ * `chooser = Chooser.Controller` means the *caster* picks the card (CR "you choose"), and
+ * `Player.ContextPlayer(0)` refers back to the shared targeted player for both the gather and the
+ * discard destination.
+ */
+val DreadFugue = card("Dread Fugue") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Sorcery"
+    oracleText = "Cleave {2}{B} (You may cast this spell for its cleave cost. If you do, remove " +
+        "the words in square brackets.)\nTarget player reveals their hand. You choose a nonland " +
+        "card from it [with mana value 2 or less]. That player discards that card."
+
+    keywordAbility(KeywordAbility.cleave("{2}{B}"))
+
+    spell {
+        target = TargetPlayer()
+
+        // Printed (brackets present): choose a nonland card with mana value 2 or less to discard.
+        effect = Effects.Composite(
+            RevealHandEffect(),
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                storeAs = "revealedHand",
+            ),
+            SelectFromCollectionEffect(
+                from = "revealedHand",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                filter = GameObjectFilter.Nonland.manaValueAtMost(2),
+                storeSelected = "toDiscard",
+                prompt = "Choose a nonland card with mana value 2 or less to discard",
+                alwaysPrompt = true,
+                showAllCards = true,
+            ),
+            MoveCollectionEffect(
+                from = "toDiscard",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                moveType = MoveType.Discard,
+            ),
+        )
+
+        // Cleaved (brackets removed): choose any nonland card to discard (no mana-value cap).
+        cleaveEffect = Effects.Composite(
+            RevealHandEffect(),
+            GatherCardsEffect(
+                source = CardSource.FromZone(Zone.HAND, Player.ContextPlayer(0)),
+                storeAs = "revealedHand",
+            ),
+            SelectFromCollectionEffect(
+                from = "revealedHand",
+                selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(1)),
+                chooser = Chooser.Controller,
+                filter = GameObjectFilter.Nonland,
+                storeSelected = "toDiscard",
+                prompt = "Choose a nonland card to discard",
+                alwaysPrompt = true,
+                showAllCards = true,
+            ),
+            MoveCollectionEffect(
+                from = "toDiscard",
+                destination = CardDestination.ToZone(Zone.GRAVEYARD, Player.ContextPlayer(0)),
+                moveType = MoveType.Discard,
+            ),
+        )
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "107"
+        artist = "Rovina Cai"
+        imageUri = "https://cards.scryfall.io/normal/front/0/a/0ad4c472-b8ce-4ae0-a6f0-726ea74722c5.jpg?1783924866"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GryffRider.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GryffRider.kt
@@ -1,0 +1,42 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.training
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Gryff Rider
+ * {2}{W}
+ * Creature — Human Knight
+ * 2/1
+ * Flying
+ * Training (Whenever this creature attacks with another creature with greater power, put a
+ * +1/+1 counter on this creature.)
+ *
+ * The baseline Training card: an unrelated evasion keyword plus [training], which installs the
+ * TRAINING keyword badge and the attack trigger (a +1/+1 counter when it attacks alongside a
+ * creature of strictly greater projected power). Its low starting power (2) makes it train easily.
+ */
+val GryffRider = card("Gryff Rider") {
+    manaCost = "{2}{W}"
+    colorIdentity = "W"
+    typeLine = "Creature — Human Knight"
+    power = 2
+    toughness = 1
+    oracleText = "Flying\n" +
+        "Training (Whenever this creature attacks with another creature with greater power, " +
+        "put a +1/+1 counter on this creature.)"
+
+    keywords(Keyword.FLYING)
+    training()
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "15"
+        artist = "Yongjae Choi"
+        flavorText = "\"Keep your heels down and bend at the hips as your mount takes flight. " +
+            "She'll do the rest.\"\n—Anders, cathar drillmaster"
+        imageUri = "https://cards.scryfall.io/normal/front/5/3/5317077b-370e-41a9-9162-c713362fd7f4.jpg?1783924922"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/LunarRejection.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/LunarRejection.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Lunar Rejection
+ * {1}{U}
+ * Instant
+ * Cleave {3}{U} (You may cast this spell for its cleave cost. If you do, remove the words in
+ * square brackets.)
+ * Return target [Wolf or Werewolf] creature to its owner's hand.
+ * Draw a card.
+ *
+ * Cleave (CR 702.148) removes the bracketed words when its alternative cost is paid. The printed
+ * (cheaper) cast is a tribal bounce — it can only return a Wolf or Werewolf creature; paying the
+ * cleave cost broadens the target to any creature.
+ *
+ * Target-only difference: the base [target] carries the "Wolf or Werewolf" subtype restriction and
+ * [cleaveTarget] drops it. The bounce + draw are identical in both modes, so only the target
+ * requirement is swapped and the effect (return the chosen target, then draw a card) is shared.
+ */
+val LunarRejection = card("Lunar Rejection") {
+    manaCost = "{1}{U}"
+    colorIdentity = "U"
+    typeLine = "Instant"
+    oracleText = "Cleave {3}{U} (You may cast this spell for its cleave cost. If you do, remove " +
+        "the words in square brackets.)\nReturn target [Wolf or Werewolf] creature to its owner's " +
+        "hand.\nDraw a card."
+
+    keywordAbility(KeywordAbility.cleave("{3}{U}"))
+
+    spell {
+        // Printed (brackets present): return target Wolf or Werewolf creature, then draw a card.
+        val wolfOrWerewolf = target(
+            "Wolf or Werewolf creature",
+            TargetCreature(
+                filter = TargetFilter(
+                    GameObjectFilter.Creature.withAnyOfSubtypes(listOf(Subtype.WOLF, Subtype.WEREWOLF)),
+                ),
+            ),
+        )
+        effect = Effects.ReturnToHand(wolfOrWerewolf).then(Effects.DrawCards(1))
+
+        // Cleaved (brackets removed): return target creature, then draw a card.
+        val anyCreature = cleaveTarget("creature", Targets.Creature)
+        cleaveEffect = Effects.ReturnToHand(anyCreature).then(Effects.DrawCards(1))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "67"
+        artist = "Donato Giancola"
+        imageUri = "https://cards.scryfall.io/normal/front/0/f/0f66511c-355f-4e8a-96fc-3afc7a315231.jpg?1783924891"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ParasiticGrasp.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/ParasiticGrasp.kt
@@ -1,0 +1,60 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Subtype
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.TargetCreature
+
+/**
+ * Parasitic Grasp
+ * {1}{B}
+ * Instant
+ * Cleave {1}{B}{B} (You may cast this spell for its cleave cost. If you do, remove the words in
+ * square brackets.)
+ * Parasitic Grasp deals 3 damage to target [Human] creature. You gain 3 life.
+ *
+ * Cleave (CR 702.148) removes the bracketed words when its alternative cost is paid. The printed
+ * (cheaper) cast can only hit a Human creature (drain-a-villager flavor); paying the cleave cost
+ * broadens the target to any creature.
+ *
+ * Target-only difference: the base [target] carries the "Human" subtype restriction and
+ * [cleaveTarget] drops it. Both modes deal 3 damage to the chosen target and gain 3 life, so only
+ * the target requirement is swapped — the 3-damage-plus-gain-3 effect is shared. The life gain is
+ * unconditional (not tied to damage dealt), so it always resolves.
+ */
+val ParasiticGrasp = card("Parasitic Grasp") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Instant"
+    oracleText = "Cleave {1}{B}{B} (You may cast this spell for its cleave cost. If you do, " +
+        "remove the words in square brackets.)\nParasitic Grasp deals 3 damage to target [Human] " +
+        "creature. You gain 3 life."
+
+    keywordAbility(KeywordAbility.cleave("{1}{B}{B}"))
+
+    spell {
+        // Printed (brackets present): 3 damage to target Human creature, gain 3 life.
+        val human = target(
+            "Human creature",
+            TargetCreature(filter = TargetFilter(GameObjectFilter.Creature.withSubtype(Subtype.HUMAN))),
+        )
+        effect = Effects.DealDamage(3, human).then(Effects.GainLife(3))
+
+        // Cleaved (brackets removed): 3 damage to target creature, gain 3 life.
+        val anyCreature = cleaveTarget("creature", Targets.Creature)
+        cleaveEffect = Effects.DealDamage(3, anyCreature).then(Effects.GainLife(3))
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "123"
+        artist = "Rovina Cai"
+        flavorText = "Some wicked souls linger only to consume the warmth of life."
+        imageUri = "https://cards.scryfall.io/normal/front/0/7/0713adf7-1770-4d5b-80f7-d6cbd24f7890.jpg?1783924860"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/Torens.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/Torens.kt
@@ -1,0 +1,63 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.training
+import com.wingedsheep.sdk.dsl.trainingTriggeredAbility
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.effects.CreateTokenEffect
+
+/**
+ * Torens, Fist of the Angels
+ * {1}{G}{W}
+ * Legendary Creature — Human Cleric
+ * 2/2
+ * Training (Whenever this creature attacks with another creature with greater power, put a
+ * +1/+1 counter on this creature.)
+ * Whenever you cast a creature spell, create a 1/1 green and white Human Soldier creature token
+ * with training.
+ *
+ * [training] gives Torens itself the keyword + attack trigger. The second ability makes a token
+ * that *intrinsically* has Training: [CreateTokenEffect] carries both `keywords`
+ * (`Keyword.TRAINING`, for the display badge) and `triggeredAbilities`
+ * ([trainingTriggeredAbility], the behavior). `CreateTokenExecutor` grants token-borne triggered
+ * abilities `Duration.Permanent`, so the token trains on its own when it later attacks alongside
+ * a creature of greater power — proving Training travels on a token definition, not just a card.
+ */
+val Torens = card("Torens, Fist of the Angels") {
+    manaCost = "{1}{G}{W}"
+    colorIdentity = "GW"
+    typeLine = "Legendary Creature — Human Cleric"
+    power = 2
+    toughness = 2
+    oracleText = "Training (Whenever this creature attacks with another creature with greater " +
+        "power, put a +1/+1 counter on this creature.)\n" +
+        "Whenever you cast a creature spell, create a 1/1 green and white Human Soldier creature " +
+        "token with training."
+
+    training()
+
+    triggeredAbility {
+        trigger = Triggers.YouCastCreature
+        effect = CreateTokenEffect(
+            // count defaults to Fixed(1); the primary (DynamicAmount) constructor is required here
+            // because only it carries `triggeredAbilities` (the token's own Training behavior).
+            power = 1,
+            toughness = 1,
+            colors = setOf(Color.GREEN, Color.WHITE),
+            creatureTypes = setOf("Human", "Soldier"),
+            keywords = setOf(Keyword.TRAINING),
+            triggeredAbilities = listOf(trainingTriggeredAbility()),
+            imageUri = "https://cards.scryfall.io/normal/front/5/f/5f3c4810-7359-42b7-905f-4845f6d1daf6.jpg?1783924693",
+        )
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "249"
+        artist = "Justine Cruz"
+        imageUri = "https://cards.scryfall.io/normal/front/b/d/bd111dc9-b8de-4e92-a63d-75a961b2db3b.jpg?1783924787"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WingedPortent.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/WingedPortent.kt
@@ -1,0 +1,59 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.DynamicAmounts
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.KeywordAbility
+import com.wingedsheep.sdk.scripting.references.Player
+
+/**
+ * Winged Portent
+ * {1}{U}{U}
+ * Instant
+ * Cleave {4}{G}{U} (You may cast this spell for its cleave cost. If you do, remove the words in
+ * square brackets.)
+ * Draw a card for each creature you control [with flying].
+ *
+ * Cleave (CR 702.148) removes the bracketed words when its alternative cost is paid. The printed
+ * (cheaper) cast draws only for your fliers (a fits-a-skies-deck payoff); paying the cleave cost
+ * drops the "with flying" restriction and draws for every creature you control.
+ *
+ * No target — only the effect differs, and only in the count filter. The count is evaluated on
+ * resolution (CR 608.2), so it reflects the creatures you control at that time. `Player.You`
+ * already scopes the battlefield query to your permanents, so the base [effect] counts your
+ * fliers and the [cleaveEffect] counts all your creatures.
+ */
+val WingedPortent = card("Winged Portent") {
+    manaCost = "{1}{U}{U}"
+    colorIdentity = "GU"
+    typeLine = "Instant"
+    oracleText = "Cleave {4}{G}{U} (You may cast this spell for its cleave cost. If you do, " +
+        "remove the words in square brackets.)\nDraw a card for each creature you control " +
+        "[with flying]."
+
+    keywordAbility(KeywordAbility.cleave("{4}{G}{U}"))
+
+    spell {
+        // Printed (brackets present): draw a card for each creature you control with flying.
+        effect = Effects.DrawCards(
+            DynamicAmounts.battlefield(
+                Player.You,
+                GameObjectFilter.Creature.withKeyword(Keyword.FLYING),
+            ).count(),
+        )
+
+        // Cleaved (brackets removed): draw a card for each creature you control.
+        cleaveEffect = Effects.DrawCards(DynamicAmounts.creaturesYouControl())
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "89"
+        artist = "Nicholas Gregory"
+        flavorText = "\"No, no, it's just a murder of crows, not an omen of murder . . . I think.\"\n—York, Kessig tracker"
+        imageUri = "https://cards.scryfall.io/normal/front/3/4/3494a4fc-37e5-4095-a3bb-5cd9280f4c77.jpg?1783924876"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -63,6 +63,68 @@
     ]
 }
 
+// Alchemist's Retrieval
+{
+    "name": "Alchemist's Retrieval",
+    "manaCost": "{U}",
+    "typeLine": "Instant",
+    "oracleText": "Cleave {1}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nReturn target nonland permanent [you control] to its owner's hand.",
+    "keywords": [
+        "CLEAVE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cleave",
+            "cost": "{1}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "nonland permanent you control"
+            },
+            "destination": "Hand"
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent ctrl:you"
+                },
+                "id": "nonland permanent you control"
+            }
+        ],
+        "cleaveTargetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "nonland permanent"
+                },
+                "id": "nonland permanent"
+            }
+        ],
+        "cleaveSpellEffect": {
+            "type": "MoveToZone",
+            "target": {
+                "type": "BoundVariable",
+                "name": "nonland permanent"
+            },
+            "destination": "Hand"
+        }
+    },
+    "metadata": {
+        "collectorNumber": "47",
+        "artist": "David Auden Nash",
+        "flavorText": "To most, a terrifying apparition. To a necro-alchemist, a potent fuel source.",
+        "imageUri": "https://cards.scryfall.io/normal/front/e/d/edbf9d4f-6027-40b8-81c1-7f001a9119dd.jpg?1783924901"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Ancestral Anger
 {
     "name": "Ancestral Anger",
@@ -908,6 +970,67 @@
     ]
 }
 
+// Cloaked Cadet
+{
+    "name": "Cloaked Cadet",
+    "manaCost": "{4}{G}",
+    "typeLine": "Creature — Human Ranger",
+    "oracleText": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever one or more +1/+1 counters are put on one or more Humans you control, draw a card. This ability triggers only once each turn.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 4
+    },
+    "keywords": [
+        "TRAINING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        "AttacksAlongsideGreaterPower"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "CountersPlacedEvent",
+                    "counterType": "+1/+1",
+                    "filter": "creature Human ctrl:you"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                },
+                "oncePerTurn": true
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "192",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Kieryluk",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/6/06d86c79-d2c7-4900-9474-4d4bc4c74d44.jpg?1783924816"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
+    ]
+}
+
 // Cobbled Lancer
 {
     "name": "Cobbled Lancer",
@@ -1530,6 +1653,131 @@
         "artist": "Manuel Castañón",
         "flavorText": "It can barely feel the sword anymore.",
         "imageUri": "https://cards.scryfall.io/normal/front/f/7/f72eb127-3f4c-42ed-8ba6-b6d83ea18545.jpg?1782703116"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Dread Fugue
+{
+    "name": "Dread Fugue",
+    "manaCost": "{B}",
+    "typeLine": "Sorcery",
+    "oracleText": "Cleave {2}{B} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nTarget player reveals their hand. You choose a nonland card from it [with mana value 2 or less]. That player discards that card.",
+    "keywords": [
+        "CLEAVE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cleave",
+            "cost": "{2}{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                "RevealHand",
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "revealedHand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "revealedHand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "nonland mv<=2",
+                    "storeSelected": "toDiscard",
+                    "prompt": "Choose a nonland card with mana value 2 or less to discard",
+                    "showAllCards": true,
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toDiscard",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                }
+            ]
+        },
+        "targetRequirements": [
+            "TargetPlayer"
+        ],
+        "cleaveSpellEffect": {
+            "type": "Composite",
+            "effects": [
+                "RevealHand",
+                {
+                    "type": "GatherCards",
+                    "source": {
+                        "type": "FromZone",
+                        "zone": "Hand",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "storeAs": "revealedHand"
+                },
+                {
+                    "type": "SelectFromCollection",
+                    "from": "revealedHand",
+                    "selection": {
+                        "type": "ChooseExactly",
+                        "count": {
+                            "type": "Fixed",
+                            "amount": 1
+                        }
+                    },
+                    "filter": "nonland",
+                    "storeSelected": "toDiscard",
+                    "prompt": "Choose a nonland card to discard",
+                    "showAllCards": true,
+                    "alwaysPrompt": true
+                },
+                {
+                    "type": "MoveCollection",
+                    "from": "toDiscard",
+                    "destination": {
+                        "type": "ToZone",
+                        "zone": "Graveyard",
+                        "player": {
+                            "type": "ContextPlayer",
+                            "index": 0
+                        }
+                    },
+                    "moveType": "Discard"
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "107",
+        "rarity": "UNCOMMON",
+        "artist": "Rovina Cai",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/a/0ad4c472-b8ce-4ae0-a6f0-726ea74722c5.jpg?1783924866"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -2395,6 +2643,51 @@
     ]
 }
 
+// Gryff Rider
+{
+    "name": "Gryff Rider",
+    "manaCost": "{2}{W}",
+    "typeLine": "Creature — Human Knight",
+    "oracleText": "Flying\nTraining (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 1
+    },
+    "keywords": [
+        "FLYING",
+        "TRAINING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        "AttacksAlongsideGreaterPower"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "15",
+        "artist": "Yongjae Choi",
+        "flavorText": "\"Keep your heels down and bend at the hips as your mount takes flight. She'll do the rest.\"\n—Anders, cathar drillmaster",
+        "imageUri": "https://cards.scryfall.io/normal/front/5/3/5317077b-370e-41a9-9162-c713362fd7f4.jpg?1783924922"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Halana and Alena, Partners
 {
     "name": "Halana and Alena, Partners",
@@ -3080,6 +3373,103 @@
     },
     "colorIdentityOverride": [
         "RED"
+    ]
+}
+
+// Lunar Rejection
+{
+    "name": "Lunar Rejection",
+    "manaCost": "{1}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Cleave {3}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nReturn target [Wolf or Werewolf] creature to its owner's hand.\nDraw a card.",
+    "keywords": [
+        "CLEAVE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cleave",
+            "cost": "{3}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "Wolf or Werewolf creature"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": {
+                        "cardPredicates": [
+                            "IsCreature",
+                            {
+                                "type": "HasAnyOfSubtypes",
+                                "subtypes": [
+                                    "Wolf",
+                                    "Werewolf"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "id": "Wolf or Werewolf creature"
+            }
+        ],
+        "cleaveTargetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ],
+        "cleaveSpellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "MoveToZone",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    },
+                    "destination": "Hand"
+                },
+                {
+                    "type": "DrawCards",
+                    "count": {
+                        "type": "Fixed",
+                        "amount": 1
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "67",
+        "rarity": "UNCOMMON",
+        "artist": "Donato Giancola",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/f/0f66511c-355f-4e8a-96fc-3afc7a315231.jpg?1783924891"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -3787,6 +4177,99 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Parasitic Grasp
+{
+    "name": "Parasitic Grasp",
+    "manaCost": "{1}{B}",
+    "typeLine": "Instant",
+    "oracleText": "Cleave {1}{B}{B} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nParasitic Grasp deals 3 damage to target [Human] creature. You gain 3 life.",
+    "keywords": [
+        "CLEAVE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cleave",
+            "cost": "{1}{B}{B}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "Human creature"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        },
+        "targetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature Human"
+                },
+                "id": "Human creature"
+            }
+        ],
+        "cleaveTargetRequirements": [
+            {
+                "type": "TargetObject",
+                "filter": {
+                    "baseFilter": "creature"
+                },
+                "id": "creature"
+            }
+        ],
+        "cleaveSpellEffect": {
+            "type": "Composite",
+            "effects": [
+                {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    },
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature"
+                    }
+                },
+                {
+                    "type": "GainLife",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 3
+                    }
+                }
+            ]
+        }
+    },
+    "metadata": {
+        "collectorNumber": "123",
+        "rarity": "UNCOMMON",
+        "artist": "Rovina Cai",
+        "flavorText": "Some wicked souls linger only to consume the warmth of life.",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/7/0713adf7-1770-4d5b-80f7-d6cbd24f7890.jpg?1783924860"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 
@@ -5408,6 +5891,98 @@
     ]
 }
 
+// Torens, Fist of the Angels
+{
+    "name": "Torens, Fist of the Angels",
+    "manaCost": "{1}{G}{W}",
+    "typeLine": "Legendary Creature — Human Cleric",
+    "oracleText": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\nWhenever you cast a creature spell, create a 1/1 green and white Human Soldier creature token with training.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "TRAINING"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "AttackEvent",
+                    "requires": [
+                        "AttacksAlongsideGreaterPower"
+                    ]
+                },
+                "effect": {
+                    "type": "AddCounters",
+                    "counterType": "+1/+1",
+                    "count": 1,
+                    "target": "Self"
+                },
+                "descriptionOverride": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "SpellCastEvent",
+                    "spellFilter": {
+                        "cardPredicates": [
+                            "IsCreature"
+                        ]
+                    }
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "CreateToken",
+                    "power": 1,
+                    "toughness": 1,
+                    "colors": [
+                        "GREEN",
+                        "WHITE"
+                    ],
+                    "creatureTypes": [
+                        "Human",
+                        "Soldier"
+                    ],
+                    "keywords": [
+                        "TRAINING"
+                    ],
+                    "imageUri": "https://cards.scryfall.io/normal/front/5/f/5f3c4810-7359-42b7-905f-4845f6d1daf6.jpg?1783924693",
+                    "triggeredAbilities": [
+                        {
+                            "id": "ability_3",
+                            "trigger": {
+                                "type": "AttackEvent",
+                                "requires": [
+                                    "AttacksAlongsideGreaterPower"
+                                ]
+                            },
+                            "effect": {
+                                "type": "AddCounters",
+                                "counterType": "+1/+1",
+                                "count": 1,
+                                "target": "Self"
+                            },
+                            "descriptionOverride": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)"
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "249",
+        "rarity": "RARE",
+        "artist": "Justine Cruz",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/d/bd111dc9-b8de-4e92-a63d-75a961b2db3b.jpg?1783924787"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
+        "WHITE"
+    ]
+}
+
 // Toxic Scorpion
 {
     "name": "Toxic Scorpion",
@@ -6501,6 +7076,52 @@
         "imageUri": "https://cards.scryfall.io/normal/front/5/4/54fb422d-71f2-44ed-9589-32630ab87050.jpg?1782703130"
     },
     "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
+// Winged Portent
+{
+    "name": "Winged Portent",
+    "manaCost": "{1}{U}{U}",
+    "typeLine": "Instant",
+    "oracleText": "Cleave {4}{G}{U} (You may cast this spell for its cleave cost. If you do, remove the words in square brackets.)\nDraw a card for each creature you control [with flying].",
+    "keywords": [
+        "CLEAVE"
+    ],
+    "keywordAbilities": [
+        {
+            "type": "Cleave",
+            "cost": "{4}{G}{U}"
+        }
+    ],
+    "script": {
+        "spellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature kw:flying"
+            }
+        },
+        "cleaveSpellEffect": {
+            "type": "DrawCards",
+            "count": {
+                "type": "AggregateBattlefield",
+                "player": "You",
+                "filter": "creature"
+            }
+        }
+    },
+    "metadata": {
+        "collectorNumber": "89",
+        "rarity": "RARE",
+        "artist": "Nicholas Gregory",
+        "flavorText": "\"No, no, it's just a murder of crows, not an omen of murder . . . I think.\"\n—York, Kessig tracker",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/4/3494a4fc-37e5-4095-a3bb-5cd9280f4c77.jpg?1783924876"
+    },
+    "colorIdentityOverride": [
+        "GREEN",
         "BLUE"
     ]
 }

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/AttachmentTriggerDetector.kt
@@ -117,7 +117,7 @@ class AttachmentTriggerDetector(private val matcher: TriggerMatcher) {
                     // Apply the trigger's attack-time predicates (e.g. AttackPredicate.Alone for
                     // Bilbo's Ring) — the same conjunctive check the main loop runs at declaration,
                     // which the ATTACHED path must not skip.
-                    trigger.requires.all { matcher.matchesAttackPredicate(it, event, attachedEntityId) }
+                    trigger.requires.all { matcher.matchesAttackPredicate(it, event, attachedEntityId, state) }
             }
             is EventPattern.TapEvent -> {
                 event is TappedEvent && event.entityId == attachedEntityId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/event/TriggerMatcher.kt
@@ -124,7 +124,7 @@ class TriggerMatcher(
             is EventPattern.AttackEvent -> {
                 event is AttackersDeclaredEvent &&
                     checkBinding(binding, sourceId, event.attackers) &&
-                    trigger.requires.all { matchesAttackPredicate(it, event, sourceId) }
+                    trigger.requires.all { matchesAttackPredicate(it, event, sourceId, state) }
             }
             is EventPattern.YouAttackEvent -> {
                 if (event !is AttackersDeclaredEvent) return false
@@ -1441,11 +1441,16 @@ class TriggerMatcher(
      * Add a new branch here when extending [AttackPredicate] with a new
      * attack-time fact. The matcher is conjunctive — every predicate the
      * trigger declares must hold.
+     *
+     * [state] is threaded for predicates that must read **projected** creature stats across the
+     * attacking band (Training's [AttackPredicate.AttackedAlongsideGreaterPower]); count-only and
+     * stamped-set predicates ignore it.
      */
     internal fun matchesAttackPredicate(
         predicate: AttackPredicate,
         event: AttackersDeclaredEvent,
-        boundEntityId: EntityId
+        boundEntityId: EntityId,
+        state: GameState
     ): Boolean = when (predicate) {
         AttackPredicate.Alone -> event.attackers.size == 1
         is AttackPredicate.AttackerCountAtLeast -> event.attackers.size >= predicate.n
@@ -1456,6 +1461,21 @@ class TriggerMatcher(
         // Per-attacker: the trigger's own source was declared as attacking a player (not a
         // planeswalker or battle). Stamped on the event at declaration (CR 508.1 defender kind).
         AttackPredicate.DefenderIsPlayer -> boundEntityId in event.attackersAgainstPlayer
+        // Training (CR 702.149a): the source attacked, and at least one *other* declared attacker
+        // has strictly greater PROJECTED power (Rule 613 layers — so an anthem/aura on the other
+        // attacker counts). Read every power through the cached projected state, never raw
+        // CreatureStatsComponent, per the projected-state load-bearing rule.
+        AttackPredicate.AttackedAlongsideGreaterPower -> {
+            if (boundEntityId !in event.attackers) {
+                false
+            } else {
+                val projected = state.projectedState
+                val myPower = projected.getPower(boundEntityId) ?: 0
+                event.attackers.any { other ->
+                    other != boundEntityId && (projected.getPower(other) ?: 0) > myPower
+                }
+            }
+        }
     }
 
     private fun matchesSpellCastPredicate(

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrainingTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/TrainingTest.kt
@@ -1,0 +1,262 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.state.components.identity.CardComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.vow.cards.CloakedCadet
+import com.wingedsheep.mtg.sets.definitions.vow.cards.GryffRider
+import com.wingedsheep.mtg.sets.definitions.vow.cards.Torens
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.training
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Training (CR 702.149, Innistrad: Midnight Hunt / VOW) — the attack-triggered self-buff proven
+ * end-to-end.
+ *
+ * CR 702.149a — "Training is a triggered ability. 'Training' means 'Whenever this creature and at
+ * least one other creature with power greater than this creature's power attack, put a +1/+1
+ * counter on this creature.'"
+ * CR 702.149b — "If a creature has multiple instances of training, each triggers separately."
+ *
+ * The engine models this as an attack trigger gated by
+ * [com.wingedsheep.sdk.scripting.events.AttackPredicate.AttackedAlongsideGreaterPower], whose
+ * matcher reads **projected** power for every attacker (Rule 613 layers). The test matrix mirrors
+ * `training.md` §5.4:
+ *  1. attacks alone → no counter;
+ *  2. attacks alongside only lower/equal power → no counter;
+ *  3. attacks alongside strictly-greater power → exactly one counter;
+ *  4. a pump on the *other* attacker flips no-trigger → trigger (proving the comparison is over
+ *     projected P/T, not printed);
+ *  plus 702.149b (two instances trigger separately → two counters), Cloaked Cadet's draw watcher
+ *  (its own Training counter feeds it, and it draws only once per turn), and Torens' Human Soldier
+ *  token training on its own.
+ */
+class TrainingTest : FunSpec({
+
+    fun newDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        driver.registerCard(GryffRider)
+        driver.registerCard(CloakedCadet)
+        driver.registerCard(Torens)
+        driver.registerCard(TwinTrainer)
+        driver.initMirrorMatch(deck = Deck.of("Plains" to 20, "Forest" to 20), startingLife = 20)
+        return driver
+    }
+
+    /** Read the +1/+1 counter count on a permanent. */
+    fun GameTestDriver.plusOneCounters(id: EntityId): Int =
+        state.getEntity(id)?.get<CountersComponent>()?.counters?.get(CounterType.PLUS_ONE_PLUS_ONE) ?: 0
+
+    /**
+     * Resolve everything currently on the stack (and any decisions it raises) without advancing the
+     * turn past it — the multi-trigger drain used by other scenario tests. Guarded by stack size so
+     * we never pass out of the step once the triggers are gone.
+     */
+    fun GameTestDriver.drainStack(player: EntityId) {
+        var guard = 0
+        while ((stackSize > 0 || pendingDecision != null) && guard < 20) {
+            if (pendingDecision != null) autoResolveDecision() else bothPass()
+            guard++
+        }
+    }
+
+    /** Find a single created token by its display name. */
+    fun GameTestDriver.tokenNamed(playerId: EntityId, name: String): EntityId? =
+        getPermanents(playerId).firstOrNull { id ->
+            state.getEntity(id)?.get<CardComponent>()?.name == name
+        }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // §5.4 case 1 — attacks alone → no counter
+    // ─────────────────────────────────────────────────────────────────────────
+    test("training does not trigger when the creature attacks alone") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val gryff = driver.putCreatureOnBattlefield(me, "Gryff Rider")
+        driver.removeSummoningSickness(gryff)
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(gryff), opp)
+        driver.drainStack(me)
+
+        driver.plusOneCounters(gryff) shouldBe 0
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // §5.4 case 2 — attacks alongside only lower/equal power → no counter
+    // ─────────────────────────────────────────────────────────────────────────
+    test("training does not trigger when no other attacker has strictly greater power") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val gryff = driver.putCreatureOnBattlefield(me, "Gryff Rider")          // power 2
+        val lions = driver.putCreatureOnBattlefield(me, "Savannah Lions")       // power 1 (lower)
+        val goblin = driver.putCreatureOnBattlefield(me, "Goblin Guide")        // power 2 (equal)
+        listOf(gryff, lions, goblin).forEach { driver.removeSummoningSickness(it) }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(gryff, lions, goblin), opp)
+        driver.drainStack(me)
+
+        // Neither a lower-power (1) nor an equal-power (2) partner satisfies "strictly greater".
+        driver.plusOneCounters(gryff) shouldBe 0
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // §5.4 case 3 — attacks alongside strictly-greater power → exactly one counter
+    // ─────────────────────────────────────────────────────────────────────────
+    test("training triggers once when attacking alongside a creature of strictly greater power") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val gryff = driver.putCreatureOnBattlefield(me, "Gryff Rider")          // power 2
+        val centaur = driver.putCreatureOnBattlefield(me, "Centaur Courser")    // power 3 (greater)
+        listOf(gryff, centaur).forEach { driver.removeSummoningSickness(it) }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(gryff, centaur), opp)
+        driver.drainStack(me)
+
+        driver.plusOneCounters(gryff) shouldBe 1
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // §5.4 case 4 — a pump on the OTHER attacker flips no-trigger → trigger.
+    // Same board as case 2's equal-power partner (Goblin Guide, power 2), but Giant Growth makes it
+    // 5/4 before attackers are declared. The matcher reads projected power, so the +3/+3 on the
+    // *other* creature is what tips Gryff Rider (power 2) into "attacked alongside greater power".
+    // ─────────────────────────────────────────────────────────────────────────
+    test("a pump on the other attacker makes training trigger (projected power, not printed)") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val gryff = driver.putCreatureOnBattlefield(me, "Gryff Rider")          // power 2
+        val goblin = driver.putCreatureOnBattlefield(me, "Goblin Guide")        // power 2 (equal, until pumped)
+        listOf(gryff, goblin).forEach { driver.removeSummoningSickness(it) }
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val giantGrowth = driver.putCardInHand(me, "Giant Growth")              // {G}: +3/+3 EOT
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.castSpell(me, giantGrowth, targets = listOf(goblin)).isSuccess shouldBe true
+        driver.drainStack(me)                                                   // resolve Giant Growth → Goblin Guide is 5/4
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(gryff, goblin), opp)
+        driver.drainStack(me)
+
+        // Goblin Guide's projected power (5) now exceeds Gryff Rider's (2) → Training fires.
+        driver.plusOneCounters(gryff) shouldBe 1
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // CR 702.149b — multiple instances of training trigger separately → two counters.
+    // ─────────────────────────────────────────────────────────────────────────
+    test("two instances of training put two counters (CR 702.149b)") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val twin = driver.putCreatureOnBattlefield(me, "Twin Trainer")          // power 2, training x2
+        val centaur = driver.putCreatureOnBattlefield(me, "Centaur Courser")    // power 3 (greater)
+        listOf(twin, centaur).forEach { driver.removeSummoningSickness(it) }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(twin, centaur), opp)
+        driver.drainStack(me)
+
+        // Both instances triggered off the single attack; each resolved a +1/+1 counter.
+        driver.plusOneCounters(twin) shouldBe 2
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Cloaked Cadet — its own Training counter feeds the draw watcher, which draws only once per
+    // turn no matter how many +1/+1 counters land on Humans that turn.
+    // ─────────────────────────────────────────────────────────────────────────
+    test("Cloaked Cadet draws exactly once even when two Humans train the same turn") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val cadet = driver.putCreatureOnBattlefield(me, "Cloaked Cadet")        // Human, power 2, training
+        val gryff = driver.putCreatureOnBattlefield(me, "Gryff Rider")          // Human, power 2, training
+        val centaur = driver.putCreatureOnBattlefield(me, "Centaur Courser")    // power 3 (greater)
+        listOf(cadet, gryff, centaur).forEach { driver.removeSummoningSickness(it) }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        val handBefore = driver.getHand(me).size
+        driver.declareAttackers(me, listOf(cadet, gryff, centaur), opp)
+        driver.drainStack(me)
+
+        // Both Humans trained (one +1/+1 counter each) — two separate counter-placement events…
+        driver.plusOneCounters(cadet) shouldBe 1
+        driver.plusOneCounters(gryff) shouldBe 1
+        // …but the "draw a card" ability triggers only once each turn (oncePerTurn): exactly +1.
+        driver.getHand(me).size shouldBe handBefore + 1
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Torens, Fist of the Angels — the 1/1 Human Soldier token it makes has Training and trains on
+    // its own when it later attacks alongside a creature of greater power.
+    // ─────────────────────────────────────────────────────────────────────────
+    test("Torens' Human Soldier token has training and trains itself") {
+        val driver = newDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+
+        val torens = driver.putCreatureOnBattlefield(me, "Torens, Fist of the Angels")
+        driver.removeSummoningSickness(torens)
+
+        // Cast a creature spell → Torens creates a 1/1 Human Soldier token with training. The
+        // Centaur (power 3) will be the greater-power partner the token trains alongside.
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val centaurCard = driver.putCardInHand(me, "Centaur Courser")           // {2}{G}
+        driver.giveMana(me, Color.GREEN, 1)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, centaurCard).isSuccess shouldBe true
+        driver.drainStack(me)                                                   // resolve Torens' trigger + the Centaur spell
+
+        val tokenId = driver.tokenNamed(me, "Human Soldier Token")
+            ?: error("Torens should have created a Human Soldier Token")
+        driver.plusOneCounters(tokenId) shouldBe 0
+
+        // Freshly-created this turn — clear sickness on the token and the resolved Centaur so both
+        // can attack.
+        val centaur = driver.getPermanents(me).first { driver.getCardName(it) == "Centaur Courser" }
+        listOf(tokenId, centaur).forEach { driver.removeSummoningSickness(it) }
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(me, listOf(tokenId, centaur), opp)              // token power 1 alongside Centaur power 3
+        driver.drainStack(me)
+
+        // The token's own Training put a +1/+1 counter on it.
+        driver.plusOneCounters(tokenId) shouldBe 1
+    }
+})
+
+/**
+ * Test-only creature carrying two instances of Training (CR 702.149b). Not registered in any set —
+ * it exists purely to prove that two `training()` calls install two independent attack triggers
+ * that each add a +1/+1 counter. Defined via the same `card { training() }` builder real cards use.
+ */
+private val TwinTrainer = card("Twin Trainer") {
+    manaCost = "{2}{G}"
+    typeLine = "Creature — Human Soldier"
+    power = 2
+    toughness = 2
+    training()
+    training()
+}

--- a/web-client/src/assets/icons/keywords/index.ts
+++ b/web-client/src/assets/icons/keywords/index.ts
@@ -53,6 +53,7 @@ export const keywordManaClass: Record<string, string> = {
   CANT_BE_BLOCKED: 'ability-unblockable',
   CHANGELING: 'ability-changeling',
   EXPLOIT: 'ability-exploit',
+  TRAINING: 'ability-training',
   /** Suspect status (CR 701.60). Rendered via the synthetic SUSPECTED pseudo-keyword from
    *  ProjectedState.isSuspected — the status itself isn't a keyword, but reusing this
    *  icon table keeps the badge rendering uniform. */
@@ -66,7 +67,7 @@ export const displayableKeywords = new Set([
   'SHROUD', 'INDESTRUCTIBLE', 'DEFENDER', 'MENACE', 'FEAR',
   'PROWESS', 'WARD', 'INTIMIDATE', 'INFECT',
   'WITHER', 'TOXIC', 'CANT_BE_BLOCKED', 'CHANGELING',
-  'PERSIST', 'BANDING', 'FLANKING', 'EXPLOIT',
+  'PERSIST', 'BANDING', 'FLANKING', 'EXPLOIT', 'TRAINING',
 ])
 
 /** Maps engine CounterType to mana-font counter class suffixes */

--- a/web-client/src/types/enums.ts
+++ b/web-client/src/types/enums.ts
@@ -214,6 +214,8 @@ export enum Keyword {
   ASCEND = 'ASCEND',
   // Token decay (Innistrad: Midnight Hunt / TDM decayed counter)
   DECAYED = 'DECAYED',
+  // Attack-triggered self-buff (Innistrad: Midnight Hunt)
+  TRAINING = 'TRAINING',
   // Equipment that makes its own bearer (Final Fantasy)
   JOB_SELECT = 'JOB_SELECT',
   // Ability words
@@ -281,6 +283,7 @@ export const KeywordDisplayNames: Record<Keyword, string> = {
   [Keyword.ENDURING]: 'Enduring',
   [Keyword.ASCEND]: 'Ascend',
   [Keyword.DECAYED]: 'Decayed',
+  [Keyword.TRAINING]: 'Training',
   [Keyword.JOB_SELECT]: 'Job select',
   [Keyword.EERIE]: 'Eerie',
 }


### PR DESCRIPTION
Training is an attack-triggered self-buff: "Whenever this creature and at least one other creature with power greater than this creature's power attack, put a +1/+1 counter on this creature" (CR 702.149a). Multiple instances trigger separately (702.149b).

Modeled as composition over new monoliths:
- SDK: TRAINING keyword + AttackPredicate.AttackedAlongsideGreaterPower (EventFilters.kt) + a TrainingDsl.kt `card { training() }` helper that installs the keyword badge plus one attack-triggered AddCounters ability. The standalone trainingTriggeredAbility() factory lets an intrinsically training token carry the behavior.
- Engine: matchesAttackPredicate gains a projected-power branch reading state.projectedState.getPower across the attacking band (Rule 613 layers), so an anthem/pump on the OTHER attacker flips the trigger. Threaded the new `state` param through the AttachmentTriggerDetector caller too.
- Client: TRAINING badge wiring (enums, display name, mana-font icon).
- Cards: Gryff Rider, Cloaked Cadet, Torens Fist of the Angels (paper VOW). Torens' 1/1 Human Soldier token carries Training and trains on its own.

CR 702.149c "when this creature trains" (TrainedEvent) is designed and reserved in the SDK reference, to ship with the first payoff card.

TrainingTest.kt covers the training.md §5.4 matrix (alone/lower-equal/ strictly-greater/projected-pump-flip) plus 702.149b two-instance, Cloaked Cadet draw-once-per-turn, and the Torens token training itself.

Also bundles five other VOW cards (Alchemist's Retrieval, Dread Fugue, Lunar Rejection, Parasitic Grasp, Winged Portent) that share the VOW.json snapshot golden.