### PR TITLE
LCI easy-wins-2: Equipment quartet, Akawalli, and conditional block-restriction fixes

### DIFF
--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 239 / 286
+**Implemented:** 243 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -27,7 +27,7 @@
 - [x] Belligerent Yearling
 - [x] Bitter Triumph
 - [x] Bloodletter of Aclazotz
-- [ ] Bloodthorn Flail
+- [x] Bloodthorn Flail
 - [x] Bonehoard Dracosaur
 - [x] Brackish Blunder
 - [x] Braided Net
@@ -69,7 +69,7 @@
 - [x] Dauntless Dismantler
 - [x] Dead Weight
 - [x] Deathcap Marionette
-- [ ] Deconstruction Hammer
+- [x] Deconstruction Hammer
 - [x] Deep Goblin Skulltaker
 - [x] Deep-Cavern Bat
 - [x] Deepfathom Echo
@@ -106,7 +106,7 @@
 - [x] Gishath, Sun's Avatar
 - [x] Glimpse the Core
 - [x] Glorifier of Suffering
-- [ ] Glowcap Lantern
+- [x] Glowcap Lantern
 - [x] Goblin Tomb Raider
 - [x] Goldfury Strider
 - [ ] Grasping Shadows
@@ -241,7 +241,7 @@
 - [x] Stinging Cave Crawler
 - [x] Subterranean Schooner
 - [x] Sunbird Standard
-- [ ] Sunfire Torch
+- [x] Sunfire Torch
 - [x] Sunken Citadel
 - [x] Sunshot Militia
 - [x] Swashbuckler's Whip

--- a/backlog/sets/the-lost-caverns-of-ixalan/cards.md
+++ b/backlog/sets/the-lost-caverns-of-ixalan/cards.md
@@ -2,7 +2,7 @@
 
 **Set Size:** 286 booster cards (excluding basic lands and tokens)
 **Release Date:** November 17, 2023
-**Implemented:** 243 / 286
+**Implemented:** 244 / 286
 - [x] Abrade
 - [x] Abuelo's Awakening
 - [x] Abuelo, Ancestral Echo
@@ -12,7 +12,7 @@
 - [x] Acrobatic Leap
 - [x] Adaptive Gemguard
 - [x] Akal Pakal, First Among Equals
-- [ ] Akawalli, the Seething Tower
+- [x] Akawalli, the Seething Tower
 - [x] Amalia Benavides Aguirre
 - [x] Ancestors' Aid
 - [x] Ancestral Reminiscence

