### PR TITLE
Implement 6 VOW exploit-payoff cards + teach mtgish the exploit mapping

### DIFF
--- a/docs/card-sdk-language-reference.md
+++ b/docs/card-sdk-language-reference.md
@@ -503,6 +503,7 @@ Atomic effect factories. For library/zone manipulation, prefer the pipelines in 
   `DynamicAmount` ("discard X cards, where X is …" — e.g. Converge's Arcane Omens with
   `DynamicAmounts.colorsOfManaSpent()`).
 - `EachOpponentDiscards(count)` — each opponent discards N.
+- `EachOpponentExilesFromHand(count)` — each opponent exiles N cards from their own hand (each chooses their own). Same `ForEachPlayer(EachOpponent)` → Gather → Select → Move pipeline as `EachOpponentDiscards`, but the destination is exile — Mindleech Ghoul.
 - `EachPlayerReturnPermanentToHand()` — each player bounces a permanent.
 - `EachPlayerDrawsForDamageDealtToSource()` — each player draws equal to damage source took this turn.
 - `ReadTheRunes()` — draw N, then discard N (or sacrifice permanents).
@@ -2028,11 +2029,13 @@ can't statically prevent (cross-trigger flows, `Self`-vs-`ContextTarget` inside 
 - `Targets.ActivatedOrTriggeredAbility` / `Targets.ActivatedAbility` — an ability on the stack (Stifle).
 - `Targets.ActivatedOrTriggeredAbilityYouControl` — an activated or triggered ability **you control** on the stack (`TargetFilter.ActivatedOrTriggeredAbilityOnStack.youControl()`). Mana abilities never use the stack, so they're excluded automatically. Pair with `Effects.CopyTargetSpellOrAbility` — **Gogo, Master of Mimicry**.
 - `Targets.SpellOrAbilityWithSingleTarget` — a spell or ability whose single target is changed (Willbender; pair with `Effects.ChangeTarget()`).
+- `Targets.SpellOrAbility` — any spell, activated ability, or triggered ability on the stack (`TargetFilter.SpellOrAbilityOnStack` = any object in the stack zone; mana abilities never use the stack). Pair with `Effects.CounterSpellOrAbility()` — "counter target spell, activated ability, or triggered ability" (Overcharged Amalgam).
 - `Targets.InstantSorcerySpellOrAbility` — one requirement admitting an instant spell, sorcery spell, activated ability, or triggered ability on the stack (`TargetFilter.InstantSorcerySpellOrAbilityOnStack`, a single `CardPredicate.Or`). Pair with `Effects.CopyTargetSpellOrAbility()` — Return the Favor. **Note:** the STACK targeting enumeration (`TargetFinder.findSpellTargets`) offers an ability as a legal target only when the requirement's filter *explicitly names an ability predicate* (anywhere inside `Or`/`And`/`Not`); plain "target spell" filters stay spell-only (CR 112.1 vs 113.3b/c).
 - `Targets.Card` — any card in any zone (e.g. graveyard).
 - `Targets.CreatureOrPlaneswalker` — combined.
 - `Targets.TappedCreature` / `UntappedCreature` — state-restricted.
 - `Targets.InstantOrSorcery` — instant-or-sorcery card.
+- `Targets.InstantOrSorceryInGraveyard` / `Targets.InstantOrSorceryInYourGraveyard` — an instant or sorcery card in a graveyard / **your** graveyard (the latter for "return target instant or sorcery card from your graveyard to your hand" — Repository Skaab; pair with `Effects.ReturnToHand`).
 
 **Chained predicates** — `.youControl()`, `.controlledByOpponent()`, `.opponent()`, `.withSubtype(...)`,
 `.withKeyword(...)`, `.ofColor(...)`, `.tapped()`, `.untapped()`, `.power(n)`, `.minPower(n)`, `.maxPower(n)`,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Effects.kt
@@ -586,6 +586,13 @@ object Effects {
     fun EachOpponentDiscards(count: Int = 1): Effect = HandPatterns.eachOpponentDiscards(count)
 
     /**
+     * Each opponent exiles N cards from their hand (Mindleech Ghoul). Same
+     * ForEachPlayer(EachOpponent) → Gather → Select → Move pipeline as [EachOpponentDiscards], but
+     * the destination is exile; each opponent chooses their own card(s).
+     */
+    fun EachOpponentExilesFromHand(count: Int = 1): Effect = HandPatterns.eachOpponentExilesFromHand(count)
+
+    /**
      * "Any player may [cost]. If a player does, [consequence]."
      * Each player in APNAP order is offered the cost; the first to pay triggers [consequence].
      * (Prowling Pangolin: "any player may sacrifice two creatures. If a player does, sacrifice this.")

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/HandPatterns.kt
@@ -90,6 +90,36 @@ object HandPatterns {
         )
     }
 
+    /**
+     * "Each opponent exiles a card from their hand" — Mindleech Ghoul's exploit payoff. Mirrors
+     * [eachOpponentDiscards]'s [ForEachPlayerEffect] shape: one iteration per opponent with
+     * `Player.You` rebound to the iterated opponent, so each opponent gathers *their own* hand,
+     * that opponent (the iteration's controller/chooser) picks the card, and it moves to *their*
+     * exile. Unlike a targeted single-player exile, this hits every opponent and needs no target.
+     *
+     * @param count how many cards each opponent exiles (default 1).
+     */
+    fun eachOpponentExilesFromHand(count: Int = 1): Effect =
+        ForEachPlayerEffect(
+            players = Player.EachOpponent,
+            effects = listOf(
+                GatherCardsEffect(
+                    source = CardSource.FromZone(Zone.HAND, Player.You),
+                    storeAs = "hand"
+                ),
+                SelectFromCollectionEffect(
+                    from = "hand",
+                    selection = SelectionMode.ChooseExactly(DynamicAmount.Fixed(count)),
+                    storeSelected = "exiled",
+                    prompt = "Choose ${if (count == 1) "a card" else "$count cards"} to exile"
+                ),
+                MoveCollectionEffect(
+                    from = "exiled",
+                    destination = CardDestination.ToZone(Zone.EXILE)
+                )
+            )
+        )
+
     fun discardCards(
         count: Int,
         target: EffectTarget = EffectTarget.Controller,

--- a/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
+++ b/mtg-sdk/src/main/kotlin/com/wingedsheep/sdk/dsl/Targets.kt
@@ -189,6 +189,11 @@ object Targets {
      */
     val PermanentOpponentControls: TargetRequirement = TargetPermanent(filter = TargetFilter.PermanentOpponentControls)
 
+    /**
+     * Target planeswalker (any player's) — "destroy target planeswalker" (Graf Reaver).
+     */
+    val Planeswalker: TargetRequirement = TargetPermanent(filter = TargetFilter.Planeswalker)
+
     // =========================================================================
     // Combined Targeting
     // =========================================================================
@@ -260,6 +265,13 @@ object Targets {
      */
     val InstantOrSorceryInGraveyard: TargetRequirement =
         TargetObject(filter = TargetFilter.InstantOrSorceryInGraveyard)
+
+    /**
+     * Target instant or sorcery card in YOUR graveyard — "return target instant or sorcery card
+     * from your graveyard to your hand" (Repository Skaab).
+     */
+    val InstantOrSorceryInYourGraveyard: TargetRequirement =
+        TargetObject(filter = TargetFilter.InstantOrSorceryInYourGraveyard)
 
     // =========================================================================
     // Spell Targeting
@@ -376,6 +388,16 @@ object Targets {
      * The single-target restriction is enforced at resolution time by the executor.
      */
     val SpellOrAbilityWithSingleTarget: TargetRequirement = TargetObject(
+        filter = TargetFilter.SpellOrAbilityOnStack
+    )
+
+    /**
+     * Target spell, activated ability, or triggered ability on the stack — "counter target spell,
+     * activated ability, or triggered ability" (Overcharged Amalgam). Any object in the stack zone
+     * qualifies; mana abilities never use the stack, so they're excluded automatically. Pair with
+     * [com.wingedsheep.sdk.dsl.Effects.CounterSpellOrAbility].
+     */
+    val SpellOrAbility: TargetRequirement = TargetObject(
         filter = TargetFilter.SpellOrAbilityOnStack
     )
 

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DiverSkaab.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/DiverSkaab.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.exploit
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Diver Skaab
+ * {3}{U}{U}
+ * Creature — Zombie
+ * 3/5
+ * Exploit (When this creature enters, you may sacrifice a creature.)
+ * When this creature exploits a creature, target creature's owner puts it on their choice of the
+ * top or bottom of their library.
+ *
+ * The payoff targets a creature, so it rides the exploit reflexive's target requirement
+ * ([exploit]'s `onExploitTargets`); the target is chosen **after** the sacrifice resolves.
+ * [Effects.PutOnTopOrBottomOfLibrary] pauses for the targeted creature's **owner** to choose top
+ * or bottom, matching the oracle wording exactly.
+ */
+val DiverSkaab = card("Diver Skaab") {
+    manaCost = "{3}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    power = 3
+    toughness = 5
+    oracleText = "Exploit (When this creature enters, you may sacrifice a creature.)\n" +
+        "When this creature exploits a creature, target creature's owner puts it on their choice " +
+        "of the top or bottom of their library."
+
+    exploit(
+        onExploit = Effects.PutOnTopOrBottomOfLibrary(EffectTarget.ContextTarget(0)),
+        onExploitTargets = listOf(Targets.Creature)
+    )
+
+    metadata {
+        rarity = Rarity.UNCOMMON
+        collectorNumber = "56"
+        artist = "Dave Kendall"
+        imageUri = "https://cards.scryfall.io/normal/front/3/8/38b5fdf4-3884-436f-8066-bc7593e72b02.jpg?1783924897"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GrafReaver.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/GrafReaver.kt
@@ -1,0 +1,55 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.Triggers
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.exploit
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Graf Reaver
+ * {1}{B}
+ * Creature — Zombie Warrior
+ * 3/3
+ * Exploit (When this creature enters, you may sacrifice a creature.)
+ * When this creature exploits a creature, destroy target planeswalker.
+ * At the beginning of your upkeep, this creature deals 1 damage to you.
+ *
+ * Two independent pieces beyond the exploit sacrifice:
+ *  - The exploit payoff targets a planeswalker ([exploit]'s `onExploitTargets` = [Targets.Planeswalker]),
+ *    chosen after the sacrifice resolves; the reflexive is only put on the stack when a legal
+ *    planeswalker exists, so exploiting with no planeswalker in play just performs the sacrifice.
+ *  - A [Triggers.YourUpkeep] drawback that deals 1 damage to you (the controller), mirroring
+ *    Ravenous Giant.
+ */
+val GrafReaver = card("Graf Reaver") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Warrior"
+    power = 3
+    toughness = 3
+    oracleText = "Exploit (When this creature enters, you may sacrifice a creature.)\n" +
+        "When this creature exploits a creature, destroy target planeswalker.\n" +
+        "At the beginning of your upkeep, this creature deals 1 damage to you."
+
+    exploit(
+        onExploit = Effects.Destroy(EffectTarget.ContextTarget(0)),
+        onExploitTargets = listOf(Targets.Planeswalker)
+    )
+
+    triggeredAbility {
+        trigger = Triggers.YourUpkeep
+        effect = Effects.DealDamage(1, EffectTarget.PlayerRef(Player.You))
+        description = "At the beginning of your upkeep, this creature deals 1 damage to you."
+    }
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "115"
+        artist = "Dave Kendall"
+        imageUri = "https://cards.scryfall.io/normal/front/0/b/0bb2103b-3462-4439-a1e1-243a15c5f318.jpg?1783924863"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MindleechGhoul.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/MindleechGhoul.kt
@@ -1,0 +1,39 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.exploit
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Mindleech Ghoul
+ * {1}{B}
+ * Creature — Zombie
+ * 2/2
+ * Exploit (When this creature enters, you may sacrifice a creature.)
+ * When this creature exploits a creature, each opponent exiles a card from their hand.
+ *
+ * The payoff is untargeted (an each-opponent effect resolved at resolution time), so it's baked
+ * straight into the exploit reflexive ([exploit]'s `onExploit`). [Effects.EachOpponentExilesFromHand]
+ * iterates each opponent, who chooses one card from their own hand to exile.
+ */
+val MindleechGhoul = card("Mindleech Ghoul") {
+    manaCost = "{1}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie"
+    power = 2
+    toughness = 2
+    oracleText = "Exploit (When this creature enters, you may sacrifice a creature.)\n" +
+        "When this creature exploits a creature, each opponent exiles a card from their hand."
+
+    exploit(
+        onExploit = Effects.EachOpponentExilesFromHand(1)
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "122"
+        artist = "Alex Brock"
+        imageUri = "https://cards.scryfall.io/normal/front/f/5/f5c4e00d-128a-4ddb-9e1b-3ee93121b262.jpg?1783924857"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/OverchargedAmalgam.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/OverchargedAmalgam.kt
@@ -1,0 +1,53 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.core.Keyword
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.exploit
+import com.wingedsheep.sdk.model.Rarity
+
+/**
+ * Overcharged Amalgam
+ * {2}{U}{U}
+ * Creature — Zombie Horror
+ * 3/3
+ * Flash
+ * Flying
+ * Exploit (When this creature enters, you may sacrifice a creature.)
+ * When this creature exploits a creature, counter target spell, activated ability, or triggered
+ * ability.
+ *
+ * Flash lets you cast it in response, and the exploit reflexive then lets you counter something —
+ * the classic "flash exploit counterspell on a stick". The payoff targets a stack object
+ * ([exploit]'s `onExploitTargets` = [Targets.SpellOrAbility]), chosen after the sacrifice resolves;
+ * [Effects.CounterSpellOrAbility] dispatches by what's actually on the stack. The reflexive is only
+ * offered when a legal spell/ability is on the stack, so exploiting with nothing to counter just
+ * performs the sacrifice.
+ */
+val OverchargedAmalgam = card("Overcharged Amalgam") {
+    manaCost = "{2}{U}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie Horror"
+    power = 3
+    toughness = 3
+    oracleText = "Flash\n" +
+        "Flying\n" +
+        "Exploit (When this creature enters, you may sacrifice a creature.)\n" +
+        "When this creature exploits a creature, counter target spell, activated ability, or " +
+        "triggered ability."
+
+    keywords(Keyword.FLASH, Keyword.FLYING)
+
+    exploit(
+        onExploit = Effects.CounterSpellOrAbility(),
+        onExploitTargets = listOf(Targets.SpellOrAbility)
+    )
+
+    metadata {
+        rarity = Rarity.RARE
+        collectorNumber = "71"
+        artist = "Mike Jordana"
+        imageUri = "https://cards.scryfall.io/normal/front/d/b/dbbcd63d-6c25-47a6-a76c-ac53bf12949c.jpg?1783924890"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RepositorySkaab.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RepositorySkaab.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.Targets
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.exploit
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Repository Skaab
+ * {3}{U}
+ * Creature — Zombie
+ * 3/3
+ * Exploit (When this creature enters, you may sacrifice a creature.)
+ * When this creature exploits a creature, return target instant or sorcery card from your
+ * graveyard to your hand.
+ *
+ * The payoff targets a card in your graveyard ([exploit]'s `onExploitTargets` =
+ * [Targets.InstantOrSorceryInYourGraveyard]), chosen after the sacrifice resolves;
+ * [Effects.ReturnToHand] moves it to your hand. The reflexive is only offered when a legal
+ * instant/sorcery card is in your graveyard, so exploiting with none just performs the sacrifice.
+ */
+val RepositorySkaab = card("Repository Skaab") {
+    manaCost = "{3}{U}"
+    colorIdentity = "U"
+    typeLine = "Creature — Zombie"
+    power = 3
+    toughness = 3
+    oracleText = "Exploit (When this creature enters, you may sacrifice a creature.)\n" +
+        "When this creature exploits a creature, return target instant or sorcery card from your " +
+        "graveyard to your hand."
+
+    exploit(
+        onExploit = Effects.ReturnToHand(EffectTarget.ContextTarget(0)),
+        onExploitTargets = listOf(Targets.InstantOrSorceryInYourGraveyard)
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "73"
+        artist = "Olivier Bernard"
+        imageUri = "https://cards.scryfall.io/normal/front/7/c/7cc22c2a-535a-46b5-817c-da5850abd669.jpg?1783924886"
+    }
+}

--- a/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RotTideGargantua.kt
+++ b/mtg-sets/src/main/kotlin/com/wingedsheep/mtg/sets/definitions/vow/cards/RotTideGargantua.kt
@@ -1,0 +1,45 @@
+package com.wingedsheep.mtg.sets.definitions.vow.cards
+
+import com.wingedsheep.sdk.dsl.Effects
+import com.wingedsheep.sdk.dsl.card
+import com.wingedsheep.sdk.dsl.exploit
+import com.wingedsheep.sdk.model.Rarity
+import com.wingedsheep.sdk.scripting.GameObjectFilter
+import com.wingedsheep.sdk.scripting.references.Player
+import com.wingedsheep.sdk.scripting.targets.EffectTarget
+
+/**
+ * Rot-Tide Gargantua
+ * {3}{B}{B}
+ * Creature — Zombie Kraken
+ * 5/4
+ * Exploit (When this creature enters, you may sacrifice a creature.)
+ * When this creature exploits a creature, each opponent sacrifices a creature of their choice.
+ *
+ * The payoff is untargeted (an edict resolved at resolution time), so it's baked straight into the
+ * exploit reflexive ([exploit]'s `onExploit`). [Effects.Sacrifice] aimed at [Player.EachOpponent]
+ * makes each opponent choose one of their own creatures to sacrifice (same shape as Tithing Blade).
+ */
+val RotTideGargantua = card("Rot-Tide Gargantua") {
+    manaCost = "{3}{B}{B}"
+    colorIdentity = "B"
+    typeLine = "Creature — Zombie Kraken"
+    power = 5
+    toughness = 4
+    oracleText = "Exploit (When this creature enters, you may sacrifice a creature.)\n" +
+        "When this creature exploits a creature, each opponent sacrifices a creature of their choice."
+
+    exploit(
+        onExploit = Effects.Sacrifice(
+            GameObjectFilter.Creature,
+            target = EffectTarget.PlayerRef(Player.EachOpponent)
+        )
+    )
+
+    metadata {
+        rarity = Rarity.COMMON
+        collectorNumber = "129"
+        artist = "Filip Burburan"
+        imageUri = "https://cards.scryfall.io/normal/front/1/e/1eafefd0-3a9e-400e-8c75-0825aeb2ded1.jpg?1783924850"
+    }
+}

--- a/mtg-sets/src/test/resources/snapshots/cards/VOW.json
+++ b/mtg-sets/src/test/resources/snapshots/cards/VOW.json
@@ -1659,6 +1659,71 @@
     ]
 }
 
+// Diver Skaab
+{
+    "name": "Diver Skaab",
+    "manaCost": "{3}{U}{U}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, target creature's owner puts it on their choice of the top or bottom of their library.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 5
+    },
+    "keywords": [
+        "EXPLOIT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Sacrifice",
+                                "filter": "creature"
+                            },
+                            "EmitExploitedEvent"
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "PutOnLibraryPositionOfChoice",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        }
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "creature"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may sacrifice a creature"
+                },
+                "descriptionOverride": "Exploit (When this creature enters, you may sacrifice a creature.)"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "56",
+        "rarity": "UNCOMMON",
+        "artist": "Dave Kendall",
+        "imageUri": "https://cards.scryfall.io/normal/front/3/8/38b5fdf4-3884-436f-8066-bc7593e72b02.jpg?1783924897"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Dread Fugue
 {
     "name": "Dread Fugue",
@@ -2593,6 +2658,93 @@
         "collectorNumber": "114",
         "artist": "Jesper Ejsing",
         "imageUri": "https://cards.scryfall.io/normal/front/1/8/18c07288-1c71-4e71-bdf5-910eb583a1d8.jpg?1782703110"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
+// Graf Reaver
+{
+    "name": "Graf Reaver",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie Warrior",
+    "oracleText": "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, destroy target planeswalker.\nAt the beginning of your upkeep, this creature deals 1 damage to you.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "EXPLOIT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Sacrifice",
+                                "filter": "creature"
+                            },
+                            "EmitExploitedEvent"
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Graveyard",
+                        "byDestruction": true
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "planeswalker"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may sacrifice a creature"
+                },
+                "descriptionOverride": "Exploit (When this creature enters, you may sacrifice a creature.)"
+            },
+            {
+                "id": "ability_2",
+                "trigger": {
+                    "type": "StepEvent",
+                    "step": "UPKEEP"
+                },
+                "binding": "ANY",
+                "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                        "type": "Fixed",
+                        "amount": 1
+                    },
+                    "target": {
+                        "type": "PlayerRef",
+                        "player": "You"
+                    }
+                },
+                "descriptionOverride": "At the beginning of your upkeep, this creature deals 1 damage to you."
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "115",
+        "rarity": "RARE",
+        "artist": "Dave Kendall",
+        "imageUri": "https://cards.scryfall.io/normal/front/0/b/0bb2103b-3462-4439-a1e1-243a15c5f318.jpg?1783924863"
     },
     "colorIdentityOverride": [
         "BLACK"
@@ -3868,6 +4020,96 @@
     ]
 }
 
+// Mindleech Ghoul
+{
+    "name": "Mindleech Ghoul",
+    "manaCost": "{1}{B}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, each opponent exiles a card from their hand.",
+    "creatureStats": {
+        "power": 2,
+        "toughness": 2
+    },
+    "keywords": [
+        "EXPLOIT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Sacrifice",
+                                "filter": "creature"
+                            },
+                            "EmitExploitedEvent"
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "ForEach",
+                        "space": {
+                            "type": "IterationSpace.Players",
+                            "players": "EachOpponent"
+                        },
+                        "body": {
+                            "type": "Composite",
+                            "effects": [
+                                {
+                                    "type": "GatherCards",
+                                    "source": {
+                                        "type": "FromZone",
+                                        "zone": "Hand"
+                                    },
+                                    "storeAs": "hand"
+                                },
+                                {
+                                    "type": "SelectFromCollection",
+                                    "from": "hand",
+                                    "selection": {
+                                        "type": "ChooseExactly",
+                                        "count": {
+                                            "type": "Fixed",
+                                            "amount": 1
+                                        }
+                                    },
+                                    "storeSelected": "exiled",
+                                    "prompt": "Choose a card to exile"
+                                },
+                                {
+                                    "type": "MoveCollection",
+                                    "from": "exiled",
+                                    "destination": {
+                                        "type": "ToZone",
+                                        "zone": "Exile"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "descriptionOverride": "You may sacrifice a creature"
+                },
+                "descriptionOverride": "Exploit (When this creature enters, you may sacrifice a creature.)"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "122",
+        "artist": "Alex Brock",
+        "imageUri": "https://cards.scryfall.io/normal/front/f/5/f5c4e00d-128a-4ddb-9e1b-3ee93121b262.jpg?1783924857"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
+    ]
+}
+
 // Moldgraf Millipede
 {
     "name": "Moldgraf Millipede",
@@ -4103,6 +4345,71 @@
     },
     "colorIdentityOverride": [
         "WHITE"
+    ]
+}
+
+// Overcharged Amalgam
+{
+    "name": "Overcharged Amalgam",
+    "manaCost": "{2}{U}{U}",
+    "typeLine": "Creature — Zombie Horror",
+    "oracleText": "Flash\nFlying\nExploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, counter target spell, activated ability, or triggered ability.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "FLASH",
+        "FLYING",
+        "EXPLOIT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Sacrifice",
+                                "filter": "creature"
+                            },
+                            "EmitExploitedEvent"
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "Counter",
+                        "target": "CounterTarget.SpellOrAbility"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": {},
+                                "zone": "Stack"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may sacrifice a creature"
+                },
+                "descriptionOverride": "Exploit (When this creature enters, you may sacrifice a creature.)"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "71",
+        "rarity": "RARE",
+        "artist": "Mike Jordana",
+        "imageUri": "https://cards.scryfall.io/normal/front/d/b/dbbcd63d-6c25-47a6-a76c-ac53bf12949c.jpg?1783924890"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
     ]
 }
 
@@ -4671,6 +4978,72 @@
     ]
 }
 
+// Repository Skaab
+{
+    "name": "Repository Skaab",
+    "manaCost": "{3}{U}",
+    "typeLine": "Creature — Zombie",
+    "oracleText": "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, return target instant or sorcery card from your graveyard to your hand.",
+    "creatureStats": {
+        "power": 3,
+        "toughness": 3
+    },
+    "keywords": [
+        "EXPLOIT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Sacrifice",
+                                "filter": "creature"
+                            },
+                            "EmitExploitedEvent"
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "MoveToZone",
+                        "target": {
+                            "type": "ContextTarget",
+                            "index": 0
+                        },
+                        "destination": "Hand"
+                    },
+                    "reflexiveTargetRequirements": [
+                        {
+                            "type": "TargetObject",
+                            "filter": {
+                                "baseFilter": "instant|sorcery own:you",
+                                "zone": "Graveyard"
+                            }
+                        }
+                    ],
+                    "descriptionOverride": "You may sacrifice a creature"
+                },
+                "descriptionOverride": "Exploit (When this creature enters, you may sacrifice a creature.)"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "73",
+        "artist": "Olivier Bernard",
+        "imageUri": "https://cards.scryfall.io/normal/front/7/c/7cc22c2a-535a-46b5-817c-da5850abd669.jpg?1783924886"
+    },
+    "colorIdentityOverride": [
+        "BLUE"
+    ]
+}
+
 // Resistance Squad
 {
     "name": "Resistance Squad",
@@ -4777,6 +5150,63 @@
     },
     "colorIdentityOverride": [
         "GREEN"
+    ]
+}
+
+// Rot-Tide Gargantua
+{
+    "name": "Rot-Tide Gargantua",
+    "manaCost": "{3}{B}{B}",
+    "typeLine": "Creature — Zombie Kraken",
+    "oracleText": "Exploit (When this creature enters, you may sacrifice a creature.)\nWhen this creature exploits a creature, each opponent sacrifices a creature of their choice.",
+    "creatureStats": {
+        "power": 5,
+        "toughness": 4
+    },
+    "keywords": [
+        "EXPLOIT"
+    ],
+    "script": {
+        "triggeredAbilities": [
+            {
+                "id": "ability_1",
+                "trigger": {
+                    "type": "ZoneChangeEvent",
+                    "to": "Battlefield"
+                },
+                "effect": {
+                    "type": "ReflexiveTrigger",
+                    "action": {
+                        "type": "Composite",
+                        "effects": [
+                            {
+                                "type": "Sacrifice",
+                                "filter": "creature"
+                            },
+                            "EmitExploitedEvent"
+                        ]
+                    },
+                    "reflexiveEffect": {
+                        "type": "ForceSacrifice",
+                        "filter": "creature",
+                        "target": {
+                            "type": "PlayerRef",
+                            "player": "EachOpponent"
+                        }
+                    },
+                    "descriptionOverride": "You may sacrifice a creature"
+                },
+                "descriptionOverride": "Exploit (When this creature enters, you may sacrifice a creature.)"
+            }
+        ]
+    },
+    "metadata": {
+        "collectorNumber": "129",
+        "artist": "Filip Burburan",
+        "imageUri": "https://cards.scryfall.io/normal/front/1/e/1eafefd0-3a9e-400e-8c75-0825aeb2ded1.jpg?1783924850"
+    },
+    "colorIdentityOverride": [
+        "BLACK"
     ]
 }
 

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/DamageLifeAndCards.kt
@@ -59,6 +59,10 @@ internal fun BridgeBuilder.damageLifeAndCards() {
 
     effect("SacrificePermanent", "Sacrifice")
     effect("CounterSpell", "Counter")
+    // "Counter target spell, activated ability, or triggered ability" (Overcharged Amalgam's exploit
+    // payoff, Teferi's Response). Same CounterEffect as CounterSpell, but its target dispatches at
+    // resolution on whatever stack-object kind was chosen -> Effects.CounterSpellOrAbility().
+    effect("CounterSpellOrAbility", "Counter")
     // Copy / retarget a spell or ability on the stack (Return the Favor). The unified copy effect
     // dispatches at resolution on the chosen stack-object kind (spell / activated / triggered ability).
     effect("CopySpellOrAbilityAndMayChooseNewTargets", "CopyTargetSpellOrAbility")

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/TriggersCostsAndContinuous.kt
@@ -81,6 +81,20 @@ internal fun BridgeBuilder.triggersCostsAndContinuous() {
     // attach-relative duration and exile linkage the emitter does NOT reconstruct, so it declines to
     // SCAFFOLD per the creator's note (chosen/inherited-value shapes). Hand-authored card is ground truth.
     supported("WhenAPermanentBecomesAttached", "trigger: an Aura/Equipment becomes attached (Triggers.becomesAttached) — capability only, emitter scaffolds")
+    // Exploit payoff (CR 702.110b) — "when this creature exploits a creature, …". NOT an engine gap:
+    // the shipped `card { exploit(onExploit, onExploitTargets) }` helper composes the whole mechanic
+    // from primitives (EXPLOIT keyword + an ETB ReflexiveTriggerEffect whose action sacrifices a
+    // creature and fires an observable EventPattern.ExploitedEvent), baking the self-payoff into the
+    // reflexive so it survives self-sacrifice. Broadcast "whenever a creature you control exploits"
+    // watchers use EventPattern.ExploitedEvent directly (Skull Skaab). Capability-only: fusing the
+    // paired Exploit-keyword rule + this trigger back into one exploit() call (recovering owner /
+    // each-opponent / targeted payoff shapes) is exactly the lossy render the fidelity policy declines,
+    // so the emitter leaves it at SCAFFOLD (like WhenAPermanentBecomesAttached). The Exploit keyword
+    // rule itself already scaffolds via `// STRUCTURE needs human wiring: Exploit`. See the Exploit
+    // keyword + ExploitedEvent entries in card-sdk-language-reference.md; hand-authored cards
+    // (VOW Diver Skaab, Graf Reaver, Mindleech Ghoul, Overcharged Amalgam, Repository Skaab,
+    // Rot-Tide Gargantua) are ground truth.
+    supported("WhenAPermanentExploitsAPermanent", "trigger: this creature exploits a creature (exploit payoff — card { exploit(onExploit, onExploitTargets) }) — capability only, emitter scaffolds")
     // OTJ crime (CR 700.10) — "Whenever you commit a crime, …" (Triggers.YouCommitCrime, Marauding Sphinx).
     supported("WhenAPlayerCommitsACrime", "trigger: you commit a crime (Triggers.YouCommitCrime)")
     // "Whenever one or more cards leave your graveyard, …" — batching leave-graveyard trigger

--- a/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
+++ b/mtgish-tooling/src/main/kotlin/com/wingedsheep/tooling/coverage/bridge/ZoneMovement.kt
@@ -12,6 +12,11 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("SearchLibrary", "Gather->Select->Move SearchLibrary pattern", composes = listOf("MoveCollection", "ShuffleLibrary"))
 
     composed("DiscardACard", "Patterns.Hand.discardCards -> Gather/Select/MoveCollection", composes = listOf("MoveCollection"))
+    // "Exile a card from your hand" (Mindleech Ghoul's exploit payoff, wrapped in an EachPlayerAction
+    // -> each opponent chooses one of their own cards). Same Gather(hand)/Select/MoveCollection pipeline
+    // as DiscardACard but the destination zone is EXILE -> Patterns.Hand.eachOpponentExilesFromHand /
+    // Effects.EachOpponentExilesFromHand(n).
+    composed("ExileACardFromHand", "Gather(hand)/Select/MoveCollection -> exile (Effects.EachOpponentExilesFromHand)", composes = listOf("MoveCollection"))
     composed("DiscardNumberCards", "MoveToZone hand->graveyard, N", composes = listOf("MoveCollection"))
     composed("DiscardAnyNumberOfCards", "MoveToZone hand->graveyard, any", composes = listOf("MoveCollection"))
     composed("DiscardACardAtRandom", "Patterns.Hand.discardRandom -> MoveCollection", composes = listOf("MoveCollection"))
@@ -25,6 +30,11 @@ internal fun BridgeBuilder.zoneMovement() {
     composed("ShuffleEachPermanentIntoLibrary", "self + target ShuffleIntoLibrary (each to owner's library)", composes = listOf("MoveToZone", "ShuffleLibrary"))
     composed("ReturnDeadGraveyardCardToTopOfLibrary", "MoveCollection -> library top", composes = listOf("MoveToZone"))
     composed("PutGraveyardCardOnBottomOfLibrary", "MoveCollection -> library bottom (Tomb Trawler)", composes = listOf("MoveToZone"))
+    // "Target creature's owner puts it on their choice of the top or bottom of their library" (Diver
+    // Skaab's exploit payoff) — the owner-chosen tuck, a native leaf effect
+    // Effects.PutOnTopOrBottomOfLibrary(target) -> PutOnLibraryPositionOfChoiceEffect [Top, Bottom].
+    effect("ReturnPermanentToTopOrBottomOfLibrary", "PutOnLibraryPositionOfChoice",
+        "owner chooses top or bottom of their library — Effects.PutOnTopOrBottomOfLibrary(target)")
     composed("ReturnGraveyardCardToHand", UNIVERSAL, composes = listOf("MoveToZone"))
     composed("PutEachGraveyardCardIntoHand", UNIVERSAL, composes = listOf("MoveCollection"))
     // "Return all <filter> cards from your graveyard to your hand" (Wisdom of Ages) — a mass

--- a/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExploitPayoffTest.kt
+++ b/rules-engine/src/test/kotlin/com/wingedsheep/engine/scenarios/ExploitPayoffTest.kt
@@ -1,0 +1,279 @@
+package com.wingedsheep.engine.scenarios
+
+import com.wingedsheep.engine.core.ChooseOptionDecision
+import com.wingedsheep.engine.core.ChooseTargetsDecision
+import com.wingedsheep.engine.core.OptionChosenResponse
+import com.wingedsheep.engine.core.SelectCardsDecision
+import com.wingedsheep.engine.core.YesNoDecision
+import com.wingedsheep.engine.state.ZoneKey
+import com.wingedsheep.engine.state.components.battlefield.CountersComponent
+import com.wingedsheep.engine.support.GameTestDriver
+import com.wingedsheep.engine.support.TestCards
+import com.wingedsheep.sdk.core.Color
+import com.wingedsheep.sdk.core.CounterType
+import com.wingedsheep.sdk.core.Step
+import com.wingedsheep.sdk.core.Zone
+import com.wingedsheep.sdk.model.Deck
+import com.wingedsheep.sdk.model.EntityId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Exploit *payoffs* (CR 702.110) — the six paper-VOW cards whose "when this creature exploits a
+ * creature" trigger does something other than Stitched Assistant / Fell Stinger / Skull Skaab
+ * (those three are covered by [ExploitTest]). Each payoff is expressed purely by composing existing
+ * SDK primitives through the `exploit(onExploit, onExploitTargets)` helper, so this test proves the
+ * composition, not new engine plumbing.
+ *
+ * Two payoff shapes are exercised:
+ *
+ *  - **Untargeted** (Mindleech Ghoul, Rot-Tide Gargantua) — the payoff is baked straight into the
+ *    exploit reflexive as `onExploit` with no `onExploitTargets`, so it resolves inline as
+ *    `CompositeEffect(sacrifice, payoff)` the moment the player says "yes".
+ *  - **Targeted** (Diver Skaab, Graf Reaver, Overcharged Amalgam, Repository Skaab) — the payoff
+ *    rides `onExploitTargets`, so its target is chosen **after** the sacrifice resolves (a
+ *    [ChooseTargetsDecision]); the reflexive is only offered when a legal target exists.
+ *
+ * All six exploiters are cast with a spare creature on the battlefield so the exploit sacrifice is a
+ * deterministic two-creature [SelectCardsDecision] (pick the fodder), never a self-sacrifice.
+ */
+class ExploitPayoffTest : FunSpec({
+
+    fun createDriver(): GameTestDriver {
+        val driver = GameTestDriver()
+        // Every VOW card (the six exploiters), Jace Reawakened (OTJ), Lightning Bolt (LEA), and the
+        // Grizzly Bears / Centaur Courser test creatures are already in TestCards.all via the set
+        // catalog, so a plain registration of the whole corpus is enough.
+        driver.registerCards(TestCards.all)
+        driver.initMirrorMatch(
+            deck = Deck.of("Island" to 20, "Swamp" to 20, "Grizzly Bears" to 20),
+            startingLife = 20,
+            skipMulligans = true
+        )
+        driver.passPriorityUntil(Step.PRECOMBAT_MAIN)
+        return driver
+    }
+
+    // Cast an exploiter from hand, paying its mana, and resolve it plus its exploit ETB trigger so
+    // the optional sacrifice [YesNoDecision] is surfaced. `mana` lists the exact colored pips; any
+    // remainder of the mana value is topped up as colorless. Mirrors ExploitTest.castExploiter.
+    fun castExploiter(driver: GameTestDriver, me: EntityId, name: String, mana: List<Color>): EntityId {
+        val card = driver.putCardInHand(me, name)
+        val manaValue = driver.state.getEntity(card)!!
+            .get<com.wingedsheep.engine.state.components.identity.CardComponent>()!!
+            .manaCost.cmc
+        mana.groupingBy { it }.eachCount().forEach { (color, n) -> driver.giveMana(me, color, n) }
+        val colorless = manaValue - mana.size
+        if (colorless > 0) driver.giveColorlessMana(me, colorless)
+        driver.castSpell(me, card).isSuccess shouldBe true
+        driver.bothPass() // resolve the creature spell -> exploit ETB trigger goes on the stack
+        driver.bothPass() // resolve the exploit ETB trigger -> optional sacrifice decision
+        return card
+    }
+
+    // Say "yes" to the exploit sacrifice and sacrifice the spare creature (a two-creature board makes
+    // this a SelectCardsDecision rather than an auto-sacrifice of the exploiter itself).
+    fun exploitSacrificing(driver: GameTestDriver, me: EntityId, fodder: EntityId) {
+        driver.pendingDecision.shouldBeInstanceOf<YesNoDecision>()
+        driver.submitYesNo(me, true)
+        driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        driver.submitCardSelection(me, listOf(fodder))
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Diver Skaab — {3}{U}{U} 3/5. "When this creature exploits a creature, target creature's owner
+    // puts it on their choice of the top or bottom of their library." (targeted + owner's top/bottom)
+    // ---------------------------------------------------------------------------------------------
+
+    test("Diver Skaab puts the targeted creature on top of its owner's library") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val victim = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        castExploiter(driver, me, "Diver Skaab", listOf(Color.BLUE, Color.BLUE))
+        exploitSacrificing(driver, me, fodder)
+
+        // Reflexive target ("target creature") is a permanent, so it always prompts — pick the
+        // opponent's Centaur Courser rather than my own Diver Skaab.
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(victim))
+
+        // The card's OWNER (the opponent) chooses top or bottom of THEIR library.
+        val choose = driver.pendingDecision.shouldBeInstanceOf<ChooseOptionDecision>()
+        choose.playerId shouldBe opp
+        val topIdx = choose.options.indexOfFirst { it.contains("Top", ignoreCase = true) }
+        driver.submitDecision(opp, OptionChosenResponse(choose.id, topIdx))
+
+        driver.findPermanent(opp, "Centaur Courser") shouldBe null
+        driver.state.getZone(ZoneKey(opp, Zone.LIBRARY)).first() shouldBe victim
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Graf Reaver — {1}{B} 3/3. "When this creature exploits a creature, destroy target planeswalker."
+    // plus "At the beginning of your upkeep, this creature deals 1 damage to you."
+    // ---------------------------------------------------------------------------------------------
+
+    test("Graf Reaver's exploit destroys the targeted planeswalker") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        // Seed the planeswalker's loyalty — the battlefield builder doesn't add loyalty counters, and
+        // a 0-loyalty planeswalker would be swept by the 704.5i SBA before it could be targeted.
+        val jace = driver.putPermanentOnBattlefield(opp, "Jace Reawakened")
+        driver.replaceState(
+            driver.state.updateEntity(jace) { c ->
+                c.with((c.get<CountersComponent>() ?: CountersComponent()).withAdded(CounterType.LOYALTY, 3))
+            }
+        )
+
+        castExploiter(driver, me, "Graf Reaver", listOf(Color.BLACK))
+        exploitSacrificing(driver, me, fodder)
+
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(jace))
+
+        driver.findPermanent(opp, "Jace Reawakened") shouldBe null
+    }
+
+    test("Graf Reaver deals 1 damage to its controller on their upkeep") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        driver.putCreatureOnBattlefield(me, "Graf Reaver")
+
+        val lifeBefore = driver.getLifeTotal(me) // 20
+
+        // Advance to my next upkeep and resolve the drawback trigger (mirrors BonehoardDracosaur's
+        // advance-to-my-upkeep helper: the first UPKEEP reached is the opponent's, so step past it).
+        driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        if (driver.activePlayer != me) {
+            driver.passPriorityUntil(Step.PRECOMBAT_MAIN, maxPasses = 200)
+            driver.passPriorityUntil(Step.UPKEEP, maxPasses = 200)
+        }
+        driver.activePlayer shouldBe me
+        var guard = 0
+        while (!driver.isPaused && driver.state.stack.isNotEmpty() && guard < 50) {
+            driver.bothPass()
+            guard++
+        }
+
+        driver.getLifeTotal(me) shouldBe lifeBefore - 1
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Mindleech Ghoul — {1}{B} 2/2. "When this creature exploits a creature, each opponent exiles a
+    // card from their hand." (untargeted each-opponent effect, resolved inline)
+    // ---------------------------------------------------------------------------------------------
+
+    test("Mindleech Ghoul makes each opponent exile a card from their hand") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val doomedCard = driver.putCardInHand(opp, "Grizzly Bears")
+
+        castExploiter(driver, me, "Mindleech Ghoul", listOf(Color.BLACK))
+        exploitSacrificing(driver, me, fodder)
+
+        // The untargeted payoff resolves inline: the opponent chooses which card of THEIRS to exile.
+        val exileChoice = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        exileChoice.playerId shouldBe opp
+        driver.submitCardSelection(opp, listOf(doomedCard))
+
+        driver.getExile(opp).contains(doomedCard) shouldBe true
+        driver.getHand(opp).contains(doomedCard) shouldBe false
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Overcharged Amalgam — {2}{U}{U} 3/3 Flash, Flying. "When this creature exploits a creature,
+    // counter target spell, activated ability, or triggered ability." (flash exploit counter on a stick)
+    // ---------------------------------------------------------------------------------------------
+
+    test("Overcharged Amalgam flashes in and counters an opponent's spell") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+
+        // Opponent casts Lightning Bolt at me; I hold priority with it on the stack.
+        val bolt = driver.putCardInHand(opp, "Lightning Bolt")
+        driver.giveMana(opp, Color.RED, 1)
+        driver.passPriority(me)                     // priority to the opponent
+        driver.castSpell(opp, bolt, listOf(me))
+        val boltOnStack = driver.getTopOfStack()!!
+        driver.passPriority(opp)                    // priority back to me, Bolt on the stack
+
+        // Flash Amalgam in response, then resolve it and its exploit ETB trigger.
+        val amalgam = driver.putCardInHand(me, "Overcharged Amalgam")
+        driver.giveMana(me, Color.BLUE, 2)
+        driver.giveColorlessMana(me, 2)
+        driver.castSpell(me, amalgam).isSuccess shouldBe true
+        driver.bothPass() // resolve Amalgam -> exploit ETB trigger on the stack (above the Bolt)
+        driver.bothPass() // resolve the exploit ETB trigger -> optional sacrifice decision
+
+        exploitSacrificing(driver, me, fodder)
+
+        // Reflexive target ("counter target spell...") — the only legal object is the Bolt.
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(boltOnStack))
+
+        driver.getGraveyardCardNames(opp) shouldContain "Lightning Bolt"
+        driver.getTopOfStack() shouldBe null
+        driver.getLifeTotal(me) shouldBe 20 // the countered Bolt never dealt its 3 damage
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Repository Skaab — {3}{U} 3/3. "When this creature exploits a creature, return target instant
+    // or sorcery card from your graveyard to your hand." (targeted graveyard retrieval)
+    // ---------------------------------------------------------------------------------------------
+
+    test("Repository Skaab returns a targeted instant/sorcery from the graveyard to hand") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        val bolt = driver.putCardInGraveyard(me, "Lightning Bolt")
+
+        castExploiter(driver, me, "Repository Skaab", listOf(Color.BLUE))
+        exploitSacrificing(driver, me, fodder)
+
+        // Reflexive target ("target instant or sorcery card in your graveyard") — the Bolt.
+        driver.pendingDecision.shouldBeInstanceOf<ChooseTargetsDecision>()
+        driver.submitTargetSelection(me, listOf(bolt))
+
+        driver.getHand(me).contains(bolt) shouldBe true
+        driver.getGraveyard(me).contains(bolt) shouldBe false
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Rot-Tide Gargantua — {3}{B}{B} 5/4. "When this creature exploits a creature, each opponent
+    // sacrifices a creature of their choice." (untargeted edict, resolved inline)
+    // ---------------------------------------------------------------------------------------------
+
+    test("Rot-Tide Gargantua makes each opponent sacrifice a creature of their choice") {
+        val driver = createDriver()
+        val me = driver.activePlayer!!
+        val opp = driver.getOpponent(me)
+        val fodder = driver.putCreatureOnBattlefield(me, "Grizzly Bears")
+        // Two opponent creatures so the edict is a genuine choice, not an auto-sacrifice.
+        driver.putCreatureOnBattlefield(opp, "Grizzly Bears")
+        val doomed = driver.putCreatureOnBattlefield(opp, "Centaur Courser")
+
+        castExploiter(driver, me, "Rot-Tide Gargantua", listOf(Color.BLACK, Color.BLACK))
+        exploitSacrificing(driver, me, fodder)
+
+        // The untargeted edict resolves inline: the opponent chooses one of THEIR creatures.
+        val edict = driver.pendingDecision.shouldBeInstanceOf<SelectCardsDecision>()
+        edict.playerId shouldBe opp
+        driver.submitCardSelection(opp, listOf(doomed))
+
+        driver.findPermanent(opp, "Centaur Courser") shouldBe null
+        driver.findPermanent(opp, "Grizzly Bears").shouldNotBeNull() // the un-chosen creature survives
+        driver.getGraveyard(opp).contains(doomed) shouldBe true
+    }
+})