--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -212,6 +212,8 @@ excluded.
 - `Costs.Sacrifice(filter)` — sacrifice a permanent matching the filter (may include self).
 - `Costs.SacrificeAnother(filter)` — sacrifice a *different* permanent matching the filter.
 - `Costs.SacrificeMultiple(count, filter = Any, distinctNames = false)` — sacrifice `count` matching permanents. With `distinctNames = true` the chosen permanents must all have **different names** ("sacrifice three artifact tokens with different names" — Transmutation Font); the cost is only payable when ≥ `count` distinctly-named candidates exist, and the activation always pauses for the selection (it's a real choice even when candidates == count).
+- `Costs.SacrificeSelf` — sacrifice this permanent (the ability's source).
+- `Costs.SacrificeGrantingPermanent` — sacrifice the permanent that *granted* this activated ability, resolved from the static-grant lookup at activation time (no filter, no prompt). The self-sacrifice sibling of `Costs.ExileGrantingPermanent`: use for an Equipment/Aura whose granted activated ability says "Sacrifice [this permanent]" — e.g. Deconstruction Hammer's "{3}, {T}, Sacrifice Deconstruction Hammer: ...". Per CR 201.5a the name refers only to the specific granting permanent, so this sacrifices exactly that one even with another same-named permanent on the battlefield.
 - `Costs.DiscardCard` — discard a card you choose (any card).
 - `Costs.Discard(filter, count = 1, atRandom = false)` — discard `count` cards matching the filter.
   When `atRandom` is true the engine picks the cards (no player selection); otherwise the player
@@ -2565,7 +2567,9 @@ work for abilities-on-stack (which carry no `CardComponent`).
   `AttachedToComponent.targetId == sourceId`. Use it to scope a static ability on the *host* to its own
   attachments — Cloud, Midgar Mercenary's "an Equipment attached to it" via
   `GameObjectFilter.Artifact.withSubtype("Equipment").attachedToSource()`. Source-relative; inert with no
-  source context.
+  source context. Negated builder `notAttachedToSource()` — excludes the source's own attachments, backing
+  "an artifact other than [this granting Equipment]" on a granted triggered ability whose source is the
+  equipped creature (Dire Blunderbuss's "sacrifice an artifact other than Dire Blunderbuss").
 - `HasGreatestPower` (filter builder `hasGreatestPower()`) / `HasLeastPower` (filter builder
   `hasLeastPower()`) — has the greatest / least projected power among creatures *its controller*
   controls (ties all qualify). Used for "creature with the greatest/least power" target and edict

--- a/manual-scenarios/sets/lci/easy-wins-2.json
+++ b/manual-scenarios/sets/lci/easy-wins-2.json
@@ -1,0 +1,55 @@
+{
+  "player1Name": "Alice",
+  "player2Name": "Bob",
+  "player1": {
+    "lifeTotal": 20,
+    "hand": [
+      "Deconstruction Hammer",
+      "Sunfire Torch",
+      "Bloodthorn Flail",
+      "Glowcap Lantern",
+      "Akawalli, the Seething Tower"
+    ],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Plains"},
+      {"name": "Plains"},
+      {"name": "Mountain"},
+      {"name": "Mountain"},
+      {"name": "Swamp"},
+      {"name": "Swamp"},
+      {"name": "Forest"},
+      {"name": "Forest"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Plains",
+      "Swamp",
+      "Forest",
+      "Mountain"
+    ]
+  },
+  "player2": {
+    "lifeTotal": 20,
+    "hand": [],
+    "battlefield": [
+      {"name": "Grizzly Bears"},
+      {"name": "Ornithopter"},
+      {"name": "Forest"},
+      {"name": "Swamp"}
+    ],
+    "graveyard": [],
+    "library": [
+      "Forest",
+      "Island",
+      "Mountain"
+    ]
+  },
+  "phase": "PRECOMBAT_MAIN",
+  "activePlayer": 1,
+  "priorityPlayer": 1,
+  "player1StopAtSteps": [],
+  "player2StopAtSteps": [],
+  "player1OpponentStopAtSteps": [],
+  "player2OpponentStopAtSteps": []
+}

--- a/manual-scenarios/sets/lci/easy-wins-2.json
+++ b/manual-scenarios/sets/lci/easy-wins-2.json
@@ -5,12 +5,16 @@
     "lifeTotal": 20,
     "hand": [
       "Deconstruction Hammer",
+      "Deconstruction Hammer",
       "Sunfire Torch",
       "Bloodthorn Flail",
       "Glowcap Lantern",
       "Akawalli, the Seething Tower"
     ],
     "battlefield": [
+      {"name": "Millstone"},
+      {"name": "Millstone"},
+      {"name": "Millstone"},
       {"name": "Grizzly Bears"},
       {"name": "Plains"},
       {"name": "Plains"},
@@ -21,8 +25,23 @@
       {"name": "Forest"},
       {"name": "Forest"}
     ],
-    "graveyard": [],
+    "graveyard": ["Forest", "Forest"],
     "library": [
+      "Plains",
+      "Swamp",
+      "Forest",
+      "Plains",
+      "Swamp",
+      "Forest",
+      "Plains",
+      "Swamp",
+      "Forest",
+      "Plains",
+      "Swamp",
+      "Forest",
+      "Plains",
+      "Swamp",
+      "Forest",
       "Plains",
       "Swamp",
       "Forest",
@@ -51,5 +70,6 @@
   "player1StopAtSteps": [],
   "player2StopAtSteps": [],
   "player1OpponentStopAtSteps": [],
-  "player2OpponentStopAtSteps": []
+  "player2OpponentStopAtSteps": [],
+  "mode": "AI"
 }

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Costs.kt
@@ -178,6 +178,14 @@ object Costs {
     val ExileGrantingPermanent: AbilityCost = AbilityCost.ExileGrantingPermanent
 
     /**
+     * Sacrifice the permanent that granted this activated ability (e.g., the Equipment
+     * granting the ability to its equipped creature, like Deconstruction Hammer). The
+     * self-sacrifice sibling of [ExileGrantingPermanent]; the granter is resolved at
+     * activation time, so it sacrifices exactly the granting permanent (CR 201.5a).
+     */
+    val SacrificeGrantingPermanent: AbilityCost = AbilityCost.SacrificeGrantingPermanent
+
+    /**
      * Sacrifice a creature of the type chosen when this permanent entered the battlefield.
      * Used by cards like Doom Cannon.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/ActivatedAbility.kt
@@ -296,6 +296,21 @@ sealed interface AbilityCost : TextReplaceable<AbilityCost> {
     }
 
     /**
+     * Sacrifice the permanent that granted this activated ability to the source.
+     * The self-sacrifice sibling of [ExileGrantingPermanent]: an Equipment/Aura whose static
+     * ability grants an activated ability to the attached creature with "Sacrifice [this
+     * permanent]" as part of the cost (e.g. Deconstruction Hammer's granted "{3}, {T},
+     * Sacrifice Deconstruction Hammer: ..."). Per CR 201.5a the name in the granted ability
+     * refers only to the specific granting permanent, so this sacrifices exactly that one —
+     * the granter resolved at activation time — not any same-named permanent.
+     */
+    @SerialName("CostSacrificeGrantingPermanent")
+    @Serializable
+    data object SacrificeGrantingPermanent : AbilityCost {
+        override val description: String = "Sacrifice the granting permanent"
+    }
+
+    /**
      * Sacrifice a creature of the type chosen when this permanent entered the battlefield.
      * Used by cards like Doom Cannon that choose a creature type on entry and reference it in costs.
      */

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/scripting/filters/unified/ObjectFilter.kt
@@ -718,6 +718,17 @@ data class GameObjectFilter(
     )
 
     /**
+     * Must NOT be an Aura/Equipment attached to the effect's source permanent — the negation of
+     * [attachedToSource]. Backs "an artifact other than [this granting Equipment]"-style
+     * exclusions on a granted triggered ability whose source is the equipped creature: the
+     * granting Equipment is the one attached to that creature, so this excludes it (Dire
+     * Blunderbuss's "sacrifice an artifact other than Dire Blunderbuss").
+     */
+    fun notAttachedToSource() = copy(
+        statePredicates = statePredicates + StatePredicate.Not(StatePredicate.IsAttachedToSource)
+    )
+
+    /**
      * Must be attached to a permanent matching [hostFilter] (general form of attachment matching —
      * the host filter may carry a controller predicate, e.g. "a creature you control"). Used by
      * Stolen Uniform's reflexive "if it's attached to a creature you control" guard.

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AkawalliTheSeethingTower.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/AkawalliTheSeethingTower.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Conditions
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantKeyword
+import com.wingedsheep.sdk.scripting.ModifyStats
+
+/**
+ * Akawalli, the Seething Tower (LCI #220) — {1}{B}{G} Legendary Creature — Fungus (uncommon)
+ * 3/3
+ *
+ * Descend 4 — As long as there are four or more permanent cards in your graveyard, Akawalli
+ *   gets +2/+2 and has trample.
+ * Descend 8 — As long as there are eight or more permanent cards in your graveyard, Akawalli
+ *   gets an additional +2/+2 and can't be blocked by more than one creature.
+ *
+ * Implementation notes:
+ * - Both descend clauses are "as long as" *static* buffs, so each is a self-scoped
+ *   ([Filters.Self]) static gated by [Conditions.CardsInGraveyardMatchingAtLeast] with
+ *   [GameObjectFilter.Permanent] (the Basking Capybara idiom). The `condition` field on the
+ *   `staticAbility { }` block auto-wraps in a ConditionalStaticAbility.
+ * - Descend 4 grants +2/+2 ([ModifyStats]) and trample ([GrantKeyword]); Descend 8 grants an
+ *   *additional* +2/+2 (stacks with the descend-4 [ModifyStats] when ≥8 cards are present, since
+ *   ≥8 implies ≥4) plus [CantBeBlockedByMoreThan] with `maxBlockers = 1`.
+ */
+val AkawalliTheSeethingTower = card("Akawalli, the Seething Tower") {
+    manaCost = "{1}{B}{G}"
+    colorIdentity = "BG"
+    typeLine = "Legendary Creature — Fungus"
+    power = 3
+    toughness = 3
+    oracleText = "Descend 4 — As long as there are four or more permanent cards in your graveyard, " +
+        "Akawalli gets +2/+2 and has trample.\n" +
+        "Descend 8 — As long as there are eight or more permanent cards in your graveyard, Akawalli " +
+        "gets an additional +2/+2 and can't be blocked by more than one creature."
+
+    // Descend 4 — +2/+2 and trample.
+    staticAbility {
+        condition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent)
+        ability = ModifyStats(+2, +2, Filters.Self)
+    }
+    staticAbility {
+        condition = Conditions.CardsInGraveyardMatchingAtLeast(4, GameObjectFilter.Permanent)
+        ability = GrantKeyword(Keyword.TRAMPLE, Filters.Self)
+    }
+
+    // Descend 8 — an additional +2/+2 and can't be blocked by more than one creature.
+    staticAbility {
+        condition = Conditions.CardsInGraveyardMatchingAtLeast(8, GameObjectFilter.Permanent)
+        ability = ModifyStats(+2, +2, Filters.Self)
+    }
+    staticAbility {
+        condition = Conditions.CardsInGraveyardMatchingAtLeast(8, GameObjectFilter.Permanent)
+        ability = CantBeBlockedByMoreThan(maxBlockers = 1)
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "220"
+        artist = "Simon Dominic"
+        imageUri = "https://cards.scryfall.io/normal/front/3/e/3ee62dd1-97d0-4e5d-8937-26c9e51e9414.jpg?1782694434"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BloodthornFlail.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/BloodthornFlail.kt
@@ -1,0 +1,61 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TimingRule
+
+/**
+ * Bloodthorn Flail (LCI #93) — {B} Artifact — Equipment (uncommon)
+ *
+ * Equipped creature gets +2/+1.
+ * Equip—Pay {3} or discard a card.
+ *
+ * Implementation notes:
+ * - The +2/+1 buff is a [ModifyStats] static scoped to [Filters.EquippedCreature].
+ * - "Equip—Pay {3} or discard a card" is a single equip ability whose cost is a *choice*
+ *   between {3} and discarding a card. The engine has no choice/"or" cost for activated
+ *   abilities, so this is modeled as the faithful decomposition into two equip-flagged,
+ *   sorcery-speed attach abilities — one costing {3} (via the [equipAbility] facade), one
+ *   costing a discarded card. The player picks whichever equip option they can/want to pay,
+ *   which is exactly the choice the printed single ability offers (only the presentation
+ *   differs: two equip buttons instead of one with a cost prompt).
+ */
+val BloodthornFlail = card("Bloodthorn Flail") {
+    manaCost = "{B}"
+    colorIdentity = "B"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +2/+1.\n" +
+        "Equip—Pay {3} or discard a card."
+
+    // Equipped creature gets +2/+1.
+    staticAbility {
+        ability = ModifyStats(+2, +1, Filters.EquippedCreature)
+    }
+
+    // Equip—Pay {3}.
+    equipAbility("{3}")
+
+    // Equip—discard a card (the alternative half of "Pay {3} or discard a card").
+    activatedAbility {
+        isEquipAbility = true
+        cost = Costs.DiscardCard
+        timing = TimingRule.SorcerySpeed
+        val creature = target("target creature you control", Targets.CreatureYouControl)
+        effect = Effects.AttachEquipment(creature)
+        description = "Equip—Discard a card."
+    }
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "93"
+        artist = "Igor Kieryluk"
+        flavorText = "\"This weapon embodies both the strength and the weakness of the Legion of Dusk. They will " +
+            "endure any pain to achieve their ends, but they suffer pointlessly just to prove their dedication.\"\n—Huatli"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/db38babd-57e8-4e59-9701-11a0682baa77.jpg?1782694536"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeconstructionHammer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeconstructionHammer.kt
@@ -1,0 +1,82 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Costs
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.AbilityId
+import com.wingedsheep.sdk.scripting.ActivatedAbility
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Deconstruction Hammer (LCI #9) — {W} Artifact — Equipment (common)
+ *
+ * Equipped creature gets +1/+1 and has "{3}, {T}, Sacrifice Deconstruction Hammer:
+ * Destroy target artifact or enchantment."
+ * Equip {1}
+ *
+ * Implementation notes:
+ * - The +1/+1 buff is a [ModifyStats] static scoped to [Filters.EquippedCreature].
+ * - The quoted activated ability is granted to the equipped creature via
+ *   [GrantActivatedAbility] (the Swashbuckler's Whip idiom): it lives on the creature, its
+ *   `{T}` taps that creature (the granted ability's source, CR 113.7), and the mana +
+ *   sacrifice are paid by that creature's controller. [Effects.Destroy] hits the ability's
+ *   sole target ([Targets.ArtifactOrEnchantment]).
+ *
+ * KNOWN APPROXIMATION — "Sacrifice Deconstruction Hammer":
+ * By CR 201.5a the name in the granted ability refers only to the specific Equipment that
+ * granted it. The engine has no cost that sacrifices the *granting* permanent (only
+ * [com.wingedsheep.sdk.scripting.AbilityCost.ExileGrantingPermanent] exists, and that
+ * exiles rather than sacrifices), so the self-sacrifice is modeled as a name filter
+ * (`Artifact you control named "Deconstruction Hammer"`) — the documented Dire Blunderbuss
+ * idiom. Corner case this mis-handles: with a second Deconstruction Hammer on the
+ * battlefield, the printed ability sacrifices *this* one, but the name filter lets you pick
+ * either. Accepted, documented corner — fix properly by adding a sacrifice-granting-permanent
+ * cost.
+ */
+val DeconstructionHammer = card("Deconstruction Hammer") {
+    manaCost = "{W}"
+    colorIdentity = "W"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+1 and has \"{3}, {T}, Sacrifice Deconstruction Hammer: " +
+        "Destroy target artifact or enchantment.\"\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    // Equipped creature gets +1/+1.
+    staticAbility {
+        ability = ModifyStats(+1, +1, Filters.EquippedCreature)
+    }
+
+    // ... and has "{3}, {T}, Sacrifice Deconstruction Hammer: Destroy target artifact or enchantment."
+    staticAbility {
+        ability = GrantActivatedAbility(
+            ability = ActivatedAbility(
+                id = AbilityId.generate(),
+                cost = Costs.Composite(
+                    Costs.Mana("{3}"),
+                    Costs.Tap,
+                    Costs.Sacrifice(GameObjectFilter.Artifact.youControl().named("Deconstruction Hammer"))
+                ),
+                effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
+                targetRequirements = listOf(Targets.ArtifactOrEnchantment),
+                descriptionOverride = "{3}, {T}, Sacrifice Deconstruction Hammer: Destroy target artifact or enchantment."
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "9"
+        artist = "Dibujante Nocturno"
+        flavorText = "\"All that is made can be unmade. Chimil's light is the only constant.\"\n—Oltec artificers' creed"
+        imageUri = "https://cards.scryfall.io/normal/front/0/c/0c7ba382-18c4-4833-b3d2-bd469ae2ad77.jpg?1782694606"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeconstructionHammer.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DeconstructionHammer.kt
@@ -8,7 +8,6 @@ import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
 import com.wingedsheep.sdk.scripting.AbilityId
 import com.wingedsheep.sdk.scripting.ActivatedAbility
-import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantActivatedAbility
 import com.wingedsheep.sdk.scripting.ModifyStats
 import com.wingedsheep.sdk.scripting.targets.EffectTarget
@@ -27,17 +26,10 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *   `{T}` taps that creature (the granted ability's source, CR 113.7), and the mana +
  *   sacrifice are paid by that creature's controller. [Effects.Destroy] hits the ability's
  *   sole target ([Targets.ArtifactOrEnchantment]).
- *
- * KNOWN APPROXIMATION — "Sacrifice Deconstruction Hammer":
- * By CR 201.5a the name in the granted ability refers only to the specific Equipment that
- * granted it. The engine has no cost that sacrifices the *granting* permanent (only
- * [com.wingedsheep.sdk.scripting.AbilityCost.ExileGrantingPermanent] exists, and that
- * exiles rather than sacrifices), so the self-sacrifice is modeled as a name filter
- * (`Artifact you control named "Deconstruction Hammer"`) — the documented Dire Blunderbuss
- * idiom. Corner case this mis-handles: with a second Deconstruction Hammer on the
- * battlefield, the printed ability sacrifices *this* one, but the name filter lets you pick
- * either. Accepted, documented corner — fix properly by adding a sacrifice-granting-permanent
- * cost.
+ * - "Sacrifice Deconstruction Hammer" refers only to the specific granting Equipment
+ *   (CR 201.5a), so the cost is [Costs.SacrificeGrantingPermanent], which sacrifices exactly
+ *   the granter resolved at activation time — no name filter, no target prompt, and correct
+ *   with a second Deconstruction Hammer on the battlefield.
  */
 val DeconstructionHammer = card("Deconstruction Hammer") {
     manaCost = "{W}"
@@ -60,7 +52,7 @@ val DeconstructionHammer = card("Deconstruction Hammer") {
                 cost = Costs.Composite(
                     Costs.Mana("{3}"),
                     Costs.Tap,
-                    Costs.Sacrifice(GameObjectFilter.Artifact.youControl().named("Deconstruction Hammer"))
+                    Costs.SacrificeGrantingPermanent
                 ),
                 effect = Effects.Destroy(EffectTarget.ContextTarget(0)),
                 targetRequirements = listOf(Targets.ArtifactOrEnchantment),

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DireFlail.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/DireFlail.kt
@@ -49,22 +49,22 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  *    Pirate Hat idiom), so it lives on the creature and fires when that creature attacks.
  *    The ability body is a [ReflexiveTriggerEffect] (the Glorifier of Suffering /
  *    Thousand Moons Crackshot idiom): the optional action selects an artifact you control
- *    (excluding Dire Blunderbuss) and sacrifices it; only "when you do" does the reflexive
- *    part go on the stack, choose target creature, and deal damage equal to the equipped
- *    creature's power ([DynamicAmounts.sourcePower] — the granted ability's source is the
- *    equipped creature; the damage source defaults to it, matching "this creature deals").
+ *    other than the granting Equipment and sacrifices it; only "when you do" does the
+ *    reflexive part go on the stack, choose target creature, and deal damage equal to the
+ *    equipped creature's power ([DynamicAmounts.sourcePower] — the granted ability's source
+ *    is the equipped creature; the damage source defaults to it, matching "this creature deals").
  *
- * KNOWN APPROXIMATION — "an artifact other than Dire Blunderbuss":
- * By CR 201.5a the name in the granted ability refers only to the specific Equipment that
- * granted it. The engine, however, threads a `granterId` only into granted *activated*
- * abilities (`AbilityOnStack.granterId` / `EffectTarget.GrantingSource`); granted
- * *triggered* abilities resolve with the equipped creature as their source and no
- * reference to the granting Equipment, so an entity-based exclusion is not expressible
- * today. The exclusion is therefore modeled as a name filter
- * (`GameObjectFilter.notNamed("Dire Blunderbuss")`). Corner case this mis-handles: with a
- * second Dire Blunderbuss on the battlefield, the printed card lets you sacrifice the
- * *other* copy, but the name filter wrongly excludes it too. Accepted, documented corner —
- * fix properly by threading granterId through granted triggered abilities.
+ * "an artifact other than Dire Blunderbuss" — CR 201.5a: the name refers only to the specific
+ * granting Equipment. A granted *triggered* ability resolves with the equipped creature as its
+ * source (not the Equipment), and the engine threads a `granterId` only into granted *activated*
+ * abilities, so the granter can't be referenced by entity here. Instead the exclusion is scoped
+ * with `.notAttachedToSource()`: the granting Blunderbuss is the Equipment attached to the
+ * attacking creature (the source), so this excludes exactly it while leaving a *second* Dire
+ * Blunderbuss elsewhere (on another creature or unattached) sacrificable — fixing the corner the
+ * old `notNamed("Dire Blunderbuss")` filter mis-handled. Residual, rarer corner: another artifact
+ * Equipment/Aura *also* attached to the same creature is likewise excluded (it shouldn't be); the
+ * fully-correct fix is an entity-based exclusion once granterId is threaded through granted
+ * triggered abilities.
  */
 
 private val DireFlailFront = card("Dire Flail") {
@@ -129,7 +129,7 @@ private val DireBlunderbuss = card("Dire Blunderbuss") {
                                 filter = TargetFilter(
                                     GameObjectFilter.Artifact
                                         .youControl()
-                                        .notNamed("Dire Blunderbuss")
+                                        .notAttachedToSource()
                                 )
                             ),
                             storeAs = "toSacrifice"

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GlowcapLantern.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GlowcapLantern.kt
@@ -1,0 +1,68 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Glowcap Lantern (LCI #187) — {G} Artifact — Equipment (uncommon)
+ *
+ * Equipped creature has "You may look at the top card of your library any time" and
+ * "Whenever this creature attacks, it explores."
+ * Equip {2}
+ *
+ * Implementation notes:
+ * - "Whenever this creature attacks, it explores" is granted to the equipped creature via
+ *   [GrantTriggeredAbility] + [Triggers.attacks] (SELF binding). The [Effects.Explore] targets
+ *   [EffectTarget.Self] — the granted ability's source, i.e. the equipped creature — so "it"
+ *   explores and any +1/+1 counter lands on that creature.
+ * - "You may look at the top card of your library any time" is the filterless player-permission
+ *   static [LookAtTopOfLibrary], which grants its controller the private peek. There is no engine
+ *   primitive to scope a filterless player static onto the *equipped creature* (no generic
+ *   grant-static-ability + no is-attached condition), so it is placed directly on the Equipment.
+ *   In the common case (Equipment and creature share a controller) this is identical to the
+ *   printed card. Minor documented deviation: an *unattached* Glowcap Lantern still lets its
+ *   controller peek — harmless, since the peek is private and changes no game state.
+ */
+val GlowcapLantern = card("Glowcap Lantern") {
+    manaCost = "{G}"
+    colorIdentity = "G"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature has \"You may look at the top card of your library any time\" and " +
+        "\"Whenever this creature attacks, it explores.\" (Reveal the top card of your library. Put that " +
+        "card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put " +
+        "the card back or put it into your graveyard.)\n" +
+        "Equip {2}"
+
+    // "You may look at the top card of your library any time" — see KDoc deviation note.
+    staticAbility {
+        ability = LookAtTopOfLibrary
+    }
+
+    // Equipped creature has "Whenever this creature attacks, it explores."
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.attacks().event,
+                binding = Triggers.attacks().binding,
+                effect = Effects.Explore(EffectTarget.Self)
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{2}")
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "187"
+        artist = "Irina Nordsol"
+        imageUri = "https://cards.scryfall.io/normal/front/b/a/bafde87c-743d-4307-93e0-fbd30f5d92f6.jpg?1782694459"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GlowcapLantern.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/GlowcapLantern.kt
@@ -1,10 +1,12 @@
 package com.wingedsheep.mtg.sets.definitions.lci.cards
 
+import com.wingedsheep.sdk.dsl.Conditions
 import com.wingedsheep.sdk.dsl.Effects
 import com.wingedsheep.sdk.dsl.Filters
 import com.wingedsheep.sdk.dsl.Triggers
 import com.wingedsheep.sdk.dsl.card
 import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
 import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
 import com.wingedsheep.sdk.scripting.LookAtTopOfLibrary
 import com.wingedsheep.sdk.scripting.TriggeredAbility
@@ -23,12 +25,12 @@ import com.wingedsheep.sdk.scripting.targets.EffectTarget
  *   [EffectTarget.Self] — the granted ability's source, i.e. the equipped creature — so "it"
  *   explores and any +1/+1 counter lands on that creature.
  * - "You may look at the top card of your library any time" is the filterless player-permission
- *   static [LookAtTopOfLibrary], which grants its controller the private peek. There is no engine
- *   primitive to scope a filterless player static onto the *equipped creature* (no generic
- *   grant-static-ability + no is-attached condition), so it is placed directly on the Equipment.
- *   In the common case (Equipment and creature share a controller) this is identical to the
- *   printed card. Minor documented deviation: an *unattached* Glowcap Lantern still lets its
- *   controller peek — harmless, since the peek is private and changes no game state.
+ *   static [LookAtTopOfLibrary], which grants its controller the private peek. It lives on the
+ *   Equipment (there is no primitive to scope a filterless player static onto the equipped
+ *   creature) but is gated on the Equipment being attached — a conditional static whose
+ *   condition is [Conditions.SourceMatches] "attached to a creature" — so an *unattached*
+ *   Glowcap Lantern grants no peek, matching the printed card (the permission only exists while
+ *   attached, as part of "Equipped creature has ...").
  */
 val GlowcapLantern = card("Glowcap Lantern") {
     manaCost = "{G}"
@@ -40,8 +42,9 @@ val GlowcapLantern = card("Glowcap Lantern") {
         "the card back or put it into your graveyard.)\n" +
         "Equip {2}"
 
-    // "You may look at the top card of your library any time" — see KDoc deviation note.
+    // "You may look at the top card of your library any time" — only while attached (see KDoc).
     staticAbility {
+        condition = Conditions.SourceMatches(GameObjectFilter.Any.attachedTo(GameObjectFilter.Creature))
         ability = LookAtTopOfLibrary
     }
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunfireTorch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunfireTorch.kt
@@ -1,0 +1,93 @@
+package com.wingedsheep.mtg.sets.definitions.lci.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Filters
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.GrantTriggeredAbility
+import com.wingedsheep.sdk.scripting.ModifyStats
+import com.wingedsheep.sdk.scripting.TriggeredAbility
+import com.wingedsheep.sdk.scripting.effects.ReflexiveTriggerEffect
+import com.wingedsheep.sdk.scripting.effects.SelectTargetEffect
+import com.wingedsheep.sdk.scripting.filters.unified.TargetFilter
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+import com.wingedsheep.sdk.scripting.targets.TargetObject
+
+/**
+ * Sunfire Torch (LCI #167) — {R} Artifact — Equipment (common)
+ *
+ * Equipped creature gets +1/+0 and has "Whenever this creature attacks, you may sacrifice
+ * Sunfire Torch. When you do, this creature deals 2 damage to any target."
+ * Equip {1}
+ *
+ * Implementation notes:
+ * - The +1/+0 buff is a [ModifyStats] static scoped to [Filters.EquippedCreature].
+ * - The quoted attack ability is granted to the equipped creature via [GrantTriggeredAbility]
+ *   + [Triggers.attacks] (SELF binding, the Pirate Hat / Dire Blunderbuss idiom), so it lives
+ *   on the creature and fires when that creature attacks. The body is a [ReflexiveTriggerEffect]:
+ *   the optional action sacrifices Sunfire Torch; only "when you do" puts the reflexive part on
+ *   the stack to choose any target and deal 2 damage. The damage source defaults to the granted
+ *   ability's source — the equipped creature — matching "this creature deals 2 damage."
+ *
+ * KNOWN APPROXIMATION — "sacrifice Sunfire Torch":
+ * As with Dire Blunderbuss, granted *triggered* abilities resolve with the equipped creature
+ * as their source and no reference to the granting Equipment, so the self-sacrifice is modeled
+ * as a name filter (`Artifact you control named "Sunfire Torch"`). Corner case: with a second
+ * Sunfire Torch on the battlefield the printed ability sacrifices *this* one, but the name
+ * filter lets you pick either. Accepted, documented corner.
+ */
+val SunfireTorch = card("Sunfire Torch") {
+    manaCost = "{R}"
+    colorIdentity = "R"
+    typeLine = "Artifact — Equipment"
+    oracleText = "Equipped creature gets +1/+0 and has \"Whenever this creature attacks, you may " +
+        "sacrifice Sunfire Torch. When you do, this creature deals 2 damage to any target.\"\n" +
+        "Equip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)"
+
+    // Equipped creature gets +1/+0.
+    staticAbility {
+        ability = ModifyStats(+1, +0, Filters.EquippedCreature)
+    }
+
+    // ... and has "Whenever this creature attacks, you may sacrifice Sunfire Torch. When you
+    // do, this creature deals 2 damage to any target."
+    staticAbility {
+        ability = GrantTriggeredAbility(
+            ability = TriggeredAbility.create(
+                trigger = Triggers.attacks().event,
+                binding = Triggers.attacks().binding,
+                effect = ReflexiveTriggerEffect(
+                    action = Effects.Composite(listOf(
+                        SelectTargetEffect(
+                            requirement = TargetObject(
+                                filter = TargetFilter(
+                                    GameObjectFilter.Artifact.youControl().named("Sunfire Torch")
+                                )
+                            ),
+                            storeAs = "toSacrifice"
+                        ),
+                        Effects.SacrificeTarget(EffectTarget.PipelineTarget("toSacrifice"))
+                    )),
+                    optional = true,
+                    reflexiveEffect = Effects.DealDamage(2, EffectTarget.ContextTarget(0)),
+                    reflexiveTargetRequirements = listOf(Targets.Any),
+                    descriptionOverride = "You may sacrifice Sunfire Torch. When you do, this creature deals 2 damage to any target."
+                )
+            ),
+            filter = Filters.EquippedCreature
+        )
+    }
+
+    equipAbility("{1}")
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "167"
+        artist = "David Szabo"
+        flavorText = "\"Let Tilonalli's light burn a path through this darkness.\""
+        imageUri = "https://cards.scryfall.io/normal/front/b/b/bb040fc7-f728-4482-92af-9a320c03bb54.jpg?1782694475"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunfireTorch.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/lci/cards/SunfireTorch.kt
@@ -32,12 +32,12 @@ import com.wingedsheep.sdk.scripting.targets.TargetObject
  *   the stack to choose any target and deal 2 damage. The damage source defaults to the granted
  *   ability's source — the equipped creature — matching "this creature deals 2 damage."
  *
- * KNOWN APPROXIMATION — "sacrifice Sunfire Torch":
- * As with Dire Blunderbuss, granted *triggered* abilities resolve with the equipped creature
- * as their source and no reference to the granting Equipment, so the self-sacrifice is modeled
- * as a name filter (`Artifact you control named "Sunfire Torch"`). Corner case: with a second
- * Sunfire Torch on the battlefield the printed ability sacrifices *this* one, but the name
- * filter lets you pick either. Accepted, documented corner.
+ * "sacrifice Sunfire Torch" — CR 201.5a: the name refers only to the specific granting
+ * Equipment. A granted *triggered* ability resolves with the equipped creature as its source
+ * (not the Equipment), so the sacrifice is scoped with `.attachedToSource()` to "the Sunfire
+ * Torch attached to this creature" — i.e. the Equipment that granted the ability. With a second
+ * Sunfire Torch elsewhere on the battlefield this correctly leaves it untouched (only the one
+ * attached to the attacking creature is a legal sacrifice).
  */
 val SunfireTorch = card("Sunfire Torch") {
     manaCost = "{R}"
@@ -64,7 +64,7 @@ val SunfireTorch = card("Sunfire Torch") {
                         SelectTargetEffect(
                             requirement = TargetObject(
                                 filter = TargetFilter(
-                                    GameObjectFilter.Artifact.youControl().named("Sunfire Torch")
+                                    GameObjectFilter.Artifact.named("Sunfire Torch").attachedToSource()
                                 )
                             ),
                             storeAs = "toSacrifice"

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -1275,6 +1275,90 @@
     ]
 }
 
+// Bloodthorn Flail
+{
+    "name": "Bloodthorn Flail",
+    "manaCost": "{B}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +2/+1.\nEquip—Pay {3} or discard a card.",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{3}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            },
+            {
+                "id": "ability_2",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": "AtomDiscard"
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "target creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "target creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true,
+                "descriptionOverride": "Equip—Discard a card."
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 2,
+                "toughnessBonus": 1
+            }
+        ]
+    },
+    "equipCost": "{3}",
+    "metadata": {
+        "collectorNumber": "93",
+        "rarity": "UNCOMMON",
+        "artist": "Igor Kieryluk",
+        "flavorText": "\"This weapon embodies both the strength and the weakness of the Legion of Dusk. They will endure any pain to achieve their ends, but they suffer pointlessly just to prove their dedication.\"\n—Huatli",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/db38babd-57e8-4e59-9701-11a0682baa77.jpg?1782694536"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Bonehoard Dracosaur
 {
     "name": "Bonehoard Dracosaur",
@@ -3783,6 +3867,107 @@
     ]
 }
 
+// Deconstruction Hammer
+{
+    "name": "Deconstruction Hammer",
+    "manaCost": "{W}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+1 and has \"{3}, {T}, Sacrifice Deconstruction Hammer: Destroy target artifact or enchantment.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 1
+            },
+            {
+                "type": "GrantActivatedAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "cost": {
+                        "type": "CostComposite",
+                        "costs": [
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomMana",
+                                    "cost": "{3}"
+                                }
+                            },
+                            "CostTap",
+                            {
+                                "type": "CostAtomWrapper",
+                                "atom": {
+                                    "type": "AtomSacrifice",
+                                    "filter": "artifact name:Deconstruction Hammer ctrl:you"
+                                }
+                            }
+                        ]
+                    },
+                    "effect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "targetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "artifact|enchantment"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "{3}, {T}, Sacrifice Deconstruction Hammer: Destroy target artifact or enchantment."
+                }
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "9",
+        "artist": "Dibujante Nocturno",
+        "flavorText": "\"All that is made can be unmade. Chimil's light is the only constant.\"\n—Oltec artificers' creed",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/c/0c7ba382-18c4-4833-b3d2-bd469ae2ad77.jpg?1782694606"
+    },
+    "colorIdentityOverride": [
+        "WHITE"
+    ]
+}
+
 // Deep Goblin Skulltaker
 {
     "name": "Deep Goblin Skulltaker",
@@ -5790,6 +5975,70 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Glowcap Lantern
+{
+    "name": "Glowcap Lantern",
+    "manaCost": "{G}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature has \"You may look at the top card of your library any time\" and \"Whenever this creature attacks, it explores.\" (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)\nEquip {2}",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{2}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            "LookAtTopOfLibrary",
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "Explore",
+                        "target": "Self"
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{2}",
+    "metadata": {
+        "collectorNumber": "187",
+        "rarity": "UNCOMMON",
+        "artist": "Irina Nordsol",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/a/bafde87c-743d-4307-93e0-fbd30f5d92f6.jpg?1782694459"
+    },
+    "colorIdentityOverride": [
+        "GREEN"
     ]
 }
 
@@ -13803,6 +14052,110 @@
         "imageUri": "https://cards.scryfall.io/normal/front/e/0/e0b6d40a-fded-4625-b03c-765c88d75766.jpg?1782694401"
     },
     "colorIdentityOverride": []
+}
+
+// Sunfire Torch
+{
+    "name": "Sunfire Torch",
+    "manaCost": "{R}",
+    "typeLine": "Artifact — Equipment",
+    "oracleText": "Equipped creature gets +1/+0 and has \"Whenever this creature attacks, you may sacrifice Sunfire Torch. When you do, this creature deals 2 damage to any target.\"\nEquip {1} ({1}: Attach to target creature you control. Equip only as a sorcery.)",
+    "script": {
+        "activatedAbilities": [
+            {
+                "id": "ability_1",
+                "cost": {
+                    "type": "CostAtomWrapper",
+                    "atom": {
+                        "type": "AtomMana",
+                        "cost": "{1}"
+                    }
+                },
+                "effect": {
+                    "type": "AttachEquipment",
+                    "target": {
+                        "type": "BoundVariable",
+                        "name": "creature you control"
+                    }
+                },
+                "targetRequirements": [
+                    {
+                        "type": "TargetObject",
+                        "filter": {
+                            "baseFilter": "creature ctrl:you"
+                        },
+                        "id": "creature you control"
+                    }
+                ],
+                "timing": "SorcerySpeed",
+                "isEquipAbility": true
+            }
+        ],
+        "staticAbilities": [
+            {
+                "type": "ModifyStats",
+                "powerBonus": 1,
+                "toughnessBonus": 0
+            },
+            {
+                "type": "GrantTriggeredAbility",
+                "ability": {
+                    "id": "ability_2",
+                    "trigger": "AttackEvent",
+                    "effect": {
+                        "type": "ReflexiveTrigger",
+                        "action": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "SelectTarget",
+                                    "requirement": {
+                                        "type": "TargetObject",
+                                        "filter": {
+                                            "baseFilter": "artifact name:Sunfire Torch ctrl:you"
+                                        }
+                                    },
+                                    "storeAs": "toSacrifice"
+                                },
+                                {
+                                    "type": "SacrificeTarget",
+                                    "target": {
+                                        "type": "PipelineTarget",
+                                        "collectionName": "toSacrifice"
+                                    }
+                                }
+                            ]
+                        },
+                        "reflexiveEffect": {
+                            "type": "DealDamage",
+                            "amount": {
+                                "type": "Fixed",
+                                "amount": 2
+                            },
+                            "target": {
+                                "type": "ContextTarget",
+                                "index": 0
+                            }
+                        },
+                        "reflexiveTargetRequirements": [
+                            "AnyTarget"
+                        ],
+                        "descriptionOverride": "You may sacrifice Sunfire Torch. When you do, this creature deals 2 damage to any target."
+                    }
+                }
+            }
+        ]
+    },
+    "equipCost": "{1}",
+    "metadata": {
+        "collectorNumber": "167",
+        "artist": "David Szabo",
+        "flavorText": "\"Let Tilonalli's light burn a path through this darkness.\"",
+        "imageUri": "https://cards.scryfall.io/normal/front/b/b/bb040fc7-f728-4482-92af-9a320c03bb54.jpg?1782694475"
+    },
+    "colorIdentityOverride": [
+        "RED"
+    ]
 }
 
 // Sunken Citadel

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -483,6 +483,130 @@
     ]
 }
 
+// Akawalli, the Seething Tower
+{
+    "name": "Akawalli, the Seething Tower",
+    "manaCost": "{1}{B}{G}",
+    "typeLine": "Legendary Creature — Fungus",
+    "oracleText": "Descend 4 — As long as there are four or more permanent cards in your graveyard, Akawalli gets +2/+2 and has trample.\nDescend 8 — As long as there are eight or more permanent cards in your graveyard, Akawalli gets an additional +2/+2 and can't be blocked by more than one creature.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "script": {
+        "staticAbilities": [
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "GrantKeyword",
+                    "keyword": "TRAMPLE",
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 4
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "ModifyStats",
+                    "powerBonus": 2,
+                    "toughnessBonus": 2,
+                    "filter": {
+                        "baseFilter": "permanent",
+                        "scope": "Self"
+                    }
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            },
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": {
+                    "type": "CantBeBlockedByMoreThan",
+                    "maxBlockers": 1
+                },
+                "condition": {
+                    "type": "Compare",
+                    "left": {
+                        "type": "Count",
+                        "player": "You",
+                        "zone": "Graveyard",
+                        "filter": "permanent"
+                    },
+                    "operator": "GTE",
+                    "right": {
+                        "type": "Fixed",
+                        "amount": 8
+                    }
+                }
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "220",
+        "rarity": "UNCOMMON",
+        "artist": "Simon Dominic",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/e/3ee62dd1-97d0-4e5d-8937-26c9e51e9414.jpg?1782694434"
+    },
+    "colorIdentityOverride": [
+        "BLACK",
+        "GREEN"
+    ]
+}
+
 // Amalia Benavides Aguirre
 {
     "name": "Amalia Benavides Aguirre",

--- a/mtg-sets/src/test/resources/snapshots/cards/LCI.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/LCI.json
@@ -4049,13 +4049,7 @@
                                 }
                             },
                             "CostTap",
-                            {
-                                "type": "CostAtomWrapper",
-                                "atom": {
-                                    "type": "AtomSacrifice",
-                                    "filter": "artifact name:Deconstruction Hammer ctrl:you"
-                                }
-                            }
+                            "CostSacrificeGrantingPermanent"
                         ]
                     },
                     "effect": {
@@ -4796,13 +4790,12 @@
                                             "filter": {
                                                 "baseFilter": {
                                                     "cardPredicates": [
-                                                        "IsArtifact",
+                                                        "IsArtifact"
+                                                    ],
+                                                    "statePredicates": [
                                                         {
-                                                            "type": "Not",
-                                                            "predicate": {
-                                                                "type": "NameEquals",
-                                                                "name": "Dire Blunderbuss"
-                                                            }
+                                                            "type": "StateNot",
+                                                            "predicate": "IsAttachedToSource"
                                                         }
                                                     ],
                                                     "controllerPredicate": "ControlledByYou"
@@ -6140,7 +6133,22 @@
             }
         ],
         "staticAbilities": [
-            "LookAtTopOfLibrary",
+            {
+                "type": "ConditionalStaticAbility",
+                "ability": "LookAtTopOfLibrary",
+                "condition": {
+                    "type": "EntityMatches",
+                    "entity": "Self",
+                    "filter": {
+                        "statePredicates": [
+                            {
+                                "type": "IsAttachedTo",
+                                "filter": "creature"
+                            }
+                        ]
+                    }
+                }
+            },
             {
                 "type": "GrantTriggeredAbility",
                 "ability": {
@@ -14236,7 +14244,18 @@
                                     "requirement": {
                                         "type": "TargetObject",
                                         "filter": {
-                                            "baseFilter": "artifact name:Sunfire Torch ctrl:you"
+                                            "baseFilter": {
+                                                "cardPredicates": [
+                                                    "IsArtifact",
+                                                    {
+                                                        "type": "NameEquals",
+                                                        "name": "Sunfire Torch"
+                                                    }
+                                                ],
+                                                "statePredicates": [
+                                                    "IsAttachedToSource"
+                                                ]
+                                            }
                                         }
                                     },
                                     "storeAs": "toSacrifice"

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -350,6 +350,11 @@ class CostHandler {
                 val granterController = granter.get<ControllerComponent>()?.playerId
                     ?: return CostPaymentResult.failure("Granting permanent has no controller")
 
+                // Capture AttachedToComponent before the zone transition so a granted effect that
+                // reads the sacrificed granter's attachment at resolution time still sees it —
+                // mirrors the SacrificeSelf branch.
+                val attachedTo = granter.get<AttachedToComponent>()
+
                 // Track Food/dies-with-counter sacrifice bookkeeping before the zone transition,
                 // then move to the graveyard — mirrors the SacrificeSelf branch, but on the granter.
                 val preState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
@@ -358,11 +363,16 @@ class CostHandler {
                     preState, granterId, Zone.GRAVEYARD
                 )
 
+                var newState = transitionResult.state
+                if (attachedTo != null) {
+                    newState = newState.updateEntity(granterId) { c -> c.with(attachedTo) }
+                }
+
                 val events = mutableListOf<GameEvent>()
                 events.add(PermanentsSacrificedEvent(granterController, listOf(granterId)))
                 events.addAll(transitionResult.events)
 
-                CostPaymentResult.success(transitionResult.state, manaPool, events)
+                CostPaymentResult.success(newState, manaPool, events)
             }
             is AbilityCost.TapAttachedCreature -> {
                 val attachedId = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/handlers/CostHandler.kt
@@ -122,6 +122,10 @@ class CostHandler {
                 // since left, ActivateAbilityHandler's lookup would have failed before payment.
                 true
             }
+            is AbilityCost.SacrificeGrantingPermanent -> {
+                // Same granter-resolution contract as ExileGrantingPermanent above.
+                true
+            }
             is AbilityCost.TapXPermanents -> {
                 // X can be 0, so this is always payable
                 // maxAffordableX is capped by untapped permanent count in LegalActionsCalculator
@@ -337,6 +341,28 @@ class CostHandler {
                 )
 
                 CostPaymentResult.success(transitionResult.state, manaPool, transitionResult.events)
+            }
+            is AbilityCost.SacrificeGrantingPermanent -> {
+                val granterId = choices.granterId
+                    ?: return CostPaymentResult.failure("Granting permanent not provided for cost")
+                val granter = state.getEntity(granterId)
+                    ?: return CostPaymentResult.failure("Granting permanent not found")
+                val granterController = granter.get<ControllerComponent>()?.playerId
+                    ?: return CostPaymentResult.failure("Granting permanent has no controller")
+
+                // Track Food/dies-with-counter sacrifice bookkeeping before the zone transition,
+                // then move to the graveyard — mirrors the SacrificeSelf branch, but on the granter.
+                val preState = com.wingedsheep.engine.handlers.effects.ZoneTransitionService
+                    .trackPermanentSacrifice(state, listOf(granterId), granterController)
+                val transitionResult = com.wingedsheep.engine.handlers.effects.ZoneTransitionService.moveToZone(
+                    preState, granterId, Zone.GRAVEYARD
+                )
+
+                val events = mutableListOf<GameEvent>()
+                events.add(PermanentsSacrificedEvent(granterController, listOf(granterId)))
+                events.addAll(transitionResult.events)
+
+                CostPaymentResult.success(transitionResult.state, manaPool, events)
             }
             is AbilityCost.TapAttachedCreature -> {
                 val attachedId = state.getEntity(sourceId)?.get<AttachedToComponent>()?.targetId

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/BlockPhaseManager.kt
@@ -585,12 +585,32 @@ internal class BlockPhaseManager(
             val attackerCard = attackerContainer.get<CardComponent>() ?: continue
             val cardDef = cardRegistry.getCard(attackerCard.cardDefinitionId)
 
-            // Printed "can't be blocked by more than N". cardDef may be null for tokens/copies
-            // without a registered definition — the granted forms below still apply.
+            // Printed "can't be blocked by more than N", including the conditional form
+            // (Akawalli's descend-8 "can't be blocked by more than one creature") — unwrap a
+            // ConditionalStaticAbility and honor it only while its condition currently holds,
+            // mirroring the MustBeBlocked handling in attackersWithMustBeBlockedStatic. cardDef
+            // may be null for tokens/copies without a registered definition — the granted forms
+            // below still apply.
+            val attackerController = state.projectedState.getController(attackerId)
             val staticLimit = cardDef?.staticAbilities
-                ?.filterIsInstance<CantBeBlockedByMoreThan>()
-                ?.filter { it.filter.scope is com.wingedsheep.sdk.scripting.filters.unified.Scope.Self }
-                ?.minOfOrNull { it.maxBlockers }
+                ?.mapNotNull { ability ->
+                    val unwrapped = if (ability is ConditionalStaticAbility) ability.ability else ability
+                    if (unwrapped !is CantBeBlockedByMoreThan) return@mapNotNull null
+                    if (unwrapped.filter.scope !is com.wingedsheep.sdk.scripting.filters.unified.Scope.Self) {
+                        return@mapNotNull null
+                    }
+                    if (ability is ConditionalStaticAbility) {
+                        if (attackerController == null) return@mapNotNull null
+                        if (!conditionEvaluator.evaluate(
+                                state,
+                                ability.condition,
+                                EffectContext(sourceId = attackerId, controllerId = attackerController)
+                            )
+                        ) return@mapNotNull null
+                    }
+                    unwrapped.maxBlockers
+                }
+                ?.minOrNull()
             // Granted static-ability form: e.g. Full Steam Ahead grants CantBeBlockedByMoreThan(1)
             // until end of turn via grantedStaticAbilities.
             val grantedLimit = state.grantedStaticAbilities

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/mechanics/combat/rules/BlockEvasionRules.kt
@@ -163,8 +163,19 @@ class CantBeBlockedByRule(
 ) : BlockEvasionRule {
     override fun check(ctx: BlockCheckContext): String? {
         val attackerCard = ctx.state.getEntity(ctx.attackerId)?.get<CardComponent>() ?: return null
-        val cardDef = ctx.cardRegistry.getCard(attackerCard.cardDefinitionId) ?: return null
-        val restrictions = cardDef.staticAbilities.filterIsInstance<CantBeBlockedBy>()
+        // Printed restrictions. cardDef may be null for tokens/copies without a registered
+        // definition — the granted form below still applies.
+        val cardDef = ctx.cardRegistry.getCard(attackerCard.cardDefinitionId)
+        val printed = cardDef?.staticAbilities?.filterIsInstance<CantBeBlockedBy>().orEmpty()
+        // Granted (floating) restrictions land in state.grantedStaticAbilities keyed to the
+        // attacker — e.g. Cavern Stomper's "{3}{G}: this creature can't be blocked by creatures
+        // with power 2 or less this turn" grants CantBeBlockedBy to itself via
+        // Effects.GrantStaticAbility, which the printed-only read above misses.
+        val granted = ctx.state.grantedStaticAbilities
+            .filter { it.entityId == ctx.attackerId }
+            .map { it.ability }
+            .filterIsInstance<CantBeBlockedBy>()
+        val restrictions = printed + granted
         if (restrictions.isEmpty()) return null
 
         val attackerController = ctx.projected.getController(ctx.attackerId) ?: return null

--- a/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
+++ b/rules-engine/src/main/kotlin/com/wingedsheep/engine/view/ClientStateTransformer.kt
@@ -2667,6 +2667,34 @@ class ClientStateTransformer(
             )
         }
 
+        // Printed "can't be blocked by more than N" restrictions (incl. the conditional descend
+        // form, e.g. Akawalli's descend-8) are read directly by BlockPhaseManager, never through
+        // the layer system, so they never reach the projected keyword set / abilityFlags and get
+        // no keyword chip. Surface an active one as a badge so the restriction is visible in play.
+        val cardDefForRestrictions = state.getEntity(entityId)?.get<CardComponent>()
+            ?.let { cardRegistry.getCard(it.cardDefinitionId) }
+        val restrictionController = state.projectedState.getController(entityId)
+        if (cardDefForRestrictions != null && restrictionController != null) {
+            for (ability in cardDefForRestrictions.script.staticAbilities) {
+                val active = activeStaticAbility(state, ability, entityId, restrictionController)
+                if (active is com.wingedsheep.sdk.scripting.CantBeBlockedByMoreThan &&
+                    active.filter.scope is com.wingedsheep.sdk.scripting.filters.unified.Scope.Self
+                ) {
+                    val description = active.description.replaceFirstChar { it.uppercase() }
+                    if (seenGrantDescriptions.add(description)) {
+                        effects.add(
+                            ClientCardEffect(
+                                effectId = "block_restriction_${description.hashCode()}",
+                                name = "Evasion",
+                                description = description,
+                                icon = "evasion"
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
         return effects
     }
 

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AkawalliDescendBadgeScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AkawalliDescendBadgeScenarioTest.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Akawalli, the Seething Tower (LCI #220) — client visibility of the descend-8 block restriction.
+ *
+ * Descend 8's "can't be blocked by more than one creature" is a printed conditional
+ * `CantBeBlockedByMoreThan` read directly by BlockPhaseManager, so it never reaches the projected
+ * keyword set / `abilityFlags` and gets no keyword chip. `ClientStateTransformer` surfaces it as
+ * an `activeEffects` badge while the descend-8 condition holds, so the player can see the
+ * restriction is in force. This pins that the badge appears only when active.
+ */
+class AkawalliDescendBadgeScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Akawalli descend-8 block-restriction badge") {
+
+            test("descend 8 active — the restriction is surfaced as a badge") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Akawalli, the Seething Tower")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(8) { builder = builder.withCardInGraveyard(1, "Grizzly Bears") }
+                val game = builder.build()
+
+                val akawalli = game.findPermanent("Akawalli, the Seething Tower")!!
+                val badges = game.getClientState(1).cards.getValue(akawalli).activeEffects
+                    .filter { it.description?.contains("more than one creature") == true }
+                badges.size shouldBe 1
+            }
+
+            test("descend 8 inactive — no restriction badge (only four permanent cards)") {
+                var builder = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Akawalli, the Seething Tower")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                repeat(4) { builder = builder.withCardInGraveyard(1, "Grizzly Bears") }
+                val game = builder.build()
+
+                val akawalli = game.findPermanent("Akawalli, the Seething Tower")!!
+                val badges = game.getClientState(1).cards.getValue(akawalli).activeEffects
+                    .filter { it.description?.contains("more than one creature") == true }
+                badges.size shouldBe 0
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AkawalliTheSeethingTowerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/AkawalliTheSeethingTowerScenarioTest.kt
@@ -1,0 +1,99 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Akawalli, the Seething Tower (LCI #220) — descend-8 "can't be blocked by more than one creature."
+ *
+ * Regression test for the conditional block-restriction fix. `BlockPhaseManager.
+ * validateMaxBlockersRequirements` previously collected `CantBeBlockedByMoreThan` via
+ * `filterIsInstance`, which skips the `ConditionalStaticAbility`-wrapped form — so Akawalli's
+ * descend-8 clause (and Cavern Stomper's identical wrapping) silently no-op'd. The evaluator now
+ * unwraps the conditional and honors the max-blocker cap only while the descend-8 condition holds.
+ *
+ * Cases:
+ *  - descend 8 active (≥8 permanent cards in graveyard): two blockers is illegal, one is legal.
+ *  - descend 8 inactive (only 4 permanent cards): the condition is false, so two blockers is legal
+ *    again — proving the cap is gated on the condition, not always-on.
+ */
+class AkawalliTheSeethingTowerScenarioTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        driver.registerCards(TestCards.all)
+        return driver
+    }
+
+    test("descend 8 active — Akawalli can't be blocked by two creatures") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val akawalli = driver.putCreatureOnBattlefield(attacker, "Akawalli, the Seething Tower")
+        driver.removeSummoningSickness(akawalli)
+        // Eight permanent cards in the attacker's graveyard → descend 8 (and 4) hold.
+        repeat(8) { driver.putCardInGraveyard(attacker, "Grizzly Bears") }
+        val blocker1 = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        val blocker2 = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(akawalli), defender).isSuccess shouldBe true
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        // Two blockers on Akawalli violates its descend-8 "can't be blocked by more than one".
+        driver.declareBlockers(
+            defender,
+            mapOf(blocker1 to listOf(akawalli), blocker2 to listOf(akawalli))
+        ).isSuccess shouldBe false
+    }
+
+    test("descend 8 active — a single blocker is still legal") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val akawalli = driver.putCreatureOnBattlefield(attacker, "Akawalli, the Seething Tower")
+        driver.removeSummoningSickness(akawalli)
+        repeat(8) { driver.putCardInGraveyard(attacker, "Grizzly Bears") }
+        val blocker1 = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(akawalli), defender).isSuccess shouldBe true
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(defender, mapOf(blocker1 to listOf(akawalli))).isSuccess shouldBe true
+    }
+
+    test("descend 8 inactive — Akawalli may be blocked by two creatures") {
+        val driver = createDriver()
+        driver.initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20)
+        val attacker = driver.activePlayer!!
+        val defender = driver.getOpponent(attacker)
+
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        val akawalli = driver.putCreatureOnBattlefield(attacker, "Akawalli, the Seething Tower")
+        driver.removeSummoningSickness(akawalli)
+        // Only four permanent cards — descend 4 holds but descend 8 does not, so no max-blocker cap.
+        repeat(4) { driver.putCardInGraveyard(attacker, "Grizzly Bears") }
+        val blocker1 = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+        val blocker2 = driver.putCreatureOnBattlefield(defender, "Grizzly Bears")
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(attacker, listOf(akawalli), defender).isSuccess shouldBe true
+
+        driver.passPriorityUntil(Step.DECLARE_BLOCKERS)
+        driver.declareBlockers(
+            defender,
+            mapOf(blocker1 to listOf(akawalli), blocker2 to listOf(akawalli))
+        ).isSuccess shouldBe true
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CavernStomperScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/CavernStomperScenarioTest.kt
@@ -1,6 +1,7 @@
 package com.wingedsheep.engine.scenarios
 
 import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ExecutionResult
 import com.wingedsheep.engine.core.SelectManaSourcesDecision
 import com.wingedsheep.engine.support.ScenarioTestBase
 import com.wingedsheep.mtg.sets.definitions.lci.cards.CavernStomper
@@ -8,6 +9,7 @@ import com.wingedsheep.sdk.core.Phase
 import com.wingedsheep.sdk.core.Step
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 /**
  * Scenario test for Cavern Stomper (LCI #177) — {4}{G}{G} Creature — Dinosaur, 7/7, Common.
@@ -62,6 +64,52 @@ class CavernStomperScenarioTest : ScenarioTestBase() {
                 withClue("exactly one granted-ability badge") { badges.size shouldBe 1 }
                 withClue("badge description names the block restriction: ${badges.firstOrNull()?.description}") {
                     (badges.single().description?.contains("power 2 or less") == true) shouldBe true
+                }
+            }
+
+            // Build a game where Cavern Stomper has activated {3}{G} (granting the "can't be blocked
+            // by creatures with power 2 or less" restriction to itself) and is attacking, then declare
+            // [blockerName] as a blocker and return the result. Proves the granted CantBeBlockedBy is
+            // actually *enforced* in combat — the coverage the badge test above lacked, and the reason
+            // the restriction previously no-op'd (CantBeBlockedByRule read only printed statics).
+            fun declareBlockOnStomper(blockerName: String): ExecutionResult {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Cavern Stomper")
+                    .withLandsOnBattlefield(1, "Forest", 4)
+                    .withCardOnBattlefield(2, "Grizzly Bears") // 2/2 — power 2, caught by the restriction
+                    .withCardOnBattlefield(2, "Hill Giant")    // 3/3 — power 3, unaffected
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val stomper = game.findPermanent("Cavern Stomper")!!
+                val activation = game.execute(
+                    ActivateAbility(playerId = game.player1Id, sourceId = stomper, abilityId = activateAbilityId)
+                )
+                check(activation.error == null) { "ability activation failed: ${activation.error}" }
+                if (game.getPendingDecision() is SelectManaSourcesDecision) {
+                    game.submitManaSourcesAutoPay()
+                }
+                game.resolveStack()
+
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_ATTACKERS)
+                check(game.declareAttackers(mapOf("Cavern Stomper" to 2)).error == null) {
+                    "Cavern Stomper should be able to attack"
+                }
+                game.passUntilPhase(Phase.COMBAT, Step.DECLARE_BLOCKERS)
+                return game.declareBlockers(mapOf(blockerName to listOf("Cavern Stomper")))
+            }
+
+            test("granted 'can't be blocked by power 2 or less' stops a power-2 blocker") {
+                withClue("a power-2 creature must not be able to block Cavern Stomper after the {3}{G} grant") {
+                    declareBlockOnStomper("Grizzly Bears").error shouldNotBe null
+                }
+            }
+
+            test("granted 'can't be blocked by power 2 or less' still lets a power-3 blocker through") {
+                withClue("a power-3 creature is unaffected by the restriction and may block") {
+                    declareBlockOnStomper("Hill Giant").error shouldBe null
                 }
             }
         }

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeconstructionHammerScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DeconstructionHammerScenarioTest.kt
@@ -1,0 +1,90 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.DeconstructionHammer
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.scripting.GrantActivatedAbility
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Deconstruction Hammer (LCI #9) — {W} Artifact — Equipment.
+ *
+ * "Equipped creature gets +1/+1 and has '{3}, {T}, Sacrifice Deconstruction Hammer: Destroy
+ *  target artifact or enchantment.'"
+ *
+ * Focus: the granted ability's "Sacrifice Deconstruction Hammer" cost. Per CR 201.5a the name
+ * refers only to the specific granting Equipment, so it is modeled as
+ * [com.wingedsheep.sdk.dsl.Costs.SacrificeGrantingPermanent]. This test pins that the cost
+ * sacrifices exactly the *attached* Hammer — not a second same-named Hammer elsewhere on the
+ * battlefield — with no target prompt for the sacrifice.
+ */
+class DeconstructionHammerScenarioTest : FunSpec({
+
+    val grantedAbilityId = DeconstructionHammer.staticAbilities
+        .filterIsInstance<GrantActivatedAbility>().first().ability.id
+    val equipAbilityId = DeconstructionHammer.activatedAbilities.single { it.isEquipAbility }.id
+
+    fun setup(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Plains" to 40), startingLife = 20, skipMulligans = true)
+    }
+
+    test("granted ability sacrifices the attached Hammer (not a second same-named one) and destroys the target") {
+        val d = setup()
+        val p1 = d.activePlayer!!
+        val opponent = d.getOpponent(p1)
+
+        val bear = d.putCreatureOnBattlefield(p1, "Grizzly Bears")
+        val attachedHammer = d.putPermanentOnBattlefield(p1, "Deconstruction Hammer")
+        // A second, unattached Deconstruction Hammer that must NOT be sacrificed.
+        val otherHammer = d.putPermanentOnBattlefield(p1, "Deconstruction Hammer")
+        val victim = d.putPermanentOnBattlefield(opponent, "Ornithopter") // 0/2 artifact creature
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+
+        // Equip the first Hammer onto the Bear.
+        d.giveColorlessMana(p1, 1)
+        d.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = attachedHammer,
+                abilityId = equipAbilityId,
+                targets = listOf(ChosenTarget.Permanent(bear))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.state.getEntity(attachedHammer)?.get<AttachedToComponent>()?.targetId shouldBe bear
+
+        // Activate the granted "{3}, {T}, Sacrifice Deconstruction Hammer: Destroy target
+        // artifact or enchantment" on the equipped creature, destroying the Ornithopter.
+        d.removeSummoningSickness(bear)
+        d.giveColorlessMana(p1, 3)
+        d.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = bear,
+                abilityId = grantedAbilityId,
+                targets = listOf(ChosenTarget.Permanent(victim))
+            )
+        ).isSuccess shouldBe true
+        var guard = 0
+        while (d.state.stack.isNotEmpty() && d.pendingDecision == null && guard++ < 20) d.bothPass()
+
+        // The *attached* Hammer was sacrificed; the second Hammer is untouched.
+        d.getGraveyard(p1) shouldContain attachedHammer
+        d.getGraveyard(p1) shouldNotContain otherHammer
+        d.state.getEntity(otherHammer)?.get<AttachedToComponent>() shouldBe null
+        d.findPermanent(p1, "Deconstruction Hammer") shouldBe otherHammer
+        // The target artifact was destroyed.
+        d.findPermanent(opponent, "Ornithopter") shouldBe null
+    }
+})

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DireFlailScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/DireFlailScenarioTest.kt
@@ -293,6 +293,51 @@ class DireFlailScenarioTest : FunSpec({
         driver.state.getEntity(blunderbuss)?.get<AttachedToComponent>()?.targetId shouldBe courser
     }
 
+    test("a second Dire Blunderbuss (unattached) is a legal sacrifice; the granting one is excluded by attachment") {
+        val driver = setup()
+        val p1 = driver.activePlayer!!
+        val opponent = driver.getOpponent(p1)
+
+        // Two Blunderbusses: b1 will be equipped (the granting Equipment), b2 left unattached.
+        val b1 = driver.craftToBlunderbuss(p1)
+        val b2 = driver.craftToBlunderbuss(p1)
+        val courser = driver.putCreatureOnBattlefield(p1, "Centaur Courser") // 3/3 → 6/3
+        driver.removeSummoningSickness(courser)
+        driver.equipBlunderbuss(p1, b1, courser)
+        val victim = driver.putCreatureOnBattlefield(opponent, "Test Sturdy Ox") // 2/4
+
+        driver.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        driver.declareAttackers(p1, listOf(courser), opponent).error shouldBe null
+
+        // Under the old `notNamed("Dire Blunderbuss")` filter both copies were excluded, leaving
+        // no fodder — so no sacrifice, no damage. With `.notAttachedToSource()` only the attached
+        // granting copy (b1) is excluded; the unattached b2 is legal fodder.
+        driver.resolveUntilDecision()
+        var guard = 0
+        while (driver.pendingDecision != null && guard++ < 10) {
+            when (val d = driver.pendingDecision) {
+                is YesNoDecision -> driver.submitYesNo(p1, true).error shouldBe null
+                is ChooseTargetsDecision -> {
+                    val legal = d.legalTargets[0].orEmpty()
+                    when {
+                        b2 in legal || b1 in legal ->
+                            driver.submitTargetSelection(p1, listOf(b2)).error shouldBe null
+                        else -> driver.submitTargetSelection(p1, listOf(victim)).error shouldBe null
+                    }
+                }
+                is SelectCardsDecision -> driver.submitCardSelection(p1, listOf(b2))
+                else -> break
+            }
+            if (driver.pendingDecision == null) driver.drainStack()
+        }
+
+        // The unattached second Blunderbuss was sacrificed; the attached granting one is intact;
+        // 6 damage killed the 2/4.
+        driver.getGraveyard(p1).shouldContain(b2)
+        driver.state.getEntity(b1)?.get<AttachedToComponent>()?.targetId shouldBe courser
+        driver.findPermanent(opponent, "Test Sturdy Ox") shouldBe null
+    }
+
     test("negative: craft rejected when the supplied material is a creature, not an artifact") {
         val driver = setup()
         val p1 = driver.activePlayer!!

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlowcapLanternScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/GlowcapLanternScenarioTest.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.support.ScenarioTestBase
+import com.wingedsheep.sdk.core.Phase
+import com.wingedsheep.sdk.core.Step
+import io.kotest.matchers.shouldBe
+
+/**
+ * Glowcap Lantern (LCI #187) — {G} Artifact — Equipment.
+ *
+ * "Equipped creature has 'You may look at the top card of your library any time' and 'Whenever
+ *  this creature attacks, it explores.'"
+ *
+ * Focus: the private "look at the top card of your library" permission exists only while the
+ * Lantern is attached (it's part of "Equipped creature has ..."). The permission is a
+ * conditional static gated on the source being attached to a creature, so an unattached Lantern
+ * reveals nothing.
+ */
+class GlowcapLanternScenarioTest : ScenarioTestBase() {
+
+    init {
+        context("Glowcap Lantern") {
+
+            test("attached Lantern reveals the top card of the controller's library to them") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Grizzly Bears")
+                    .withCardOnBattlefield(1, "Glowcap Lantern")
+                    .withCardAttachedTo(1, "Glowcap Lantern", "Grizzly Bears")
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val topCard = game.state.getLibrary(game.player1Id).first()
+                game.getClientState(1).cards.containsKey(topCard) shouldBe true
+            }
+
+            test("unattached Lantern reveals nothing (peek is gated on attachment)") {
+                val game = scenario()
+                    .withPlayers("Player", "Opponent")
+                    .withCardOnBattlefield(1, "Glowcap Lantern") // on the battlefield but not attached
+                    .withCardInLibrary(1, "Grizzly Bears")
+                    .withActivePlayer(1)
+                    .inPhase(Phase.PRECOMBAT_MAIN, Step.PRECOMBAT_MAIN)
+                    .build()
+
+                val topCard = game.state.getLibrary(game.player1Id).first()
+                game.getClientState(1).cards.containsKey(topCard) shouldBe false
+            }
+        }
+    }
+}

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SunfireTorchScenarioTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/SunfireTorchScenarioTest.kt
@@ -1,0 +1,103 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ActivateAbility
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.components.battlefield.AttachedToComponent
+import com.wingedsheep.engine.state.components.stack.ChosenTarget
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.mtg.sets.definitions.lci.cards.SunfireTorch
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.model.Deck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Sunfire Torch (LCI #167) — {R} Artifact — Equipment.
+ *
+ * "Equipped creature gets +1/+0 and has 'Whenever this creature attacks, you may sacrifice
+ *  Sunfire Torch. When you do, this creature deals 2 damage to any target.'"
+ *
+ * Focus: the granted attack trigger's "sacrifice Sunfire Torch" refers only to the specific
+ * granting Equipment (CR 201.5a). The sacrifice is scoped with `.attachedToSource()`, so with a
+ * second Sunfire Torch elsewhere on the battlefield only the one attached to the attacking
+ * creature is a legal sacrifice — and that is the one that goes to the graveyard.
+ */
+class SunfireTorchScenarioTest : FunSpec({
+
+    val equipAbilityId = SunfireTorch.activatedAbilities.single { it.isEquipAbility }.id
+
+    fun setup(): GameTestDriver = GameTestDriver().apply {
+        registerCards(TestCards.all)
+        initMirrorMatch(deck = Deck.of("Mountain" to 40), startingLife = 20, skipMulligans = true)
+    }
+
+    test("granted attack trigger sacrifices the attached Torch (only it is legal) and deals 2 damage") {
+        val d = setup()
+        val p1 = d.activePlayer!!
+        val opponent = d.getOpponent(p1)
+
+        val courser = d.putCreatureOnBattlefield(p1, "Centaur Courser") // 3/3
+        d.removeSummoningSickness(courser)
+        val attachedTorch = d.putPermanentOnBattlefield(p1, "Sunfire Torch")
+        // A second, unattached Sunfire Torch that must NOT be a legal sacrifice.
+        val otherTorch = d.putPermanentOnBattlefield(p1, "Sunfire Torch")
+
+        d.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        d.giveColorlessMana(p1, 1)
+        d.submit(
+            ActivateAbility(
+                playerId = p1,
+                sourceId = attachedTorch,
+                abilityId = equipAbilityId,
+                targets = listOf(ChosenTarget.Permanent(courser))
+            )
+        ).isSuccess shouldBe true
+        d.bothPass()
+        d.state.getEntity(attachedTorch)?.get<AttachedToComponent>()?.targetId shouldBe courser
+
+        d.passPriorityUntil(Step.DECLARE_ATTACKERS)
+        d.declareAttackers(p1, listOf(courser), opponent).error shouldBe null
+
+        // Resolve the granted attack trigger by decision shape (may → sacrifice → reflexive
+        // damage target). The `.attachedToSource()` scope means the sacrifice has exactly one
+        // legal target (the attached Torch), so it never presents a two-way choice — the key
+        // discriminator: under the old `youControl().named(...)` filter BOTH Torches would be
+        // offerable. Assert the unattached Torch is never an offered sacrifice, and hit the
+        // opponent with the 2 damage.
+        var guard = 0
+        var otherTorchWasOfferable = false
+        while (guard++ < 8) {
+            while (d.pendingDecision == null && d.state.stack.isNotEmpty()) d.bothPass()
+            when (val decision = d.pendingDecision) {
+                is YesNoDecision -> d.submitYesNo(p1, true).error shouldBe null
+                is ChooseTargetsDecision -> {
+                    val legal = decision.legalTargets[0].orEmpty()
+                    if (otherTorch in legal) otherTorchWasOfferable = true
+                    when {
+                        attachedTorch in legal ->
+                            d.submitTargetSelection(p1, listOf(attachedTorch)).error shouldBe null
+                        else -> // "deal 2 damage to any target" — hit the opponent.
+                            d.submitTargetSelection(p1, listOf(opponent)).error shouldBe null
+                    }
+                }
+                is SelectCardsDecision -> {
+                    if (otherTorch in decision.options) otherTorchWasOfferable = true
+                    d.submitCardSelection(p1, listOf(attachedTorch))
+                }
+                else -> break
+            }
+        }
+        while (d.pendingDecision == null && d.state.stack.isNotEmpty()) d.bothPass()
+
+        // The unattached Torch was never a legal sacrifice (the granting-permanent rule).
+        otherTorchWasOfferable shouldBe false
+        // The attached Torch was sacrificed; the second Torch is untouched; 2 damage dealt.
+        d.getGraveyard(p1) shouldContain attachedTorch
+        d.findPermanent(p1, "Sunfire Torch") shouldBe otherTorch
+        d.getLifeTotal(opponent) shouldBe 18
+    }
+})


### PR DESCRIPTION
Added UI element:
<img width="290" height="161" alt="image" src="https://github.com/user-attachments/assets/f64d8111-576f-44bb-93cf-e054a6f56510" />


## LCI easy-wins-2: Equipment quartet, Akawalli, and conditional block-restriction fixes

Implements five Lost Caverns of Ixalan cards and the small engine/SDK capabilities they need, plus two combat-evaluator fixes for granted and conditional block restrictions.

### Cards (5)
- **Deconstruction Hammer** (#9) — Equipment granting `{3}, {T}, Sacrifice Deconstruction Hammer: Destroy target artifact or enchantment`.
- **Sunfire Torch** (#167) — Equipment granting an attack-triggered "sacrifice this, deal 2 damage to any target".
- **Bloodthorn Flail** (#93) — Equipment with `Equip—Pay {3} or discard a card` (modeled as two equip options).
- **Glowcap Lantern** (#187) — Equipment granting a peek-at-top-of-library static (gated on attachment) + "whenever this attacks, it explores".
- **Akawalli, the Seething Tower** (#220) — descend 4 / descend 8 conditional static buffs, including "can't be blocked by more than one creature".

### SDK additions (each documented in `card-sdk-language-reference.md`)
- `Costs.SacrificeGrantingPermanent` — self-sacrifice sibling of `Costs.ExileGrantingPermanent`; resolves the granting permanent from the static-grant lookup at activation time (CR 201.5a), so a granted "Sacrifice [this Equipment]" cost sacrifices exactly the granter even with a second same-named permanent in play. Preserves the granter's `AttachedToComponent` across the sacrifice, mirroring `SacrificeSelf`.
- `GameObjectFilter.notAttachedToSource()` — negation of `attachedToSource()`; backs "an artifact other than [this granting Equipment]" on a granted triggered ability whose source is the equipped creature (Dire Blunderbuss). Replaces the old `notNamed("Dire Blunderbuss")` approximation, which wrongly excluded a *second* Blunderbuss elsewhere on the battlefield.

### Engine fixes
- **`BlockPhaseManager`** — honor the conditional (`ConditionalStaticAbility`-wrapped) form of `CantBeBlockedByMoreThan`, evaluated only while its condition holds (Akawalli's descend-8). Previously `filterIsInstance` skipped the wrapped form and it silently no-op'd. Mirrors the existing conditional `MustBeBlocked` handling.
- **`BlockEvasionRules` (`CantBeBlockedByRule`)** — also read granted (floating) `CantBeBlockedBy` from `grantedStaticAbilities`, so Cavern Stomper's `{3}{G}` evasion grant is actually enforced in combat, not just displayed.
- **`ClientStateTransformer`** — surface an active `CantBeBlockedByMoreThan` (incl. the conditional descend form) as an "Evasion" badge, since it's read directly by `BlockPhaseManager` and never reaches the projected keyword chips.

### Tests
19 new scenario tests across 7 classes (`rules-engine`), each exercising the rule corner that drove its change — second same-named permanent not sacrificed, `notAttachedToSource` vs the old `notNamed`, descend-8 conditional gating, granted-restriction enforcement, attachment-gated peek. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