### PR DESCRIPTION
The Exploit keyword (CR 702.110), ExploitedEvent pattern, and card { exploit(onExploit, onExploitTargets) } helper already shipped. This adds the six paper-VOW cards whose "when this creature exploits a creature" trigger does something beyond the three already-covered exploiters, each expressed purely by composing existing SDK primitives through exploit():

  - Diver Skaab {3}{U}{U}  — owner tucks target creature top/bottom of library
  - Graf Reaver {1}{B}     — destroy target planeswalker (+ upkeep self-ping)
  - Mindleech Ghoul {1}{B} — each opponent exiles a card from their hand
  - Overcharged Amalgam {2}{U}{U} — counter target spell/ability (Flash/Flying)
  - Repository Skaab {3}{U} — return target instant/sorcery from your graveyard
  - Rot-Tide Gargantua {3}{B}{B} — each opponent sacrifices a creature (edict)

SDK additions (parameterized, reusable — not card-specific):
  - Effects.EachOpponentExilesFromHand(count) + HandPatterns.eachOpponentExilesFromHand (ForEachPlayer(EachOpponent) -> Gather -> Select -> Move to EXILE)
  - Targets.SpellOrAbility, Targets.InstantOrSorceryInYourGraveyard, Targets.Planeswalker

mtgish-tooling: teach the capability bridge the exploit-payoff shapes so the probe scores these cards as coverable (capability axis only; the emitter still scaffolds the exploit() fusion, per the fidelity policy):
  - WhenAPermanentExploitsAPermanent (supported trigger), CounterSpellOrAbility, ReturnPermanentToTopOrBottomOfLibrary, ExileACardFromHand

Re-bless the INR mtgish emitter golden: the merged Training (TRAINING) and Exploit (EXPLOIT) keyword enum members made the emitter render those keyword lines on Hopeful Initiate / Torens / Overcharged Amalgam, which the golden predated.

Tests: ExploitPayoffTest (7 cases) green; VOW CardDefinitionSnapshotTest, CardLintTest, and the full :mtgish-tooling suite (BridgeResolveTest, EmitterGoldenTest) all pass. Updates docs/card-sdk-language-reference.md.